### PR TITLE
Move from peer dependencies to direct dependencies

### DIFF
--- a/libs/data-mapper/project.json
+++ b/libs/data-mapper/project.json
@@ -13,6 +13,7 @@
         "entryFile": "libs/data-mapper/src/index.ts",
         "external": ["react/jsx-runtime"],
         "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "extractCss": true,
         "format": ["cjs", "esm"],
         "assets": [

--- a/libs/designer-ui/project.json
+++ b/libs/designer-ui/project.json
@@ -14,6 +14,7 @@
         "entryFile": "libs/designer-ui/src/index.ts",
         "external": ["react/jsx-runtime"],
         "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "format": ["cjs", "esm"],
         "assets": [
           {

--- a/libs/designer/project.json
+++ b/libs/designer/project.json
@@ -13,6 +13,7 @@
         "entryFile": "libs/designer/src/index.ts",
         "external": ["react/jsx-runtime"],
         "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "extractCss": true,
         "format": ["cjs", "esm"],
         "assets": [

--- a/libs/parsers/project.json
+++ b/libs/parsers/project.json
@@ -13,6 +13,7 @@
         "project": "libs/parsers/package.json",
         "entryFile": "libs/parsers/src/index.ts",
         "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "format": ["cjs", "esm"],
         "assets": [
           {

--- a/libs/services/designer-client-services/project.json
+++ b/libs/services/designer-client-services/project.json
@@ -13,6 +13,7 @@
         "project": "libs/services/designer-client-services/package.json",
         "entryFile": "libs/services/designer-client-services/src/index.ts",
         "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "format": ["cjs", "esm"],
         "assets": [
           {

--- a/libs/services/intl/project.json
+++ b/libs/services/intl/project.json
@@ -14,6 +14,7 @@
         "entryFile": "libs/services/intl/src/index.ts",
         "external": ["react/jsx-runtime"],
         "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "format": ["cjs", "esm"],
         "assets": [
           {

--- a/libs/utils/project.json
+++ b/libs/utils/project.json
@@ -11,6 +11,7 @@
         "main": "libs/utils/src/index.ts",
         "tsConfig": "libs/utils/tsconfig.lib.json",
         "project": "libs/utils/package.json",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "entryFile": "libs/utils/src/index.ts",
         "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
         "format": ["cjs", "esm"],


### PR DESCRIPTION
This will allow us to remove most dependencies from the portal size package.json