### PR TITLE
[DM | BUGFIX] Fix PropPane InputDropdown inner-Dropdown stale values

### DIFF
--- a/libs/data-mapper/src/lib/components/inputDropdown/InputDropdown.tsx
+++ b/libs/data-mapper/src/lib/components/inputDropdown/InputDropdown.tsx
@@ -393,7 +393,7 @@ export const InputDropdown = (props: InputDropdownProps) => {
       {!inputIsCustomValue ? (
         <Dropdown
           options={modifiedDropdownOptions}
-          selectedKey={inputValue}
+          selectedKey={inputValue ?? null}
           onChange={(_e, option) => onSelectOption(option)}
           label={label}
           placeholder={placeholder}


### PR DESCRIPTION
...by setting selectedKey to null when we change (or just start with) our controlled inputValue to/at undefined

![InputDropdownStaleValueNullFix](https://user-images.githubusercontent.com/49288482/205338626-0edeb966-d784-40ce-abeb-ebf0a540d4ef.gif)
