### PR TITLE
refactor: Export lib/utils helpers from designer-ui

### DIFF
--- a/libs/designer-ui/src/lib/checkbox.ts
+++ b/libs/designer-ui/src/lib/checkbox.ts
@@ -1,1 +1,0 @@
-export * from './checkbox/index';

--- a/libs/designer-ui/src/lib/index.ts
+++ b/libs/designer-ui/src/lib/index.ts
@@ -44,5 +44,5 @@ export * from './pager';
 // export * from './textbox';
 export * from './tip';
 // export * from './tokenpicker';
-// export * from './utils';
+export * from './utils';
 // export * from './workflowparameters';

--- a/libs/designer-ui/src/lib/monitoring/statuspill/index.tsx
+++ b/libs/designer-ui/src/lib/monitoring/statuspill/index.tsx
@@ -1,5 +1,5 @@
 import { TooltipHost } from '@fluentui/react';
-import { getStatusString } from '../../utils/utils';
+import { getStatusString } from '../../utils';
 import { StatusIcon } from './statusicon';
 
 export interface StatusPillProps {

--- a/libs/designer-ui/src/lib/monitoring/utils.ts
+++ b/libs/designer-ui/src/lib/monitoring/utils.ts
@@ -1,4 +1,4 @@
-import { getDurationString } from '../utils/utils';
+import { getDurationString } from '../utils';
 
 export function calculateDuration(startTime: string, endTime: string | undefined): string {
   return endTime ? getDurationString(Date.parse(endTime) - Date.parse(startTime), /* abbreviated */ false) : getDurationString(NaN);

--- a/libs/designer-ui/src/lib/overview/utils.ts
+++ b/libs/designer-ui/src/lib/overview/utils.ts
@@ -1,5 +1,5 @@
 import { isObject } from '@microsoft-logic-apps/utils';
-import { getDurationString } from '../utils/utils';
+import { getDurationString } from '../utils';
 import { CallbackInfo, isCallbackInfoWithRelativePath, Run, RunDisplayItem, RunError } from './types';
 
 export function getCallbackUrl(callbackInfo: CallbackInfo | undefined): string | undefined {

--- a/libs/designer-ui/src/lib/utils/__test__/utils.spec.ts
+++ b/libs/designer-ui/src/lib/utils/__test__/utils.spec.ts
@@ -1,5 +1,5 @@
 import Constants from '../../constants';
-import { getDurationString, getDurationStringPanelMode, getStatusString } from '../utils';
+import { getDurationString, getDurationStringPanelMode, getStatusString } from '../index';
 
 describe('ui/utils/utils', () => {
   describe('getDurationString', () => {

--- a/libs/designer-ui/src/lib/utils/index.ts
+++ b/libs/designer-ui/src/lib/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './keyboardUtils';
+export * from './theme';
+export * from './utils';


### PR DESCRIPTION
- Rename `index.tsx` to `index.ts`
- Remove unused `checkbox.ts`