### PR TITLE
Remove FormattedMessage in favor of intl.formatMessage

### DIFF
--- a/libs/designer-ui/src/lib/about/__test__/__snapshots__/about.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/about/__test__/__snapshots__/about.spec.tsx.snap
@@ -17,17 +17,7 @@ exports[`lib/monitoring/requestpanel/request should render 1`] = `
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Connector",
-            },
-          ]
-        }
-        id="99vsJy"
-      />
+      Connector
     </StyledLabelBase>
     <StyledLabelBase
       className="msla-panel-connector-name"
@@ -48,17 +38,7 @@ exports[`lib/monitoring/requestpanel/request should render 1`] = `
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Operation note",
-            },
-          ]
-        }
-        id="YHsAKl"
-      />
+      Operation note
     </StyledLabelBase>
     <div
       className="msla-panel-description"
@@ -79,17 +59,7 @@ exports[`lib/monitoring/requestpanel/request should render 1`] = `
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Tags",
-            },
-          ]
-        }
-        id="TgcgXE"
-      />
+      Tags
     </StyledLabelBase>
     <div
       className="msla-panel-tags"
@@ -117,17 +87,7 @@ exports[`lib/monitoring/requestpanel/request should render a body 1`] = `
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Connector",
-            },
-          ]
-        }
-        id="99vsJy"
-      />
+      Connector
     </StyledLabelBase>
     <StyledLabelBase
       className="msla-panel-connector-name"
@@ -148,17 +108,7 @@ exports[`lib/monitoring/requestpanel/request should render a body 1`] = `
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Operation note",
-            },
-          ]
-        }
-        id="YHsAKl"
-      />
+      Operation note
     </StyledLabelBase>
     <div
       className="msla-panel-description"
@@ -181,17 +131,7 @@ exports[`lib/monitoring/requestpanel/request should render a body 1`] = `
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Tags",
-            },
-          ]
-        }
-        id="TgcgXE"
-      />
+      Tags
     </StyledLabelBase>
     <div
       className="msla-panel-tags"
@@ -234,17 +174,7 @@ exports[`lib/monitoring/requestpanel/request should render a description with ex
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Connector",
-            },
-          ]
-        }
-        id="99vsJy"
-      />
+      Connector
     </StyledLabelBase>
     <StyledLabelBase
       className="msla-panel-connector-name"
@@ -265,17 +195,7 @@ exports[`lib/monitoring/requestpanel/request should render a description with ex
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Operation note",
-            },
-          ]
-        }
-        id="YHsAKl"
-      />
+      Operation note
     </StyledLabelBase>
     <div
       className="msla-panel-description"
@@ -304,17 +224,7 @@ exports[`lib/monitoring/requestpanel/request should render a description with ex
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Tags",
-            },
-          ]
-        }
-        id="TgcgXE"
-      />
+      Tags
     </StyledLabelBase>
     <div
       className="msla-panel-tags"

--- a/libs/designer-ui/src/lib/about/index.tsx
+++ b/libs/designer-ui/src/lib/about/index.tsx
@@ -2,8 +2,7 @@ import type { BadgeProps } from '../card';
 import { DocumentationItem } from '../recommendation/documentationItem';
 import type { ILabelStyles } from '@fluentui/react/lib/Label';
 import { Label } from '@fluentui/react/lib/Label';
-import * as React from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 const labelStyles: Partial<ILabelStyles> = {
   root: {
@@ -48,17 +47,31 @@ export const About = ({ connectorDisplayName, description, descriptionDocumentat
     description: 'Display text for when About Panel has no Tags',
   });
 
+  const connectorMsg = intl.formatMessage({
+    defaultMessage: 'Connector',
+    description: 'Label For Connector Name in About Panel',
+  });
+
+  const operationNoteMsg = intl.formatMessage({
+    defaultMessage: 'Operation note',
+    description: 'Label For Operation Description in About Panel',
+  });
+
+  const tagsMessage = intl.formatMessage({
+    defaultMessage: 'Tags',
+    description: 'Label For Tags in About Panel',
+  });
   return (
     <div className="msla-panel-about-container">
       <div className="msla-panel-about-name">
         <Label className="msla-panel-connector-label" styles={labelStyles}>
-          <FormattedMessage defaultMessage="Connector" description="Label For Connector Name in About Panel" />
+          {connectorMsg}
         </Label>
         <Label className="msla-panel-connector-name">{connectorDisplayName ? connectorDisplayName : notAvailable}</Label>
       </div>
       <div className="msla-panel-about-description">
         <Label className="msla-panel-description-label" styles={labelStyles}>
-          <FormattedMessage defaultMessage="Operation note" description="Label For Operation Description in About Panel" />
+          {operationNoteMsg}
         </Label>
         <div className="msla-panel-description">
           <DocumentationItem
@@ -71,7 +84,7 @@ export const About = ({ connectorDisplayName, description, descriptionDocumentat
       </div>
       <div className="msla-panel-about-tags">
         <Label className="msla-panel-tags-label" styles={labelStyles}>
-          <FormattedMessage defaultMessage="Tags" description="Label For Tags in About Panel" />
+          {tagsMessage}
         </Label>
         <div className="msla-panel-tags">{headerIcons && headerIcons.length > 0 ? badgeHeaderIcons(headerIcons) : noTags}</div>
       </div>

--- a/libs/designer-ui/src/lib/card/__test__/emptycontent.spec.tsx
+++ b/libs/designer-ui/src/lib/card/__test__/emptycontent.spec.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { FormattedMessage } from 'react-intl';
-import ShallowRenderer from 'react-test-renderer/shallow';
 import { EmptyContent } from '../emptycontent';
+import React from 'react';
+import ShallowRenderer from 'react-test-renderer/shallow';
 
 describe('lib/card/emptycontent', () => {
   let renderer: ShallowRenderer.ShallowRenderer;
@@ -29,9 +28,6 @@ describe('lib/card/emptycontent', () => {
     );
     expect(text.props.className).toBe('msla-panel-empty-text');
 
-    const message = React.Children.only(text.props.children);
-    expect(message).toEqual(
-      <FormattedMessage defaultMessage="Please select a card to see the content" description="Empty Panel Content Message" />
-    );
+    expect(text.props.children).toEqual('Please select a card to see the content');
   });
 });

--- a/libs/designer-ui/src/lib/card/emptycontent.tsx
+++ b/libs/designer-ui/src/lib/card/emptycontent.tsx
@@ -1,13 +1,16 @@
-import { FormattedMessage } from 'react-intl';
 import EmptyPanel from './images/empty-panel.svg';
+import { useIntl } from 'react-intl';
 
 export const EmptyContent: React.FC = () => {
+  const intl = useIntl();
+  const emptyContentMessage = intl.formatMessage({
+    defaultMessage: 'Please select a card to see the content',
+    description: 'Empty Panel Content Message',
+  });
   return (
     <div className="msla-panel-select-card-container-empty">
       <img src={EmptyPanel} alt="" role="presentation" />
-      <div className="msla-panel-empty-text">
-        <FormattedMessage defaultMessage="Please select a card to see the content" description="Empty Panel Content Message" />
-      </div>
+      <div className="msla-panel-empty-text">{emptyContentMessage}</div>
     </div>
   );
 };

--- a/libs/designer-ui/src/lib/dialogs/__test__/__snapshots__/alert.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/dialogs/__test__/__snapshots__/alert.spec.tsx.snap
@@ -22,17 +22,7 @@ exports[`ui/dialogs/_alert should render 1`] = `
       className="dialog-ok-button"
       onClick={[MockFunction]}
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "OK",
-            },
-          ]
-        }
-        id="uN4zFU"
-      />
+      OK
     </CustomizedPrimaryButton>
   </StyledDialogFooterBase>
 </Dialog>

--- a/libs/designer-ui/src/lib/dialogs/__test__/__snapshots__/confirm.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/dialogs/__test__/__snapshots__/confirm.spec.tsx.snap
@@ -22,32 +22,12 @@ exports[`ui/dialogs/_confirm should render 1`] = `
       className="dialog-ok-button"
       onClick={[MockFunction]}
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "OK",
-            },
-          ]
-        }
-        id="7GSk99"
-      />
+      OK
     </CustomizedPrimaryButton>
     <CustomizedDefaultButton
       onClick={[MockFunction]}
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Cancel",
-            },
-          ]
-        }
-        id="iUs7pv"
-      />
+      Cancel
     </CustomizedDefaultButton>
   </StyledDialogFooterBase>
 </Dialog>

--- a/libs/designer-ui/src/lib/dialogs/alert.tsx
+++ b/libs/designer-ui/src/lib/dialogs/alert.tsx
@@ -1,6 +1,6 @@
 import type { IDialogContentProps, IModalProps } from '@fluentui/react';
 import { Dialog, DialogFooter, PrimaryButton } from '@fluentui/react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 export interface AlertProps {
   hidden: boolean;
@@ -15,6 +15,7 @@ const modalProps: IModalProps = {
 };
 
 export const Alert: React.FC<AlertProps> = ({ hidden, message, title, onDismiss }) => {
+  const intl = useIntl();
   if (hidden) {
     return null;
   }
@@ -23,12 +24,16 @@ export const Alert: React.FC<AlertProps> = ({ hidden, message, title, onDismiss 
     title,
   };
 
+  const okMessage = intl.formatMessage({
+    defaultMessage: 'OK',
+    description: 'OK message appearing on a alert message modal.',
+  });
   return (
     <Dialog dialogContentProps={dialogContentProps} hidden={hidden} modalProps={modalProps} onDismiss={onDismiss}>
       {message}
       <DialogFooter>
         <PrimaryButton className="dialog-ok-button" onClick={onDismiss}>
-          <FormattedMessage defaultMessage="OK" description="OK message appearing on a alert message modal." />
+          {okMessage}
         </PrimaryButton>
       </DialogFooter>
     </Dialog>

--- a/libs/designer-ui/src/lib/dialogs/confirm.tsx
+++ b/libs/designer-ui/src/lib/dialogs/confirm.tsx
@@ -1,6 +1,6 @@
 import type { IDialogContentProps, IModalProps } from '@fluentui/react';
 import { DefaultButton, Dialog, DialogFooter, PrimaryButton } from '@fluentui/react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 export interface ConfirmProps {
   hidden: boolean;
@@ -16,6 +16,7 @@ const modalProps: IModalProps = {
 };
 
 export const Confirm: React.FC<ConfirmProps> = ({ hidden, message, title, onConfirm, onDismiss }) => {
+  const intl = useIntl();
   if (hidden) {
     return null;
   }
@@ -24,16 +25,22 @@ export const Confirm: React.FC<ConfirmProps> = ({ hidden, message, title, onConf
     title,
   };
 
+  const okMessage = intl.formatMessage({
+    defaultMessage: 'OK',
+    description: 'OK message appearing on a confirmation dialog.',
+  });
+  const cancelMessage = intl.formatMessage({
+    defaultMessage: 'Cancel',
+    description: 'Cancel message appearing on a confirmation dialog.',
+  });
   return (
     <Dialog dialogContentProps={dialogContentProps} hidden={hidden} modalProps={modalProps} onDismiss={onDismiss}>
       {message}
       <DialogFooter>
         <PrimaryButton className="dialog-ok-button" onClick={onConfirm}>
-          <FormattedMessage defaultMessage="OK" description="OK message appearing on a confirmation dialog." />
+          {okMessage}
         </PrimaryButton>
-        <DefaultButton onClick={onDismiss}>
-          <FormattedMessage defaultMessage="Cancel" description="Cancel message appearing on a confirmation dialog." />
-        </DefaultButton>
+        <DefaultButton onClick={onDismiss}>{cancelMessage}</DefaultButton>
       </DialogFooter>
     </Dialog>
   );

--- a/libs/designer-ui/src/lib/workflowparameters/__tests__/__snapshots__/workflowParametersReadOnly.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/workflowparameters/__tests__/__snapshots__/workflowParametersReadOnly.spec.tsx.snap
@@ -18,17 +18,7 @@ exports[`ui/workflowparameters/workflowparameterReadOnly should construct. 1`] =
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Name",
-            },
-          ]
-        }
-        id="TZv5JE"
-      />
+      Name
     </StyledLabelBase>
     <Text
       className="msla-workflow-parameter-read-only"
@@ -51,17 +41,7 @@ exports[`ui/workflowparameters/workflowparameterReadOnly should construct. 1`] =
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Title",
-            },
-          ]
-        }
-        id="lV77P8"
-      />
+      Title
     </StyledLabelBase>
     <Text
       className="msla-workflow-parameter-read-only"
@@ -84,17 +64,7 @@ exports[`ui/workflowparameters/workflowparameterReadOnly should construct. 1`] =
         }
       }
     >
-      <Memo(MemoizedFormattedMessage)
-        defaultMessage={
-          Array [
-            Object {
-              "type": 0,
-              "value": "Value",
-            },
-          ]
-        }
-        id="ci6ex1"
-      />
+      Value
     </StyledLabelBase>
     <Text
       block={true}

--- a/libs/designer-ui/src/lib/workflowparameters/__tests__/__snapshots__/workflowparameters.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/workflowparameters/__tests__/__snapshots__/workflowparameters.spec.tsx.snap
@@ -7,17 +7,7 @@ exports[`ui/workflowparameters/workflowparameters should construct. 1`] = `
   <h3
     className="msla-workflow-parameters-create"
   >
-    <Memo(MemoizedFormattedMessage)
-      defaultMessage={
-        Array [
-          Object {
-            "type": 0,
-            "value": "Parameters",
-          },
-        ]
-      }
-      id="pRUJff"
-    />
+    Parameters
   </h3>
   <InfoBar
     isInverted={false}

--- a/libs/designer-ui/src/lib/workflowparameters/__tests__/workflowparameters.spec.tsx
+++ b/libs/designer-ui/src/lib/workflowparameters/__tests__/workflowparameters.spec.tsx
@@ -52,7 +52,7 @@ describe('ui/workflowparameters/workflowparameters', () => {
     });
     expect(header.props.className).toBe('msla-workflow-parameters-create');
     const headerText = header.props.children;
-    expect(headerText.props.defaultMessage[0].value).toBe(headerTitle);
+    expect(headerText).toBe(headerTitle);
 
     expect(messageBar).toBeDefined();
 

--- a/libs/designer-ui/src/lib/workflowparameters/workflowparameters.tsx
+++ b/libs/designer-ui/src/lib/workflowparameters/workflowparameters.tsx
@@ -5,7 +5,7 @@ import type { WorkflowParameterDefinition, WorkflowParameterDeleteHandler, Workf
 import { WorkflowParameter } from './workflowparameter';
 import type { IIconProps, IIconStyles, IMessageBarStyles } from '@fluentui/react';
 import { CommandBarButton, Icon, Link, List, MessageBar, useTheme } from '@fluentui/react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 const navigateIconStyle: IIconStyles = {
   root: {
@@ -38,13 +38,16 @@ const darkMessageBarStyles: IMessageBarStyles = {
 };
 
 const InfoBar = ({ isInverted }: { isInverted: boolean }) => {
+  const intl = useIntl();
+  const text = intl.formatMessage({
+    defaultMessage:
+      'The parameters will be saved when the workflow is saved. You can edit it here before save or edit it in the parameter page after save.',
+    description: 'Text for Info Bar',
+  });
   return (
     <div className="msla-workflow-parameters-message-bar">
       <MessageBar isMultiline={true} styles={isInverted ? darkMessageBarStyles : lightMessageBarStyles}>
-        <FormattedMessage
-          defaultMessage="The parameters will be saved when the workflow is saved. You can edit it here before save or edit it in the parameter page after save."
-          description="Text for Info Bar"
-        />
+        {text}
       </MessageBar>
     </div>
   );
@@ -113,11 +116,17 @@ export function WorkflowParameters({
     );
   };
 
-  const renderManageParametersLink = (): JSX.Element => {
+  const ManageParametersLink = (): JSX.Element => {
+    const intl = useIntl();
+
+    const jsonText = intl.formatMessage({
+      defaultMessage: 'Edit in JSON',
+      description: 'Parameter Link Text',
+    });
     return (
       <footer className="msla-workflow-parameters-link">
         <Link className="msla-workflow-parameters-link-text" onClick={onManageParameters}>
-          <FormattedMessage defaultMessage="Edit in JSON" description="Parameter Link Text" />
+          {jsonText}
         </Link>
         <Icon iconName="NavigateExternalInline" styles={navigateIconStyle} className="msla-workflow-parameters-link-icon" />
       </footer>
@@ -145,11 +154,13 @@ export function WorkflowParameters({
     defaultMessage: 'Create parameter',
     description: 'Create Parameter Text',
   });
+  const createTitleText = intl.formatMessage({
+    defaultMessage: 'Parameters',
+    description: 'Create Title',
+  });
   return (
     <div className="msla-workflow-parameters">
-      <h3 className="msla-workflow-parameters-create">
-        <FormattedMessage defaultMessage="Parameters" description="Create Title" />
-      </h3>
+      <h3 className="msla-workflow-parameters-create">{createTitleText}</h3>
       {parameters.length ? <InfoBar isInverted={isInverted} /> : null}
       <div className="msla-workflow-parameters-add">
         <CommandBarButton
@@ -162,7 +173,7 @@ export function WorkflowParameters({
       </div>
       {parameters.length ? null : renderTitleAndDescription()}
       {parameters.length ? <List items={parameters} onRenderCell={renderParameter} /> : null}
-      {onManageParameters ? renderManageParametersLink() : null}
+      {onManageParameters ? <ManageParametersLink /> : null}
     </div>
   );
 }

--- a/libs/designer-ui/src/lib/workflowparameters/workflowparametersReadOnly.tsx
+++ b/libs/designer-ui/src/lib/workflowparameters/workflowparametersReadOnly.tsx
@@ -1,7 +1,7 @@
 import type { ParameterFieldDetails } from './workflowparametersField';
 import { labelStyles } from './workflowparametersField';
 import { Label, Text } from '@fluentui/react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 export interface ReadOnlyParametersProps {
   parameterDetails: ParameterFieldDetails;
@@ -11,23 +11,38 @@ export interface ReadOnlyParametersProps {
 }
 
 export const ReadOnlyParameters = ({ name, type, defaultValue, parameterDetails }: ReadOnlyParametersProps): JSX.Element => {
+  const intl = useIntl();
+  const nameTitle = intl.formatMessage({
+    defaultMessage: 'Name',
+    description: 'Name Title',
+  });
+
+  const typeTitle = intl.formatMessage({
+    defaultMessage: 'Title',
+    description: 'Type Title',
+  });
+
+  const valueTitle = intl.formatMessage({
+    defaultMessage: 'Value',
+    description: 'Value Title',
+  });
   return (
     <>
       <div className="msla-workflow-parameter-field">
         <Label data-testid="readonly-name-label" styles={labelStyles} htmlFor={parameterDetails.name}>
-          <FormattedMessage defaultMessage="Name" description="Name Title" />
+          {nameTitle}
         </Label>
         <Text className="msla-workflow-parameter-read-only">{name}</Text>
       </div>
       <div className="msla-workflow-parameter-field">
         <Label styles={labelStyles} htmlFor={parameterDetails.type}>
-          <FormattedMessage defaultMessage="Title" description="Type Title" />
+          {typeTitle}
         </Label>
         <Text className="msla-workflow-parameter-read-only">{type}</Text>
       </div>
       <div className="msla-workflow-parameter-value-field">
         <Label styles={labelStyles} htmlFor={parameterDetails.value}>
-          <FormattedMessage defaultMessage="Value" description="Value Title" />
+          {valueTitle}
         </Label>
         <Text block className="msla-workflow-parameter-read-only">
           {defaultValue}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsoft-logic-apps",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "microsoft-logic-apps",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Turns out the babel transform doesn't work on typescripts transpilation of jsx components. So either we have to do this or we have to go through and put import React from 'react' at the top of every file.