### PR TITLE
[DM | Canvas] Restrict panning to certain bounds

### DIFF
--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -114,7 +114,7 @@ export const DataMapperDesigner = ({
   const currentConnections = useSelector((state: RootState) => state.dataMap.curDataMapOperation.dataMapConnections);
   const selectedItemKey = useSelector((state: RootState) => state.dataMap.curDataMapOperation.selectedItemKey);
 
-  const centerViewHeight = useCenterViewHeight();
+  const { centerViewHeight, centerViewWidth } = useCenterViewHeight();
   const [isPropPaneExpanded, setIsPropPaneExpanded] = useState(!!selectedItemKey);
   const [propPaneExpandedHeight, setPropPaneExpandedHeight] = useState(basePropPaneContentHeight);
   const [isCodeViewOpen, setIsCodeViewOpen] = useState(false);
@@ -264,7 +264,8 @@ export const DataMapperDesigner = ({
                       <MapOverview />
                     ) : (
                       <ReactFlowProvider>
-                        <ReactFlowWrapper canvasBlockHeight={getCanvasAreaHeight()} />
+                        {/* TODO: Update width calculations once Code View becomes resizable */}
+                        <ReactFlowWrapper canvasBlockHeight={getCanvasAreaHeight()} canvasBlockWidth={centerViewWidth} />
                       </ReactFlowProvider>
                     )}
                   </div>
@@ -303,6 +304,7 @@ export const DataMapperDesigner = ({
 };
 
 const useCenterViewHeight = () => {
+  const [centerViewWidth, setCenterViewWidth] = useState(0);
   const [centerViewHeight, setCenterViewHeight] = useState(0);
 
   useEffect(() => {
@@ -311,6 +313,7 @@ const useCenterViewHeight = () => {
     const centerViewResizeObserver = new ResizeObserver((entries) => {
       if (entries.length && entries.length > 0) {
         setCenterViewHeight(entries[0].contentRect.height);
+        setCenterViewWidth(entries[0].contentRect.width);
       }
     });
 
@@ -321,5 +324,5 @@ const useCenterViewHeight = () => {
     return () => centerViewResizeObserver.disconnect();
   }, []);
 
-  return centerViewHeight;
+  return { centerViewWidth, centerViewHeight };
 };

--- a/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
+++ b/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
@@ -6,8 +6,10 @@ import { SchemaCard } from '../components/nodeCard/SchemaCard';
 import { Notification } from '../components/notification/Notification';
 import { SchemaNameBadge } from '../components/schemaSelection/SchemaNameBadge';
 import { SourceSchemaPlaceholder } from '../components/schemaSelection/SourceSchemaPlaceholder';
+import { schemaNodeCardHeight, schemaNodeCardWidth } from '../constants/NodeConstants';
 import {
   checkerboardBackgroundImage,
+  defaultCanvasZoom,
   ReactFlowEdgeType,
   reactFlowFitViewOptions,
   ReactFlowNodeType,
@@ -31,20 +33,23 @@ import { useLayout } from '../utils/ReactFlow.Util';
 import { tokens } from '@fluentui/react-components';
 import { useBoolean } from '@fluentui/react-hooks';
 import type { KeyboardEventHandler, MouseEvent as ReactMouseEvent } from 'react';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { Connection as ReactFlowConnection, Edge as ReactFlowEdge, Node as ReactFlowNode, OnConnectStartParams } from 'reactflow';
 // eslint-disable-next-line import/no-named-as-default
 import ReactFlow, { ConnectionLineType, useKeyPress } from 'reactflow';
+
+type CanvasExtent = [[number, number], [number, number]];
 
 export const nodeTypes = { [ReactFlowNodeType.SchemaNode]: SchemaCard, [ReactFlowNodeType.FunctionNode]: FunctionCard };
 export const edgeTypes = { [ReactFlowEdgeType.ConnectionEdge]: ConnectionEdge };
 
 interface ReactFlowWrapperProps {
   canvasBlockHeight: number;
+  canvasBlockWidth: number;
 }
 
-export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) => {
+export const ReactFlowWrapper = ({ canvasBlockHeight, canvasBlockWidth }: ReactFlowWrapperProps) => {
   const dispatch = useDispatch<AppDispatch>();
   const reactFlowRef = useRef<HTMLDivElement>(null);
 
@@ -61,6 +66,7 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
   const flattenedTargetSchema = useSelector((state: RootState) => state.dataMap.curDataMapOperation.flattenedTargetSchema);
   const notificationData = useSelector((state: RootState) => state.dataMap.notificationData);
 
+  const [canvasZoom, setCanvasZoom] = useState(defaultCanvasZoom);
   const [displayMiniMap, { toggle: toggleDisplayMiniMap }] = useBoolean(false);
 
   const onPaneClick = (_event: ReactMouseEvent | MouseEvent | TouchEvent): void => {
@@ -134,7 +140,7 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
     }
   }, [ctrlYPressed, dispatch]);
 
-  const [nodes, edges] = useLayout(
+  const [nodes, edges, diagramSize] = useLayout(
     currentSourceSchemaNodes,
     currentFunctionNodes,
     currentTargetSchemaNode,
@@ -150,21 +156,38 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
     [nodes]
   );
 
+  // Restrict canvas panning to certain bounds
+  const translateExtent = useMemo<CanvasExtent>(() => {
+    const xOffset = schemaNodeCardWidth * 2;
+    const yOffset = schemaNodeCardHeight * 2;
+
+    const xPos = canvasBlockWidth / canvasZoom - xOffset;
+    const yPos = canvasBlockHeight / canvasZoom - yOffset;
+
+    return [
+      [-xPos, -yPos],
+      [xPos + diagramSize.width, yPos + diagramSize.height],
+    ];
+  }, [diagramSize, canvasBlockHeight, canvasBlockWidth, canvasZoom]);
+
   return (
     <ReactFlow
       ref={reactFlowRef}
-      onKeyDown={keyDownHandler}
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       nodes={nodes}
       edges={edges}
+      onPaneClick={onPaneClick}
+      // Not ideal, but it's this or useViewport that re-renders 3000 (due to x/y changes)
+      onMove={(_e, viewport) => setCanvasZoom(viewport.zoom)}
+      onKeyDown={keyDownHandler}
       onConnect={onConnect}
       onConnectStart={onConnectStart}
       onConnectEnd={onConnectEnd}
-      onPaneClick={onPaneClick}
+      onEdgeClick={onEdgeClick}
       onNodeClick={onNodeSingleClick}
       nodesDraggable={false}
-      // With custom edge component, only affects appearance when drawing edge
+      // When using custom edge component, only affects appearance when drawing edge
       connectionLineType={ConnectionLineType.SmoothStep}
       proOptions={{
         account: 'paid-sponsor',
@@ -176,7 +199,7 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
         backgroundSize: '22px 22px',
         borderRadius: tokens.borderRadiusMedium,
       }}
-      onEdgeClick={onEdgeClick}
+      translateExtent={translateExtent}
       fitViewOptions={reactFlowFitViewOptions}
       fitView
     >

--- a/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
+++ b/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
@@ -48,22 +48,6 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
   const dispatch = useDispatch<AppDispatch>();
   const reactFlowRef = useRef<HTMLDivElement>(null);
 
-  const ctrlZPressed = useKeyPress(['Meta+z', 'ctrl+z']);
-  useEffect(() => {
-    if (ctrlZPressed) {
-      dispatch(undoDataMapOperation());
-      console.log('Z');
-    }
-  }, [ctrlZPressed, dispatch]);
-
-  const ctrlYPressed = useKeyPress(['Meta+y', 'ctrl+y']);
-  useEffect(() => {
-    if (ctrlYPressed) {
-      dispatch(redoDataMapOperation());
-      console.log('Y');
-    }
-  }, [ctrlYPressed, dispatch]);
-
   const selectedItemKey = useSelector((state: RootState) => state.dataMap.curDataMapOperation.selectedItemKey);
   const currentTargetSchemaNode = useSelector((state: RootState) => state.dataMap.curDataMapOperation.currentTargetSchemaNode);
   const connections = useSelector((state: RootState) => state.dataMap.curDataMapOperation.dataMapConnections);
@@ -135,6 +119,20 @@ export const ReactFlowWrapper = ({ canvasBlockHeight }: ReactFlowWrapperProps) =
       dispatch(deleteCurrentlySelectedItem());
     }
   };
+
+  const ctrlZPressed = useKeyPress(['Meta+z', 'ctrl+z']);
+  useEffect(() => {
+    if (ctrlZPressed) {
+      dispatch(undoDataMapOperation());
+    }
+  }, [ctrlZPressed, dispatch]);
+
+  const ctrlYPressed = useKeyPress(['Meta+y', 'ctrl+y']);
+  useEffect(() => {
+    if (ctrlYPressed) {
+      dispatch(redoDataMapOperation());
+    }
+  }, [ctrlYPressed, dispatch]);
 
   const [nodes, edges] = useLayout(
     currentSourceSchemaNodes,

--- a/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
+++ b/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
@@ -18,12 +18,17 @@ import { useEffect, useState } from 'react';
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from 'reactflow';
 import { Position } from 'reactflow';
 
+export const overviewTgtSchemaX = 600;
+
 interface SimplifiedElkEdge {
   srcRfId: string;
   tgtRfId: string;
 }
 
-export const overviewTgtSchemaX = 600;
+interface Size2D {
+  width: number;
+  height: number;
+}
 
 // Hidden dummy node placed at 0,0 (same as source schema block) to allow initial load fitView to center diagram
 // NOTE: Not documented, but hidden nodes need a width/height to properly affect fitView when includeHiddenNodes option is true
@@ -47,9 +52,10 @@ export const useLayout = (
   connections: ConnectionDictionary,
   selectedItemKey: string | undefined,
   sourceSchemaOrdering: string[]
-): [ReactFlowNode[], ReactFlowEdge[]] => {
+): [ReactFlowNode[], ReactFlowEdge[], Size2D] => {
   const [reactFlowNodes, setReactFlowNodes] = useState<ReactFlowNode[]>([]);
   const [reactFlowEdges, setReactFlowEdges] = useState<ReactFlowEdge[]>([]);
+  const [diagramSize, setDiagramSize] = useState<Size2D>({ width: 0, height: 0 });
 
   useEffect(() => {
     if (currentTargetSchemaNode) {
@@ -106,6 +112,12 @@ export const useLayout = (
           }
 
           setReactFlowEdges(convertToReactFlowEdges(simpleElkEdgeResults, selectedItemKey));
+
+          // Calculate diagram size
+          setDiagramSize({
+            width: layoutedElkTree.width ?? 0,
+            height: layoutedElkTree.height ?? 0,
+          });
         })
         .catch((error) => {
           console.error(`Elk Layout Error: ${error}`);
@@ -114,10 +126,11 @@ export const useLayout = (
     } else {
       setReactFlowNodes([]);
       setReactFlowEdges([]);
+      setDiagramSize({ width: 0, height: 0 });
     }
   }, [currentTargetSchemaNode, currentSourceSchemaNodes, currentFunctionNodes, connections, sourceSchemaOrdering, selectedItemKey]);
 
-  return [reactFlowNodes, reactFlowEdges];
+  return [reactFlowNodes, reactFlowEdges, diagramSize];
 };
 
 export const convertToReactFlowNodes = (


### PR DESCRIPTION
Totally not shamelessly piggybacking off @rllyy97 (Thank you! :^) )

*Tradeoff (as rllyy97 probably discovered as well) is moving the canvas' zoom to controlled state, but as the comment I left suggests, it's that, or useViewport which re-renders not only each time zoom changes, but on any sort of panning action == lag

-It does confirmed-ly adapt to the diagram as it expands (see the 5-10 ToStrings in the GIF)
-It will need to a little more fine-tuned once the Code View gets some love again (as this currently just uses the canvas width as if the CV was never open - not a huge deal though)

![CanvasPanningBounds](https://user-images.githubusercontent.com/49288482/206570631-f5a132c1-0901-420c-93f9-e1955c95bef4.gif)
