### PR TITLE
Fixed designer workflow not loading

### DIFF
--- a/apps/designer-standalone/src/state/workflowLoadingSlice.ts
+++ b/apps/designer-standalone/src/state/workflowLoadingSlice.ts
@@ -52,7 +52,7 @@ export const loadWorkflow = createAsyncThunk('workflowLoadingState/loadWorkflow'
   } else {
     try {
       const wf = await import(`../../../../__mocks__/workflows/${currentState.workflowLoader.resourcePath}`);
-      return wf.definition;
+      return { workflowDefinition: wf.definition, connectionReferences: {} } as WorkflowPayload;
     } catch {
       return null;
     }
@@ -128,9 +128,10 @@ export const workflowLoadingSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(loadWorkflow.fulfilled, (state, action: PayloadAction<WorkflowPayload>) => {
+    builder.addCase(loadWorkflow.fulfilled, (state, action: PayloadAction<WorkflowPayload | null>) => {
+      if (!action.payload) return;
       state.workflowDefinition = action.payload?.workflowDefinition;
-      state.connections = action.payload?.connectionReferences ? action.payload.connectionReferences : {};
+      state.connections = action.payload?.connectionReferences ?? {};
     });
     builder.addCase(loadWorkflow.rejected, (state) => {
       state.workflowDefinition = null;


### PR DESCRIPTION
The return object for the `loadWorkflow` thunk was expanded for connections, but only modified on the ARM import.  This just adjusts the normal json input as well so the data is correctly imported, and then fixes a null typing error that came afterwords.