### PR TITLE
Fixing Azure functions load and adding loading indicator

### DIFF
--- a/libs/designer-ui/src/lib/about/index.tsx
+++ b/libs/designer-ui/src/lib/about/index.tsx
@@ -1,5 +1,6 @@
 import type { BadgeProps } from '../card';
 import { DocumentationItem } from '../recommendation/documentationItem';
+import { Spinner, SpinnerSize } from '@fluentui/react';
 import type { ILabelStyles } from '@fluentui/react/lib/Label';
 import { Label } from '@fluentui/react/lib/Label';
 import { useIntl } from 'react-intl';
@@ -15,10 +16,19 @@ export interface AboutProps {
   description?: string;
   descriptionDocumentation?: OpenAPIV2.ExternalDocumentationObject;
   headerIcons?: BadgeProps[];
+  isLoading?: boolean;
 }
 
-export const About = ({ connectorDisplayName, description, descriptionDocumentation, headerIcons }: AboutProps): JSX.Element => {
+export const About = ({ connectorDisplayName, description, descriptionDocumentation, headerIcons, isLoading }: AboutProps): JSX.Element => {
   const intl = useIntl();
+
+  if (isLoading) {
+    return (
+      <div className="msla-panel-about-container">
+        <Spinner size={SpinnerSize.large} />
+      </div>
+    );
+  }
 
   const badgeHeaderIcons = (badges: BadgeProps[]): JSX.Element => {
     return (

--- a/libs/designer-ui/src/lib/card/cardv2.less
+++ b/libs/designer-ui/src/lib/card/cardv2.less
@@ -58,3 +58,7 @@ body.dark {
     }
   }
 }
+
+.msla-card-header-spinner {
+  padding-right: 5px;
+}

--- a/libs/designer-ui/src/lib/card/index.tsx
+++ b/libs/designer-ui/src/lib/card/index.tsx
@@ -7,7 +7,7 @@ import { Gripper } from './images/dynamicsvgs/gripper';
 import type { CommentBoxProps, MenuItemOption } from './types';
 import { getCardStyle } from './utils';
 import type { ISpinnerStyles, MessageBarType } from '@fluentui/react';
-import { css } from '@fluentui/react';
+import { Spinner, SpinnerSize, css } from '@fluentui/react';
 import { equals } from '@microsoft-logic-apps/utils';
 import { useState } from 'react';
 import type { ConnectDragPreview, ConnectDragSource } from 'react-dnd';
@@ -30,6 +30,7 @@ export interface CardProps {
   id: string;
   isDragging?: boolean;
   isMonitoringView?: boolean;
+  isLoading?: boolean;
   readOnly?: boolean;
   rootRef?: React.RefObject<HTMLDivElement>;
   selected?: boolean;
@@ -67,6 +68,7 @@ export const Card: React.FC<CardProps> = ({
   icon,
   isDragging,
   isMonitoringView,
+  isLoading,
   selected,
   staticResultsEnabled,
   title,
@@ -114,6 +116,14 @@ export const Card: React.FC<CardProps> = ({
     }
   };
 
+  const cardIcon = isLoading ? (
+    <Spinner className="msla-card-header-spinner" size={SpinnerSize.small} />
+  ) : icon ? (
+    <div className="panel-card-content-icon-section">
+      <img className="panel-card-icon" src={icon} alt="" />
+    </div>
+  ) : null;
+
   return (
     <div ref={dragPreview}>
       <div
@@ -143,11 +153,7 @@ export const Card: React.FC<CardProps> = ({
           >
             <div className="panel-card-content-container">
               <div className={css('panel-card-content-gripper-section', draggable && 'draggable')}>{draggable ? <Gripper /> : null}</div>
-              {icon ? (
-                <div className="panel-card-content-icon-section">
-                  <img className="panel-card-icon" src={icon} alt="" />
-                </div>
-              ) : null}
+              {cardIcon}
               <div className="panel-card-top-content">
                 <div className="panel-msla-title">{title}</div>
               </div>

--- a/libs/designer-ui/src/lib/card/scope/index.tsx
+++ b/libs/designer-ui/src/lib/card/scope/index.tsx
@@ -2,7 +2,7 @@ import CollapseToggle from '../../collapseToggle';
 import { StatusPill } from '../../monitoring';
 import { Gripper } from '../images/dynamicsvgs/gripper';
 import type { CardProps } from '../index';
-import { css, Icon, TooltipHost } from '@fluentui/react';
+import { css, Icon, Spinner, SpinnerSize, TooltipHost } from '@fluentui/react';
 
 export interface ScopeCardProps extends CardProps {
   collapsed?: boolean;
@@ -20,6 +20,7 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
   dragPreview,
   icon,
   isMonitoringView,
+  isLoading,
   title,
   onClick,
   onCollapse,
@@ -43,6 +44,11 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
   ];
 
   const colorVars = { ['--brand-color' as any]: brandColor };
+  const cardIcon = isLoading ? (
+    <Spinner className="msla-card-header-spinner" size={SpinnerSize.small} />
+  ) : icon ? (
+    <img className="scope-icon" alt="" role="presentation" src={icon} />
+  ) : null;
 
   return (
     <div ref={dragPreview} className="msla-content-fit" style={{ cursor: 'default' }}>
@@ -59,7 +65,7 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
             <div className={css('msla-selection-box', false && 'selected')} /> {/* TODO: Assign selection here */}
             <button className="msla-scope-header-title-box">
               <div className={css('gripper-section', draggable && 'draggable')}>{draggable ? <Gripper /> : null}</div>
-              {icon ? <img className="scope-icon" alt="" role="presentation" src={icon} /> : null}
+              {cardIcon}
               <div className="msla-scope-title">{title}</div>
             </button>
             <CollapseToggle collapsed={collapsed} handleCollapse={handleCollapse} />

--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -19,6 +19,7 @@ export type PanelContainerProps = {
   comment?: string;
   panelLocation: PanelLocation;
   noNodeSelected: boolean;
+  isLoading?: boolean;
   panelScope: PanelScope;
   pivotDisabled?: boolean;
   panelHeaderControlType?: PanelHeaderControlType;
@@ -43,6 +44,7 @@ export const PanelContainer = ({
   isCollapsed,
   panelLocation,
   noNodeSelected,
+  isLoading,
   panelScope,
   panelHeaderControlType,
   panelHeaderMenu,
@@ -82,6 +84,7 @@ export const PanelContainer = ({
           titleId={headerTextId}
           title={title}
           includeTitle={true}
+          isLoading={isLoading}
           comment={comment}
           commentChange={onCommentChange}
           toggleCollapse={toggleCollapse}
@@ -91,6 +94,7 @@ export const PanelContainer = ({
     [
       cardIcon,
       isCollapsed,
+      isLoading,
       panelLocation,
       showCommentBox,
       noNodeSelected,

--- a/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
@@ -2,6 +2,7 @@ import type { MenuItemOption } from '../../card/types';
 import { PanelLocation, PanelScope } from '../panelUtil';
 import { PanelHeaderComment } from './panelheadercomment';
 import { PanelHeaderTitle } from './panelheadertitle';
+import { Spinner, SpinnerSize } from '@fluentui/react';
 import type { IButton, IButtonStyles } from '@fluentui/react/lib/Button';
 import { IconButton } from '@fluentui/react/lib/Button';
 import type { ICalloutProps } from '@fluentui/react/lib/Callout';
@@ -27,6 +28,7 @@ export interface PanelHeaderProps {
   cardIcon?: string;
   comment?: string;
   titleId?: string;
+  isLoading?: boolean;
   panelHeaderControlType?: PanelHeaderControlType;
   panelHeaderMenu: MenuItemOption[];
   noNodeSelected?: boolean;
@@ -85,6 +87,7 @@ export const PanelHeader = ({
   cardIcon,
   comment,
   noNodeSelected,
+  isLoading,
   panelScope,
   titleId,
   panelHeaderControlType,
@@ -115,6 +118,12 @@ export const PanelHeader = ({
   const getCollapseIconName: string = (isRight && isCollapsed) || (!isRight && !isCollapsed) ? 'DoubleChevronLeft8' : 'DoubleChevronRight8';
 
   const noNodeOnCardLevel = noNodeSelected && panelScope === PanelScope.CardLevel;
+
+  const iconComponent = isLoading ? (
+    <Spinner size={SpinnerSize.small} />
+  ) : cardIcon ? (
+    <img className="msla-panel-card-icon" src={cardIcon} hidden={isCollapsed} alt="panel card icon" />
+  ) : null;
 
   const getPanelHeaderMenu = (): JSX.Element => {
     const panelHeaderMenuItems = panelHeaderMenu.map((item) => ({
@@ -192,7 +201,7 @@ export const PanelHeader = ({
       {!noNodeOnCardLevel ? (
         <>
           <div className="msla-panel-card-header">
-            {cardIcon ? <img className="msla-panel-card-icon" src={cardIcon} hidden={isCollapsed} alt="panel card icon" /> : null}
+            {iconComponent}
             {includeTitle ? (
               <div className="msla-panel-card-title-container" hidden={isCollapsed}>
                 <PanelHeaderTitle

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -66,19 +66,27 @@ const initializeOperationDetailsForManifest = async (
   isTrigger: boolean,
   dispatch: Dispatch
 ): Promise<NodeDataWithManifest | undefined> => {
-  const operationInfo = await getOperationInfo(nodeId, operation);
+  try {
+    const operationInfo = await getOperationInfo(nodeId, operation);
 
-  if (operationInfo) {
-    const manifest = await getOperationManifest(operationInfo);
+    if (operationInfo) {
+      const manifest = await getOperationManifest(operationInfo);
 
-    dispatch(initializeOperationInfo({ id: nodeId, ...operationInfo }));
+      dispatch(initializeOperationInfo({ id: nodeId, ...operationInfo }));
 
-    const nodeInputs = getInputParametersFromManifest(nodeId, manifest, operation);
-    const nodeOutputs = getOutputParametersFromManifest(nodeId, manifest);
-    const settings = getOperationSettings(operation, isTrigger, operation.type, manifest);
-    return { id: nodeId, nodeInputs, nodeOutputs, settings, manifest };
+      const nodeInputs = getInputParametersFromManifest(nodeId, manifest, operation);
+      const nodeOutputs = getOutputParametersFromManifest(nodeId, manifest);
+      const settings = getOperationSettings(operation, isTrigger, operation.type, manifest);
+      return { id: nodeId, nodeInputs, nodeOutputs, settings, manifest };
+    }
+
+    return;
+  } catch (error) {
+    const errorMessage = `Unable to initialize operation details for operation - ${nodeId}. Error details - ${error}`;
+    console.log(errorMessage);
+
+    return;
   }
-  return;
 };
 
 const getInputParametersFromManifest = (nodeId: string, manifest: OperationManifest, stepDefinition: any): NodeInputs => {

--- a/libs/designer/src/lib/ui/CustomNodes/GraphNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/GraphNode.tsx
@@ -45,8 +45,8 @@ const GraphNode = ({ data, targetPosition = Position.Top, sourcePosition = Posit
   const isCollapsed = useSelector((state: RootState) => state.panel.collapsed);
   const graph = useWorkflowNode(id) as WorkflowGraph;
   const operationInfo = useOperationInfo(id);
-  const brandColor = useBrandColor(operationInfo);
-  const iconUri = useIconUri(operationInfo);
+  const brandColorResult = useBrandColor(operationInfo);
+  const iconUriResult = useIconUri(operationInfo);
   const dispatch = useDispatch<AppDispatch>();
   const nodeClick = useCallback(() => {
     if (isCollapsed) {
@@ -69,8 +69,8 @@ const GraphNode = ({ data, targetPosition = Position.Top, sourcePosition = Posit
       <div className="msla-scope-v2 msla-scope-card">
         <Handle className="node-handle top" type="target" position={targetPosition} isConnectable={false} />
         <ScopeCard
-          brandColor={brandColor}
-          icon={iconUri}
+          brandColor={brandColorResult.result}
+          icon={iconUriResult.result}
           collapsed={false}
           drag={drag}
           draggable={!readOnly}
@@ -78,6 +78,7 @@ const GraphNode = ({ data, targetPosition = Position.Top, sourcePosition = Posit
           isDragging={isDragging}
           id={id}
           isMonitoringView={isMonitoringView}
+          isLoading={iconUriResult.isLoading}
           title={label}
           readOnly={readOnly}
           onClick={nodeClick}

--- a/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -79,8 +79,9 @@ const DefaultNode = ({ data, targetPosition = Position.Top, sourcePosition = Pos
     [dispatch, isCollapsed]
   );
 
-  const brandColor = useBrandColor(operationInfo);
-  const iconUri = useIconUri(operationInfo);
+  const brandColorResult = useBrandColor(operationInfo);
+  const iconUriResult = useIconUri(operationInfo);
+
   if (metadata?.isPlaceholderNode) {
     if (readOnly || !isFirstChild) return null;
     return (
@@ -93,9 +94,10 @@ const DefaultNode = ({ data, targetPosition = Position.Top, sourcePosition = Pos
     );
   }
 
+  const brandColor = brandColorResult.result;
   const comment = nodeComment
     ? {
-        brandColor: brandColor,
+        brandColor,
         comment: nodeComment,
         isDismissed: false,
         isEditing: false,
@@ -124,7 +126,7 @@ const DefaultNode = ({ data, targetPosition = Position.Top, sourcePosition = Pos
         ) : (
           <Card
             title={label}
-            icon={iconUri}
+            icon={iconUriResult.result}
             draggable={!readOnly}
             brandColor={brandColor}
             id={id}
@@ -135,6 +137,7 @@ const DefaultNode = ({ data, targetPosition = Position.Top, sourcePosition = Pos
             dragPreview={dragPreview}
             isDragging={isDragging}
             isMonitoringView={isMonitoringView}
+            isLoading={iconUriResult.isLoading}
             readOnly={readOnly}
             onClick={nodeClick}
           />

--- a/libs/designer/src/lib/ui/panel/panelTabs/aboutTab.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/aboutTab.tsx
@@ -15,11 +15,11 @@ import { useSelector } from 'react-redux';
 export const AboutTab = () => {
   const nodeId = useSelector((state: RootState) => state.panel.selectedNode);
   const operationInfo = useOperationInfo(nodeId);
-  const displayName = useConnectorName(operationInfo);
-  const description = useConnectorDescription(operationInfo);
-  const documentation = useConnectorDocumentation(operationInfo);
-  const environmentBadge = useConnectorEnvironmentBadge(operationInfo);
-  const statusBadge = useConnectorStatusBadge(operationInfo);
+  const displayNameResult = useConnectorName(operationInfo);
+  const { result: description } = useConnectorDescription(operationInfo);
+  const { result: documentation } = useConnectorDocumentation(operationInfo);
+  const { result: environmentBadge } = useConnectorEnvironmentBadge(operationInfo);
+  const { result: statusBadge } = useConnectorStatusBadge(operationInfo);
 
   const headerIcons = [
     ...(environmentBadge ? [{ badgeText: environmentBadge.name, title: environmentBadge.description }] : []),
@@ -28,10 +28,11 @@ export const AboutTab = () => {
 
   return (
     <About
-      connectorDisplayName={displayName}
+      connectorDisplayName={displayNameResult.result}
       description={description}
       descriptionDocumentation={documentation}
       headerIcons={headerIcons}
+      isLoading={displayNameResult.isLoading}
     />
   );
 };

--- a/libs/designer/src/lib/ui/panel/panelroot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelroot.tsx
@@ -47,8 +47,9 @@ export const PanelRoot = ({ selectedTabId }: PanelRootProps): JSX.Element => {
 
   const comment = useNodeDescription(selectedNode);
   const operationInfo = useOperationInfo(selectedNode);
-  const iconUri = useIconUri(operationInfo);
+  const iconUriResult = useIconUri(operationInfo);
   const showCommentBox = !isNullOrUndefined(comment);
+
   useEffect(() => {
     monitoringTab.enabled = !!isMonitoringView;
     setRegisteredTabs((currentTabs) => registerTabs([monitoringTab, parametersTab, SettingsTab, codeViewTab, aboutTab], currentTabs));
@@ -163,11 +164,12 @@ export const PanelRoot = ({ selectedTabId }: PanelRootProps): JSX.Element => {
     <RecommendationPanelContext isCollapsed={collapsed} toggleCollapse={togglePanel} width={width}></RecommendationPanelContext>
   ) : (
     <PanelContainer
-      cardIcon={iconUri}
+      cardIcon={iconUriResult.result}
       comment={comment}
       panelLocation={PanelLocation.Right}
       isCollapsed={collapsed}
       noNodeSelected={!selectedNode}
+      isLoading={iconUriResult.isLoading}
       panelScope={PanelScope.CardLevel}
       panelHeaderControlType={getPanelHeaderControlType() ? PanelHeaderControlType.DISMISS_BUTTON : PanelHeaderControlType.MENU}
       panelHeaderMenu={getPanelHeaderMenu()}

--- a/libs/designer/src/lib/ui/settings/sections/runafterconfiguration/runafteractiondetails.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/runafterconfiguration/runafteractiondetails.tsx
@@ -175,5 +175,5 @@ const Label = ({ label, status }: LabelProps): JSX.Element => {
 
 const useIcon = (selectedNode: string): string => {
   const operationInfo = useOperationInfo(selectedNode);
-  return useIconUri(operationInfo);
+  return useIconUri(operationInfo).result;
 };


### PR DESCRIPTION
1. Adding a loading indicator in card title, panel title and About tab when it is loading data from manifest.
2. Adding a try catch on each node load, so other node load can continue even when one fails. Right now this does not contain showing error indicators on node load failures.

![image](https://user-images.githubusercontent.com/48265693/174402089-6579409d-2110-4b03-a1f7-b40e75596936.png)
