### PR TITLE
[Data Mapper] Tie canvas controls to bottom left (compat w/ proppane resizing)

### DIFF
--- a/libs/data-mapper/src/lib/components/buttonContainer/ButtonContainer.tsx
+++ b/libs/data-mapper/src/lib/components/buttonContainer/ButtonContainer.tsx
@@ -6,6 +6,9 @@ import type { IconType } from 'react-icons/lib';
 export interface ButtonContainerProps {
   buttons: ButtonContainerButtonProps[];
   horizontal: boolean;
+  xPos: string;
+  yPos: string;
+  anchorToBottom?: boolean;
 }
 
 export interface ButtonContainerButtonProps {
@@ -16,7 +19,13 @@ export interface ButtonContainerButtonProps {
   onClick: () => void;
 }
 
-export const ButtonContainer: React.FC<ButtonContainerProps> = ({ buttons, horizontal }: ButtonContainerProps) => {
+export const ButtonContainer: React.FC<ButtonContainerProps> = ({
+  buttons,
+  horizontal,
+  xPos,
+  yPos,
+  anchorToBottom,
+}: ButtonContainerProps) => {
   const stackItems = buttons.map((buttonProps, index) => {
     const BundledIcon = bundleIcon(buttonProps.filledIcon, buttonProps.regularIcon);
 
@@ -35,9 +44,14 @@ export const ButtonContainer: React.FC<ButtonContainerProps> = ({ buttons, horiz
     zIndex: 5,
     boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12)',
     borderRadius: '4px',
-    bottom: '16px',
-    left: '16px',
+    left: xPos,
   };
+
+  if (anchorToBottom) {
+    stackStyle.bottom = yPos;
+  } else {
+    stackStyle.top = yPos;
+  }
 
   return (
     <Stack horizontal={horizontal} style={stackStyle}>

--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -351,6 +351,9 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
         },
       ],
       horizontal: true,
+      xPos: '16px',
+      yPos: '16px',
+      anchorToBottom: true,
     };
 
     return (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49288482/189745628-79e083af-2c43-4855-a3f2-4f5d9d6f9049.png)

![image](https://user-images.githubusercontent.com/49288482/189745646-b3794f03-e71d-46ce-b540-50f0686d6951.png)

![image](https://user-images.githubusercontent.com/49288482/189745670-dbaaa4ae-c595-489e-b7f0-0b529d43ad9b.png)

![image](https://user-images.githubusercontent.com/49288482/189745693-a24dcf64-eead-4793-a83c-5f2f6ba82ee2.png)
