### PR TITLE
[DM | Schema node card] Name tooltip update

### DIFF
--- a/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
@@ -193,11 +193,12 @@ export const SchemaCard = (props: NodeProps<SchemaCardProps>) => {
   const [isChevronHovered, setIsChevronHovered] = useState<boolean>(false);
   const [isTooltipEnabled, setIsTooltipEnabled] = useState<boolean>(false);
 
-  const isNodeConnected = useMemo(() => {
-    return (
-      connections[reactFlowId] && (connections[reactFlowId].outputs.length > 0 || flattenInputs(connections[reactFlowId].inputs).length > 0)
-    );
-  }, [connections, reactFlowId]);
+  const isNodeConnected = useMemo(
+    () =>
+      connections[reactFlowId] &&
+      (connections[reactFlowId].outputs.length > 0 || flattenInputs(connections[reactFlowId].inputs).length > 0),
+    [connections, reactFlowId]
+  );
 
   const isSourceSchemaNode = useMemo(() => schemaType === SchemaType.Source, [schemaType]);
   const showOutputChevron = useMemo(() => !isSourceSchemaNode && !isLeaf && displayChevron, [isSourceSchemaNode, displayChevron, isLeaf]);

--- a/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
@@ -188,7 +188,7 @@ export const SchemaCard = (props: NodeProps<SchemaCardProps>) => {
 
   const connections = useSelector((state: RootState) => state.dataMap.curDataMapOperation.dataMapConnections);
 
-  const schemaNameTextRef = useRef<HTMLInputElement>(null);
+  const schemaNameTextRef = useRef<HTMLDivElement>(null);
   const [_isCardHovered, setIsCardHovered] = useState<boolean>(false);
   const [isChevronHovered, setIsChevronHovered] = useState<boolean>(false);
   const [isTooltipEnabled, setIsTooltipEnabled] = useState<boolean>(false);
@@ -206,10 +206,7 @@ export const SchemaCard = (props: NodeProps<SchemaCardProps>) => {
     () => isNodeConnected && schemaNode.properties === SchemaNodeProperties.Repeating,
     [isNodeConnected, schemaNode]
   );
-  const shouldNameTooltipDisplay = useMemo(
-    () => (schemaNameTextRef?.current ? isTextUsingEllipsis(schemaNameTextRef.current) : false),
-    [schemaNameTextRef]
-  );
+  const shouldNameTooltipDisplay = schemaNameTextRef?.current ? isTextUsingEllipsis(schemaNameTextRef.current) : false;
 
   const containerStyle = useMemo(() => {
     const newContStyles = [sharedStyles.root, classes.container];

--- a/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
@@ -227,38 +227,38 @@ export const SchemaCard = (props: NodeProps<SchemaCardProps>) => {
     <div className={classes.badgeContainer}>
       {isNBadgeRequired && !isSourceSchemaNode && <NBadge />}
 
-      <Tooltip relationship="label" content={schemaNode.name}>
-        <div className={containerStyle} onMouseLeave={() => setIsCardHovered(false)} onMouseEnter={() => setIsCardHovered(true)}>
-          {displayHandle && (
-            <Handle
-              type={isSourceSchemaNode ? 'source' : 'target'}
-              position={isSourceSchemaNode ? Position.Right : Position.Left}
-              style={handleStyle}
-              isValidConnection={isSourceSchemaNode ? isValidConnection : () => false}
-            />
-          )}
-          {error && <Badge size="small" icon={<ExclamationIcon />} color="danger" className={classes.errorBadge}></Badge>}{' '}
-          <Button disabled={!!disabled} onClick={onClick} appearance={'transparent'} className={classes.contentButton}>
-            <span className={classes.cardIcon}>
-              <BundledTypeIcon />
-            </span>
+      <div className={containerStyle} onMouseLeave={() => setIsCardHovered(false)} onMouseEnter={() => setIsCardHovered(true)}>
+        {displayHandle && (
+          <Handle
+            type={isSourceSchemaNode ? 'source' : 'target'}
+            position={isSourceSchemaNode ? Position.Right : Position.Left}
+            style={handleStyle}
+            isValidConnection={isSourceSchemaNode ? isValidConnection : () => false}
+          />
+        )}
+        {error && <Badge size="small" icon={<ExclamationIcon />} color="danger" className={classes.errorBadge}></Badge>}{' '}
+        <Button disabled={!!disabled} onClick={onClick} appearance={'transparent'} className={classes.contentButton}>
+          <span className={classes.cardIcon}>
+            <BundledTypeIcon />
+          </span>
 
+          <Tooltip relationship="label" content={schemaNode.name}>
             <Text className={classes.cardText} style={{ width: !isSourceSchemaNode ? '100%' : '136px' }} block={true} nowrap={true}>
               {schemaNode.name}
             </Text>
-          </Button>
-          {showOutputChevron && (
-            <Button
-              className={classes.cardChevron}
-              onClick={outputChevronOnClick}
-              icon={<ChevronIcon filled={isChevronHovered ? true : undefined} />}
-              appearance={'transparent'}
-              onMouseEnter={() => setIsChevronHovered(true)}
-              onMouseLeave={() => setIsChevronHovered(false)}
-            />
-          )}
-        </div>
-      </Tooltip>
+          </Tooltip>
+        </Button>
+        {showOutputChevron && (
+          <Button
+            className={classes.cardChevron}
+            onClick={outputChevronOnClick}
+            icon={<ChevronIcon filled={isChevronHovered ? true : undefined} />}
+            appearance={'transparent'}
+            onMouseEnter={() => setIsChevronHovered(true)}
+            onMouseLeave={() => setIsChevronHovered(false)}
+          />
+        )}
+      </div>
 
       {isNBadgeRequired && isSourceSchemaNode && <NBadge />}
     </div>

--- a/libs/data-mapper/src/lib/utils/Browser.Utils.ts
+++ b/libs/data-mapper/src/lib/utils/Browser.Utils.ts
@@ -1,1 +1,1 @@
-export const isTextUsingEllipsis = (element: HTMLElement) => element.offsetWidth <= element.scrollWidth;
+export const isTextUsingEllipsis = (element: HTMLDivElement) => element.offsetWidth < element.scrollWidth;

--- a/libs/data-mapper/src/lib/utils/Browser.Utils.ts
+++ b/libs/data-mapper/src/lib/utils/Browser.Utils.ts
@@ -1,0 +1,1 @@
+export const isTextUsingEllipsis = (element: HTMLElement) => element.offsetWidth <= element.scrollWidth;


### PR DESCRIPTION
-Now show tooltip only over name text instead of entire card

-Only show tooltip if the name actually overflows/ellipsis's

![SchemaCardNameTooltip](https://user-images.githubusercontent.com/49288482/198700486-0ded1f5f-4dcd-4cdf-8712-d33f6a3c7e13.gif)
