### PR TITLE
test: Chain type, wait, and clear in overview test

### DIFF
--- a/apps/designer-e2e/src/integration/vs-code-overview-react/app.specs.ts
+++ b/apps/designer-e2e/src/integration/vs-code-overview-react/app.specs.ts
@@ -31,10 +31,11 @@ describe('vs-code-overview-react/app', () => {
   });
 
   it('should display an error message if a run name is entered and then cleared', () => {
-    cy.get('[data-testid="msla-run-history-filter-input"]').type('08585565587643197854783809524CU00');
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000); // deferredValidation set to 1000
-    cy.get('[data-testid="msla-run-history-filter-input"]').clear();
+    cy.get('[data-testid="msla-run-history-filter-input"]')
+      .type('08585565587643197854783809524CU00')
+      .wait(1000) // deferredValidation set to 1000
+      .clear();
 
     cy.get('[data-testid="msla-run-history-filter-button"]').should('have.attr', 'disabled');
     cy.get('[data-automation-id="error-message"]').should('exist');


### PR DESCRIPTION
The wait is deliberate, because, without it, Cypress may not spend enough time typing and then clearing to trigger the validation.