### PR TITLE
[Data Mapper] Selecting an input node now adds a new node to the screen

### DIFF
--- a/libs/data-mapper/src/lib/ReactFlow.Util.ts
+++ b/libs/data-mapper/src/lib/ReactFlow.Util.ts
@@ -3,87 +3,85 @@ import type { SchemaNodeExtended } from './models/Schema';
 import type { Node as ReactFlowNode } from 'react-flow-renderer';
 import { Position } from 'react-flow-renderer';
 
-const rootInputX = 0;
-const rootInputY = 0;
-const childInputX = rootInputX + 30;
-const childInputYOffset = 60;
+const inputX = 0;
+const inputY = 0;
+const inputYOffset = 60;
 
 const rootOutputX = 500;
 const rootOutputY = 0;
-const childOutputX = rootOutputX + 30;
-const childOutputYOffset = 60;
+const childXOffSet = 30;
+const childYOffset = 60;
 
 export enum ReactFlowNodeType {
   SchemaNode = 'schemaNode',
   ExpressionNode = 'expressionNode',
 }
 
-export const convertToReactFlowNode = (inputSchemaNode?: SchemaNodeExtended, outputSchemaNode?: SchemaNodeExtended): ReactFlowNode[] => {
+export const convertToReactFlowNodes = (inputSchemaNodes: SchemaNodeExtended[], outputSchemaNode: SchemaNodeExtended): ReactFlowNode[] => {
   const reactFlowNodes: ReactFlowNode[] = [];
 
-  if (inputSchemaNode) {
+  inputSchemaNodes.forEach((inputNodes, index) => {
     reactFlowNodes.push({
-      id: `input-${inputSchemaNode.key}`,
+      id: `input-${inputNodes.key}`,
       data: {
-        label: inputSchemaNode.name,
+        label: inputNodes.name,
         schemaType: SchemaTypes.Input,
+        displayHandle: true,
       },
+      type: ReactFlowNodeType.SchemaNode,
       sourcePosition: Position.Right,
-      type: ReactFlowNodeType.SchemaNode,
       position: {
-        x: rootInputX,
-        y: rootInputY,
+        x: inputX,
+        y: inputYOffset * index,
       },
     });
+  });
 
-    inputSchemaNode.children?.forEach((childNode, index) => {
-      reactFlowNodes.push({
-        id: `input-${childNode.key}`,
-        data: {
-          label: childNode.name,
-          schemaType: SchemaTypes.Input,
-        },
-        type: ReactFlowNodeType.SchemaNode,
-        sourcePosition: Position.Right,
-        position: {
-          x: childInputX,
-          y: childInputYOffset * (index + 1),
-        },
-      });
-    });
-  }
+  reactFlowNodes.push(...convertToReactFlowParentAndChildNodes(outputSchemaNode, SchemaTypes.Output, true));
 
-  if (outputSchemaNode) {
+  return reactFlowNodes;
+};
+
+export const convertToReactFlowParentAndChildNodes = (
+  parentSchemaNode: SchemaNodeExtended,
+  schemaType: SchemaTypes,
+  displayTargets: boolean
+): ReactFlowNode[] => {
+  const reactFlowNodes: ReactFlowNode[] = [];
+  const rootX = schemaType === SchemaTypes.Input ? inputX : rootOutputX;
+  const rootY = schemaType === SchemaTypes.Input ? inputY : rootOutputY;
+
+  reactFlowNodes.push({
+    id: `${schemaType}-${parentSchemaNode.key}`,
+    data: {
+      label: parentSchemaNode.name,
+      schemaType,
+      displayHandle: displayTargets,
+    },
+    type: ReactFlowNodeType.SchemaNode,
+    targetPosition: !displayTargets ? undefined : SchemaTypes.Input ? Position.Right : Position.Left,
+    position: {
+      x: rootX,
+      y: rootY,
+    },
+  });
+
+  parentSchemaNode.children?.forEach((childNode, index) => {
     reactFlowNodes.push({
-      id: `output-${outputSchemaNode.key}`,
+      id: `${schemaType}-${childNode.key}`,
       data: {
-        label: outputSchemaNode.name,
-        schemaType: SchemaTypes.Output,
+        label: childNode.name,
+        schemaType,
+        displayHandle: displayTargets,
       },
       type: ReactFlowNodeType.SchemaNode,
-      targetPosition: Position.Left,
+      targetPosition: !displayTargets ? undefined : SchemaTypes.Input ? Position.Right : Position.Left,
       position: {
-        x: rootOutputX,
-        y: rootOutputY,
+        x: rootX + childXOffSet,
+        y: childYOffset * (index + 1),
       },
     });
-
-    outputSchemaNode.children?.forEach((childNode, index) => {
-      reactFlowNodes.push({
-        id: `output-${childNode.key}`,
-        data: {
-          label: childNode.name,
-          schemaType: SchemaTypes.Output,
-        },
-        type: ReactFlowNodeType.SchemaNode,
-        targetPosition: Position.Left,
-        position: {
-          x: childOutputX,
-          y: childOutputYOffset * (index + 1),
-        },
-      });
-    });
-  }
+  });
 
   return reactFlowNodes;
 };

--- a/libs/data-mapper/src/lib/components/mapOverview/MapOverview.tsx
+++ b/libs/data-mapper/src/lib/components/mapOverview/MapOverview.tsx
@@ -1,4 +1,4 @@
-import { convertToReactFlowNode } from '../../ReactFlow.Util';
+import { convertToReactFlowParentAndChildNodes } from '../../ReactFlow.Util';
 import { openInputSchemaPanel, openOutputSchemaPanel } from '../../core/state/PanelSlice';
 import type { AppDispatch } from '../../core/state/Store';
 import type { SchemaExtended } from '../../models/';
@@ -7,6 +7,7 @@ import { SchemaCard } from '../nodeCard/SchemaCard';
 import { SelectSchemaCard } from '../schemaSelection/selectSchemaCard';
 import { useMemo } from 'react';
 import ReactFlow, { ReactFlowProvider } from 'react-flow-renderer';
+import type { Node as ReactFlowNode } from 'react-flow-renderer';
 import { useDispatch } from 'react-redux';
 
 export interface MapOverviewProps {
@@ -18,7 +19,16 @@ export const MapOverview: React.FC<MapOverviewProps> = ({ inputSchema, outputSch
   const dispatch = useDispatch<AppDispatch>();
 
   const reactFlowNodes = useMemo(() => {
-    return convertToReactFlowNode(inputSchema?.schemaTreeRoot, outputSchema?.schemaTreeRoot);
+    const reactFlowNodes: ReactFlowNode[] = [];
+    if (inputSchema) {
+      reactFlowNodes.push(...convertToReactFlowParentAndChildNodes(inputSchema.schemaTreeRoot, SchemaTypes.Input, false));
+    }
+
+    if (outputSchema) {
+      reactFlowNodes.push(...convertToReactFlowParentAndChildNodes(outputSchema.schemaTreeRoot, SchemaTypes.Output, false));
+    }
+
+    return reactFlowNodes;
   }, [inputSchema, outputSchema]);
 
   const onInputSchemaClick = () => {

--- a/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
@@ -12,6 +12,7 @@ interface SchemaCardProps {
 interface SchemaCardWrapperProps {
   label: string;
   schemaType: SchemaTypes;
+  displayHandle: boolean;
   isLeaf?: boolean;
   onClick?: () => void;
   disabled?: boolean;
@@ -70,11 +71,17 @@ export const SchemaCard: FunctionComponent<SchemaCardProps> = ({ data }) => {
   return (
     <div>
       {/* TODO: remove handle and make a part of card clickable and drawable instead (14957766) */}
-      <Handle type="target" position={data.schemaType === SchemaTypes.Input ? Position.Right : Position.Left} style={handleStyle} />
-
+      {data.displayHandle ? (
+        <Handle
+          type={data.schemaType === SchemaTypes.Input ? 'source' : 'target'}
+          position={data.schemaType === SchemaTypes.Input ? Position.Right : Position.Left}
+          style={handleStyle}
+        />
+      ) : null}
       <SchemaCardWrapper
         label={data.label}
         schemaType={data.schemaType}
+        displayHandle={data.displayHandle}
         isLeaf={data?.isLeaf}
         onClick={data?.onClick}
         disabled={data?.disabled}

--- a/libs/data-mapper/src/lib/components/tree/SchemaTree.tsx
+++ b/libs/data-mapper/src/lib/components/tree/SchemaTree.tsx
@@ -9,23 +9,33 @@ export const FastTreeItem = wrap(fastTreeItem());
 
 export interface SchemaTreeProps {
   schema: SchemaExtended;
+  onLeafNodeClick: (schemaNode: SchemaNodeExtended) => void;
 }
 
-export const SchemaTree: React.FC<SchemaTreeProps> = ({ schema }: SchemaTreeProps) => {
-  return <FastTreeView>{convertToFastTreeItem(schema.schemaTreeRoot)}</FastTreeView>;
+export const SchemaTree: React.FC<SchemaTreeProps> = ({ schema, onLeafNodeClick }: SchemaTreeProps) => {
+  return <FastTreeView>{convertToFastTreeItem(schema.schemaTreeRoot, onLeafNodeClick)}</FastTreeView>;
 };
 
-const convertToFastTreeItem = (node: SchemaNodeExtended) => {
+const convertToFastTreeItem = (node: SchemaNodeExtended, onLeafNodeClick: (schemaNode: SchemaNodeExtended) => void) => {
   return node.children.map((childNode) => {
     if (childNode.schemaNodeDataType === 'ComplexType' || childNode.schemaNodeDataType === 'None') {
       return (
-        <FastTreeItem>
+        <FastTreeItem key={childNode.key}>
           {childNode.name}
-          {convertToFastTreeItem(childNode)}
+          {convertToFastTreeItem(childNode, onLeafNodeClick)}
         </FastTreeItem>
       );
     } else {
-      return <FastTreeItem>{childNode.name}</FastTreeItem>;
+      return (
+        <FastTreeItem
+          key={childNode.key}
+          onClick={() => {
+            onLeafNodeClick(childNode);
+          }}
+        >
+          {childNode.name}
+        </FastTreeItem>
+      );
     }
   });
 };

--- a/libs/data-mapper/src/lib/core/state/DataMapSlice.ts
+++ b/libs/data-mapper/src/lib/core/state/DataMapSlice.ts
@@ -15,7 +15,7 @@ export interface DataMapOperationState {
   curDataMap: JsonInputStyle;
   currentInputSchemaExtended?: SchemaExtended;
   currentOutputSchemaExtended?: SchemaExtended;
-  currentInputNode?: SchemaNodeExtended;
+  currentInputNodes?: SchemaNodeExtended[];
   currentOutputNode?: SchemaNodeExtended;
 }
 

--- a/libs/data-mapper/src/lib/core/state/SchemaSlice.ts
+++ b/libs/data-mapper/src/lib/core/state/SchemaSlice.ts
@@ -11,12 +11,15 @@ export interface UpdateBreadcrumbAction {
 export interface SchemaState {
   inputSchema?: SchemaExtended;
   outputSchema?: SchemaExtended;
-  availableSchemas?: Schema[];
-  currentInputNode?: SchemaNodeExtended;
+  availableSchemas: Schema[];
+  currentInputNodes: SchemaNodeExtended[];
   currentOutputNode?: SchemaNodeExtended;
 }
 
-export const initialSchemaState: SchemaState = {};
+export const initialSchemaState: SchemaState = {
+  availableSchemas: [],
+  currentInputNodes: [],
+};
 
 export const schemaSlice = createSlice({
   name: 'schema',
@@ -27,12 +30,12 @@ export const schemaSlice = createSlice({
       if (incomingSchema) {
         const extendedSchema = convertSchemaToSchemaExtended(incomingSchema);
         state.inputSchema = extendedSchema;
-        state.currentInputNode = extendedSchema.schemaTreeRoot;
+        state.currentInputNodes = [];
       }
     },
     setInputSchemaExtended: (state, action: PayloadAction<SchemaExtended | undefined>) => {
       state.inputSchema = action.payload;
-      state.currentInputNode = action.payload?.schemaTreeRoot;
+      state.currentInputNodes = [];
     },
     setOutputSchema: (state, action: PayloadAction<Schema | undefined>) => {
       const incomingSchema = action.payload;
@@ -47,11 +50,27 @@ export const schemaSlice = createSlice({
       state.currentOutputNode = action.payload?.schemaTreeRoot;
     },
     setAvailableSchemas: (state, action: PayloadAction<Schema[] | undefined>) => {
-      state.availableSchemas = action.payload;
+      if (action.payload) {
+        state.availableSchemas = action.payload;
+      } else {
+        state.availableSchemas = [];
+      }
     },
-
-    setCurrentInputNode: (state, action: PayloadAction<SchemaNodeExtended | undefined>) => {
-      state.currentInputNode = action.payload;
+    setCurrentInputNodes: (state, action: PayloadAction<SchemaNodeExtended[] | undefined>) => {
+      if (action.payload) {
+        const uniqueNodes = state.currentInputNodes.concat(action.payload).filter((node, index, self) => {
+          return self.findIndex((subNode) => subNode.key === node.key) === index;
+        });
+        state.currentInputNodes = uniqueNodes;
+      } else {
+        state.currentInputNodes = [];
+      }
+    },
+    addCurrentInputNodes: (state, action: PayloadAction<SchemaNodeExtended[]>) => {
+      const uniqueNodes = state.currentInputNodes.concat(action.payload).filter((node, index, self) => {
+        return self.findIndex((subNode) => subNode.key === node.key) === index;
+      });
+      state.currentInputNodes = uniqueNodes;
     },
     setCurrentOutputNode: (state, action: PayloadAction<SchemaNodeExtended | undefined>) => {
       state.currentOutputNode = action.payload;
@@ -65,7 +84,8 @@ export const {
   setOutputSchema,
   setOutputSchemaExtended,
   setAvailableSchemas,
-  setCurrentInputNode,
+  setCurrentInputNodes,
+  addCurrentInputNodes,
   setCurrentOutputNode,
 } = schemaSlice.actions;
 

--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -1,10 +1,10 @@
 import { checkerboardBackgroundImage } from '../Constants';
-import { convertToReactFlowNode } from '../ReactFlow.Util';
+import { convertToReactFlowNodes } from '../ReactFlow.Util';
 import { EditorBreadcrumb } from '../components/breadcrumb/EditorBreadcrumb';
 import type { ButtonContainerProps } from '../components/buttonContainer/ButtonContainer';
 import { ButtonContainer } from '../components/buttonContainer/ButtonContainer';
 import { EditorCommandBar } from '../components/commandBar/EditorCommandBar';
-import { EditorConfigPanel } from '../components/configPanel/EditorConfigPanel';
+import { EditorConfigPanel, SchemaTypes } from '../components/configPanel/EditorConfigPanel';
 import type { FloatingPanelProps } from '../components/floatingPanel/FloatingPanel';
 import { FloatingPanel } from '../components/floatingPanel/FloatingPanel';
 import { MapOverview } from '../components/mapOverview/MapOverview';
@@ -19,10 +19,16 @@ import {
   saveDataMap,
   undoDataMapOperation,
 } from '../core/state/DataMapSlice';
-import { setCurrentInputNode, setCurrentOutputNode, setInputSchema, setOutputSchema } from '../core/state/SchemaSlice';
+import {
+  addCurrentInputNodes,
+  setCurrentInputNodes,
+  setCurrentOutputNode,
+  setInputSchema,
+  setOutputSchema,
+} from '../core/state/SchemaSlice';
 import type { AppDispatch, RootState } from '../core/state/Store';
 import { store } from '../core/state/Store';
-import type { Schema } from '../models';
+import type { Schema, SchemaNodeExtended } from '../models';
 import { useBoolean } from '@fluentui/react-hooks';
 import {
   CubeTree20Filled,
@@ -62,18 +68,13 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
   const [displayExpressions, { toggle: toggleDisplayExpressions, setFalse: setDisplayExpressionsFalse }] = useBoolean(false);
   const [nodes, edges] = useLayout();
 
+  const onToolboxLeafItemClick = (selectedNode: SchemaNodeExtended) => {
+    dispatch(addCurrentInputNodes([selectedNode]));
+  };
+
   const onNodeDoubleClick = (_event: ReactMouseEvent, node: ReactFlowNode): void => {
     const schemaState = store.getState().schema;
-    if (node.data.schemaType === 'input') {
-      const currentSchemaNode = schemaState.currentInputNode;
-      if (currentSchemaNode) {
-        const newCurrentSchemaNode =
-          currentSchemaNode.key === node.id
-            ? currentSchemaNode
-            : currentSchemaNode.children.find((schemaNode) => schemaNode.key === node.id);
-        dispatch(setCurrentInputNode(newCurrentSchemaNode));
-      }
-    } else {
+    if (node.data.schemaType === SchemaTypes.Output) {
       const currentSchemaNode = schemaState.currentOutputNode;
       if (currentSchemaNode) {
         const trimmedNodeId = node.id.substring(7);
@@ -90,9 +91,6 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
     dispatch(setInputSchema(inputSchema));
 
     const schemaState = store.getState().schema;
-    const currentSchemaNode = schemaState.currentInputNode;
-
-    dispatch(setCurrentInputNode(currentSchemaNode));
 
     if (outputSchema) {
       const dataMapOperationState: DataMapOperationState = {
@@ -101,7 +99,7 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
           dstSchemaName: outputSchema.name,
           mappings: { targetNodeKey: `ns0:${outputSchema.name}` },
         },
-        currentInputNode: currentSchemaNode,
+        currentInputNodes: [],
         currentOutputNode: schemaState.currentOutputNode,
       };
       dispatch(changeInputSchemaOperation(dataMapOperationState));
@@ -122,7 +120,7 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
           dstSchemaName: outputSchema.name,
           mappings: { targetNodeKey: `ns0:${outputSchema.name}` },
         },
-        currentInputNode: schemaState.currentInputNode,
+        currentInputNodes: [],
         currentOutputNode: currentSchemaNode,
       };
       dispatch(changeOutputSchemaOperation(dataMapOperationState));
@@ -141,13 +139,13 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
 
   const onUndoClick = () => {
     dispatch(undoDataMapOperation());
-    dispatch(setCurrentInputNode(curDataMapOperation?.currentInputNode));
+    dispatch(setCurrentInputNodes(curDataMapOperation?.currentInputNodes));
     dispatch(setCurrentOutputNode(curDataMapOperation?.currentOutputNode));
   };
 
   const onRedoClick = () => {
     dispatch(redoDataMapOperation());
-    dispatch(setCurrentInputNode(curDataMapOperation?.currentInputNode));
+    dispatch(setCurrentInputNodes(curDataMapOperation?.currentInputNodes));
     dispatch(setCurrentOutputNode(curDataMapOperation?.currentOutputNode));
   };
 
@@ -314,7 +312,7 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
             <ButtonContainer {...toolboxButtonContainerProps} />
             {displayToolbox ? (
               <FloatingPanel {...toolboxPanelProps}>
-                <SchemaTree schema={inputSchema} />
+                <SchemaTree schema={inputSchema} onLeafNodeClick={onToolboxLeafItemClick} />
               </FloatingPanel>
             ) : null}
             <div className="msla-designer-canvas msla-panel-mode">
@@ -333,12 +331,16 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
 
 export const useLayout = (): [ReactFlowNode[], ReactFlowEdge[]] => {
   const reactFlowEdges: ReactFlowEdge[] = [];
-  const inputSchemaNode = useSelector((state: RootState) => state.schema.currentInputNode);
+  const inputSchemaNodes = useSelector((state: RootState) => state.schema.currentInputNodes);
   const outputSchemaNode = useSelector((state: RootState) => state.schema.currentOutputNode);
 
   const reactFlowNodes = useMemo(() => {
-    return convertToReactFlowNode(inputSchemaNode, outputSchemaNode);
-  }, [inputSchemaNode, outputSchemaNode]);
+    if (outputSchemaNode) {
+      return convertToReactFlowNodes(Array.from(inputSchemaNodes), outputSchemaNode);
+    } else {
+      return [];
+    }
+  }, [inputSchemaNodes, outputSchemaNode]);
 
   return [reactFlowNodes, reactFlowEdges];
 };


### PR DESCRIPTION
Removed the default input nodes being added when a schema is selected. Now you need to add them manually using the toolbox. Nodes can currently only be added, not removed and changing output locations doesn't reset selected nodes

![AddingInputNodes](https://user-images.githubusercontent.com/37600290/181631773-1d34b08d-9c1a-43ad-85ad-a992e5d6128c.gif)
