### PR TITLE
Fixed a run-after settings initialization issue

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -79,7 +79,7 @@ export const initializeOperationDetails = async (
     const manifest = await getOperationManifest(operationInfo);
 
     // TODO(Danielle) - Please set the isTrigger correctly once we know the added operation is trigger or action.
-    const settings = getOperationSettings(false /* isTrigger */, operationType, operationKind, manifest);
+    const settings = getOperationSettings(false /* isTrigger */, operationType, operationKind, manifest, workflowState.operations[nodeId]);
     const nodeInputs = getInputParametersFromManifest(nodeId, manifest);
     const nodeOutputs = getOutputParametersFromManifest(manifest, false /* isTrigger */, nodeInputs, settings.splitOn?.value?.value);
     const nodeDependencies = getParameterDependencies(manifest, nodeInputs, nodeOutputs);


### PR DESCRIPTION
Run After settings were not appearing on nodes that were just added, the settings initialization was running without the operation data so it didn't see any run after configuration, hiding the settings.