### PR TITLE
chore: Update Nx to 13.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "@nrwl/jest": "^13.8.3",
         "@nrwl/linter": "^13.8.3",
         "@nrwl/node": "^13.8.3",
-        "@nrwl/nx": "^7.8.7",
         "@nrwl/react": "^13.8.3",
         "@nrwl/storybook": "^13.8.3",
         "@nrwl/tao": "^13.8.3",
@@ -4454,16 +4453,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/@nrwl/nx": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx/-/nx-7.8.7.tgz",
-      "integrity": "sha512-a/pOozIT86IIWue6MSwN2EKO4grJ8My7QMl+g535/vrDg75riyBTkWF+nX6VM/JjGz40Y5nFZaX94924cZWt5g==",
-      "deprecated": "This package has been replaced by @nrwl/workspace. See https://nx.dev/angular/guides/nx7-to-nx8 on how to upgrade.",
-      "dev": true,
-      "peerDependencies": {
-        "jasmine-marbles": "0.4.0"
       }
     },
     "node_modules/@nrwl/react": {
@@ -25832,19 +25821,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/jasmine-marbles": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/jasmine-marbles/-/jasmine-marbles-0.4.0.tgz",
-      "integrity": "sha512-fV8fXz5K3p6LUYyElkmXDMZmtxe9c1/8nmD5H9r2TDix/sJAhd/PFoPXym1c7gZCXByx7tfoiVVyc2t/AxtS6Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.5.0"
-      },
-      "peerDependencies": {
-        "rxjs": "^6.1.0"
-      }
-    },
     "node_modules/jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
@@ -42120,13 +42096,6 @@
           }
         }
       }
-    },
-    "@nrwl/nx": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx/-/nx-7.8.7.tgz",
-      "integrity": "sha512-a/pOozIT86IIWue6MSwN2EKO4grJ8My7QMl+g535/vrDg75riyBTkWF+nX6VM/JjGz40Y5nFZaX94924cZWt5g==",
-      "dev": true,
-      "requires": {}
     },
     "@nrwl/react": {
       "version": "13.8.3",
@@ -58597,16 +58566,6 @@
             "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "jasmine-marbles": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/jasmine-marbles/-/jasmine-marbles-0.4.0.tgz",
-      "integrity": "sha512-fV8fXz5K3p6LUYyElkmXDMZmtxe9c1/8nmD5H9r2TDix/sJAhd/PFoPXym1c7gZCXByx7tfoiVVyc2t/AxtS6Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.5.0"
       }
     },
     "jest": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@nrwl/jest": "^13.8.3",
     "@nrwl/linter": "^13.8.3",
     "@nrwl/node": "^13.8.3",
-    "@nrwl/nx": "^7.8.7",
     "@nrwl/react": "^13.8.3",
     "@nrwl/storybook": "^13.8.3",
     "@nrwl/tao": "^13.8.3",


### PR DESCRIPTION
Fix build break on Windows caused by dependencies removed in 7ff682f520214f764bb13b1ddafa9500b8f8e9bf