### PR TITLE
Fix panel header button tooltip centering

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
@@ -75,6 +75,7 @@ const overflowStyle: Partial<IOverflowSetStyles> = {
 const tooltipStyles: ITooltipHostStyles = {
   root: {
     display: 'block',
+    height: '32px'
   },
 };
 


### PR DESCRIPTION
Fix the tooltip so it is centered in the middle of the button

Before
![image](https://user-images.githubusercontent.com/37600290/170558092-6adf68f1-d5dd-4d06-b1b4-c6d12721a862.png)

After
![image](https://user-images.githubusercontent.com/37600290/170557813-fbec3318-0586-49ea-9dc2-1c67fe034d7a.png)
