### PR TITLE
fixed bug with hooks rendering settings panel

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -5,6 +5,7 @@ import { isRootNode } from '../../parsers/models/workflowNode';
 import { getOperationInfo, getOperationManifest } from '../../queries/operation';
 import type { NodeData, NodeInputs, NodeOutputs, OutputInfo } from '../../state/operationMetadataSlice';
 import { initializeNodes } from '../../state/operationMetadataSlice';
+import { clearPanel } from '../../state/panelSlice';
 import {
   loadParameterValuesFromDefault,
   ParameterGroupKeys,
@@ -32,7 +33,7 @@ export const initializeOperationMetadata = async (deserializedWorkflow: Deserial
       // swagger case here
     }
   }
-
+  dispatch(clearPanel());
   dispatch(initializeNodes(await Promise.all(promises)));
 };
 

--- a/libs/designer/src/lib/core/state/panelSlice.ts
+++ b/libs/designer/src/lib/core/state/panelSlice.ts
@@ -25,6 +25,10 @@ export const panelSlice = createSlice({
     collapsePanel: (state) => {
       state.collapsed = true;
     },
+    clearPanel: (state) => {
+      state.collapsed = true;
+      state.selectedNode = '';
+    },
     changePanelNode: (state, action: PayloadAction<string>) => {
       if (!action) return;
       state.selectedNode = action.payload;
@@ -45,6 +49,6 @@ export const panelSlice = createSlice({
 });
 
 // Action creators are generated for each case reducer function
-export const { expandPanel, collapsePanel, changePanelNode, expandDiscoveryPanel, switchToOperationPanel } = panelSlice.actions;
+export const { expandPanel, collapsePanel, clearPanel, changePanelNode, expandDiscoveryPanel, switchToOperationPanel } = panelSlice.actions;
 
 export default panelSlice.reducer;


### PR DESCRIPTION
Because on the run after in the settings we use hooks for each of the incoming edges to get their respective icons, it was running into an issue when switching workflows that we were getting a different number of hooks being called. 
Now, when switching workflows, the panel will now close and no longer keep the selected node that it previously had (we probably don't want it keep the state of previous workflows as well)