### PR TITLE
[DM | VSIX | Map Definitions] Display dirty state + save drafts between actual saves

### DIFF
--- a/apps/vs-code-data-mapper-react/src/app/app.tsx
+++ b/apps/vs-code-data-mapper-react/src/app/app.tsx
@@ -62,7 +62,6 @@ export const App = () => {
     });
   }, [vscode]);
 
-  // TODO: May combine the below two functions - will revisit when touched on again in future
   const saveDataMapDefinition = (dataMapDefinition: string) => {
     vscode.postMessage({
       command: 'saveDataMapDefinition',
@@ -74,6 +73,13 @@ export const App = () => {
     vscode.postMessage({
       command: 'saveDataMapXslt',
       data: dataMapXslt,
+    });
+  };
+
+  const saveDraftDataMapDefinition = (dataMapDefinition: string) => {
+    vscode.postMessage({
+      command: 'saveDraftDataMapDefinition',
+      data: dataMapDefinition,
     });
   };
 
@@ -171,6 +177,7 @@ export const App = () => {
       >
         <DataMapperDesigner
           saveStateCall={saveStateCall}
+          saveDraftStateCall={saveDraftDataMapDefinition}
           addSchemaFromFile={addSchemaFromFile}
           readCurrentSchemaOptions={readLocalFileOptions}
           setIsMapStateDirty={setIsMapStateDirty}

--- a/apps/vs-code-data-mapper-react/src/app/app.tsx
+++ b/apps/vs-code-data-mapper-react/src/app/app.tsx
@@ -77,6 +77,13 @@ export const App = () => {
     });
   };
 
+  const setIsMapStateDirty = (isMapStateDirty: boolean) => {
+    vscode.postMessage({
+      command: 'setIsMapStateDirty',
+      data: isMapStateDirty,
+    });
+  };
+
   const handleRscLoadError = useCallback(
     (error: unknown) => {
       let errorMsg: string;
@@ -166,6 +173,7 @@ export const App = () => {
           saveStateCall={saveStateCall}
           addSchemaFromFile={addSchemaFromFile}
           readCurrentSchemaOptions={readLocalFileOptions}
+          setIsMapStateDirty={setIsMapStateDirty}
         />
       </DataMapDataProvider>
     </DataMapperDesignerProvider>

--- a/apps/vs-code-data-mapper/src/extensionConfig.ts
+++ b/apps/vs-code-data-mapper/src/extensionConfig.ts
@@ -1,6 +1,5 @@
-export const webviewTitle = 'Data Mapper';
 export const webviewType = 'dataMapperWebview';
-export const outputChannelTitle = webviewTitle;
+export const outputChannelTitle = 'Data Mapper';
 export const outputChannelPrefix = 'azureLogicAppsDataMapper';
 
 export const supportedDataMapDefinitionFileExts = ['.yml'];

--- a/apps/vs-code-data-mapper/src/extensionConfig.ts
+++ b/apps/vs-code-data-mapper/src/extensionConfig.ts
@@ -12,6 +12,7 @@ export const dataMapDefinitionsPath = `${artifactsPath}/MapDefinitions`;
 export const workflowDesignTimeDir = '/workflow-designtime';
 
 export const defaultDatamapFilename = 'default';
+export const draftMapDefinitionSuffix = '-draft';
 export const mapDefinitionExtension = '.yml';
 export const mapXsltExtension = '.xslt';
 

--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -84,7 +84,6 @@ const useStyles = makeStyles({
     ...shorthands.flex(1, 1, '1px'),
   },
   canvasWrapper: {
-    backgroundColor: '#edebe9',
     height: '100%',
   },
 });
@@ -93,13 +92,20 @@ export interface DataMapperDesignerProps {
   saveStateCall: (dataMapDefinition: string, dataMapXslt: string) => void;
   addSchemaFromFile?: (selectedSchemaFile: SchemaFile) => void;
   readCurrentSchemaOptions?: () => void;
+  setIsMapStateDirty?: (isMapStateDirty: boolean) => void;
 }
 
-export const DataMapperDesigner = ({ saveStateCall, addSchemaFromFile, readCurrentSchemaOptions }: DataMapperDesignerProps) => {
+export const DataMapperDesigner = ({
+  saveStateCall,
+  addSchemaFromFile,
+  readCurrentSchemaOptions,
+  setIsMapStateDirty,
+}: DataMapperDesignerProps) => {
   const dispatch = useDispatch<AppDispatch>();
   useStaticStyles();
   const styles = useStyles();
 
+  const isMapStateDirty = useSelector((state: RootState) => state.dataMap.isDirty);
   const sourceSchema = useSelector((state: RootState) => state.dataMap.curDataMapOperation.sourceSchema);
   const targetSchema = useSelector((state: RootState) => state.dataMap.curDataMapOperation.targetSchema);
   const currentTargetSchemaNode = useSelector((state: RootState) => state.dataMap.curDataMapOperation.currentTargetSchemaNode);
@@ -170,6 +176,13 @@ export const DataMapperDesigner = ({ saveStateCall, addSchemaFromFile, readCurre
         );
       });
   }, [dispatch, dataMapDefinition, saveStateCall, sourceSchema, targetSchema]);
+
+  // NOTE: Putting this useEffect here for vis next to onSave
+  useEffect(() => {
+    if (setIsMapStateDirty) {
+      setIsMapStateDirty(isMapStateDirty);
+    }
+  }, [isMapStateDirty, setIsMapStateDirty]);
 
   const ctrlSPressed = useKeyPress(['Meta+s', 'ctrl+s']);
   useEffect(() => {

--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -90,6 +90,7 @@ const useStyles = makeStyles({
 
 export interface DataMapperDesignerProps {
   saveStateCall: (dataMapDefinition: string, dataMapXslt: string) => void;
+  saveDraftStateCall?: (dataMapDefinition: string) => void;
   addSchemaFromFile?: (selectedSchemaFile: SchemaFile) => void;
   readCurrentSchemaOptions?: () => void;
   setIsMapStateDirty?: (isMapStateDirty: boolean) => void;
@@ -97,6 +98,7 @@ export interface DataMapperDesignerProps {
 
 export const DataMapperDesigner = ({
   saveStateCall,
+  saveDraftStateCall,
   addSchemaFromFile,
   readCurrentSchemaOptions,
   setIsMapStateDirty,
@@ -122,7 +124,13 @@ export const DataMapperDesigner = ({
   const dataMapDefinition = useMemo<string>(() => {
     if (sourceSchema && targetSchema) {
       try {
-        return convertToMapDefinition(currentConnections, sourceSchema, targetSchema);
+        const newDataMapDefinition = convertToMapDefinition(currentConnections, sourceSchema, targetSchema);
+
+        if (saveDraftStateCall) {
+          saveDraftStateCall(newDataMapDefinition);
+        }
+
+        return newDataMapDefinition;
       } catch (error) {
         // NOTE: Doing it this way so that the error, whatever it is, just gets formatted/logged on its own
         // - can and maybe should change if we add more infrastructure around error classes/types
@@ -140,7 +148,7 @@ export const DataMapperDesigner = ({
     }
 
     return '';
-  }, [currentConnections, sourceSchema, targetSchema]);
+  }, [currentConnections, sourceSchema, targetSchema, saveDraftStateCall]);
 
   const showMapOverview = useMemo<boolean>(
     () => !sourceSchema || !targetSchema || !currentTargetSchemaNode,


### PR DESCRIPTION
-Data map name is now shown in panel title (along with dirty state - filled dot text icon)
-Save a draft file of map definition (.yml) as changes are made, deleting this draft file in favor of the "actual" one once an actual save is initiated using the Save button

-Also tested MapDef draft functionality with 'Create new data map' - worked great

![VsixMapDefDirtyState+Drafts](https://user-images.githubusercontent.com/49288482/202741966-dbda6211-0525-4a8e-b3d6-001431304fc3.gif)
