### PR TITLE
labugfix: Root Node Run-After Bugfix

### DIFF
--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -2,7 +2,7 @@
 import CONSTANTS from '../../common/constants';
 import type { RelationshipIds } from '../state/panel/panelInterfaces';
 import type { NodesMetadata, WorkflowState } from '../state/workflow/workflowInterfaces';
-import { createWorkflowNode, createWorkflowEdge, isRootNodeInGraph } from '../utils/graph';
+import { createWorkflowNode, createWorkflowEdge } from '../utils/graph';
 import type { WorkflowEdge, WorkflowNode } from './models/workflowNode';
 import {
   reassignEdgeSources,
@@ -29,7 +29,7 @@ export const addNodeToWorkflow = (
   nodesMetadata: NodesMetadata,
   state: WorkflowState
 ) => {
-  const { nodeId: newNodeId, operation } = payload;
+  const { nodeId: newNodeId } = payload;
   const { graphId, parentId, childId } = payload.relationshipIds;
 
   // Add Node Data
@@ -43,15 +43,14 @@ export const addNodeToWorkflow = (
   if (workflowNode.id) workflowGraph.children = [...(workflowGraph?.children ?? []), workflowNode];
 
   // Update metadata
-  const isTrigger = !!operation.properties?.trigger;
-  const isRoot = isTrigger ?? (parentId ? parentId?.split('-#')[0] === graphId : false);
+  const isRoot = parentId ? parentId?.split('-#')[0] === graphId : false;
   const parentNodeId = graphId !== 'root' ? graphId : undefined;
   nodesMetadata[newNodeId] = { graphId, parentNodeId, isRoot };
 
   state.operations[newNodeId] = { ...state.operations[newNodeId], type: payload.operation.type };
   state.newlyAddedOperations[newNodeId] = newNodeId;
 
-  const shouldAddRunAfters = parentId ? !isRootNodeInGraph(parentId, 'root', state.nodesMetadata) : true;
+  const shouldAddRunAfters = !isRoot;
 
   // Parallel Branch creation, just add the singular node
   if (payload.isParallelBranch && parentId) {

--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -29,7 +29,7 @@ export const addNodeToWorkflow = (
   nodesMetadata: NodesMetadata,
   state: WorkflowState
 ) => {
-  const { nodeId: newNodeId } = payload;
+  const { nodeId: newNodeId, operation } = payload;
   const { graphId, parentId, childId } = payload.relationshipIds;
 
   // Add Node Data
@@ -43,7 +43,8 @@ export const addNodeToWorkflow = (
   if (workflowNode.id) workflowGraph.children = [...(workflowGraph?.children ?? []), workflowNode];
 
   // Update metadata
-  const isRoot = parentId ? parentId?.split('-#')[0] === graphId : false;
+  const isTrigger = !!operation.properties?.trigger;
+  const isRoot = isTrigger || (parentId ? parentId?.split('-#')[0] === graphId : false);
   const parentNodeId = graphId !== 'root' ? graphId : undefined;
   nodesMetadata[newNodeId] = { graphId, parentNodeId, isRoot };
 

--- a/libs/designer/src/lib/core/parsers/restructuringHelpers.ts
+++ b/libs/designer/src/lib/core/parsers/restructuringHelpers.ts
@@ -55,6 +55,7 @@ export const reassignEdgeSources = (
 
   // Remove would-be duplicate edges
   const targetEdges = graph.edges?.filter((edge) => edge.source === oldSourceId) ?? [];
+  if (targetEdges.length === 0) return;
   targetEdges.forEach((tEdge) => {
     if (graph.edges?.some((aEdge) => aEdge.source === newSourceId && aEdge.target === tEdge.target)) {
       removeEdge(state, oldSourceId, tEdge.target, graph);
@@ -112,10 +113,9 @@ const moveRunAfterSource = (
 
 export const applyIsRootNode = (state: WorkflowState, rootNodeId: string, graph: WorkflowNode, metadata: NodesMetadata) => {
   graph.edges?.forEach((edge) => {
-    if (edge.source === rootNodeId)
-      if (metadata?.[edge.target]) {
-        delete metadata[edge.target].isRoot;
-        (state.operations[edge.target] as LogicAppsV2.ActionDefinition).runAfter = {};
-      }
+    if (edge.source === rootNodeId && metadata?.[edge.target]) {
+      delete metadata[edge.target].isRoot;
+      (state.operations[edge.target] as LogicAppsV2.ActionDefinition).runAfter = {};
+    }
   });
 };

--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -76,7 +76,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
   const brandColor = useBrandColor(scopeId);
   const iconUri = useIconUri(scopeId);
   const isLeaf = useIsLeafNode(id);
-  const isScopeNode = useOperationInfo(scopeId).type.toLowerCase() === constants.NODE.TYPE.SCOPE;
+  const isScopeNode = useOperationInfo(scopeId)?.type.toLowerCase() === constants.NODE.TYPE.SCOPE;
 
   const label = useNodeDisplayName(scopeId);
   const nodeClick = useCallback(() => {
@@ -97,7 +97,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
     return null;
   }
 
-  const normalizedType = node.type.toLowerCase();
+  const normalizedType = node?.type.toLowerCase();
   const actionCount = metadata?.actionCount ?? 0;
 
   const actionString = intl.formatMessage(


### PR DESCRIPTION
## Main Changes
- Fixed a bug where the run-after setting for graph root nodes was configured incorrectly, preventing saving and returning a validation error