### PR TITLE
Shake Off prototype additions on dynamic imports for loc files.

### DIFF
--- a/libs/designer/src/lib/core/state/localizationSlice.ts
+++ b/libs/designer/src/lib/core/state/localizationSlice.ts
@@ -52,7 +52,7 @@ const loadLocaleData = async (locale: string) => {
 export const loadLocaleMessages = createAsyncThunk('localizations/loadLocaleMessages', async (locale: string) => {
   const messages = await loadLocaleData(locale);
   return {
-    messages: messages,
+    messages: { ...messages },
     locale,
   };
 });


### PR DESCRIPTION
the dynamic import imports as a module and causes some potential issues with some extra non serializable attachments. Redux doesn't like this so this spread takes the properties and removes the unneeded cruft.