### PR TITLE
[DM | VSIX] Use workflow-designtime + other e2e refinements

### DIFF
--- a/apps/data-mapper-standalone/src/app/DataMapperStandaloneDesigner.tsx
+++ b/apps/data-mapper-standalone/src/app/DataMapperStandaloneDesigner.tsx
@@ -1,27 +1,30 @@
 import { DevToolbox } from '../components/DevToolbox';
-import type { RootState } from '../state/Store';
+import { dataMapDataLoaderSlice } from '../state/DataMapDataLoader';
+import type { AppDispatch, RootState } from '../state/Store';
 import { FluentProvider, webDarkTheme, webLightTheme } from '@fluentui/react-components';
 import {
   DataMapDataProvider,
   DataMapperDesigner,
   DataMapperDesignerProvider,
   defaultDataMapperApiServiceOptions,
+  getFunctions,
   InitDataMapperApiService,
 } from '@microsoft/logic-apps-data-mapper';
 import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 const workflowSchemaFilenames = ['Source.xsd', 'Target.xsd'];
 
 export const DataMapperStandaloneDesigner = () => {
+  const dispatch = useDispatch<AppDispatch>();
   const theme = useSelector((state: RootState) => state.dataMapDataLoader.theme);
+  const armToken = useSelector((state: RootState) => state.dataMapDataLoader.armToken);
 
   const xsltFilename = useSelector((state: RootState) => state.dataMapDataLoader.xsltFilename);
   const mapDefinition = useSelector((state: RootState) => state.dataMapDataLoader.mapDefinition);
+  const fetchedFunctions = useSelector((state: RootState) => state.dataMapDataLoader.fetchedFunctions);
   const sourceSchema = useSelector((state: RootState) => state.schemaDataLoader.sourceSchema);
   const targetSchema = useSelector((state: RootState) => state.schemaDataLoader.targetSchema);
-
-  const armToken = useSelector((state: RootState) => state.dataMapDataLoader.armToken);
 
   const saveStateCall = (dataMapDefinition: string, dataMapXslt: string) => {
     console.log('Map Definition\n===============');
@@ -31,12 +34,18 @@ export const DataMapperStandaloneDesigner = () => {
   };
 
   useEffect(() => {
+    const fetchFunctionList = async () => {
+      dispatch(dataMapDataLoaderSlice.actions.changeFetchedFunctions(await getFunctions()));
+    };
+
     // Standalone uses default/dev runtime settings - can just run 'func host start' in the workflow root
     InitDataMapperApiService({
       ...defaultDataMapperApiServiceOptions,
       accessToken: armToken,
     });
-  }, [armToken]);
+
+    fetchFunctionList();
+  }, [dispatch, armToken]);
 
   return (
     <div style={{ flex: '1 1 1px', display: 'flex', flexDirection: 'column' }}>
@@ -54,6 +63,7 @@ export const DataMapperStandaloneDesigner = () => {
             sourceSchema={sourceSchema}
             targetSchema={targetSchema}
             availableSchemas={workflowSchemaFilenames}
+            fetchedFunctions={fetchedFunctions}
           >
             <DataMapperDesigner saveStateCall={saveStateCall} />
           </DataMapDataProvider>

--- a/apps/data-mapper-standalone/src/app/DataMapperStandaloneDesigner.tsx
+++ b/apps/data-mapper-standalone/src/app/DataMapperStandaloneDesigner.tsx
@@ -8,6 +8,7 @@ import {
   defaultDataMapperApiServiceOptions,
   InitDataMapperApiService,
 } from '@microsoft/logic-apps-data-mapper';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 const workflowSchemaFilenames = ['Source.xsd', 'Target.xsd'];
@@ -22,17 +23,20 @@ export const DataMapperStandaloneDesigner = () => {
 
   const armToken = useSelector((state: RootState) => state.dataMapDataLoader.armToken);
 
-  InitDataMapperApiService({
-    baseUrl: defaultDataMapperApiServiceOptions.baseUrl,
-    accessToken: armToken,
-  });
-
   const saveStateCall = (dataMapDefinition: string, dataMapXslt: string) => {
     console.log('Map Definition\n===============');
     console.log(dataMapDefinition);
     console.log('\nXSLT\n===============');
     console.log(dataMapXslt);
   };
+
+  useEffect(() => {
+    // Standalone uses default/dev runtime settings - can just run 'func host start' in the workflow root
+    InitDataMapperApiService({
+      ...defaultDataMapperApiServiceOptions,
+      accessToken: armToken,
+    });
+  }, [armToken]);
 
   return (
     <div style={{ flex: '1 1 1px', display: 'flex', flexDirection: 'column' }}>

--- a/apps/data-mapper-standalone/src/state/DataMapDataLoader.ts
+++ b/apps/data-mapper-standalone/src/state/DataMapDataLoader.ts
@@ -1,6 +1,6 @@
 import type { RootState } from './Store';
 import type { IDropdownOption } from '@fluentui/react';
-import type { MapDefinitionEntry } from '@microsoft/logic-apps-data-mapper';
+import type { MapDefinitionEntry, FunctionData } from '@microsoft/logic-apps-data-mapper';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import * as yaml from 'js-yaml';
@@ -14,6 +14,7 @@ export interface DataMapLoadingState {
   loadingMethod: 'file' | 'arm';
   mapDefinition: MapDefinitionEntry;
   xsltFilename: string;
+  fetchedFunctions?: FunctionData[];
 }
 
 const initialState: DataMapLoadingState = {
@@ -58,6 +59,9 @@ export const dataMapDataLoaderSlice = createSlice({
     },
     changeXsltFilename: (state, action: PayloadAction<string>) => {
       state.xsltFilename = action.payload;
+    },
+    changeFetchedFunctions: (state, action: PayloadAction<FunctionData[]>) => {
+      state.fetchedFunctions = action.payload;
     },
   },
   extraReducers: (builder) => {

--- a/apps/vs-code-data-mapper-react/src/app/app.tsx
+++ b/apps/vs-code-data-mapper-react/src/app/app.tsx
@@ -1,7 +1,13 @@
 import { VSCodeContext } from '../WebViewMsgHandler';
 import type { RootState } from '../state/Store';
-import { DataMapDataProvider, DataMapperDesigner, DataMapperDesignerProvider } from '@microsoft/logic-apps-data-mapper';
-import { useCallback, useContext, useState } from 'react';
+import {
+  DataMapDataProvider,
+  DataMapperDesigner,
+  DataMapperDesignerProvider,
+  defaultDataMapperApiServiceOptions,
+  InitDataMapperApiService,
+} from '@microsoft/logic-apps-data-mapper';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 enum VsCodeThemeType {
@@ -27,6 +33,8 @@ export const App = (): JSX.Element => {
   const sourceSchema = useSelector((state: RootState) => state.dataMapDataLoader.sourceSchema);
   const targetSchema = useSelector((state: RootState) => state.dataMapDataLoader.targetSchema);
   const schemaFileList = useSelector((state: RootState) => state.dataMapDataLoader.schemaFileList);
+
+  const runtimePort = useSelector((state: RootState) => state.dataMapDataLoader.runtimePort);
 
   /*
   // Monitor document.body for VS Code theme changes
@@ -68,6 +76,14 @@ export const App = (): JSX.Element => {
       data: dataMapXslt,
     });
   };
+
+  // Init runtime API service
+  useEffect(() => {
+    InitDataMapperApiService({
+      ...defaultDataMapperApiServiceOptions,
+      port: runtimePort ?? defaultDataMapperApiServiceOptions.port,
+    });
+  }, [runtimePort]);
 
   return (
     <DataMapperDesignerProvider locale="en-US" theme={vsCodeTheme === VsCodeThemeType.VsCodeLight ? 'light' : 'dark'} options={{}}>

--- a/apps/vs-code-data-mapper-react/src/app/app.tsx
+++ b/apps/vs-code-data-mapper-react/src/app/app.tsx
@@ -87,12 +87,14 @@ export const App = () => {
       dispatch(dataMapDataLoaderSlice.actions.changeFetchedFunctions(await getFunctions()));
     };
 
-    InitDataMapperApiService({
-      ...defaultDataMapperApiServiceOptions,
-      port: runtimePort ?? defaultDataMapperApiServiceOptions.port,
-    });
+    if (runtimePort) {
+      InitDataMapperApiService({
+        ...defaultDataMapperApiServiceOptions,
+        port: runtimePort ?? defaultDataMapperApiServiceOptions.port,
+      });
 
-    fetchFunctionList();
+      fetchFunctionList();
+    }
   }, [dispatch, runtimePort]);
 
   return (

--- a/apps/vs-code-data-mapper-react/src/main.tsx
+++ b/apps/vs-code-data-mapper-react/src/main.tsx
@@ -2,14 +2,11 @@ import { WebViewMsgHandler } from './WebViewMsgHandler';
 import { App } from './app/app';
 import { store } from './state/Store';
 import { initializeIcons } from '@fluentui/react';
-import { defaultDataMapperApiServiceOptions, InitDataMapperApiService } from '@microsoft/logic-apps-data-mapper';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 
 initializeIcons();
-
-InitDataMapperApiService(defaultDataMapperApiServiceOptions);
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const container = document.getElementById('root')!;

--- a/apps/vs-code-data-mapper-react/src/state/DataMapDataLoader.ts
+++ b/apps/vs-code-data-mapper-react/src/state/DataMapDataLoader.ts
@@ -1,4 +1,4 @@
-import type { MapDefinitionEntry, Schema } from '@microsoft/logic-apps-data-mapper';
+import type { FunctionData, MapDefinitionEntry, Schema } from '@microsoft/logic-apps-data-mapper';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
@@ -11,6 +11,7 @@ export interface DataMapLoadingState {
   targetSchema?: Schema;
   schemaFileList?: string[];
   xsltFilename: string;
+  fetchedFunctions?: FunctionData[];
 }
 
 const initialState: DataMapLoadingState = {
@@ -45,6 +46,9 @@ export const dataMapDataLoaderSlice = createSlice({
     },
     changeSchemaList: (state, action: PayloadAction<string[]>) => {
       state.schemaFileList = action.payload;
+    },
+    changeFetchedFunctions: (state, action: PayloadAction<FunctionData[]>) => {
+      state.fetchedFunctions = action.payload;
     },
   },
 });

--- a/apps/vs-code-data-mapper-react/src/state/DataMapDataLoader.ts
+++ b/apps/vs-code-data-mapper-react/src/state/DataMapDataLoader.ts
@@ -7,7 +7,9 @@ export interface DataMapLoadingState {
   armToken?: string;
   loadingMethod: 'file' | 'arm';
   mapDefinition?: MapDefinitionEntry;
+  sourceSchemaFilename?: string;
   sourceSchema?: Schema;
+  targetSchemaFilename?: string;
   targetSchema?: Schema;
   schemaFileList?: string[];
   xsltFilename: string;
@@ -38,8 +40,14 @@ export const dataMapDataLoaderSlice = createSlice({
     changeMapDefinition: (state, action: PayloadAction<MapDefinitionEntry>) => {
       state.mapDefinition = action.payload;
     },
+    changeSourceSchemaFilename: (state, action: PayloadAction<string>) => {
+      state.sourceSchemaFilename = action.payload;
+    },
     changeSourceSchema: (state, action: PayloadAction<Schema>) => {
       state.sourceSchema = action.payload;
+    },
+    changeTargetSchemaFilename: (state, action: PayloadAction<string>) => {
+      state.targetSchemaFilename = action.payload;
     },
     changeTargetSchema: (state, action: PayloadAction<Schema>) => {
       state.targetSchema = action.payload;
@@ -59,9 +67,12 @@ export const {
   changeLoadingMethod,
   changeXsltFilename,
   changeMapDefinition,
+  changeSourceSchemaFilename,
   changeSourceSchema,
+  changeTargetSchemaFilename,
   changeTargetSchema,
   changeSchemaList,
+  changeFetchedFunctions,
 } = dataMapDataLoaderSlice.actions;
 
 export default dataMapDataLoaderSlice.reducer;

--- a/apps/vs-code-data-mapper-react/src/state/DataMapDataLoader.ts
+++ b/apps/vs-code-data-mapper-react/src/state/DataMapDataLoader.ts
@@ -3,6 +3,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
 export interface DataMapLoadingState {
+  runtimePort?: string;
   armToken?: string;
   loadingMethod: 'file' | 'arm';
   mapDefinition?: MapDefinitionEntry;
@@ -21,6 +22,9 @@ export const dataMapDataLoaderSlice = createSlice({
   name: 'dataMapDataLoader',
   initialState,
   reducers: {
+    changeRuntimePort: (state, action: PayloadAction<string>) => {
+      state.runtimePort = action.payload;
+    },
     changeArmToken: (state, action: PayloadAction<string>) => {
       state.armToken = action.payload;
     },
@@ -44,3 +48,16 @@ export const dataMapDataLoaderSlice = createSlice({
     },
   },
 });
+
+export const {
+  changeRuntimePort,
+  changeArmToken,
+  changeLoadingMethod,
+  changeXsltFilename,
+  changeMapDefinition,
+  changeSourceSchema,
+  changeTargetSchema,
+  changeSchemaList,
+} = dataMapDataLoaderSlice.actions;
+
+export default dataMapDataLoaderSlice.reducer;

--- a/apps/vs-code-data-mapper/src/DataMapperExt.ts
+++ b/apps/vs-code-data-mapper/src/DataMapperExt.ts
@@ -20,10 +20,10 @@ type MapDefinitionEntry = { [key: string]: MapDefinitionEntry | string };
 
 type SendingMessageTypes =
   | { command: 'fetchSchema'; data: { fileName: string; type: SchemaType } }
-  | { command: 'loadNewDataMap'; data: MapDefinitionEntry }
   | { command: 'loadDataMap'; data: { mapDefinition: MapDefinitionEntry; sourceSchemaFileName: string; targetSchemaFileName: string } }
   | { command: 'showAvailableSchemas'; data: string[] }
-  | { command: 'setXsltFilename'; data: string };
+  | { command: 'setXsltFilename'; data: string }
+  | { command: 'setRuntimePort'; data: string };
 type ReceivingMessageTypes =
   | {
       command: 'addSchemaFromFile' | 'readLocalFileOptions';
@@ -70,6 +70,9 @@ export default class DataMapperExt {
     );
 
     this.currentPanel = new DataMapperExt(panel, DataMapperExt.context.extensionPath);
+
+    // Send runtime port to webview
+    this.currentPanel.sendMsgToWebview({ command: 'setRuntimePort', data: `${this.backendRuntimePort}` });
   }
 
   public sendMsgToWebview(msg: SendingMessageTypes) {

--- a/apps/vs-code-data-mapper/src/DataMapperExt.ts
+++ b/apps/vs-code-data-mapper/src/DataMapperExt.ts
@@ -53,6 +53,7 @@ export default class DataMapperExt {
   public static createOrShow() {
     // If a panel has already been created, re-show it
     if (DataMapperExt.currentPanel) {
+      DataMapperExt.currentPanel?.sendMsgToWebview({ command: 'setRuntimePort', data: `${DataMapperExt.backendRuntimePort}` });
       DataMapperExt.currentPanel._panel.reveal(ViewColumn.Active);
       return;
     }
@@ -72,7 +73,7 @@ export default class DataMapperExt {
     this.currentPanel = new DataMapperExt(panel, DataMapperExt.context.extensionPath);
 
     // Send runtime port to webview
-    this.currentPanel.sendMsgToWebview({ command: 'setRuntimePort', data: `${this.backendRuntimePort}` });
+    this.currentPanel.sendMsgToWebview({ command: 'setRuntimePort', data: `${DataMapperExt.backendRuntimePort}` });
   }
 
   public sendMsgToWebview(msg: SendingMessageTypes) {

--- a/apps/vs-code-data-mapper/src/FxWorkflowRuntime.ts
+++ b/apps/vs-code-data-mapper/src/FxWorkflowRuntime.ts
@@ -94,7 +94,7 @@ async function createJsonFile(
 
 async function waitForBackendRuntimeStartUp(url: string, initialTime: number): Promise<void> {
   while (!(await isBackendRuntimeUp(url)) && new Date().getTime() - initialTime < backendRuntimeTimeout) {
-    await delay(2000);
+    await delay(1000); // Re-poll every X ms
   }
 
   if (await isBackendRuntimeUp(url)) {

--- a/apps/vs-code-data-mapper/src/commands/commands.ts
+++ b/apps/vs-code-data-mapper/src/commands/commands.ts
@@ -35,8 +35,6 @@ const createNewDataMapCmd = () => {
     DataMapperExt.currentDataMapName = newDatamapName;
 
     await openDataMapperCmd();
-
-    DataMapperExt.currentPanel?.sendMsgToWebview({ command: 'loadNewDataMap', data: {} });
   });
 };
 

--- a/apps/vs-code-data-mapper/src/commands/commands.ts
+++ b/apps/vs-code-data-mapper/src/commands/commands.ts
@@ -1,7 +1,7 @@
 import DataMapperExt from '../DataMapperExt';
 import { startBackendRuntime } from '../FxWorkflowRuntime';
 import { schemasPath } from '../extensionConfig';
-import { callWithTelemetryAndErrorHandlingSync, registerCommand } from '@microsoft/vscode-azext-utils';
+import { callWithTelemetryAndErrorHandling, registerCommand } from '@microsoft/vscode-azext-utils';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { promises as fs, existsSync as fileExists } from 'fs';
 import * as yaml from 'js-yaml';
@@ -56,7 +56,7 @@ const loadDataMapFileCmd = async (uri: Uri) => {
   const tgtSchemaPath = path.join(schemasFolder, mapDefinition.$targetSchema);
 
   const attemptToResolveMissingSchemaFile = async (schemaName: string, schemaPath: string): Promise<boolean> => {
-    return !!callWithTelemetryAndErrorHandlingSync(
+    return !!(await callWithTelemetryAndErrorHandling(
       'azureDataMapper.attemptToResolveMissingSchemaFile',
       async (_context: IActionContext) => {
         const findSchemaFileButton = 'Find schema file';
@@ -83,7 +83,7 @@ const loadDataMapFileCmd = async (uri: Uri) => {
         // If user doesn't select a file, or doesn't click the above action, just return (cancel loading the MapDef)
         return false;
       }
-    );
+    ));
   };
 
   // If schema file doesn't exist, prompt to find/select it

--- a/apps/vs-code-data-mapper/src/commands/commands.ts
+++ b/apps/vs-code-data-mapper/src/commands/commands.ts
@@ -6,7 +6,7 @@ import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { promises as fs, existsSync as fileExists } from 'fs';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
-import { window, workspace } from 'vscode';
+import { window } from 'vscode';
 import type { Uri } from 'vscode';
 
 export const registerCommands = () => {
@@ -16,9 +16,13 @@ export const registerCommands = () => {
 };
 
 const openDataMapperCmd = async () => {
-  await startBackendRuntime(DataMapperExt.getWorkspaceFolderFsPath());
+  const workflowFolder = DataMapperExt.getWorkspaceFolderFsPath();
 
-  DataMapperExt.createOrShow();
+  if (workflowFolder) {
+    await startBackendRuntime(workflowFolder);
+
+    DataMapperExt.createOrShow();
+  }
 };
 
 const createNewDataMapCmd = () => {
@@ -32,7 +36,7 @@ const createNewDataMapCmd = () => {
 
     await openDataMapperCmd();
 
-    DataMapperExt.currentPanel.sendMsgToWebview({ command: 'loadNewDataMap', data: {} });
+    DataMapperExt.currentPanel?.sendMsgToWebview({ command: 'loadNewDataMap', data: {} });
   });
 };
 
@@ -44,36 +48,45 @@ const loadDataMapFileCmd = async (uri: Uri) => {
   };
 
   // Attempt to load schema files if specified
-  const schemasFolder = path.join(workspace.workspaceFolders[0].uri.fsPath, schemasPath);
+  const workflowFolder = DataMapperExt.getWorkspaceFolderFsPath();
+  if (!workflowFolder) {
+    throw new Error('No workflow folder found onLoadDataMapFile');
+    return;
+  }
+
+  const schemasFolder = path.join(workflowFolder, schemasPath);
   const srcSchemaPath = path.join(schemasFolder, mapDefinition.$sourceSchema);
   const tgtSchemaPath = path.join(schemasFolder, mapDefinition.$targetSchema);
 
   const attemptToResolveMissingSchemaFile = async (schemaName: string, schemaPath: string): Promise<boolean> => {
-    return callWithTelemetryAndErrorHandlingSync('azureDataMapper.attemptToResolveMissingSchemaFile', async (_context: IActionContext) => {
-      const findSchemaFileButton = 'Find schema file';
-      const clickedButton = await window.showErrorMessage(
-        `Error loading map definition: ${schemaName} was not found in the Schemas folder!`,
-        findSchemaFileButton
-      );
+    return !!callWithTelemetryAndErrorHandlingSync(
+      'azureDataMapper.attemptToResolveMissingSchemaFile',
+      async (_context: IActionContext) => {
+        const findSchemaFileButton = 'Find schema file';
+        const clickedButton = await window.showErrorMessage(
+          `Error loading map definition: ${schemaName} was not found in the Schemas folder!`,
+          findSchemaFileButton
+        );
 
-      if (clickedButton && clickedButton === findSchemaFileButton) {
-        const fileUris = await window.showOpenDialog({
-          canSelectMany: false,
-          canSelectFiles: true,
-          canSelectFolders: false,
-          filters: { 'XML Schema Definition': ['xsd'] },
-        });
+        if (clickedButton && clickedButton === findSchemaFileButton) {
+          const fileUris = await window.showOpenDialog({
+            canSelectMany: false,
+            canSelectFiles: true,
+            canSelectFolders: false,
+            filters: { 'XML Schema Definition': ['xsd'] },
+          });
 
-        if (fileUris && fileUris.length > 0) {
-          // Copy the schema file they selected to the Schemas folder (can safely continue map definition loading)
-          await fs.copyFile(fileUris[0].fsPath, schemaPath);
-          return true;
+          if (fileUris && fileUris.length > 0) {
+            // Copy the schema file they selected to the Schemas folder (can safely continue map definition loading)
+            await fs.copyFile(fileUris[0].fsPath, schemaPath);
+            return true;
+          }
         }
-      }
 
-      // If user doesn't select a file, or doesn't click the above action, just return (cancel loading the MapDef)
-      return false;
-    });
+        // If user doesn't select a file, or doesn't click the above action, just return (cancel loading the MapDef)
+        return false;
+      }
+    );
   };
 
   // If schema file doesn't exist, prompt to find/select it
@@ -99,7 +112,7 @@ const loadDataMapFileCmd = async (uri: Uri) => {
 
   await openDataMapperCmd();
 
-  DataMapperExt.currentPanel.sendMsgToWebview({
+  DataMapperExt.currentPanel?.sendMsgToWebview({
     command: 'loadDataMap',
     data: {
       mapDefinition: mapDefinition,

--- a/apps/vs-code-data-mapper/src/commands/commands.ts
+++ b/apps/vs-code-data-mapper/src/commands/commands.ts
@@ -12,7 +12,7 @@ import type { Uri } from 'vscode';
 export const registerCommands = () => {
   registerCommand('azureDataMapper.openDataMapper', () => openDataMapperCmd());
   registerCommand('azureDataMapper.createNewDataMap', () => createNewDataMapCmd());
-  registerCommand('azureDataMapper.loadDataMapFile', (context: IActionContext, uri: Uri) => loadDataMapFileCmd(uri));
+  registerCommand('azureDataMapper.loadDataMapFile', (_context: IActionContext, uri: Uri) => loadDataMapFileCmd(uri));
 };
 
 const openDataMapperCmd = async () => {
@@ -49,7 +49,6 @@ const loadDataMapFileCmd = async (uri: Uri) => {
   const workflowFolder = DataMapperExt.getWorkspaceFolderFsPath();
   if (!workflowFolder) {
     throw new Error('No workflow folder found onLoadDataMapFile');
-    return;
   }
 
   const schemasFolder = path.join(workflowFolder, schemasPath);

--- a/apps/vs-code-data-mapper/src/extensionConfig.ts
+++ b/apps/vs-code-data-mapper/src/extensionConfig.ts
@@ -9,6 +9,7 @@ const artifactsPath = '/Artifacts/';
 export const schemasPath = `${artifactsPath}/Schemas`;
 export const dataMapsPath = `${artifactsPath}/Maps`;
 export const dataMapDefinitionsPath = `${artifactsPath}/MapDefinitions`;
+export const workflowDesignTimeDir = '/workflow-designtime';
 
 export const defaultDatamapFilename = 'default';
 export const mapDefinitionExtension = '.yml';
@@ -35,9 +36,10 @@ export const settingsFileContent = {
   Values: {
     AzureWebJobsSecretStorageType: 'Files',
     FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated',
+    ProjectDirectoryPath: 'should/be/set/by/code',
   },
 };
 
-export const backendRuntimeBaseUrl = 'http://localhost:7071';
+export const backendRuntimeBaseUrl = 'http://localhost:';
 export const workflowMgmtApi = '/runtime/webhooks/workflow/api/management/';
 export const backendRuntimeTimeout = 60000;

--- a/apps/vs-code-data-mapper/tsconfig.json
+++ b/apps/vs-code-data-mapper/tsconfig.json
@@ -1,5 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true
+  },
   "files": [
     "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
     "../../node_modules/@nrwl/react/typings/image.d.ts",

--- a/libs/data-mapper/src/lib/components/propertiesPane/tabs/SchemaNodePropertiesTab.tsx
+++ b/libs/data-mapper/src/lib/components/propertiesPane/tabs/SchemaNodePropertiesTab.tsx
@@ -148,23 +148,25 @@ export const SchemaNodePropertiesTab = ({ currentNode }: SchemaNodePropertiesTab
             <InputDropdown currentNode={currentNode} inputValue={inputValue} inputStyles={{ gridColumn: gridColumnSpan2 }} inputIndex={0} />
           </div>
 
-          <Accordion collapsible defaultOpenItems={'1'} style={{ width: '94%', marginTop: '16px', marginLeft: '-12px' }}>
-            <AccordionItem value="1">
-              <AccordionHeader className={styles.bodyText}>{advOptLoc}</AccordionHeader>
-              <AccordionPanel>
-                <div className={styles.nodeInfoGridContainer} style={{ marginTop: '16px' }}>
-                  <Text className={styles.bodyText} style={{ gridColumn: gridColumnSpan1 }}>
-                    {defValLoc}
-                  </Text>
-                  <Input style={{ gridColumn: gridColumnSpan2 }} />
-                </div>
+          {false && ( // Hiding advanced options until implemented
+            <Accordion collapsible defaultOpenItems={'1'} style={{ width: '94%', marginTop: '16px', marginLeft: '-12px' }}>
+              <AccordionItem value="1">
+                <AccordionHeader className={styles.bodyText}>{advOptLoc}</AccordionHeader>
+                <AccordionPanel>
+                  <div className={styles.nodeInfoGridContainer} style={{ marginTop: '16px' }}>
+                    <Text className={styles.bodyText} style={{ gridColumn: gridColumnSpan1 }}>
+                      {defValLoc}
+                    </Text>
+                    <Input style={{ gridColumn: gridColumnSpan2 }} />
+                  </div>
 
-                <Stack>
-                  <Checkbox label={noValueLabelLoc} defaultChecked style={{ marginTop: '16px' }} />
-                </Stack>
-              </AccordionPanel>
-            </AccordionItem>
-          </Accordion>
+                  <Stack>
+                    <Checkbox label={noValueLabelLoc} defaultChecked style={{ marginTop: '16px' }} />
+                  </Stack>
+                </AccordionPanel>
+              </AccordionItem>
+            </Accordion>
+          )}
         </div>
       )}
     </div>

--- a/libs/data-mapper/src/lib/core/DataMapDataProvider.tsx
+++ b/libs/data-mapper/src/lib/core/DataMapDataProvider.tsx
@@ -8,9 +8,9 @@ import { DataMapperWrappedContext } from './DataMapperDesignerContext';
 import { setInitialDataMap, setInitialSchema, setXsltFilename } from './state/DataMapSlice';
 import { loadFunctions } from './state/FunctionSlice';
 import { setAvailableSchemas } from './state/SchemaSlice';
-import type { AppDispatch, RootState } from './state/Store';
+import type { AppDispatch } from './state/Store';
 import React, { useContext, useEffect, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 export interface DataMapDataProviderProps {
   xsltFilename?: string;
@@ -33,8 +33,6 @@ const DataProviderInner: React.FC<DataMapDataProviderProps> = ({
 }) => {
   const dispatch = useDispatch<AppDispatch>();
 
-  const loadedFunctions = useSelector((state: RootState) => state.function.availableFunctions);
-
   const extendedSourceSchema = useMemo(() => sourceSchema && convertSchemaToSchemaExtended(sourceSchema), [sourceSchema]);
   const extendedTargetSchema = useMemo(() => targetSchema && convertSchemaToSchemaExtended(targetSchema), [targetSchema]);
 
@@ -43,13 +41,13 @@ const DataProviderInner: React.FC<DataMapDataProviderProps> = ({
   }, [dispatch, xsltFilename]);
 
   useEffect(() => {
-    if (mapDefinition && extendedSourceSchema && extendedTargetSchema) {
-      const connections = convertFromMapDefinition(mapDefinition, extendedSourceSchema, extendedTargetSchema, loadedFunctions);
+    if (mapDefinition && extendedSourceSchema && extendedTargetSchema && fetchedFunctions) {
+      const connections = convertFromMapDefinition(mapDefinition, extendedSourceSchema, extendedTargetSchema, fetchedFunctions);
       dispatch(
         setInitialDataMap({ sourceSchema: extendedSourceSchema, targetSchema: extendedTargetSchema, dataMapConnections: connections })
       );
     }
-  }, [dispatch, mapDefinition, extendedSourceSchema, extendedTargetSchema, loadedFunctions]);
+  }, [dispatch, mapDefinition, extendedSourceSchema, extendedTargetSchema, fetchedFunctions]);
 
   useEffect(() => {
     if (extendedSourceSchema) {

--- a/libs/data-mapper/src/lib/core/index.ts
+++ b/libs/data-mapper/src/lib/core/index.ts
@@ -3,3 +3,4 @@ export * from './DataMapperDesignerProvider';
 export * from './DataMapDataProvider';
 export * from './services';
 export * from './queries/schema';
+export * from './queries/functions';

--- a/libs/data-mapper/src/lib/core/queries/schema.ts
+++ b/libs/data-mapper/src/lib/core/queries/schema.ts
@@ -1,13 +1,17 @@
+import type { Schema } from '../../models';
 import { DataMapperApiServiceInstance } from '../services';
+import type { SchemaInfoProperties } from '../services';
 
-export const getSchemaList = () => {
+export const getSchemaList = (): Promise<SchemaInfoProperties[]> => {
   const service = DataMapperApiServiceInstance();
+
   const response = service.getSchemas();
   return response;
 };
 
-export const getSelectedSchema = (fileName: string) => {
+export const getSelectedSchema = (fileName: string): Promise<Schema> => {
   const service = DataMapperApiServiceInstance();
+
   const response = service.getSchemaFile(fileName);
   return response;
 };

--- a/libs/data-mapper/src/lib/core/services/dataMapperApiService/DataMapperApiService.ts
+++ b/libs/data-mapper/src/lib/core/services/dataMapperApiService/DataMapperApiService.ts
@@ -3,11 +3,11 @@ import type { FunctionManifest } from '../../../models/Function';
 
 export interface DataMapperApiServiceOptions {
   baseUrl: string;
+  port: string;
   accessToken?: string;
 }
 
 export class DataMapperApiService {
-  // TODO: add back when questions answered
   private options: DataMapperApiServiceOptions;
 
   constructor(options: DataMapperApiServiceOptions) {
@@ -31,6 +31,7 @@ export class DataMapperApiService {
       'api-version': '2019-10-01-edge-preview',
     });
   };
+
   private getHeaders = () => {
     return new Headers({
       Accept: 'application/json',
@@ -39,24 +40,28 @@ export class DataMapperApiService {
     });
   };
 
+  private getBaseUri = () => {
+    return `${this.options.baseUrl}:${this.options.port}`;
+  };
+
   private getSchemasUri = () => {
-    return `${this.options.baseUrl}/hostruntime/admin/vfs/Artifacts/Schemas?api-version=2018-11-01&relativepath=1`;
+    return `${this.getBaseUri()}/hostruntime/admin/vfs/Artifacts/Schemas?api-version=2018-11-01&relativepath=1`;
   };
 
   private getSchemaFileUri = (xmlName: string) => {
-    return `${this.options.baseUrl}/runtime/webhooks/workflow/api/management/schemas/${xmlName}/contents/schemaTree`;
+    return `${this.getBaseUri()}/runtime/webhooks/workflow/api/management/schemas/${xmlName}/contents/schemaTree`;
   };
 
   private getFunctionsManifestUri = () => {
-    return `${this.options.baseUrl}/runtime/webhooks/workflow/api/management/mapTransformations?api-version=2019-10-01-edge-preview`;
+    return `${this.getBaseUri()}/runtime/webhooks/workflow/api/management/mapTransformations?api-version=2019-10-01-edge-preview`;
   };
 
   private getGenerateXsltUri = () => {
-    return `${this.options.baseUrl}/runtime/webhooks/workflow/api/management/generateXslt?api-version=2019-10-01-edge-preview`;
+    return `${this.getBaseUri()}/runtime/webhooks/workflow/api/management/generateXslt?api-version=2019-10-01-edge-preview`;
   };
 
   private getTestMapUri = (xsltFilename: string) => {
-    return `${this.options.baseUrl}/runtime/webhooks/workflow/api/management/maps/${xsltFilename}/testMap?api-version=2019-10-01-edge-preview`;
+    return `${this.getBaseUri()}/runtime/webhooks/workflow/api/management/maps/${xsltFilename}/testMap?api-version=2019-10-01-edge-preview`;
   };
 
   async getFunctionsManifest(): Promise<FunctionManifest> {

--- a/libs/data-mapper/src/lib/core/services/dataMapperApiService/DataMapperApiService.ts
+++ b/libs/data-mapper/src/lib/core/services/dataMapperApiService/DataMapperApiService.ts
@@ -67,9 +67,11 @@ export class DataMapperApiService {
   async getFunctionsManifest(): Promise<FunctionManifest> {
     const uri = this.getFunctionsManifestUri();
     const response = await fetch(uri, { method: 'GET' });
+
     if (!response.ok) {
       throw new Error(`${response.status} ${response.statusText}`);
     }
+
     const functions = await response.json();
     return functions;
   }

--- a/libs/data-mapper/src/lib/core/services/dataMapperApiService/index.ts
+++ b/libs/data-mapper/src/lib/core/services/dataMapperApiService/index.ts
@@ -6,7 +6,8 @@ import { AssertionErrorCode, AssertionException } from '@microsoft-logic-apps/ut
 let service: IDataMapperApiService;
 
 export const defaultDataMapperApiServiceOptions = {
-  baseUrl: 'http://localhost:7071',
+  baseUrl: 'http://localhost',
+  port: '7071',
   accessToken: '',
 };
 

--- a/libs/data-mapper/src/lib/models/index.ts
+++ b/libs/data-mapper/src/lib/models/index.ts
@@ -1,2 +1,3 @@
 export * from './Schema';
 export * from './MapDefinition';
+export * from './Function';


### PR DESCRIPTION
DM VSIX now:
-Utilizes workflow-designtime API
-Deeply merges settings (no more overwriting specific local.settings.json Values{} properties configured by the user)
-Properly awaits a schema-file-not-found resolution when loading data maps (got broken by telemetry integration)
-Uses portfinder to find an open port instead of using our default of 7071 all the time

*This involved some shuffling around of where we init the DmApiService and thus make calls to GET schemaTree and GET functionManifest/List -> this probably actually did some good by eliminating some uncertainty around race conditions that previously existed in the realm of VSIX webview message-passing
**Standalone was updated to match this ^ (and was a lot less involved to do so based on how we do some things differently there already)


Unrelated change: Properties Pane -> Target schema node properties -> Advanced options has been hidden until it actually gets implemented