### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 2: Build ID 161

### DIFF
--- a/Localize/lang/strings.cs.json
+++ b/Localize/lang/strings.cs.json
@@ -76,6 +76,7 @@
   "gCXOd5": "Identifikátor URI",
   "gKq3Jv": "Předchozí neúspěšné",
   "hN7iBP": "{seconds, plural, one {# sekunda} few {# sekundy} many {# sekund} other {# sekund}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Doba trvání",
   "iJOIca": "Další",
   "iRjBf4": "Tato akce má nakonfigurované testování.",

--- a/Localize/lang/strings.de.json
+++ b/Localize/lang/strings.de.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Vorheriger Fehler",
   "hN7iBP": "{seconds, plural, one {# Sekunde} other {# Sekunden}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Dauer",
   "iJOIca": "Weiter",
   "iRjBf4": "Für diese Aktion sind Tests konfiguriert.",

--- a/Localize/lang/strings.es.json
+++ b/Localize/lang/strings.es.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Anterior con error",
   "hN7iBP": "{seconds, plural, one {# segundo} other {# segundos}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Duración",
   "iJOIca": "Siguiente",
   "iRjBf4": "Las pruebas están configuradas para esta acción.",

--- a/Localize/lang/strings.fr.json
+++ b/Localize/lang/strings.fr.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Précédent échec",
   "hN7iBP": "{seconds, plural, one {# seconde} other {# secondes}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Durée",
   "iJOIca": "Suivant",
   "iRjBf4": "Des tests sont configurés pour cette action.",

--- a/Localize/lang/strings.hu.json
+++ b/Localize/lang/strings.hu.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Előző sikertelen",
   "hN7iBP": "{seconds, plural, one {# másodperc} other {# másodperc}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Időtartam",
   "iJOIca": "Tovább",
   "iRjBf4": "A Művelet tesztelése konfigurálva van.",

--- a/Localize/lang/strings.id.json
+++ b/Localize/lang/strings.id.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Sebelumnya gagal",
   "hN7iBP": "{seconds, plural,  other {# detik}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Durasi",
   "iJOIca": "Berikutnya",
   "iRjBf4": "Tindakan ini memiliki pengujian yang dikonfigurasi.",

--- a/Localize/lang/strings.it.json
+++ b/Localize/lang/strings.it.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Operazione precedente non riuscita",
   "hN7iBP": "{seconds, plural, one {# secondo} other {# secondi}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Durata",
   "iJOIca": "Avanti",
   "iRjBf4": "Questa azione ha il testing configurato.",

--- a/Localize/lang/strings.ja.json
+++ b/Localize/lang/strings.ja.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "前の失敗",
   "hN7iBP": "{seconds, plural,  other {# 秒}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "期間",
   "iJOIca": "次へ",
   "iRjBf4": "このアクションにはテストが構成されています。",

--- a/Localize/lang/strings.ko.json
+++ b/Localize/lang/strings.ko.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "이전 항목 실패",
   "hN7iBP": "{seconds, plural,  other {#초}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "기간",
   "iJOIca": "다음",
   "iRjBf4": "이 작업에는 테스트가 구성되어 있습니다.",

--- a/Localize/lang/strings.nl.json
+++ b/Localize/lang/strings.nl.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Vorige mislukt",
   "hN7iBP": "{seconds, plural, one {# seconden} other {# seconden}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Duur",
   "iJOIca": "Volgende",
   "iRjBf4": "Voor deze actie zijn tests geconfigureerd.",

--- a/Localize/lang/strings.pl.json
+++ b/Localize/lang/strings.pl.json
@@ -76,6 +76,7 @@
   "gCXOd5": "Identyfikator URI",
   "gKq3Jv": "Poprzednie z niepowodzeniem",
   "hN7iBP": "{seconds, plural, one {# sekunda} few {# sekundy} many {# sekundy} other {# sekundy}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Czas trwania",
   "iJOIca": "Następna",
   "iRjBf4": "Ta akcja ma skonfigurowane testowanie.",

--- a/Localize/lang/strings.pt-BR.json
+++ b/Localize/lang/strings.pt-BR.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Anterior com falha",
   "hN7iBP": "{seconds, plural, one {# segundo} other {# segundos}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Duração",
   "iJOIca": "Próximo",
   "iRjBf4": "Esta Ação tem testes configurados.",

--- a/Localize/lang/strings.pt-PT.json
+++ b/Localize/lang/strings.pt-PT.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "O anterior falhou",
   "hN7iBP": "{seconds, plural, one {# segundo} other {# segundos}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Duração",
   "iJOIca": "Seguinte",
   "iRjBf4": "Esta Ação tem os testes ativados.",

--- a/Localize/lang/strings.ru.json
+++ b/Localize/lang/strings.ru.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Предыдущее со сбоем",
   "hN7iBP": "{seconds, plural, one {# секунда} few {# с} many {# с} other {# с}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Продолжительность",
   "iJOIca": "Далее",
   "iRjBf4": "Для этого действия настроено тестирование.",

--- a/Localize/lang/strings.sv.json
+++ b/Localize/lang/strings.sv.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Föregående misslyckad",
   "hN7iBP": "{seconds, plural, one {# sekund} other {# sekunder}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Varaktighet",
   "iJOIca": "Nästa",
   "iRjBf4": "Den här åtgärden har konfigurerats för testning.",

--- a/Localize/lang/strings.tr.json
+++ b/Localize/lang/strings.tr.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "Önceki seçeneği başarısız oldu",
   "hN7iBP": "{seconds, plural, one {# saniye} other {# saniye}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "Süre",
   "iJOIca": "İleri",
   "iRjBf4": "Bu Eylemde test yapılandırıldı.",

--- a/Localize/lang/strings.zh-Hans.json
+++ b/Localize/lang/strings.zh-Hans.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "上一次失败",
   "hN7iBP": "{seconds, plural,  other {# 秒}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "持续时间",
   "iJOIca": "下一页",
   "iRjBf4": "此操作已配置测试。",

--- a/Localize/lang/strings.zh-Hant.json
+++ b/Localize/lang/strings.zh-Hant.json
@@ -76,6 +76,7 @@
   "gCXOd5": "URI",
   "gKq3Jv": "上一個失敗",
   "hN7iBP": "{seconds, plural,  other {# 秒}}",
+  "hdnZ9Y": "Alt/Option + click to download '{displayName}'",
   "hrbDu6": "持續時間",
   "iJOIca": "下一步",
   "iRjBf4": "此動作已設定測試。",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.