### PR TITLE
Add Open File Command

### DIFF
--- a/apps/vs-code-designer/src/app/commands/openFile.ts
+++ b/apps/vs-code-designer/src/app/commands/openFile.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { extensionCommand } from '../../constants';
+import type { FileTreeItem } from '@microsoft/vscode-azext-azureappservice';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import { commands } from 'vscode';
+
+export async function openFile(context: IActionContext, node: FileTreeItem): Promise<void> {
+  await commands.executeCommand(extensionCommand.azureFunctionsOpenFile, node, context);
+}

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 import { extensionCommand } from '../../constants';
 import { ext } from '../../extensionVariables';
+import { executeOnFunctions } from '../functionsExtension/executeOnFunctionsExt';
+import { openFile } from './openFile';
 import { openDesigner } from './workflows/openDesigner/openDesigner';
+import type { FileTreeItem } from '@microsoft/vscode-azext-azureappservice';
 import { registerCommand } from '@microsoft/vscode-azext-utils';
 import type { AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
 import { commands } from 'vscode';
@@ -16,4 +19,5 @@ export function registerCommands(): void {
     async (context: IActionContext, node: AzExtTreeItem) => await ext.tree.loadMore(node, context)
   );
   registerCommand(extensionCommand.selectSubscriptions, () => commands.executeCommand(extensionCommand.azureSelectSubscriptions));
+  registerCommand(extensionCommand.openFile, (context: IActionContext, node: FileTreeItem) => executeOnFunctions(openFile, context, node));
 }

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -19,5 +19,7 @@ export function registerCommands(): void {
     async (context: IActionContext, node: AzExtTreeItem) => await ext.tree.loadMore(node, context)
   );
   registerCommand(extensionCommand.selectSubscriptions, () => commands.executeCommand(extensionCommand.azureSelectSubscriptions));
-  registerCommand(extensionCommand.openFile, (context: IActionContext, node: FileTreeItem) => executeOnFunctions(openFile, context, node));
+  registerCommand(extensionCommand.openFile, (context: IActionContext, node: FileTreeItem) =>
+    executeOnFunctions(openFile, context, context, node)
+  );
 }

--- a/apps/vs-code-designer/src/app/functionsExtension/executeOnFunctionsExt.ts
+++ b/apps/vs-code-designer/src/app/functionsExtension/executeOnFunctionsExt.ts
@@ -3,12 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { functionsExtensionId } from '../../constants';
+import { localize } from '../../localize';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { extensions } from 'vscode';
 
-export async function executeOnFunctions(callback, ...args: any[]): Promise<void> {
+export async function executeOnFunctions(callback: any, context: IActionContext, ...args: any[]): Promise<void> {
   const functionsExtension = extensions.getExtension(functionsExtensionId);
 
   if (functionsExtension?.isActive) {
     callback(...args);
+  } else {
+    const message: string = localize('deactivatedFunctionsExt', 'Functions extension is deactivated, make sure to activate it');
+    await context.ui.showWarningMessage(message);
   }
 }

--- a/apps/vs-code-designer/src/app/functionsExtension/executeOnFunctionsExt.ts
+++ b/apps/vs-code-designer/src/app/functionsExtension/executeOnFunctionsExt.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { functionsExtensionId } from '../../constants';
+import { extensions } from 'vscode';
+
+export async function executeOnFunctions(callback, ...args: any[]): Promise<void> {
+  const functionsExtension = extensions.getExtension(functionsExtensionId);
+
+  if (functionsExtension?.isActive) {
+    callback(...args);
+  }
+}

--- a/apps/vs-code-designer/src/app/tree/remoteWorkflowsTree/RemoteWorkflowTreeItem.ts
+++ b/apps/vs-code-designer/src/app/tree/remoteWorkflowsTree/RemoteWorkflowTreeItem.ts
@@ -17,8 +17,13 @@ import { isEmptyString, HTTP_METHODS } from '@microsoft/utils-logic-apps';
 import { AzExtTreeItem, DialogResponses } from '@microsoft/vscode-azext-utils';
 import type { AzExtParentTreeItem, IActionContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import { ProjectResource } from '@microsoft/vscode-extension';
-import type { ServiceProviderConnectionModel } from '@microsoft/vscode-extension';
-import type { IWorkflowFileContent, Artifacts, Parameter, ICallbackUrlResponse } from '@microsoft/vscode-extension';
+import type {
+  ServiceProviderConnectionModel,
+  IWorkflowFileContent,
+  Artifacts,
+  Parameter,
+  ICallbackUrlResponse,
+} from '@microsoft/vscode-extension';
 import { ProgressLocation, window } from 'vscode';
 
 export class RemoteWorkflowTreeItem extends AzExtTreeItem {

--- a/apps/vs-code-designer/src/app/tree/slotsTree/SlotTreeItemBase.ts
+++ b/apps/vs-code-designer/src/app/tree/slotsTree/SlotTreeItemBase.ts
@@ -28,9 +28,15 @@ import {
 import type { IDeployContext } from '@microsoft/vscode-azext-azureappservice';
 import { AzExtParentTreeItem, AzureWizard, DeleteConfirmationStep, nonNullValue } from '@microsoft/vscode-azext-utils';
 import type { AzExtTreeItem, IActionContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
-import type { ApplicationSettings, FuncHostRequest, FuncVersion, IParsedHostJson, IProjectTreeItem } from '@microsoft/vscode-extension';
+import type {
+  ApplicationSettings,
+  ILocalSettingsJson,
+  FuncHostRequest,
+  FuncVersion,
+  IParsedHostJson,
+  IProjectTreeItem,
+} from '@microsoft/vscode-extension';
 import { latestGAVersion, ProjectSource } from '@microsoft/vscode-extension';
-import type { ILocalSettingsJson } from '@microsoft/vscode-extension';
 import * as path from 'path';
 
 export abstract class SlotTreeItemBase extends AzExtParentTreeItem implements IProjectTreeItem {

--- a/apps/vs-code-designer/src/app/utils/codeless/apiUtils.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/apiUtils.ts
@@ -9,8 +9,14 @@ import type { SlotTreeItemBase } from '../../tree/slotsTree/SlotTreeItemBase';
 import { sendAzureRequest } from '../requestUtils';
 import { HTTP_METHODS } from '@microsoft/utils-logic-apps';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
-import type { IConnectionsFileContent } from '@microsoft/vscode-extension';
-import type { IParametersFileContent, Parameter, IWorkflowFileContent, IArtifactFile, Artifacts } from '@microsoft/vscode-extension';
+import type {
+  IParametersFileContent,
+  IConnectionsFileContent,
+  Parameter,
+  IWorkflowFileContent,
+  IArtifactFile,
+  Artifacts,
+} from '@microsoft/vscode-extension';
 import * as path from 'path';
 import * as vscode from 'vscode';
 

--- a/apps/vs-code-designer/src/app/utils/codeless/connection.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/connection.ts
@@ -8,8 +8,12 @@ import { getParametersJson } from './parameter';
 import { HTTP_METHODS } from '@microsoft/utils-logic-apps';
 import { nonNullValue } from '@microsoft/vscode-azext-utils';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
-import type { ServiceProviderConnectionModel, ConnectionAndSettings, ConnectionReferenceModel } from '@microsoft/vscode-extension';
-import type { Parameter } from '@microsoft/vscode-extension';
+import type {
+  ServiceProviderConnectionModel,
+  Parameter,
+  ConnectionAndSettings,
+  ConnectionReferenceModel,
+} from '@microsoft/vscode-extension';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as requestP from 'request-promise';

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -16,6 +16,7 @@ export const parametersFileName = 'parameters.json';
 
 // Functions
 export const func = 'func';
+export const functionsExtensionId = 'ms-azuretools.vscode-azurefunctions';
 
 // Workflow
 export const workflowLocationKey = 'WORKFLOWS_LOCATION_NAME';
@@ -42,6 +43,8 @@ export enum extensionCommand {
   activate = 'logicAppsExtension.activate',
   selectSubscriptions = 'logicAppsExtension.selectSubscriptions',
   azureSelectSubscriptions = 'azure-account.selectSubscriptions',
+  openFile = 'logicAppsExtension.openFile',
+  azureFunctionsOpenFile = 'azureFunctions.openFile',
 }
 
 // Context

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -100,7 +100,8 @@
     ]
   },
   "extensionDependencies": [
-    "ms-vscode.azure-account"
+    "ms-vscode.azure-account",
+    "ms-azuretools.vscode-azurefunctions"
   ],
   "activationEvents": [
     "onCommand:logicAppsExtension.openDesigner",


### PR DESCRIPTION
### Main Code Changes
- Add azure functions extension to dependencies
- Add open file command relying on azure functions
- Add reusable function to double check azure functions extension is enable


### Implementation
#### Error message when azure functions is not installed or deactivated. Extension doesn't load at all until installed or activated
<img width="1496" alt="Screenshot 2022-12-09 at 11 08 47 AM" src="https://user-images.githubusercontent.com/102700317/206797275-d210af16-c6a7-4a23-9748-635d5c40f073.png">

#### Video Implementation

https://user-images.githubusercontent.com/102700317/206797711-75b6f380-b2cd-4c08-b709-aad54944e24f.mov


