### PR TITLE
[DM | Accessibility] Wrap SelectSchemaCards in button to get tabIndex/ENTER support

### DIFF
--- a/libs/data-mapper/src/lib/components/schemaSelection/SelectSchemaCard.tsx
+++ b/libs/data-mapper/src/lib/components/schemaSelection/SelectSchemaCard.tsx
@@ -82,7 +82,7 @@ export const SelectSchemaCard = ({ schemaType, style }: SelectSchemaCardProps) =
   };
 
   return (
-    <Button appearance="transparent" onClick={onClickSchemaCard} style={{ padding: 0 }}>
+    <Button appearance="transparent" onClick={onClickSchemaCard} style={{ padding: 0 }} aria-label={selectSchemaMsg}>
       <Stack
         verticalAlign="center"
         horizontalAlign="center"

--- a/libs/data-mapper/src/lib/components/schemaSelection/SelectSchemaCard.tsx
+++ b/libs/data-mapper/src/lib/components/schemaSelection/SelectSchemaCard.tsx
@@ -6,7 +6,7 @@ import CardOnHoverDark from './card_onHover_dark.svg';
 import CardOnRest from './card_onRest.svg';
 import CardOnRestDark from './card_onRest_dark.svg';
 import { Image, Stack } from '@fluentui/react';
-import { makeStyles, shorthands, Text, tokens, typographyStyles } from '@fluentui/react-components';
+import { Button, makeStyles, shorthands, Text, tokens, typographyStyles } from '@fluentui/react-components';
 import { useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
@@ -82,18 +82,19 @@ export const SelectSchemaCard = ({ schemaType, style }: SelectSchemaCardProps) =
   };
 
   return (
-    <Stack
-      verticalAlign="center"
-      horizontalAlign="center"
-      className={styles.selectSchemaCard}
-      onClick={onClickSchemaCard}
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseLeave={() => setIsHovering(false)}
-      style={style}
-    >
-      <Image src={isHovering ? cardOnHoverSvg : cardOnRestSvg} alt="Schema selection card" style={{ paddingBottom: '28px' }} />
+    <Button appearance="transparent" onClick={onClickSchemaCard} style={{ padding: 0 }}>
+      <Stack
+        verticalAlign="center"
+        horizontalAlign="center"
+        className={styles.selectSchemaCard}
+        onMouseEnter={() => setIsHovering(true)}
+        onMouseLeave={() => setIsHovering(false)}
+        style={style}
+      >
+        <Image src={isHovering ? cardOnHoverSvg : cardOnRestSvg} alt="Schema selection card" style={{ paddingBottom: '28px' }} />
 
-      <Text className={styles.selectSchemaText}>{selectSchemaMsg}</Text>
-    </Stack>
+        <Text className={styles.selectSchemaText}>{selectSchemaMsg}</Text>
+      </Stack>
+    </Button>
   );
 };


### PR DESCRIPTION
Tabbed to schema selection card:
![image](https://user-images.githubusercontent.com/49288482/206541479-3e8ff831-7a97-4874-a506-bb1559cd8b3a.png)


Hitting ENTER:
![image](https://user-images.githubusercontent.com/49288482/206541575-aa9090f0-94a2-411a-b134-ce915e54c85e.png)

Hovering the card w/ mouse (styles/look remain unaffected):
![image](https://user-images.githubusercontent.com/49288482/206541672-d1958ce6-a921-4937-b28e-2cca80d16dbe.png)





