### PR TITLE
[DM | ReactFlow] Better fitView + remove edge updating

### DIFF
--- a/libs/data-mapper/src/lib/core/state/DataMapSlice.ts
+++ b/libs/data-mapper/src/lib/core/state/DataMapSlice.ts
@@ -446,6 +446,7 @@ export const dataMapSlice = createSlice({
       doDataMapOperation(state, newState);
     },
 
+    /* DEPRECATED: Will be removed in the near future once it's certain it won't be used again elsewhere
     // NOTE: Specifically for dragging existing connection to a new target
     changeConnection: (state, action: PayloadAction<ConnectionAction & DeleteConnectionAction>) => {
       const newState: DataMapOperationState = {
@@ -458,6 +459,7 @@ export const dataMapSlice = createSlice({
 
       doDataMapOperation(state, newState);
     },
+    */
 
     updateConnectionInput: (state, action: PayloadAction<UpdateConnectionInputAction>) => {
       const newState: DataMapOperationState = {
@@ -470,6 +472,7 @@ export const dataMapSlice = createSlice({
       doDataMapOperation(state, newState);
     },
 
+    /* DEPRECATED: Will be removed in the near future once it's certain it won't be used again elsewhere
     deleteConnection: (state, action: PayloadAction<DeleteConnectionAction>) => {
       const newState: DataMapOperationState = {
         ...state.curDataMapOperation,
@@ -481,6 +484,7 @@ export const dataMapSlice = createSlice({
       doDataMapOperation(state, newState);
       state.notificationData = { type: NotificationTypes.ConnectionDeleted, autoHideDurationMs: deletedNotificationAutoHideDuration };
     },
+    */
 
     undoDataMapOperation: (state) => {
       const lastDataMap = state.undoStack.pop();
@@ -566,9 +570,7 @@ export const {
   setSelectedItem,
   addFunctionNode,
   makeConnection,
-  changeConnection,
   updateConnectionInput,
-  deleteConnection,
   undoDataMapOperation,
   redoDataMapOperation,
   saveDataMap,

--- a/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
+++ b/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
@@ -158,7 +158,7 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
         borderRadius: tokens.borderRadiusMedium,
       }}
       onEdgeClick={onEdgeClick}
-      fitViewOptions={{ maxZoom: defaultCanvasZoom }}
+      fitViewOptions={{ maxZoom: defaultCanvasZoom, includeHiddenNodes: true }}
       fitView
     >
       <CanvasToolbox canvasBlockHeight={canvasBlockHeight} />

--- a/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
+++ b/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
@@ -14,8 +14,6 @@ import {
   targetPrefix,
 } from '../constants/ReactFlowConstants';
 import {
-  changeConnection,
-  deleteConnection,
   deleteCurrentlySelectedItem,
   hideNotification,
   makeConnection,
@@ -29,7 +27,7 @@ import { useLayout } from '../utils/ReactFlow.Util';
 import { tokens } from '@fluentui/react-components';
 import { useBoolean } from '@fluentui/react-hooks';
 import type { KeyboardEventHandler, MouseEvent as ReactMouseEvent } from 'react';
-import React, { useCallback, useRef } from 'react';
+import React, { useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type {
   Connection as ReactFlowConnection,
@@ -65,7 +63,6 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
   const [displayMiniMap, { toggle: toggleDisplayMiniMap }] = useBoolean(false);
 
   const reactFlowRef = useRef<HTMLDivElement>(null);
-  const edgeUpdateSuccessful = useRef(true);
 
   const onPaneClick = (_event: ReactMouseEvent | MouseEvent | TouchEvent): void => {
     // If user clicks on pane (empty canvas area), "deselect" node
@@ -114,49 +111,6 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
     dispatch(setSourceNodeConnectionBeingDrawnFromId(undefined));
   };
 
-  const onEdgeUpdateStart = useCallback(() => {
-    edgeUpdateSuccessful.current = false;
-  }, []);
-
-  const onEdgeUpdate = useCallback(
-    (oldEdge: ReactFlowEdge, newConnection: ReactFlowConnection) => {
-      edgeUpdateSuccessful.current = true;
-      if (newConnection.target && newConnection.source && oldEdge.target) {
-        const source = newConnection.source.startsWith(sourcePrefix)
-          ? flattenedSourceSchema[newConnection.source]
-          : currentFunctionNodes[newConnection.source];
-        const destination = newConnection.target.startsWith(targetPrefix)
-          ? flattenedTargetSchema[newConnection.target]
-          : currentFunctionNodes[newConnection.target];
-
-        dispatch(
-          changeConnection({
-            destination,
-            source,
-            reactFlowDestination: newConnection.target,
-            reactFlowSource: newConnection.source,
-            connectionKey: oldEdge.target,
-            inputKey: oldEdge.source,
-          })
-        );
-      }
-    },
-    [dispatch, flattenedSourceSchema, flattenedTargetSchema, currentFunctionNodes]
-  );
-
-  const onEdgeUpdateEnd = useCallback(
-    (_: any, edge: ReactFlowEdge) => {
-      if (!edgeUpdateSuccessful.current) {
-        if (edge.target) {
-          dispatch(deleteConnection({ connectionKey: edge.target, inputKey: edge.source }));
-        }
-      }
-
-      edgeUpdateSuccessful.current = true;
-    },
-    [dispatch]
-  );
-
   const onEdgeClick = (_event: React.MouseEvent, node: ReactFlowEdge) => {
     dispatch(setSelectedItem(node.id));
   };
@@ -203,9 +157,6 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
         backgroundSize: '22px 22px',
         borderRadius: tokens.borderRadiusMedium,
       }}
-      onEdgeUpdate={onEdgeUpdate}
-      onEdgeUpdateStart={onEdgeUpdateStart}
-      onEdgeUpdateEnd={onEdgeUpdateEnd}
       onEdgeClick={onEdgeClick}
       fitViewOptions={{ maxZoom: defaultCanvasZoom }}
       fitView

--- a/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
+++ b/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
@@ -18,6 +18,21 @@ import { useEffect, useState } from 'react';
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from 'reactflow';
 import { Position } from 'reactflow';
 
+// Hidden dummy node placed at 0,0 (same as source schema block) to allow initial load fitView to center diagram
+// NOTE: Not documented, but hidden nodes need a width/height to properly affect fitView when includeHiddenNodes option is true
+const placeholderReactFlowNode: ReactFlowNode = {
+  id: 'layouting-&-Placeholder',
+  hidden: true,
+  sourcePosition: Position.Right,
+  data: null,
+  width: 10,
+  height: 10,
+  position: {
+    x: 0,
+    y: 0,
+  },
+};
+
 export const useLayout = (
   currentSourceSchemaNodes: SchemaNodeExtended[],
   allSourceSchemaNodes: SchemaNodeDictionary,
@@ -53,9 +68,16 @@ export const useLayout = (
         .then((layoutedElkTree) => {
           // Convert newly-calculated ELK node data to React Flow nodes
           // NOTE: edges were only used to aid ELK in layout calculation, ReactFlow still handles creating/routing/etc them
-          setReactFlowNodes(
-            convertToReactFlowNodes(layoutedElkTree, sortedSourceSchemaNodes, currentFunctionNodes, currentTargetSchemaNode, connections)
-          );
+          setReactFlowNodes([
+            placeholderReactFlowNode,
+            ...convertToReactFlowNodes(
+              layoutedElkTree,
+              sortedSourceSchemaNodes,
+              currentFunctionNodes,
+              currentTargetSchemaNode,
+              connections
+            ),
+          ]);
         })
         .catch((error) => {
           console.error(`Elk Layout Error: ${error}`);


### PR DESCRIPTION
-Remove edge updating behavior (deprecated/removed from requirements)

-Use a hidden dummy placeholder node for ReactFlow so the initial fitView centers the entire diagram, not just the target schema (we've already been doing this with elk.js layouting with no issues, but many benefits!)

![HiddenDummyNodeFitView](https://user-images.githubusercontent.com/49288482/200839021-8e1d137d-096b-4a50-91db-3f888f06371f.gif)
