### PR TITLE
[DM | Trees] Migrate Function List to Tree (from FluentV8 GroupedList)

### DIFF
--- a/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
+++ b/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
@@ -7,9 +7,10 @@ import { ButtonPivot } from '../buttonPivot/ButtonPivot';
 import { FloatingPanel } from '../floatingPanel/FloatingPanel';
 import type { FloatingPanelProps } from '../floatingPanel/FloatingPanel';
 import { FunctionList } from '../functionList/FunctionList';
-import SourceSchemaTreeItem from '../tree/SourceSchemaTreeItem';
+import SourceSchemaTreeItem, { useSchemaTreeItemStyles } from '../tree/SourceSchemaTreeItem';
 import Tree from '../tree/Tree';
 import { TreeHeader } from '../tree/TreeHeader';
+import { mergeClasses, tokens } from '@fluentui/react-components';
 import type { SelectTabData, SelectTabEvent } from '@fluentui/react-components';
 import { CubeTree20Filled, CubeTree20Regular, MathFormula20Filled, MathFormula20Regular } from '@fluentui/react-icons';
 import { useCallback, useMemo, useState } from 'react';
@@ -35,6 +36,7 @@ interface CanvasToolboxProps {
 export const CanvasToolbox = ({ canvasBlockHeight }: CanvasToolboxProps) => {
   const intl = useIntl();
   const dispatch = useDispatch<AppDispatch>();
+  const schemaNodeItemStyles = useSchemaTreeItemStyles();
 
   const toolboxTabToDisplay = useSelector((state: RootState) => state.dataMap.canvasToolboxTabToDisplay);
   const sourceSchema = useSelector((state: RootState) => state.dataMap.curDataMapOperation.sourceSchema);
@@ -156,9 +158,15 @@ export const CanvasToolbox = ({ canvasBlockHeight }: CanvasToolboxProps) => {
               <SourceSchemaTreeItem
                 node={node}
                 isNodeAdded={currentSourceSchemaNodes.some((srcSchemaNode) => srcSchemaNode.key === node.key)}
-                onClick={() => onSourceSchemaItemClick(node)}
               />
             )}
+            onClickItem={(node) => onSourceSchemaItemClick(node)}
+            nodeContainerClassName={mergeClasses(schemaNodeItemStyles.nodeContainer, schemaNodeItemStyles.sourceSchemaNode)}
+            nodeContainerStyle={(node) => ({
+              backgroundColor: currentSourceSchemaNodes.some((srcSchemaNode) => srcSchemaNode.key === node.key)
+                ? tokens.colorBrandBackground2
+                : undefined,
+            })}
           />
         </FloatingPanel>
       )}

--- a/libs/data-mapper/src/lib/components/functionList/FunctionList.tsx
+++ b/libs/data-mapper/src/lib/components/functionList/FunctionList.tsx
@@ -141,9 +141,12 @@ export const FunctionList = () => {
           node.key.startsWith(functionCategoryItemKeyPrefix) ? (
             <FunctionListHeader category={node.key.replace(functionCategoryItemKeyPrefix, '') as FunctionCategory} />
           ) : (
-            <FunctionListItem functionData={node} onFunctionClick={onFunctionItemClick} />
+            <FunctionListItem functionData={node} />
           )
         }
+        childPadding={0}
+        onClickItem={(node) => !node.key.startsWith(functionCategoryItemKeyPrefix) && onFunctionItemClick(node)}
+        parentItemClickShouldExpand
       />
     </>
   );

--- a/libs/data-mapper/src/lib/components/functionList/FunctionListHeader.tsx
+++ b/libs/data-mapper/src/lib/components/functionList/FunctionListHeader.tsx
@@ -7,6 +7,8 @@ const useStyles = makeStyles({
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     color: tokens.colorNeutralForeground1,
     paddingLeft: tokens.spacingHorizontalXS,
+    marginTop: '8px',
+    marginBottom: '8px',
   },
 });
 

--- a/libs/data-mapper/src/lib/components/functionList/FunctionListHeader.tsx
+++ b/libs/data-mapper/src/lib/components/functionList/FunctionListHeader.tsx
@@ -1,0 +1,23 @@
+import type { FunctionCategory } from '../../models/Function';
+import { makeStyles, shorthands, Text, tokens, typographyStyles } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  header: {
+    ...typographyStyles.caption1,
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    color: tokens.colorNeutralForeground1,
+    paddingLeft: tokens.spacingHorizontalXS,
+  },
+});
+
+interface FunctionListHeaderProps {
+  category: FunctionCategory;
+}
+
+const FunctionListHeader = ({ category }: FunctionListHeaderProps) => {
+  const styles = useStyles();
+
+  return <Text className={styles.header}>{category}</Text>;
+};
+
+export default FunctionListHeader;

--- a/libs/data-mapper/src/lib/components/functionList/FunctionListItem.tsx
+++ b/libs/data-mapper/src/lib/components/functionList/FunctionListItem.tsx
@@ -17,6 +17,9 @@ const useCardStyles = makeStyles({
     ':hover': {
       backgroundColor: tokens.colorNeutralBackground1Hover,
     },
+    '&:hover .fui-Text': {
+      ...typographyStyles.caption1Strong,
+    },
   },
   iconContainer: {
     height: fnIconSize,
@@ -33,18 +36,14 @@ const useCardStyles = makeStyles({
     paddingLeft: '4px',
     paddingRight: '4px',
     ...shorthands.overflow('hidden'),
-    ':hover': {
-      ...typographyStyles.caption1Strong,
-    },
   },
 });
 
 interface FunctionListItemProps {
   functionData: FunctionData;
-  onFunctionClick: (functionNode: FunctionData) => void;
 }
 
-const FunctionListItem = ({ functionData, onFunctionClick }: FunctionListItemProps) => {
+const FunctionListItem = ({ functionData }: FunctionListItemProps) => {
   const cardStyles = useCardStyles();
 
   const fnBranding = getFunctionBrandingForCategory(functionData.category);
@@ -52,14 +51,7 @@ const FunctionListItem = ({ functionData, onFunctionClick }: FunctionListItemPro
   const fnIcon = getIconForFunction(functionData.displayName, undefined, fnBranding);
 
   return (
-    <Button
-      key={functionData.key}
-      alt-text={functionData.displayName}
-      className={cardStyles.button}
-      onClick={() => {
-        onFunctionClick(functionData);
-      }}
-    >
+    <Button key={functionData.key} alt-text={functionData.displayName} className={cardStyles.button}>
       <div className={cardStyles.iconContainer} style={{ backgroundColor: customTokens[fnBranding.colorTokenName] }}>
         {fnIcon}
       </div>

--- a/libs/data-mapper/src/lib/components/functionList/FunctionListItem.tsx
+++ b/libs/data-mapper/src/lib/components/functionList/FunctionListItem.tsx
@@ -5,18 +5,28 @@ import { getIconForFunction } from '../../utils/Icon.Utils';
 import { DMTooltip } from '../tooltip/tooltip';
 import { Button, Caption1, makeStyles, shorthands, tokens, typographyStyles } from '@fluentui/react-components';
 
+const fnIconSize = '28px';
+
 const useCardStyles = makeStyles({
   button: {
-    width: '100%',
     height: '40px',
     backgroundColor: tokens.colorNeutralBackground1,
     display: 'flex',
-    justifyContent: 'left',
     ...shorthands.border('0px'),
     ...shorthands.padding('1px 4px 1px 4px'),
     ':hover': {
       backgroundColor: tokens.colorNeutralBackground1Hover,
     },
+  },
+  iconContainer: {
+    height: fnIconSize,
+    flexShrink: '0 !important',
+    flexBasis: fnIconSize,
+    ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    color: tokens.colorNeutralBackground1,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   text: {
     width: '180px',
@@ -29,16 +39,17 @@ const useCardStyles = makeStyles({
   },
 });
 
-const fnIconSize = '28px';
-
-interface FunctionListCellProps {
+interface FunctionListItemProps {
   functionData: FunctionData;
   onFunctionClick: (functionNode: FunctionData) => void;
 }
 
-const FunctionListCell = ({ functionData, onFunctionClick }: FunctionListCellProps) => {
+const FunctionListItem = ({ functionData, onFunctionClick }: FunctionListItemProps) => {
   const cardStyles = useCardStyles();
-  const branding = getFunctionBrandingForCategory(functionData.category);
+
+  const fnBranding = getFunctionBrandingForCategory(functionData.category);
+  // TODO: undefined -> functionData.iconFileName once all SVGs in
+  const fnIcon = getIconForFunction(functionData.displayName, undefined, fnBranding);
 
   return (
     <Button
@@ -49,32 +60,19 @@ const FunctionListCell = ({ functionData, onFunctionClick }: FunctionListCellPro
         onFunctionClick(functionData);
       }}
     >
-      <span
-        style={{
-          backgroundColor: customTokens[branding.colorTokenName],
-          height: fnIconSize,
-          width: fnIconSize,
-          borderRadius: '50%',
-        }}
-      >
-        <div style={{ paddingTop: '4px', color: tokens.colorNeutralBackground1 }}>
-          {
-            getIconForFunction(
-              functionData.displayName,
-              undefined,
-              branding
-            ) /* TODO: undefined -> functionData.iconFileName once all SVGs in */
-          }
-        </div>
-      </span>
+      <div className={cardStyles.iconContainer} style={{ backgroundColor: customTokens[fnBranding.colorTokenName] }}>
+        {fnIcon}
+      </div>
+
       <Caption1 truncate block className={cardStyles.text}>
         {functionData.displayName}
       </Caption1>
-      <span style={{ justifyContent: 'right' }}>
+
+      <span style={{ marginLeft: 'auto' }}>
         <DMTooltip text={functionData.description} />
       </span>
     </Button>
   );
 };
 
-export default FunctionListCell;
+export default FunctionListItem;

--- a/libs/data-mapper/src/lib/components/targetSchemaPane/TargetSchemaPane.tsx
+++ b/libs/data-mapper/src/lib/components/targetSchemaPane/TargetSchemaPane.tsx
@@ -3,12 +3,13 @@ import type { AppDispatch, RootState } from '../../core/state/Store';
 import { NormalizedDataType, SchemaNodeDataType } from '../../models';
 import type { SchemaNodeExtended } from '../../models';
 import { searchSchemaTreeFromRoot } from '../../utils/Schema.Utils';
+import { useSchemaTreeItemStyles } from '../tree/SourceSchemaTreeItem';
 import TargetSchemaTreeItem, { ItemToggledState } from '../tree/TargetSchemaTreeItem';
 import type { NodeToggledStateDictionary } from '../tree/TargetSchemaTreeItem';
 import Tree from '../tree/Tree';
 import { TreeHeader } from '../tree/TreeHeader';
 import { Stack } from '@fluentui/react';
-import { Button, makeStyles, shorthands, Text, tokens, typographyStyles } from '@fluentui/react-components';
+import { Button, makeStyles, mergeClasses, shorthands, Text, tokens, typographyStyles } from '@fluentui/react-components';
 import { ChevronDoubleLeft20Regular, ChevronDoubleRight20Regular } from '@fluentui/react-icons';
 import { useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -40,11 +41,13 @@ export type TargetSchemaPaneProps = {
 export const TargetSchemaPane = ({ isExpanded, setIsExpanded }: TargetSchemaPaneProps) => {
   const intl = useIntl();
   const styles = useStyles();
+  const schemaNodeItemStyles = useSchemaTreeItemStyles();
   const dispatch = useDispatch<AppDispatch>();
 
   const targetSchema = useSelector((state: RootState) => state.dataMap.curDataMapOperation.targetSchema);
   const targetSchemaDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.flattenedTargetSchema);
   const connectionDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.dataMapConnections);
+  const currentTargetSchemaNode = useSelector((state: RootState) => state.dataMap.curDataMapOperation.currentTargetSchemaNode);
 
   const [toggledStatesDictionary, setToggledStatesDictionary] = useState<NodeToggledStateDictionary | undefined>({});
   const [targetSchemaSearchTerm, setTargetSchemaSearchTerm] = useState<string>('');
@@ -54,7 +57,7 @@ export const TargetSchemaPane = ({ isExpanded, setIsExpanded }: TargetSchemaPane
     description: 'Target schema',
   });
 
-  const handleItemClick = (schemaNode: SchemaNodeExtended) => {
+  const onTargetSchemaItemClick = (schemaNode: SchemaNodeExtended) => {
     dispatch(setCurrentTargetSchemaNode(schemaNode));
   };
 
@@ -139,9 +142,16 @@ export const TargetSchemaPane = ({ isExpanded, setIsExpanded }: TargetSchemaPane
             // Add one extra root layer so schemaTreeRoot is shown as well
             // Can safely typecast as only the children[] are used from root
             treeRoot={{ children: [searchedTargetSchemaTreeRoot] } as SchemaNodeExtended}
-            nodeContent={(node: SchemaNodeExtended) => (
-              <TargetSchemaTreeItem node={node} status={toggledStatesDictionary[node.key]} onClick={() => handleItemClick(node)} />
-            )}
+            nodeContent={(node: SchemaNodeExtended) => <TargetSchemaTreeItem node={node} status={toggledStatesDictionary[node.key]} />}
+            onClickItem={(node) => onTargetSchemaItemClick(node)}
+            nodeContainerClassName={mergeClasses(schemaNodeItemStyles.nodeContainer, schemaNodeItemStyles.targetSchemaNode)}
+            nodeContainerStyle={(node) =>
+              node.key === currentTargetSchemaNode?.key
+                ? {
+                    backgroundColor: tokens.colorNeutralBackground4Selected,
+                  }
+                : {}
+            }
           />
         </div>
       )}

--- a/libs/data-mapper/src/lib/components/tree/SourceSchemaTreeItem.tsx
+++ b/libs/data-mapper/src/lib/components/tree/SourceSchemaTreeItem.tsx
@@ -1,9 +1,8 @@
 import type { SchemaNodeExtended } from '../../models';
 import { iconForSchemaNodeDataType } from '../../utils/Icon.Utils';
 import { Stack } from '@fluentui/react';
-import { makeStyles, mergeClasses, shorthands, Text, tokens, typographyStyles } from '@fluentui/react-components';
+import { makeStyles, shorthands, Text, tokens, typographyStyles } from '@fluentui/react-components';
 import { CheckmarkCircle16Filled, Circle16Regular } from '@fluentui/react-icons';
-import { useState } from 'react';
 
 export const useSchemaTreeItemStyles = makeStyles({
   nodeContainer: {
@@ -11,9 +10,11 @@ export const useSchemaTreeItemStyles = makeStyles({
     width: '100%',
     height: '28px',
     ...shorthands.padding('4px', '6px'),
-    ...shorthands.borderRadius(`${tokens.borderRadiusMedium}`),
-    ':hover': {
-      cursor: 'pointer',
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    marginTop: '2px',
+    marginBottom: '2px',
+    '&:hover .fui-Text': {
+      ...typographyStyles.caption1Strong,
     },
   },
   sourceSchemaNode: {
@@ -44,6 +45,7 @@ export const useSchemaTreeItemStyles = makeStyles({
   indicator: {
     height: '16px',
     width: '2px',
+    flexShrink: `0 !important`,
     ...shorthands.borderRadius(tokens.borderRadiusSmall),
     backgroundColor: tokens.colorBrandForeground1,
     marginRight: '4px',
@@ -53,34 +55,22 @@ export const useSchemaTreeItemStyles = makeStyles({
 interface SourceSchemaTreeItemProps {
   node: SchemaNodeExtended;
   isNodeAdded: boolean;
-  onClick: () => void;
 }
 
-const SourceSchemaTreeItem = ({ node, isNodeAdded, onClick }: SourceSchemaTreeItemProps) => {
+const SourceSchemaTreeItem = ({ node, isNodeAdded }: SourceSchemaTreeItemProps) => {
   const styles = useSchemaTreeItemStyles();
-  const [isContainerHovered, setIsContainerHovered] = useState(false);
 
   const BundledTypeIcon = iconForSchemaNodeDataType(node.schemaNodeDataType, 16, true, node.nodeProperties);
 
   return (
-    <Stack
-      className={mergeClasses(styles.nodeContainer, styles.sourceSchemaNode)}
-      style={{ backgroundColor: isNodeAdded ? tokens.colorBrandBackground2 : undefined }}
-      onClick={onClick}
-      onMouseEnter={() => setIsContainerHovered(true)}
-      onMouseLeave={() => setIsContainerHovered(false)}
-      horizontal
-      verticalAlign="center"
-    >
+    <Stack horizontal verticalAlign="center" style={{ width: '100%', minWidth: 0 }}>
       <BundledTypeIcon
         className={styles.dataTypeIcon}
         style={{ color: isNodeAdded ? tokens.colorBrandForeground1 : undefined }}
         filled={isNodeAdded ? true : undefined}
       />
 
-      <Text className={styles.nodeName} style={isContainerHovered ? { ...typographyStyles.caption1Strong } : undefined}>
-        {node.name}
-      </Text>
+      <Text className={styles.nodeName}>{node.name}</Text>
 
       <span style={{ display: 'flex', position: 'sticky', right: 10 }}>
         {isNodeAdded ? (

--- a/libs/data-mapper/src/lib/components/tree/TargetSchemaTreeItem.tsx
+++ b/libs/data-mapper/src/lib/components/tree/TargetSchemaTreeItem.tsx
@@ -3,9 +3,9 @@ import type { SchemaNodeExtended } from '../../models';
 import { iconForSchemaNodeDataType } from '../../utils/Icon.Utils';
 import { useSchemaTreeItemStyles } from './SourceSchemaTreeItem';
 import { Stack } from '@fluentui/react';
-import { mergeClasses, Text, tokens, typographyStyles } from '@fluentui/react-components';
+import { Text, tokens } from '@fluentui/react-components';
 import { CheckmarkCircle12Filled, CircleHalfFill12Regular, Circle12Regular } from '@fluentui/react-icons';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 export type NodeToggledStateDictionary = { [key: string]: ItemToggledState };
@@ -18,15 +18,12 @@ export enum ItemToggledState {
 interface TargetSchemaTreeItemProps {
   node: SchemaNodeExtended;
   status: ItemToggledState;
-  onClick: () => void;
 }
 
-const TargetSchemaTreeItem = ({ node, status, onClick }: TargetSchemaTreeItemProps) => {
+const TargetSchemaTreeItem = ({ node, status }: TargetSchemaTreeItemProps) => {
   const styles = useSchemaTreeItemStyles();
 
   const currentTargetSchemaNode = useSelector((state: RootState) => state.dataMap.curDataMapOperation.currentTargetSchemaNode);
-
-  const [isContainerHovered, setIsContainerHovered] = useState(false);
 
   const isItemCurrentNode = useMemo(() => currentTargetSchemaNode?.key === node.key, [currentTargetSchemaNode, node]);
 
@@ -46,15 +43,7 @@ const TargetSchemaTreeItem = ({ node, status, onClick }: TargetSchemaTreeItemPro
   const BundledTypeIcon = iconForSchemaNodeDataType(node.schemaNodeDataType, 16, true, node.nodeProperties);
 
   return (
-    <Stack
-      className={mergeClasses(styles.nodeContainer, styles.targetSchemaNode)}
-      style={{ backgroundColor: isItemCurrentNode ? tokens.colorNeutralBackground4Selected : undefined }}
-      onClick={onClick}
-      onMouseEnter={() => setIsContainerHovered(true)}
-      onMouseLeave={() => setIsContainerHovered(false)}
-      horizontal
-      verticalAlign="center"
-    >
+    <Stack horizontal verticalAlign="center">
       <div className={styles.indicator} style={{ visibility: isItemCurrentNode ? 'visible' : 'hidden' }} />
 
       <span style={{ marginRight: '4px', marginTop: '2px' }}>{statusIcon}</span>
@@ -67,9 +56,7 @@ const TargetSchemaTreeItem = ({ node, status, onClick }: TargetSchemaTreeItemPro
         />
       </div>
 
-      <Text className={styles.nodeName} style={isContainerHovered ? { ...typographyStyles.caption1Strong } : undefined}>
-        {node.name}
-      </Text>
+      <Text className={styles.nodeName}>{node.name}</Text>
     </Stack>
   );
 };

--- a/libs/data-mapper/src/lib/components/tree/Tree.tsx
+++ b/libs/data-mapper/src/lib/components/tree/Tree.tsx
@@ -17,28 +17,28 @@ export const useTreeStyles = makeStyles({
   },
 });
 
-interface TreeProps<T> {
-  treeRoot: T;
+export interface CoreTreeProps<T> {
   nodeContent: (node: T) => ReactNode;
-  treeContainerClassName?: string;
   nodeContainerClassName?: string;
+  nodeContainerStyle?: (node: T) => React.CSSProperties;
+  childPadding?: number; // 0 will also not render hidden chevrons (meaning the space is recouped) - used in FxList
+  onClickItem?: (node: T) => void;
+  parentItemClickShouldExpand?: boolean;
 }
 
-const Tree = <T extends ITreeNode<T>>({ treeRoot, nodeContent, treeContainerClassName, nodeContainerClassName }: TreeProps<T>) => {
+interface TreeProps<T> extends CoreTreeProps<T> {
+  treeRoot: T;
+  treeContainerClassName?: string;
+}
+
+const Tree = <T extends ITreeNode<T>>(props: TreeProps<T>) => {
+  const { treeRoot, treeContainerClassName } = props;
   const styles = useTreeStyles();
 
   return (
     <div className={mergeClasses(styles.treeContainer, treeContainerClassName)}>
       {treeRoot.children &&
-        treeRoot.children.map((childNode) => (
-          <TreeBranch<T>
-            key={childNode.key}
-            level={0}
-            node={childNode}
-            nodeContent={nodeContent}
-            nodeContainerClassName={nodeContainerClassName}
-          />
-        ))}
+        treeRoot.children.map((childNode) => <TreeBranch<T> {...props} key={childNode.key} level={0} node={childNode} />)}
     </div>
   );
 };

--- a/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
+++ b/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
@@ -41,7 +41,9 @@ const TreeBranch = <T extends ITreeNode<T>>({ level, node, nodeContent, nodeCont
 
       {hasChildren &&
         isExpanded &&
-        node.children?.map((childNode) => <TreeBranch<T> key={node.key} node={childNode} level={level + 1} nodeContent={nodeContent} />)}
+        node.children?.map((childNode) => (
+          <TreeBranch<T> key={childNode.key} node={childNode} level={level + 1} nodeContent={nodeContent} />
+        ))}
     </>
   );
 };

--- a/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
+++ b/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
@@ -1,39 +1,71 @@
 import { useTreeStyles } from './Tree';
-import type { ITreeNode } from './Tree';
+import type { ITreeNode, CoreTreeProps } from './Tree';
 import { Stack } from '@fluentui/react';
 import { Button, mergeClasses } from '@fluentui/react-components';
 import { useBoolean } from '@fluentui/react-hooks';
 import { ChevronDown20Regular, ChevronRight20Regular } from '@fluentui/react-icons';
-import { useMemo } from 'react';
-import type { ReactNode } from 'react';
+import React, { useMemo } from 'react';
 
-interface TreeBranchProps<T> {
+const defaultChildPadding = 16;
+
+interface TreeBranchProps<T> extends CoreTreeProps<T> {
   level: number;
   node: T;
-  nodeContent: (node: T) => ReactNode;
-  nodeContainerClassName?: string;
 }
 
-const TreeBranch = <T extends ITreeNode<T>>({ level, node, nodeContent, nodeContainerClassName }: TreeBranchProps<T>) => {
+const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
+  const {
+    level,
+    node,
+    nodeContent,
+    nodeContainerClassName,
+    nodeContainerStyle,
+    childPadding = defaultChildPadding,
+    onClickItem,
+    parentItemClickShouldExpand,
+  } = props;
   const styles = useTreeStyles();
   const [isExpanded, { toggle: toggleExpanded }] = useBoolean(false);
 
   const hasChildren = useMemo<boolean>(() => !!(node.children && node.children.length > 0), [node]);
 
+  const handleItemClick = () => {
+    if (hasChildren && parentItemClickShouldExpand) {
+      toggleExpanded();
+    }
+
+    if (onClickItem) {
+      onClickItem(node);
+    }
+  };
+
+  const handleChevronClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    toggleExpanded();
+  };
+
   return (
     <>
       <Stack
         className={mergeClasses(styles.nodeContainer, nodeContainerClassName)}
-        style={{ paddingLeft: `${level * 16}px` }}
+        style={{
+          ...(nodeContainerStyle ? nodeContainerStyle(node) : {}),
+          paddingLeft: `${level * childPadding}px`,
+          cursor: onClickItem || !!parentItemClickShouldExpand ? 'pointer' : undefined,
+        }}
         horizontal
         verticalAlign="center"
+        onClick={handleItemClick}
       >
         <Button
-          appearance="subtle"
+          appearance="transparent"
           size="small"
           icon={isExpanded ? <ChevronDown20Regular /> : <ChevronRight20Regular />}
-          onClick={toggleExpanded}
-          style={{ visibility: hasChildren ? 'visible' : 'hidden' }}
+          onClick={handleChevronClick}
+          style={{
+            visibility: hasChildren ? 'visible' : 'hidden',
+            display: childPadding === 0 && !hasChildren ? 'none' : undefined,
+          }}
         />
 
         {nodeContent(node)}
@@ -41,9 +73,7 @@ const TreeBranch = <T extends ITreeNode<T>>({ level, node, nodeContent, nodeCont
 
       {hasChildren &&
         isExpanded &&
-        node.children?.map((childNode) => (
-          <TreeBranch<T> key={childNode.key} node={childNode} level={level + 1} nodeContent={nodeContent} />
-        ))}
+        node.children?.map((childNode) => <TreeBranch<T> {...props} key={childNode.key} node={childNode} level={level + 1} />)}
     </>
   );
 };


### PR DESCRIPTION
-This should help keep things pretty consistent and easy/quick to change - I was as careful as I could be to still keep the core Tree component pretty generic and reusable while still allowing it to be useful in both typical tree situations (such as the schema trees) and Function List type situations

-Part of this migration/swap was to move some generic, or tree-node-container scoped items, such as styles and the click handler, to the actual node container the Tree wraps the nodeComponent prop in

- @refortie You can now click the Function List header to expand it - you're welcome :)

Pics or it didn't happen (what's that - you can barely tell a difference from the way it was? That's mostly the point :P):
![image](https://user-images.githubusercontent.com/49288482/200956727-d198a5c0-84d6-4e22-950d-b3d55e6c9131.png)

![image](https://user-images.githubusercontent.com/49288482/200956749-282f2290-da66-4a75-b63c-79b32876ee3e.png)

![image](https://user-images.githubusercontent.com/49288482/200956798-472ead79-f3ad-40d0-b0a0-06b32ac72c9d.png)

![image](https://user-images.githubusercontent.com/49288482/200956850-87781423-8653-453d-99c7-cd4891651a3b.png)
