### PR TITLE
Update TypeScript to 4.5.5

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@storybook/builder-webpack5": "~6.4.5",
         "@storybook/manager-webpack5": "~6.4.5",
         "@types/dagre": "^0.7.46",
-        "@types/react-dnd": "^3.0.2",
         "core-js": "^3.6.5",
         "dagre": "^0.8.5",
         "eslint-plugin-formatjs": "^2.17.8",
@@ -93,7 +92,7 @@
         "react-test-renderer": "^17.0.2",
         "style-loader": "^3.3.0",
         "ts-jest": "27.0.5",
-        "typescript": "~4.4.2",
+        "typescript": "^4.5.5",
         "url-loader": "^3.0.0",
         "webpack-cli": "^4.9.0"
       }
@@ -2694,19 +2693,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@formatjs/cli/node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.0.tgz",
@@ -2741,28 +2727,6 @@
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.11.0",
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@formatjs/intl": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-1.18.0.tgz",
-      "integrity": "sha512-qPdfj4sjzQiLyY154JM0ktQVYc7spksV3Ak8glgzAz7IG/xC3JOBKYrQzV3cGrUeN1+cG/dEzxLMYkvjqoNNUA==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.0",
-        "@formatjs/fast-memoize": "1.2.1",
-        "@formatjs/icu-messageformat-parser": "2.0.15",
-        "@formatjs/intl-displaynames": "5.3.0",
-        "@formatjs/intl-listformat": "6.4.0",
-        "intl-messageformat": "9.11.0",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@formatjs/intl-displaynames": {
@@ -2817,18 +2781,6 @@
       "version": "16.11.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.17.tgz",
       "integrity": "sha512-C1vTZME8cFo8uxY2ui41xcynEotVkczIVI5AjLmy5pkpBv/FtG+jhtOlfcPysI8VRVwoOMv6NJm44LGnoMSWkw=="
-    },
-    "node_modules/@formatjs/ts-transformer/node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.2",
@@ -13659,15 +13611,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/react-dnd": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dnd/-/react-dnd-3.0.2.tgz",
-      "integrity": "sha512-Z1BqHYGFtfSPfWs+kgX4b6wQmwwtqq4/pLo4zdO9xcDUB1ZQP8iWTAYNf3EJ2f0WiVQpSLN8UytP+ILzZHDLYw==",
-      "deprecated": "This is a stub types definition. react-dnd provides its own type definitions, so you don't need this installed.",
-      "dependencies": {
-        "react-dnd": "*"
-      }
-    },
     "node_modules/@types/react-dnd-multi-backend": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-dnd-multi-backend/-/react-dnd-multi-backend-6.0.1.tgz",
@@ -19873,18 +19816,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-    },
-    "node_modules/eslint-plugin-formatjs/node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.25.2",
@@ -29385,6 +29316,28 @@
         }
       }
     },
+    "node_modules/react-intl/node_modules/@formatjs/intl": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-1.18.0.tgz",
+      "integrity": "sha512-qPdfj4sjzQiLyY154JM0ktQVYc7spksV3Ak8glgzAz7IG/xC3JOBKYrQzV3cGrUeN1+cG/dEzxLMYkvjqoNNUA==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.0",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.15",
+        "@formatjs/intl-displaynames": "5.3.0",
+        "@formatjs/intl-listformat": "6.4.0",
+        "intl-messageformat": "9.11.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -33256,9 +33209,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -37039,12 +36992,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "typescript": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-          "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-          "dev": true
         }
       }
     },
@@ -37081,20 +37028,6 @@
       "integrity": "sha512-ChKmnVCE/LbJzedRgA/EeL5+tfjx/6ZWunqNiEC5BtqHnnwmLN/oPuCPb8b3NhuGiwTqp+LkaS70tga5kXRHxg==",
       "requires": {
         "@formatjs/ecma402-abstract": "1.11.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@formatjs/intl": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-1.18.0.tgz",
-      "integrity": "sha512-qPdfj4sjzQiLyY154JM0ktQVYc7spksV3Ak8glgzAz7IG/xC3JOBKYrQzV3cGrUeN1+cG/dEzxLMYkvjqoNNUA==",
-      "requires": {
-        "@formatjs/ecma402-abstract": "1.11.0",
-        "@formatjs/fast-memoize": "1.2.1",
-        "@formatjs/icu-messageformat-parser": "2.0.15",
-        "@formatjs/intl-displaynames": "5.3.0",
-        "@formatjs/intl-listformat": "6.4.0",
-        "intl-messageformat": "9.11.0",
         "tslib": "^2.1.0"
       }
     },
@@ -37142,11 +37075,6 @@
           "version": "16.11.17",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.17.tgz",
           "integrity": "sha512-C1vTZME8cFo8uxY2ui41xcynEotVkczIVI5AjLmy5pkpBv/FtG+jhtOlfcPysI8VRVwoOMv6NJm44LGnoMSWkw=="
-        },
-        "typescript": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-          "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
         }
       }
     },
@@ -45508,14 +45436,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "@types/react-dnd": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dnd/-/react-dnd-3.0.2.tgz",
-      "integrity": "sha512-Z1BqHYGFtfSPfWs+kgX4b6wQmwwtqq4/pLo4zdO9xcDUB1ZQP8iWTAYNf3EJ2f0WiVQpSLN8UytP+ILzZHDLYw==",
-      "requires": {
-        "react-dnd": "*"
-      }
-    },
     "@types/react-dnd-multi-backend": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-dnd-multi-backend/-/react-dnd-multi-backend-6.0.1.tgz",
@@ -50464,11 +50384,6 @@
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
           "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-        },
-        "typescript": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-          "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
         }
       }
     },
@@ -57597,6 +57512,22 @@
         "hoist-non-react-statics": "^3.3.2",
         "intl-messageformat": "9.11.0",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@formatjs/intl": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-1.18.0.tgz",
+          "integrity": "sha512-qPdfj4sjzQiLyY154JM0ktQVYc7spksV3Ak8glgzAz7IG/xC3JOBKYrQzV3cGrUeN1+cG/dEzxLMYkvjqoNNUA==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.11.0",
+            "@formatjs/fast-memoize": "1.2.1",
+            "@formatjs/icu-messageformat-parser": "2.0.15",
+            "@formatjs/intl-displaynames": "5.3.0",
+            "@formatjs/intl-listformat": "6.4.0",
+            "intl-messageformat": "9.11.0",
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "react-is": {
@@ -60642,9 +60573,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "uglify-js": {
       "version": "3.14.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@storybook/builder-webpack5": "~6.4.5",
     "@storybook/manager-webpack5": "~6.4.5",
     "@types/dagre": "^0.7.46",
-    "@types/react-dnd": "^3.0.2",
     "core-js": "^3.6.5",
     "dagre": "^0.8.5",
     "eslint-plugin-formatjs": "^2.17.8",
@@ -102,7 +101,7 @@
     "react-test-renderer": "^17.0.2",
     "style-loader": "^3.3.0",
     "ts-jest": "27.0.5",
-    "typescript": "~4.4.2",
+    "typescript": "^4.5.5",
     "url-loader": "^3.0.0",
     "webpack-cli": "^4.9.0"
   }


### PR DESCRIPTION
Remove @types/react-dnd..
> @types/react-dnd@3.0.2: This is a stub types definition. react-dnd provides its own type definitions, so you don't need this installed.

Use the npm registry (registry.npmjs.org).