### PR TITLE
[Data Mapper] Differentiate node single/double clicks

### DIFF
--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -27,8 +27,8 @@ import {
 import type { AppDispatch, RootState } from '../core/state/Store';
 import { store } from '../core/state/Store';
 import type { Schema, SchemaNodeExtended } from '../models';
-import { SchemaTypes } from '../models';
-import { convertToReactFlowEdges, convertToReactFlowNodes } from '../utils/ReactFlow.Util';
+import { NodeType, SchemaTypes } from '../models';
+import { convertToReactFlowEdges, convertToReactFlowNodes, ReactFlowNodeType } from '../utils/ReactFlow.Util';
 import { convertSchemaToSchemaExtended } from '../utils/Schema.Utils';
 import { useBoolean } from '@fluentui/react-hooks';
 import {
@@ -102,7 +102,7 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
   };
 
   const onNodeSingleClick = (node: ReactFlowNode): void => {
-    const newCurrentlySelectedNode = { type: node.data.schemaType };
+    const newCurrentlySelectedNode = { type: node.type === ReactFlowNodeType.SchemaNode ? node.data.schemaType : NodeType.Expression };
     dispatch(setCurrentlySelectedNode(newCurrentlySelectedNode));
   };
 


### PR DESCRIPTION
Fixing issue where single and double clicks on nodes weren't differentiated (only single clicks fired)

![Ex](https://user-images.githubusercontent.com/49288482/186716899-e91b01e1-e80c-4d76-a9fa-a309a9d71631.gif)
