### PR TITLE
[DM | Tree] Add isHovered render prop for nodeContent + isExpanded property on TreeNode for controlled expanded states

### DIFF
--- a/apps/vs-code-data-mapper-react/src/app/app.tsx
+++ b/apps/vs-code-data-mapper-react/src/app/app.tsx
@@ -43,13 +43,6 @@ export const App = () => {
 
   const runtimePort = useSelector((state: RootState) => state.dataMapDataLoader.runtimePort);
 
-  /*
-  // Monitor document.body for VS Code theme changes
-  new MutationObserver(() => {
-    setVsCodeTheme(getVscodeTheme());
-  }).observe(document.body, { attributes: true });
-  */
-
   const saveStateCall = (dataMapDefinition: string, dataMapXslt: string) => {
     saveDataMapDefinition(dataMapDefinition);
 
@@ -83,6 +76,17 @@ export const App = () => {
       data: dataMapXslt,
     });
   };
+
+  /*
+  // Monitor document.body for VS Code theme changes
+  useEffect(() => {
+    const themeMutationObserver = new MutationObserver(() => {
+      setVsCodeTheme(getVscodeTheme());
+    }).observe(document.body, { attributes: true });
+
+    return () => themeMutationObserver.disconnect();
+  }, []);
+  */
 
   // Init runtime API service and make calls
   useEffect(() => {

--- a/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
+++ b/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
@@ -154,10 +154,11 @@ export const CanvasToolbox = ({ canvasBlockHeight }: CanvasToolboxProps) => {
             // Add one extra root layer so schemaTreeRoot is shown as well
             // Can safely typecast as only the children[] are used from root
             treeRoot={{ children: [searchedSourceSchemaTreeRoot] } as SchemaNodeExtended}
-            nodeContent={(node: SchemaNodeExtended) => (
+            nodeContent={(node: SchemaNodeExtended, isHovered: boolean) => (
               <SourceSchemaTreeItem
                 node={node}
                 isNodeAdded={currentSourceSchemaNodes.some((srcSchemaNode) => srcSchemaNode.key === node.key)}
+                isNodeHovered={isHovered}
               />
             )}
             onClickItem={(node) => onSourceSchemaItemClick(node)}

--- a/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
+++ b/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
@@ -9,6 +9,7 @@ import type { FloatingPanelProps } from '../floatingPanel/FloatingPanel';
 import { FunctionList } from '../functionList/FunctionList';
 import SourceSchemaTreeItem, { useSchemaTreeItemStyles } from '../tree/SourceSchemaTreeItem';
 import Tree from '../tree/Tree';
+import type { ITreeNode } from '../tree/Tree';
 import { TreeHeader } from '../tree/TreeHeader';
 import { mergeClasses, tokens } from '@fluentui/react-components';
 import type { SelectTabData, SelectTabEvent } from '@fluentui/react-components';
@@ -97,7 +98,7 @@ export const CanvasToolbox = ({ canvasBlockHeight }: CanvasToolboxProps) => {
     }
   };
 
-  const searchedSourceSchemaTreeRoot = useMemo<SchemaNodeExtended | undefined>(() => {
+  const searchedSourceSchemaTreeRoot = useMemo<ITreeNode<ITreeNode<SchemaNodeExtended>> | undefined>(() => {
     if (!sourceSchema) {
       return undefined;
     }

--- a/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
+++ b/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
@@ -142,13 +142,7 @@ export const CanvasToolbox = ({ canvasBlockHeight }: CanvasToolboxProps) => {
       <ButtonPivot {...toolboxButtonPivotProps} />
 
       {toolboxTabToDisplay === ToolboxPanelTabs.sourceSchemaTree && sourceSchema && searchedSourceSchemaTreeRoot && (
-        <FloatingPanel
-          {...generalToolboxPanelProps}
-          height={floatingPanelHeight}
-          title={sourceSchemaLoc}
-          subtitle={sourceSchema.name}
-          onClose={closeToolbox}
-        >
+        <FloatingPanel {...generalToolboxPanelProps} height={floatingPanelHeight} title={sourceSchemaLoc} onClose={closeToolbox}>
           <TreeHeader onSearch={setSourceSchemaSearchTerm} onClear={() => setSourceSchemaSearchTerm('')} />
 
           <Tree<SchemaNodeExtended>

--- a/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
+++ b/libs/data-mapper/src/lib/components/canvasToolbox/CanvasToolbox.tsx
@@ -1,5 +1,6 @@
 import { addSourceSchemaNodes, removeSourceSchemaNodes, setCanvasToolboxTabToDisplay } from '../../core/state/DataMapSlice';
 import type { AppDispatch, RootState } from '../../core/state/Store';
+import { SchemaNodeDataType } from '../../models';
 import type { SchemaNodeExtended } from '../../models';
 import { searchSchemaTreeFromRoot } from '../../utils/Schema.Utils';
 import type { ButtonPivotProps } from '../buttonPivot/ButtonPivot';
@@ -7,6 +8,7 @@ import { ButtonPivot } from '../buttonPivot/ButtonPivot';
 import { FloatingPanel } from '../floatingPanel/FloatingPanel';
 import type { FloatingPanelProps } from '../floatingPanel/FloatingPanel';
 import { FunctionList } from '../functionList/FunctionList';
+import { schemaRootKey } from '../targetSchemaPane/TargetSchemaPane';
 import SourceSchemaTreeItem, { useSchemaTreeItemStyles } from '../tree/SourceSchemaTreeItem';
 import Tree from '../tree/Tree';
 import type { ITreeNode } from '../tree/Tree';
@@ -91,6 +93,11 @@ export const CanvasToolbox = ({ canvasBlockHeight }: CanvasToolboxProps) => {
   );
 
   const onSourceSchemaItemClick = (selectedNode: SchemaNodeExtended) => {
+    // If click schema name, just return (don't do anything)
+    if (selectedNode.key === schemaRootKey) {
+      return;
+    }
+
     if (currentSourceSchemaNodes.some((node) => node.key === selectedNode.key)) {
       dispatch(removeSourceSchemaNodes([selectedNode]));
     } else {
@@ -98,16 +105,30 @@ export const CanvasToolbox = ({ canvasBlockHeight }: CanvasToolboxProps) => {
     }
   };
 
-  const searchedSourceSchemaTreeRoot = useMemo<ITreeNode<ITreeNode<SchemaNodeExtended>> | undefined>(() => {
+  const searchedSourceSchemaTreeRoot = useMemo<ITreeNode<SchemaNodeExtended> | undefined>(() => {
     if (!sourceSchema) {
       return undefined;
     }
 
-    if (!sourceSchemaSearchTerm) {
-      return { ...sourceSchema.schemaTreeRoot };
-    } else {
-      return searchSchemaTreeFromRoot(sourceSchema.schemaTreeRoot, sourceSchemaSearchTerm);
+    let newSourceSchemaTreeRoot: ITreeNode<SchemaNodeExtended> = { ...sourceSchema.schemaTreeRoot };
+
+    if (sourceSchemaSearchTerm) {
+      newSourceSchemaTreeRoot = searchSchemaTreeFromRoot(sourceSchema.schemaTreeRoot, sourceSchemaSearchTerm);
     }
+
+    // Format extra top layers to show schema name and schemaTreeRoot
+    // Can safely typecast with the root node(s) as we only use the properties defined here
+    const schemaRoot = {} as ITreeNode<SchemaNodeExtended>;
+    const schemaNameRoot = {} as ITreeNode<SchemaNodeExtended>;
+
+    schemaNameRoot.key = schemaRootKey;
+    schemaNameRoot.name = sourceSchema.name;
+    schemaNameRoot.schemaNodeDataType = SchemaNodeDataType.None;
+    schemaNameRoot.children = [newSourceSchemaTreeRoot];
+
+    schemaRoot.children = [schemaNameRoot];
+
+    return schemaRoot;
   }, [sourceSchema, sourceSchemaSearchTerm]);
 
   const toolboxButtonPivotProps: ButtonPivotProps = useMemo(
@@ -148,15 +169,15 @@ export const CanvasToolbox = ({ canvasBlockHeight }: CanvasToolboxProps) => {
           <Tree<SchemaNodeExtended>
             // Add one extra root layer so schemaTreeRoot is shown as well
             // Can safely typecast as only the children[] are used from root
-            treeRoot={{ children: [searchedSourceSchemaTreeRoot] } as SchemaNodeExtended}
-            nodeContent={(node: SchemaNodeExtended, isHovered: boolean) => (
+            treeRoot={searchedSourceSchemaTreeRoot}
+            nodeContent={(node, isHovered) => (
               <SourceSchemaTreeItem
-                node={node}
+                node={node as SchemaNodeExtended}
                 isNodeAdded={currentSourceSchemaNodes.some((srcSchemaNode) => srcSchemaNode.key === node.key)}
                 isNodeHovered={isHovered}
               />
             )}
-            onClickItem={(node) => onSourceSchemaItemClick(node)}
+            onClickItem={(node) => onSourceSchemaItemClick(node as SchemaNodeExtended)}
             nodeContainerClassName={mergeClasses(schemaNodeItemStyles.nodeContainer, schemaNodeItemStyles.sourceSchemaNode)}
             nodeContainerStyle={(node) => ({
               backgroundColor: currentSourceSchemaNodes.some((srcSchemaNode) => srcSchemaNode.key === node.key)

--- a/libs/data-mapper/src/lib/components/functionList/FunctionList.tsx
+++ b/libs/data-mapper/src/lib/components/functionList/FunctionList.tsx
@@ -31,6 +31,7 @@ const fuseFunctionSearchOptions: Fuse.IFuseOptions<FunctionData> = {
 export const functionCategoryItemKeyPrefix = 'category&';
 
 interface FunctionDataTreeItem extends FunctionData {
+  isExpanded?: boolean;
   children: FunctionDataTreeItem[];
 }
 
@@ -124,6 +125,12 @@ export const FunctionList = () => {
         // Add functions to their respective categories
         functionsList.forEach((functionData) => {
           functionCategoryDictionary[functionData.category].children.push({ ...functionData, children: [] });
+
+          // If there's a search term, all present categories should be expanded as
+          // they only show when they have Functions that match the search
+          if (searchTerm) {
+            functionCategoryDictionary[functionData.category].isExpanded = true;
+          }
         });
 
         // Add function categories as children to the tree root, filtering out any that don't have any children

--- a/libs/data-mapper/src/lib/components/functionList/FunctionList.tsx
+++ b/libs/data-mapper/src/lib/components/functionList/FunctionList.tsx
@@ -153,15 +153,15 @@ export const FunctionList = () => {
 
       <Tree<FunctionDataTreeItem>
         treeRoot={functionListTree}
-        nodeContent={(node: FunctionDataTreeItem) =>
+        nodeContent={(node) =>
           node.key.startsWith(functionCategoryItemKeyPrefix) ? (
             <FunctionListHeader category={node.key.replace(functionCategoryItemKeyPrefix, '') as FunctionCategory} />
           ) : (
-            <FunctionListItem functionData={node} />
+            <FunctionListItem functionData={node as FunctionData} />
           )
         }
         childPadding={0}
-        onClickItem={(node) => !node.key.startsWith(functionCategoryItemKeyPrefix) && onFunctionItemClick(node)}
+        onClickItem={(node) => !node.key.startsWith(functionCategoryItemKeyPrefix) && onFunctionItemClick(node as FunctionData)}
         parentItemClickShouldExpand
       />
     </>

--- a/libs/data-mapper/src/lib/components/targetSchemaPane/TargetSchemaPane.tsx
+++ b/libs/data-mapper/src/lib/components/targetSchemaPane/TargetSchemaPane.tsx
@@ -7,6 +7,7 @@ import { useSchemaTreeItemStyles } from '../tree/SourceSchemaTreeItem';
 import TargetSchemaTreeItem, { ItemToggledState } from '../tree/TargetSchemaTreeItem';
 import type { NodeToggledStateDictionary } from '../tree/TargetSchemaTreeItem';
 import Tree from '../tree/Tree';
+import type { ITreeNode } from '../tree/Tree';
 import { TreeHeader } from '../tree/TreeHeader';
 import { Stack } from '@fluentui/react';
 import { Button, makeStyles, mergeClasses, shorthands, Text, tokens, typographyStyles } from '@fluentui/react-components';
@@ -73,7 +74,7 @@ export const TargetSchemaPane = ({ isExpanded, setIsExpanded }: TargetSchemaPane
     return nodesWithConnections;
   }, [connectionDictionary, targetSchemaDictionary]);
 
-  const searchedTargetSchemaTreeRoot = useMemo<SchemaNodeExtended | undefined>(() => {
+  const searchedTargetSchemaTreeRoot = useMemo<ITreeNode<ITreeNode<SchemaNodeExtended>> | undefined>(() => {
     if (!targetSchema) {
       return undefined;
     }

--- a/libs/data-mapper/src/lib/components/targetSchemaPane/TargetSchemaPane.tsx
+++ b/libs/data-mapper/src/lib/components/targetSchemaPane/TargetSchemaPane.tsx
@@ -127,12 +127,6 @@ export const TargetSchemaPane = ({ isExpanded, setIsExpanded }: TargetSchemaPane
         >
           {targetSchemaLoc}
         </Text>
-
-        {isExpanded && targetSchema && (
-          <Text className={styles.subtitle} style={{ marginLeft: 4 }}>
-            {targetSchema.name}
-          </Text>
-        )}
       </Stack>
 
       {isExpanded && targetSchema && toggledStatesDictionary && searchedTargetSchemaTreeRoot && (

--- a/libs/data-mapper/src/lib/components/tree/SourceSchemaTreeItem.tsx
+++ b/libs/data-mapper/src/lib/components/tree/SourceSchemaTreeItem.tsx
@@ -2,7 +2,7 @@ import type { SchemaNodeExtended } from '../../models';
 import { iconForSchemaNodeDataType } from '../../utils/Icon.Utils';
 import { Stack } from '@fluentui/react';
 import { makeStyles, shorthands, Text, tokens, typographyStyles } from '@fluentui/react-components';
-import { CheckmarkCircle16Filled, Circle16Regular } from '@fluentui/react-icons';
+import { CheckmarkCircle16Filled, Circle16Regular, AddCircle16Regular } from '@fluentui/react-icons';
 
 export const useSchemaTreeItemStyles = makeStyles({
   nodeContainer: {
@@ -55,9 +55,10 @@ export const useSchemaTreeItemStyles = makeStyles({
 interface SourceSchemaTreeItemProps {
   node: SchemaNodeExtended;
   isNodeAdded: boolean;
+  isNodeHovered: boolean;
 }
 
-const SourceSchemaTreeItem = ({ node, isNodeAdded }: SourceSchemaTreeItemProps) => {
+const SourceSchemaTreeItem = ({ node, isNodeAdded, isNodeHovered }: SourceSchemaTreeItemProps) => {
   const styles = useSchemaTreeItemStyles();
 
   const BundledTypeIcon = iconForSchemaNodeDataType(node.schemaNodeDataType, 16, true, node.nodeProperties);
@@ -75,6 +76,8 @@ const SourceSchemaTreeItem = ({ node, isNodeAdded }: SourceSchemaTreeItemProps) 
       <span style={{ display: 'flex', position: 'sticky', right: 10 }}>
         {isNodeAdded ? (
           <CheckmarkCircle16Filled primaryFill={tokens.colorBrandForeground1} />
+        ) : isNodeHovered ? (
+          <AddCircle16Regular primaryFill={tokens.colorNeutralForeground3} />
         ) : (
           <Circle16Regular primaryFill={tokens.colorNeutralForeground3} />
         )}

--- a/libs/data-mapper/src/lib/components/tree/Tree.tsx
+++ b/libs/data-mapper/src/lib/components/tree/Tree.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 
 export interface ITreeNode<T> {
   key: string | number;
+  isExpanded?: boolean;
   children?: T[];
   [key: string]: any;
 }

--- a/libs/data-mapper/src/lib/components/tree/Tree.tsx
+++ b/libs/data-mapper/src/lib/components/tree/Tree.tsx
@@ -18,7 +18,7 @@ export const useTreeStyles = makeStyles({
 });
 
 export interface CoreTreeProps<T> {
-  nodeContent: (node: T) => ReactNode;
+  nodeContent: (node: T, isHovered: boolean) => ReactNode;
   nodeContainerClassName?: string;
   nodeContainerStyle?: (node: T) => React.CSSProperties;
   childPadding?: number; // 0 will also not render hidden chevrons (meaning the space is recouped) - used in FxList

--- a/libs/data-mapper/src/lib/components/tree/Tree.tsx
+++ b/libs/data-mapper/src/lib/components/tree/Tree.tsx
@@ -3,9 +3,9 @@ import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-components
 import type { ReactNode } from 'react';
 
 export interface ITreeNode<T> {
-  key: string | number;
+  key: string;
   isExpanded?: boolean;
-  children?: T[];
+  children?: ITreeNode<T>[];
   [key: string]: any;
 }
 
@@ -19,16 +19,16 @@ export const useTreeStyles = makeStyles({
 });
 
 export interface CoreTreeProps<T> {
-  nodeContent: (node: T, isHovered: boolean) => ReactNode;
+  nodeContent: (node: ITreeNode<T>, isHovered: boolean) => ReactNode;
   nodeContainerClassName?: string;
-  nodeContainerStyle?: (node: T) => React.CSSProperties;
+  nodeContainerStyle?: (node: ITreeNode<T>) => React.CSSProperties;
   childPadding?: number; // 0 will also not render hidden chevrons (meaning the space is recouped) - used in FxList
-  onClickItem?: (node: T) => void;
+  onClickItem?: (node: ITreeNode<T>) => void;
   parentItemClickShouldExpand?: boolean;
 }
 
 interface TreeProps<T> extends CoreTreeProps<T> {
-  treeRoot: T;
+  treeRoot: ITreeNode<T>;
   treeContainerClassName?: string;
 }
 
@@ -39,7 +39,7 @@ const Tree = <T extends ITreeNode<T>>(props: TreeProps<T>) => {
   return (
     <div className={mergeClasses(styles.treeContainer, treeContainerClassName)}>
       {treeRoot.children &&
-        treeRoot.children.map((childNode) => <TreeBranch<T> {...props} key={childNode.key} level={0} node={childNode} />)}
+        treeRoot.children.map((childNode) => <TreeBranch<ITreeNode<T>> {...props} key={childNode.key} level={0} node={childNode} />)}
     </div>
   );
 };

--- a/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
+++ b/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
@@ -10,7 +10,7 @@ const defaultChildPadding = 16;
 
 interface TreeBranchProps<T> extends CoreTreeProps<T> {
   level: number;
-  node: T;
+  node: ITreeNode<T>;
 }
 
 const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
@@ -77,7 +77,7 @@ const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
 
       {hasChildren &&
         isNodeExpanded &&
-        node.children?.map((childNode) => <TreeBranch<T> {...props} key={childNode.key} node={childNode} level={level + 1} />)}
+        node.children?.map((childNode) => <TreeBranch<ITreeNode<T>> {...props} key={childNode.key} node={childNode} level={level + 1} />)}
     </>
   );
 };

--- a/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
+++ b/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
@@ -26,6 +26,7 @@ const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
   } = props;
   const styles = useTreeStyles();
   const [isExpanded, { toggle: toggleExpanded }] = useBoolean(false);
+  const [isHovered, { setFalse: setNotHovered, setTrue: setIsHovered }] = useBoolean(false);
 
   const hasChildren = useMemo<boolean>(() => !!(node.children && node.children.length > 0), [node]);
 
@@ -56,6 +57,8 @@ const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
         horizontal
         verticalAlign="center"
         onClick={handleItemClick}
+        onMouseEnter={setIsHovered}
+        onMouseLeave={setNotHovered}
       >
         <Button
           appearance="transparent"
@@ -68,7 +71,7 @@ const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
           }}
         />
 
-        {nodeContent(node)}
+        {nodeContent(node, isHovered)}
       </Stack>
 
       {hasChildren &&

--- a/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
+++ b/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
@@ -29,6 +29,7 @@ const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
   const [isHovered, { setFalse: setNotHovered, setTrue: setIsHovered }] = useBoolean(false);
 
   const hasChildren = useMemo<boolean>(() => !!(node.children && node.children.length > 0), [node]);
+  const isNodeExpanded = useMemo<boolean>(() => (node.isExpanded === undefined ? isExpanded : node.isExpanded), [node, isExpanded]);
 
   const handleItemClick = () => {
     if (hasChildren && parentItemClickShouldExpand) {
@@ -63,7 +64,7 @@ const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
         <Button
           appearance="transparent"
           size="small"
-          icon={isExpanded ? <ChevronDown20Regular /> : <ChevronRight20Regular />}
+          icon={isNodeExpanded ? <ChevronDown20Regular /> : <ChevronRight20Regular />}
           onClick={handleChevronClick}
           style={{
             visibility: hasChildren ? 'visible' : 'hidden',
@@ -75,7 +76,7 @@ const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
       </Stack>
 
       {hasChildren &&
-        isExpanded &&
+        isNodeExpanded &&
         node.children?.map((childNode) => <TreeBranch<T> {...props} key={childNode.key} node={childNode} level={level + 1} />)}
     </>
   );

--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -110,7 +110,7 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
   const [propPaneExpandedHeight, setPropPaneExpandedHeight] = useState(basePropPaneContentHeight);
   const [isCodeViewOpen, setIsCodeViewOpen] = useState(false);
   const [isTestMapPanelOpen, setIsTestMapPanelOpen] = useState(false);
-  const [isOutputPaneExpanded, setIsOutputPaneExpanded] = useState(false);
+  const [isTargetSchemaPaneExpanded, setIsTargetSchemaPaneExpanded] = useState(false);
 
   const dataMapDefinition = useMemo<string>(() => {
     if (sourceSchema && targetSchema) {
@@ -190,6 +190,11 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
   };
 
   const getCanvasAreaHeight = () => {
+    // PropPane isn't shown when in Overview, so canvas can use full height
+    if (showMapOverview) {
+      return centerViewHeight - 8;
+    }
+
     if (isPropPaneExpanded) {
       return centerViewHeight - getExpandedPropPaneTotalHeight();
     } else {
@@ -241,18 +246,20 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
                 )}
               </div>
 
-              <PropertiesPane
-                selectedItemKey={selectedItemKey ?? ''}
-                isExpanded={isPropPaneExpanded}
-                setIsExpanded={setIsPropPaneExpanded}
-                centerViewHeight={centerViewHeight}
-                contentHeight={propPaneExpandedHeight}
-                setContentHeight={setPropPaneExpandedHeight}
-              />
+              {!showMapOverview && (
+                <PropertiesPane
+                  selectedItemKey={selectedItemKey ?? ''}
+                  isExpanded={isPropPaneExpanded}
+                  setIsExpanded={setIsPropPaneExpanded}
+                  centerViewHeight={centerViewHeight}
+                  contentHeight={propPaneExpandedHeight}
+                  setContentHeight={setPropPaneExpandedHeight}
+                />
+              )}
             </div>
           </div>
 
-          <TargetSchemaPane isExpanded={isOutputPaneExpanded} setIsExpanded={setIsOutputPaneExpanded} />
+          <TargetSchemaPane isExpanded={isTargetSchemaPaneExpanded} setIsExpanded={setIsTargetSchemaPaneExpanded} />
         </div>
 
         <WarningModal />

--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -22,11 +22,13 @@ import './ReactFlowStyleOverrides.css';
 import { ReactFlowWrapper } from './ReactFlowWrapper';
 import { Stack } from '@fluentui/react';
 import { makeStaticStyles, makeStyles, shorthands, tokens } from '@fluentui/react-components';
-import { useLayoutEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { useDispatch, useSelector } from 'react-redux';
 import { ReactFlowProvider } from 'reactflow';
+
+const centerViewId = 'centerView';
 
 const useStaticStyles = makeStaticStyles({
   // Firefox who's trying to early-adopt a WIP CSS standard (as of 11/2/2022)
@@ -204,7 +206,7 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
           <div id="centerViewWithBreadcrumb" style={{ display: 'flex', flexDirection: 'column', flex: '1 1 1px' }}>
             <EditorBreadcrumb isCodeViewOpen={isCodeViewOpen} setIsCodeViewOpen={setIsCodeViewOpen} />
 
-            <div id="centerView" style={{ minHeight: 400, flex: '1 1 1px' }}>
+            <div id={centerViewId} style={{ minHeight: 400, flex: '1 1 1px' }}>
               <div
                 style={{
                   height: getCanvasAreaHeight(),
@@ -264,21 +266,20 @@ export const DataMapperDesigner: React.FC<DataMapperDesignerProps> = ({ saveStat
 const useCenterViewHeight = () => {
   const [centerViewHeight, setCenterViewHeight] = useState(0);
 
-  const handleCenterViewHeight = () => {
-    const centerView = document.getElementById('centerView');
+  useEffect(() => {
+    const centerViewElement = document.getElementById(centerViewId);
 
-    if (centerView?.clientHeight) {
-      setCenterViewHeight(centerView.clientHeight);
+    const centerViewResizeObserver = new ResizeObserver((entries) => {
+      if (entries.length && entries.length > 0) {
+        setCenterViewHeight(entries[0].contentRect.height);
+      }
+    });
+
+    if (centerViewElement) {
+      centerViewResizeObserver.observe(centerViewElement);
     }
-  };
 
-  useLayoutEffect(() => {
-    window.addEventListener('resize', handleCenterViewHeight);
-
-    // NOTE: Not the nicest, but it's required to ensure we get the actual final height after the initial render
-    setTimeout(handleCenterViewHeight, 125);
-
-    return () => window.removeEventListener('resize', handleCenterViewHeight);
+    return () => centerViewResizeObserver.disconnect();
   }, []);
 
   return centerViewHeight;

--- a/libs/data-mapper/src/lib/utils/Schema.Utils.ts
+++ b/libs/data-mapper/src/lib/utils/Schema.Utils.ts
@@ -1,3 +1,4 @@
+import type { ITreeNode } from '../components/tree/Tree';
 import { mapNodeParams } from '../constants/MapDefinitionConstants';
 import { sourcePrefix, targetPrefix } from '../constants/ReactFlowConstants';
 import type { PathItem, Schema, SchemaExtended, SchemaNode, SchemaNodeDictionary, SchemaNodeExtended } from '../models';
@@ -98,28 +99,32 @@ export const searchSchemaTreeFromRoot = (
   schemaTreeRoot: SchemaNodeExtended,
   nodeKeySearchTerm: string,
   minSearchCharacters = 2
-): SchemaNodeExtended => {
+): ITreeNode<ITreeNode<SchemaNodeExtended>> => {
   if (nodeKeySearchTerm.length < minSearchCharacters) {
     return { ...schemaTreeRoot };
   }
 
-  const searchChildren = (result: SchemaNodeExtended[], node: SchemaNodeExtended) => {
-    if (node.key.toLowerCase().includes(nodeKeySearchTerm.toLowerCase())) {
+  const searchChildren = (result: ITreeNode<ITreeNode<SchemaNodeExtended>>[], node: ITreeNode<ITreeNode<SchemaNodeExtended>>) => {
+    if (node.key.toString().toLowerCase().includes(nodeKeySearchTerm.toLowerCase())) {
       result.push({ ...node });
       return result;
     }
 
-    if (node.children.length > 0) {
+    if (node.children && node.children.length > 0) {
       const childNodes = node.children.reduce(searchChildren, []);
       if (childNodes.length) {
-        result.push({ ...node, children: childNodes });
+        result.push({ ...node, isExpanded: true, children: childNodes } as ITreeNode<ITreeNode<SchemaNodeExtended>>);
       }
     }
 
     return result;
   };
 
-  return { ...schemaTreeRoot, children: schemaTreeRoot.children.reduce(searchChildren, []) };
+  return {
+    ...schemaTreeRoot,
+    isExpanded: true,
+    children: schemaTreeRoot.children.reduce(searchChildren, []) as ITreeNode<SchemaNodeExtended>[],
+  };
 };
 
 export const isSchemaNodeExtended = (node: SchemaNodeExtended | FunctionData): node is SchemaNodeExtended => 'pathToRoot' in node;


### PR DESCRIPTION
-Show different icon on source schema item on hover
-Auto-expand searched tree items

-Edit: Additionally, made better sense of Tree generic typings, and made some schema tree functionality changes based off new spec

-Unrelated: Swap center view height tracking to ResizeObserver API for more PropPane placement/height-ing consistency (and maybe performance/speed/snappy-ness if I'm not crazy or seeing things)