### PR TITLE
feat: Syntax coloring in monitoring view value components

### DIFF
--- a/libs/designer-ui/src/lib/colorizer/colorizer.less
+++ b/libs/designer-ui/src/lib/colorizer/colorizer.less
@@ -2,24 +2,22 @@
 
 .msla-colorizer-json-body {
   margin: 0.5em 1.25em;
-  max-height: 12em;
+  max-height: 12rem; /* 192px = 12×16px = 10×19px + 2px borders */
   border: 1px solid lightgray;
 
-  .msla-monaco {
-    .monaco-editor {
-      .decorationsOverviewRuler {
-        display: none;
-      }
-
-      .overflowingContentWidgets {
-        display: none;
-      }
+  .monaco-editor {
+    .decorationsOverviewRuler {
+      display: none;
     }
 
-    .monaco-editor-scrollable {
-      .decorationsOverviewRuler {
-        display: none;
-      }
+    .overflowingContentWidgets {
+      display: none;
+    }
+  }
+
+  .monaco-editor-scrollable {
+    .decorationsOverviewRuler {
+      display: none;
     }
   }
 }

--- a/libs/designer-ui/src/lib/editor/index.tsx
+++ b/libs/designer-ui/src/lib/editor/index.tsx
@@ -1,21 +1,35 @@
 import Editor, { loader } from '@monaco-editor/react';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 // TODO: Add more languages
 export enum EditorLanguage {
   javascript = 'javascript',
+  json = 'json',
+  xml = 'xml',
 }
 
 export interface EditorProps {
-  height: string;
-  width: string;
-  language?: EditorLanguage;
-  value?: string;
   defaultValue?: string;
+  height?: number | string;
+  language?: EditorLanguage;
+  lineNumbers?: 'on' | 'off' | 'relative' | 'interval' | ((lineNumber: number) => string);
+  minimapEnabled?: boolean;
+  readOnly?: boolean;
+  width?: number | string;
+  value?: string;
 }
 
 const CustomEditor: React.FC<EditorProps> = (props) => {
-  const { height, width, value, language, defaultValue } = props;
+  const {
+    height = '100%',
+    width = '100%',
+    lineNumbers = 'on',
+    minimapEnabled = true,
+    readOnly = false,
+    value,
+    language,
+    defaultValue,
+  } = props;
 
   const initEditor = () => {
     loader.init().then((monaco) => {
@@ -31,6 +45,7 @@ const CustomEditor: React.FC<EditorProps> = (props) => {
     <Editor
       height={height}
       width={width}
+      options={{ lineNumbers, minimap: { enabled: minimapEnabled }, readOnly }}
       value={value}
       defaultValue={defaultValue}
       defaultLanguage={language ? language.toString() : undefined}

--- a/libs/designer-ui/src/lib/monitoring/requestpanel/__test__/__snapshots__/request.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/requestpanel/__test__/__snapshots__/request.spec.tsx.snap
@@ -23,10 +23,41 @@ exports[`lib/monitoring/requestpanel/request should render 1`] = `
         Method
       </label>
       <div
-        className="msla-trace-value-text"
-        tabIndex={0}
+        className="msla-colorizer-json-body"
       >
-        GET
+        <section
+          style={
+            Object {
+              "display": "flex",
+              "height": 19,
+              "position": "relative",
+              "textAlign": "initial",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignItems": "center",
+                "display": "flex",
+                "height": "100%",
+                "justifyContent": "center",
+                "width": "100%",
+              }
+            }
+          >
+            Loading...
+          </div>
+          <div
+            style={
+              Object {
+                "display": "none",
+                "width": "100%",
+              }
+            }
+          />
+        </section>
       </div>
     </section>
     <section
@@ -38,10 +69,41 @@ exports[`lib/monitoring/requestpanel/request should render 1`] = `
         URI
       </label>
       <div
-        className="msla-trace-value-text"
-        tabIndex={0}
+        className="msla-colorizer-json-body"
       >
-        https://httpbin.org/get
+        <section
+          style={
+            Object {
+              "display": "flex",
+              "height": 19,
+              "position": "relative",
+              "textAlign": "initial",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignItems": "center",
+                "display": "flex",
+                "height": "100%",
+                "justifyContent": "center",
+                "width": "100%",
+              }
+            }
+          >
+            Loading...
+          </div>
+          <div
+            style={
+              Object {
+                "display": "none",
+                "width": "100%",
+              }
+            }
+          />
+        </section>
       </div>
     </section>
     <section
@@ -266,10 +328,41 @@ exports[`lib/monitoring/requestpanel/request should render a body 1`] = `
         Method
       </label>
       <div
-        className="msla-trace-value-text"
-        tabIndex={0}
+        className="msla-colorizer-json-body"
       >
-        POST
+        <section
+          style={
+            Object {
+              "display": "flex",
+              "height": 19,
+              "position": "relative",
+              "textAlign": "initial",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignItems": "center",
+                "display": "flex",
+                "height": "100%",
+                "justifyContent": "center",
+                "width": "100%",
+              }
+            }
+          >
+            Loading...
+          </div>
+          <div
+            style={
+              Object {
+                "display": "none",
+                "width": "100%",
+              }
+            }
+          />
+        </section>
       </div>
     </section>
     <section
@@ -281,10 +374,41 @@ exports[`lib/monitoring/requestpanel/request should render a body 1`] = `
         URI
       </label>
       <div
-        className="msla-trace-value-text"
-        tabIndex={0}
+        className="msla-colorizer-json-body"
       >
-        https://httpbin.org/post
+        <section
+          style={
+            Object {
+              "display": "flex",
+              "height": 19,
+              "position": "relative",
+              "textAlign": "initial",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignItems": "center",
+                "display": "flex",
+                "height": "100%",
+                "justifyContent": "center",
+                "width": "100%",
+              }
+            }
+          >
+            Loading...
+          </div>
+          <div
+            style={
+              Object {
+                "display": "none",
+                "width": "100%",
+              }
+            }
+          />
+        </section>
       </div>
     </section>
     <section
@@ -491,12 +615,41 @@ exports[`lib/monitoring/requestpanel/request should render a body 1`] = `
         Body
       </label>
       <div
-        className="msla-trace-value-text"
-        tabIndex={0}
+        className="msla-colorizer-json-body"
       >
-        {
-  "hello": "world!"
-}
+        <section
+          style={
+            Object {
+              "display": "flex",
+              "height": 57,
+              "position": "relative",
+              "textAlign": "initial",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignItems": "center",
+                "display": "flex",
+                "height": "100%",
+                "justifyContent": "center",
+                "width": "100%",
+              }
+            }
+          >
+            Loading...
+          </div>
+          <div
+            style={
+              Object {
+                "display": "none",
+                "width": "100%",
+              }
+            }
+          />
+        </section>
       </div>
     </section>
   </div>
@@ -526,10 +679,41 @@ exports[`lib/monitoring/requestpanel/request should render a body link 1`] = `
         Method
       </label>
       <div
-        className="msla-trace-value-text"
-        tabIndex={0}
+        className="msla-colorizer-json-body"
       >
-        POST
+        <section
+          style={
+            Object {
+              "display": "flex",
+              "height": 19,
+              "position": "relative",
+              "textAlign": "initial",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignItems": "center",
+                "display": "flex",
+                "height": "100%",
+                "justifyContent": "center",
+                "width": "100%",
+              }
+            }
+          >
+            Loading...
+          </div>
+          <div
+            style={
+              Object {
+                "display": "none",
+                "width": "100%",
+              }
+            }
+          />
+        </section>
       </div>
     </section>
     <section
@@ -541,10 +725,41 @@ exports[`lib/monitoring/requestpanel/request should render a body link 1`] = `
         URI
       </label>
       <div
-        className="msla-trace-value-text"
-        tabIndex={0}
+        className="msla-colorizer-json-body"
       >
-        https://httpbin.org/post
+        <section
+          style={
+            Object {
+              "display": "flex",
+              "height": 19,
+              "position": "relative",
+              "textAlign": "initial",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "alignItems": "center",
+                "display": "flex",
+                "height": "100%",
+                "justifyContent": "center",
+                "width": "100%",
+              }
+            }
+          >
+            Loading...
+          </div>
+          <div
+            style={
+              Object {
+                "display": "none",
+                "width": "100%",
+              }
+            }
+          />
+        </section>
       </div>
     </section>
     <section

--- a/libs/designer-ui/src/lib/monitoring/requestpanel/__test__/__snapshots__/requestpanel.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/requestpanel/__test__/__snapshots__/requestpanel.spec.tsx.snap
@@ -139,10 +139,41 @@ Array [
             Duration
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            1 minute
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -154,10 +185,41 @@ Array [
             Start time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:52:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -169,10 +231,41 @@ Array [
             End time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:53:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>
@@ -320,10 +413,41 @@ Array [
             Duration
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            1 minute
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -335,10 +459,41 @@ Array [
             Start time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:52:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -350,10 +505,41 @@ Array [
             End time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:53:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>
@@ -380,10 +566,41 @@ Array [
             Method
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            GET
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -395,10 +612,41 @@ Array [
             URI
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            https://httpbin.org/get
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -741,10 +989,41 @@ Array [
             Duration
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            1 minute
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -756,10 +1035,41 @@ Array [
             Start time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:52:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -771,10 +1081,41 @@ Array [
             End time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:53:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>
@@ -801,10 +1142,41 @@ Array [
             Status code
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            200
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -1011,10 +1383,41 @@ Array [
             Body
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            {}
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>
@@ -1162,10 +1565,41 @@ Array [
             Duration
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            1 minute
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -1177,10 +1611,41 @@ Array [
             Start time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:52:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -1192,10 +1657,41 @@ Array [
             End time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:53:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>
@@ -1373,10 +1869,41 @@ Array [
             Duration
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            1 minute
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -1388,10 +1915,41 @@ Array [
             Start time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:52:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -1403,10 +1961,41 @@ Array [
             End time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/9/2022, 1:53:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>

--- a/libs/designer-ui/src/lib/monitoring/retrypanel/__test__/__snapshots__/retrypanel.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/retrypanel/__test__/__snapshots__/retrypanel.spec.tsx.snap
@@ -139,10 +139,41 @@ Array [
             Duration
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            --
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -154,10 +185,41 @@ Array [
             Start time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/8/2022, 7:52:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -169,10 +231,41 @@ Array [
             Status
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            code
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -184,10 +277,41 @@ Array [
             Client request ID
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            clientRequestId
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>
@@ -335,10 +459,41 @@ Array [
             Duration
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            --
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -350,10 +505,41 @@ Array [
             Start time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/8/2022, 7:52:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -365,10 +551,41 @@ Array [
             Status
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            code
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -380,10 +597,41 @@ Array [
             Client request ID
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            clientRequestId
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -395,10 +643,41 @@ Array [
             Service request ID
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            serviceRequestId
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>
@@ -546,10 +825,41 @@ Array [
             Duration
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            18 minutes
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -561,10 +871,41 @@ Array [
             Start time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/8/2022, 7:52:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -576,10 +917,41 @@ Array [
             End time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/8/2022, 8:10:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -591,10 +963,41 @@ Array [
             Status
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            code
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -606,10 +1009,41 @@ Array [
             Client request ID
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            clientRequestId
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>
@@ -785,10 +1219,41 @@ Array [
             Duration
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            --
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -800,10 +1265,41 @@ Array [
             Start time
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            2/8/2022, 7:52:00 PM
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -815,10 +1311,41 @@ Array [
             Status
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            code
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
         <section
@@ -830,10 +1357,41 @@ Array [
             Client request ID
           </label>
           <div
-            className="msla-trace-value-text"
-            tabIndex={0}
+            className="msla-colorizer-json-body"
           >
-            clientRequestId
+            <section
+              style={
+                Object {
+                  "display": "flex",
+                  "height": 19,
+                  "position": "relative",
+                  "textAlign": "initial",
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "height": "100%",
+                    "justifyContent": "center",
+                    "width": "100%",
+                  }
+                }
+              >
+                Loading...
+              </div>
+              <div
+                style={
+                  Object {
+                    "display": "none",
+                    "width": "100%",
+                  }
+                }
+              />
+            </section>
           </div>
         </section>
       </div>

--- a/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/raw.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/raw.spec.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ui/monitoring/values/_raw should not render when not visible 1`] = `null`;
+
+exports[`ui/monitoring/values/_raw should render 1`] = `
+<section
+  className="msla-trace-value-label"
+>
+  <label
+    className="msla-trace-value-display-name"
+  >
+    display-name
+  </label>
+  <div
+    className="msla-colorizer-json-body"
+  >
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
+  </div>
+</section>
+`;
+
+exports[`ui/monitoring/values/_raw should rendered a zero-width space if value is empty 1`] = `
+<section
+  className="msla-trace-value-label"
+>
+  <label
+    className="msla-trace-value-display-name"
+  >
+    display-name
+  </label>
+  <div
+    className="msla-colorizer-json-body"
+  >
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
+  </div>
+</section>
+`;

--- a/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/values.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/values.spec.tsx.snap
@@ -65,10 +65,41 @@ exports[`ui/monitoring/values/value should render a decimal value 1`] = `
     display-name
   </label>
   <div
-    className="msla-trace-value-text"
-    tabIndex={0}
+    className="msla-colorizer-json-body"
   >
-    -123.45
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
   </div>
 </section>
 `;
@@ -499,10 +530,41 @@ exports[`ui/monitoring/values/value should render a number value 1`] = `
     display-name
   </label>
   <div
-    className="msla-trace-value-text"
-    tabIndex={0}
+    className="msla-colorizer-json-body"
   >
-    -123.45
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
   </div>
 </section>
 `;
@@ -517,10 +579,41 @@ exports[`ui/monitoring/values/value should render a raw value 1`] = `
     raw
   </label>
   <div
-    className="msla-trace-value-text"
-    tabIndex={0}
+    className="msla-colorizer-json-body"
   >
-    Hello World
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
   </div>
 </section>
 `;
@@ -535,10 +628,41 @@ exports[`ui/monitoring/values/value should render an XML value 1`] = `
     XML
   </label>
   <div
-    className="msla-trace-value-text"
-    tabIndex={0}
+    className="msla-colorizer-json-body"
   >
-    &lt;xml&gt;&lt;/xml&gt;
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
   </div>
 </section>
 `;

--- a/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/xml.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/xml.spec.tsx.snap
@@ -1,0 +1,199 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ui/monitoring/values/xml should not render when not visible 1`] = `null`;
+
+exports[`ui/monitoring/values/xml should render XML 1`] = `
+<section
+  className="msla-trace-value-label"
+>
+  <label
+    className="msla-trace-value-display-name"
+  >
+    XML
+  </label>
+  <div
+    className="msla-colorizer-json-body"
+  >
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
+  </div>
+</section>
+`;
+
+exports[`ui/monitoring/values/xml should render XML with encoded UTF-8 Chinese correctly 1`] = `
+<section
+  className="msla-trace-value-label"
+>
+  <label
+    className="msla-trace-value-display-name"
+  >
+    XML
+  </label>
+  <div
+    className="msla-colorizer-json-body"
+  >
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
+  </div>
+</section>
+`;
+
+exports[`ui/monitoring/values/xml should render XML without the UTF-8 byte order mark (BOM) 1`] = `
+<section
+  className="msla-trace-value-label"
+>
+  <label
+    className="msla-trace-value-display-name"
+  >
+    XML
+  </label>
+  <div
+    className="msla-colorizer-json-body"
+  >
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
+  </div>
+</section>
+`;
+
+exports[`ui/monitoring/values/xml should render a zero-width space if value is empty 1`] = `
+<section
+  className="msla-trace-value-label"
+>
+  <label
+    className="msla-trace-value-display-name"
+  >
+    XML
+  </label>
+  <div
+    className="msla-colorizer-json-body"
+  >
+    <section
+      style={
+        Object {
+          "display": "flex",
+          "height": 19,
+          "position": "relative",
+          "textAlign": "initial",
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        Loading...
+      </div>
+      <div
+        style={
+          Object {
+            "display": "none",
+            "width": "100%",
+          }
+        }
+      />
+    </section>
+  </div>
+</section>
+`;

--- a/libs/designer-ui/src/lib/monitoring/values/__test__/raw.spec.tsx
+++ b/libs/designer-ui/src/lib/monitoring/values/__test__/raw.spec.tsx
@@ -1,57 +1,29 @@
-import * as React from 'react';
-import * as ReactShallowRenderer from 'react-test-renderer/shallow';
-import Constants from '../../../constants';
+import renderer from 'react-test-renderer';
 import { RawValue } from '../raw';
 import type { ValueProps } from '../types';
 
 describe('ui/monitoring/values/_raw', () => {
-  const classNames = {
-    displayName: 'msla-trace-value-display-name',
-    label: 'msla-trace-value-label',
-    text: 'msla-trace-value-text',
-  };
-
-  let props: ValueProps, renderer: ReactShallowRenderer.ShallowRenderer;
+  let props: ValueProps;
 
   beforeEach(() => {
     props = {
       displayName: 'display-name',
       value: 'value',
     };
-    renderer = ReactShallowRenderer.createRenderer();
-  });
-
-  afterEach(() => {
-    renderer.unmount();
   });
 
   it('should render', () => {
-    renderer.render(<RawValue {...props} />);
-
-    const section = renderer.getRenderOutput();
-    expect(section.props.className).toBe(classNames.label);
-
-    const [displayName, text]: any[] = React.Children.toArray(section.props.children);
-    expect(displayName.props.className).toBe(classNames.displayName);
-    expect(displayName.props.children).toBe(props.displayName);
-    expect(text.props.className).toBe(classNames.text);
-    expect(text.props.children).toBe(props.value);
-    expect(text.props.tabIndex).toBe(0);
+    const tree = renderer.create(<RawValue {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
   it('should rendered a zero-width space if value is empty', () => {
-    props.value = '';
-    renderer.render(<RawValue {...props} />);
-
-    const section = renderer.getRenderOutput();
-    const [, text]: any[] = React.Children.toArray(section.props.children);
-    expect(text.props.children).toBe(Constants.ZERO_WIDTH_SPACE);
+    const tree = renderer.create(<RawValue {...props} value="" />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
   it('should not render when not visible', () => {
-    renderer.render(<RawValue {...props} visible={false} />);
-
-    const section = renderer.getRenderOutput();
-    expect(section).toBeNull();
+    const tree = renderer.create(<RawValue {...props} visible={false} />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/libs/designer-ui/src/lib/monitoring/values/__test__/xml.spec.tsx
+++ b/libs/designer-ui/src/lib/monitoring/values/__test__/xml.spec.tsx
@@ -1,20 +1,11 @@
-import * as React from 'react';
-import * as ReactShallowRenderer from 'react-test-renderer/shallow';
-import Constants from '../../../constants';
+import renderer from 'react-test-renderer';
 import type { ValueProps } from '../types';
 import { XmlValue } from '../xml';
 
 describe('ui/monitoring/values/xml', () => {
-  const classNames = {
-    displayName: 'msla-trace-value-display-name',
-    label: 'msla-trace-value-label',
-    text: 'msla-trace-value-text',
-  };
-
-  let props: ValueProps, renderer: ReactShallowRenderer.ShallowRenderer;
+  let props: ValueProps;
 
   beforeEach(() => {
-    renderer = ReactShallowRenderer.createRenderer();
     props = {
       displayName: 'XML',
       value: {
@@ -24,21 +15,9 @@ describe('ui/monitoring/values/xml', () => {
     };
   });
 
-  afterEach(() => {
-    renderer.unmount();
-  });
-
   it('should render XML', () => {
-    renderer.render(<XmlValue {...props} />);
-
-    const section = renderer.getRenderOutput();
-    expect(section.props.className).toBe(classNames.label);
-
-    const [displayName, text]: any[] = React.Children.toArray(section.props.children);
-    expect(displayName.props.className).toBe(classNames.displayName);
-    expect(displayName.props.children).toBe(props.displayName);
-    expect(text.props.className).toBe(classNames.text);
-    expect(text.props.children).toBe('<xml></xml>');
+    const tree = renderer.create(<XmlValue {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
   it('should render XML without the UTF-8 byte order mark (BOM)', () => {
@@ -46,11 +25,8 @@ describe('ui/monitoring/values/xml', () => {
       '$content-type': 'application/xml',
       $content: '77u/PHhtbD48L3htbD4=', // <xml></xml> with a prepended UTF-8 BOM
     };
-    renderer.render(<XmlValue {...props} />);
-
-    const section = renderer.getRenderOutput();
-    const [, text]: any[] = React.Children.toArray(section.props.children);
-    expect(text.props.children).toBe('<xml></xml>');
+    const tree = renderer.create(<XmlValue {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
   it('should render a zero-width space if value is empty', () => {
@@ -58,11 +34,8 @@ describe('ui/monitoring/values/xml', () => {
       '$content-type': 'application/xml',
       $content: '',
     };
-    renderer.render(<XmlValue {...props} />);
-
-    const section = renderer.getRenderOutput();
-    const [, text]: any[] = React.Children.toArray(section.props.children);
-    expect(text.props.children).toBe(Constants.ZERO_WIDTH_SPACE);
+    const tree = renderer.create(<XmlValue {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
   it('should render XML with encoded UTF-8 Chinese correctly', () => {
@@ -71,19 +44,12 @@ describe('ui/monitoring/values/xml', () => {
       $content:
         '77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48cm9vdD48bmFtZSB1c2VybmFtZT0iSlMx55So5oi35ZCNIj7kvaDlpb0gSm9objwvbmFtZT48bmFtZSB1c2VybmFtZT0iTUkx55So5oi35ZCNIj7kuK3mlofmtYvor5U8L25hbWU+PC9yb290Pg==',
     };
-    renderer.render(<XmlValue {...props} />);
-
-    const section = renderer.getRenderOutput();
-    const [, text]: any[] = React.Children.toArray(section.props.children);
-    expect(text.props.children).toBe(
-      '<?xml version="1.0" encoding="utf-8"?><root><name username="JS1用户名">你好 John</name><name username="MI1用户名">中文测试</name></root>'
-    );
+    const tree = renderer.create(<XmlValue {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
   it('should not render when not visible', () => {
-    renderer.render(<XmlValue {...props} visible={false} />);
-
-    const section = renderer.getRenderOutput();
-    expect(section).toBeNull();
+    const tree = renderer.create(<XmlValue {...props} visible={false} />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/libs/designer-ui/src/lib/monitoring/values/raw.tsx
+++ b/libs/designer-ui/src/lib/monitoring/values/raw.tsx
@@ -1,19 +1,29 @@
+import { useMemo } from 'react';
 import Constants from '../../constants';
+import CustomEditor, { EditorLanguage } from '../../editor';
 import type { ValueProps } from './types';
 
-export const RawValue: React.FC<ValueProps> = (props) => {
-  const { displayName, value, visible = true } = props;
+export const RawValue: React.FC<ValueProps> = ({ displayName, value, visible = true }) => {
+  const { height, language, valueAsString } = useMemo(() => {
+    const valueAsString = (typeof value === 'string' ? value : JSON.stringify(value, null, 2)) || Constants.ZERO_WIDTH_SPACE;
+    const language = typeof value === 'string' ? undefined : { language: EditorLanguage.json };
+    const height = 19 * Math.min(valueAsString.split('\n').length, 10);
+    return {
+      height,
+      language,
+      valueAsString,
+    };
+  }, [value]);
+
   if (!visible) {
     return null;
   }
 
-  const valueAsString = (typeof value === 'string' ? value : JSON.stringify(value, null, 2)) || Constants.ZERO_WIDTH_SPACE;
-
   return (
     <section className="msla-trace-value-label">
       <label className="msla-trace-value-display-name">{displayName}</label>
-      <div className="msla-trace-value-text" tabIndex={0}>
-        {valueAsString}
+      <div className="msla-colorizer-json-body">
+        <CustomEditor defaultValue={valueAsString} height={height} {...language} lineNumbers="off" minimapEnabled={false} readOnly={true} />
       </div>
     </section>
   );

--- a/libs/designer-ui/src/lib/monitoring/values/xml.tsx
+++ b/libs/designer-ui/src/lib/monitoring/values/xml.tsx
@@ -1,4 +1,5 @@
 import Constants from '../../constants';
+import CustomEditor, { EditorLanguage } from '../../editor';
 import { RawValue } from './raw';
 import type { ValueProps } from './types';
 import { isXml } from './utils';
@@ -20,11 +21,20 @@ export const XmlValue: React.FC<ValueProps> = (props) => {
     valueAsString = String(value) || Constants.ZERO_WIDTH_SPACE;
   }
 
+  const height = 19 * Math.min(valueAsString.split('\n').length, 10);
+
   return (
     <section className="msla-trace-value-label">
       <label className="msla-trace-value-display-name">{displayName}</label>
-      <div className="msla-trace-value-text" tabIndex={0}>
-        {valueAsString}
+      <div className="msla-colorizer-json-body">
+        <CustomEditor
+          defaultValue={valueAsString}
+          height={height}
+          language={EditorLanguage.xml}
+          lineNumbers="off"
+          minimapEnabled={false}
+          readOnly={true}
+        />
       </div>
     </section>
   );


### PR DESCRIPTION
Use Monaco editor for syntax coloring. I may follow up with a PR to replace with `prism-react-renderer` if it is suitable.