### PR TITLE
[DM | Overview] Overview operates at "schema root" instead of schemaTreeRoot

### DIFF
--- a/libs/data-mapper/src/lib/components/breadcrumb/EditorBreadcrumb.tsx
+++ b/libs/data-mapper/src/lib/components/breadcrumb/EditorBreadcrumb.tsx
@@ -125,7 +125,7 @@ const convertToBreadcrumbItems = (
     key: schema.name,
     text: schema.name,
     onClick: () => {
-      dispatch(setCurrentTargetSchemaNode(schema.schemaTreeRoot));
+      dispatch(setCurrentTargetSchemaNode(undefined));
     },
   };
 
@@ -151,11 +151,8 @@ const convertToBreadcrumbItems = (
     });
   }
 
-  // When in overview (at schemaTreeRoot), don't show the root node in the breadcrumb
-  if (breadcrumbItems.length === 2) {
-    breadcrumbItems.pop();
-
-    // Instead, show placeholder text
+  // When in overview (at schema root, NOT schemaTreeRoot), show placeholder text
+  if (breadcrumbItems.length === 1) {
     breadcrumbItems.push({
       key: 'placeholder',
       text: breadcrumbPlaceholder,

--- a/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
+++ b/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
@@ -149,7 +149,9 @@ export const CanvasToolbox = ({ canvasBlockHeight }: CanvasToolboxProps) => {
           <TreeHeader onSearch={setSourceSchemaSearchTerm} onClear={() => setSourceSchemaSearchTerm('')} />
 
           <Tree<SchemaNodeExtended>
-            treeRoot={searchedSourceSchemaTreeRoot}
+            // Add one extra root layer so schemaTreeRoot is shown as well
+            // Can safely typecast as only the children[] are used from root
+            treeRoot={{ children: [searchedSourceSchemaTreeRoot] } as SchemaNodeExtended}
             nodeContent={(node: SchemaNodeExtended) => (
               <SourceSchemaTreeItem
                 node={node}

--- a/libs/data-mapper/src/lib/components/targetSchemaPane/TargetSchemaPane.tsx
+++ b/libs/data-mapper/src/lib/components/targetSchemaPane/TargetSchemaPane.tsx
@@ -136,7 +136,9 @@ export const TargetSchemaPane = ({ isExpanded, setIsExpanded }: TargetSchemaPane
           <TreeHeader onSearch={setTargetSchemaSearchTerm} onClear={() => setTargetSchemaSearchTerm('')} />
 
           <Tree<SchemaNodeExtended>
-            treeRoot={searchedTargetSchemaTreeRoot}
+            // Add one extra root layer so schemaTreeRoot is shown as well
+            // Can safely typecast as only the children[] are used from root
+            treeRoot={{ children: [searchedTargetSchemaTreeRoot] } as SchemaNodeExtended}
             nodeContent={(node: SchemaNodeExtended) => (
               <TargetSchemaTreeItem node={node} status={toggledStatesDictionary[node.key]} onClick={() => handleItemClick(node)} />
             )}

--- a/libs/data-mapper/src/lib/core/state/DataMapSlice.ts
+++ b/libs/data-mapper/src/lib/core/state/DataMapSlice.ts
@@ -125,10 +125,8 @@ export const dataMapSlice = createSlice({
       } else {
         state.curDataMapOperation.targetSchema = action.payload.schema;
         state.curDataMapOperation.flattenedTargetSchema = flattenedSchema;
-        state.curDataMapOperation.currentTargetSchemaNode = action.payload.schema.schemaTreeRoot;
         state.pristineDataMap.targetSchema = action.payload.schema;
         state.pristineDataMap.flattenedTargetSchema = flattenedSchema;
-        state.pristineDataMap.currentTargetSchemaNode = action.payload.schema.schemaTreeRoot;
       }
     },
 
@@ -147,7 +145,7 @@ export const dataMapSlice = createSlice({
         flattenedTargetSchema,
         dataMapConnections: dataMapConnections ?? {},
         currentSourceSchemaNodes: [],
-        currentTargetSchemaNode: targetSchema.schemaTreeRoot,
+        currentTargetSchemaNode: undefined,
       };
 
       state.curDataMapOperation = newState;
@@ -241,7 +239,7 @@ export const dataMapSlice = createSlice({
       doDataMapOperation(state, newState);
     },
 
-    setCurrentTargetSchemaNode: (state, action: PayloadAction<SchemaNodeExtended>) => {
+    setCurrentTargetSchemaNode: (state, action: PayloadAction<SchemaNodeExtended | undefined>) => {
       const currentTargetSchemaNode = state.curDataMapOperation.currentTargetSchemaNode;
       const newTargetSchemaNode = action.payload;
 

--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -128,7 +128,7 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
   }, [currentConnections, sourceSchema, targetSchema]);
 
   const showMapOverview = useMemo<boolean>(
-    () => !sourceSchema || !targetSchema || (!!currentTargetSchemaNode && currentTargetSchemaNode.key === targetSchema.schemaTreeRoot.key),
+    () => !sourceSchema || !targetSchema || !currentTargetSchemaNode,
     [sourceSchema, targetSchema, currentTargetSchemaNode]
   );
 

--- a/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
+++ b/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
@@ -299,7 +299,7 @@ export const useOverviewLayout = (
         schemaNode: parentSchemaNode,
         schemaType,
         displayHandle: false,
-        displayChevron: false,
+        displayChevron: schemaType === SchemaType.Target && !!shouldTargetSchemaDisplayChevrons,
         isLeaf: false,
         isChild: false,
         disabled: false,


### PR DESCRIPTION
It just makes sense, see the gif:

![OverviewSchemaRoot](https://user-images.githubusercontent.com/49288482/200825791-58619ee9-53b6-4abc-a67f-68cc452f3405.gif)
