### PR TITLE
Add Create Logic App in Advanced Mode

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicApp.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicApp.ts
@@ -38,3 +38,11 @@ export async function createLogicApp(
     throw new Error(`Error in creating logic app. ${error}`);
   }
 }
+
+export async function createLogicAppAdvanced(
+  context: IActionContext,
+  subscription?: AzExtParentTreeItem | string,
+  newResourceGroupName?: string
+): Promise<string> {
+  return await createLogicApp({ ...context, advancedCreation: true }, subscription, newResourceGroupName);
+}

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -6,7 +6,7 @@ import { extensionCommand } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { executeOnFunctions } from '../functionsExtension/executeOnFunctionsExt';
 import { createCodeless } from './createCodeless/createCodeless';
-import { createLogicApp } from './createLogicApp/createLogicApp';
+import { createLogicApp, createLogicAppAdvanced } from './createLogicApp/createLogicApp';
 import { createNewProjectFromCommand } from './createNewProject/createNewProject';
 import { deployProductionSlot, deploySlot } from './deploy/deploy';
 import { openFile } from './openFile';
@@ -32,6 +32,7 @@ export function registerCommands(): void {
   registerCommand(extensionCommand.createNewProject, createNewProjectFromCommand);
   registerCommand(extensionCommand.createCodeless, createCodeless);
   registerCommand(extensionCommand.createLogicApp, createLogicApp);
+  registerCommand(extensionCommand.createLogicAppAdvanced, createLogicAppAdvanced);
   registerSiteCommand(extensionCommand.deploy, deployProductionSlot);
   registerSiteCommand(extensionCommand.deploySlot, deploySlot);
   registerCommand(extensionCommand.showOutputChannel, () => {

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -60,6 +60,7 @@ export enum extensionCommand {
   createNewProject = 'logicAppsExtension.createNewProject',
   createCodeless = 'logicAppsExtension.createCodeless',
   createLogicApp = 'logicAppsExtension.createLogicApp',
+  createLogicAppAdvanced = 'logicAppsExtension.createLogicAppAdvanced',
   deploy = 'logicAppsExtension.deploy',
   deploySlot = 'logicAppsExtension.deploySlot',
   showOutputChannel = 'logicAppsExtension.showOutputChannel',

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -73,6 +73,11 @@
         "command": "logicAppsExtension.createLogicApp",
         "title": "Create Logic App in Azure...",
         "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.createLogicAppAdvanced",
+        "title": "Create Logic App in Azure... (Advanced)",
+        "category": "Azure Logic Apps"
       }
     ],
     "viewsContainers": {
@@ -121,6 +126,11 @@
           "command": "logicAppsExtension.createLogicApp",
           "when": "view == newAzLogicApps && viewItem == azureextensionui.azureSubscription",
           "group": "1@1"
+        },
+        {
+          "command": "logicAppsExtension.createLogicAppAdvanced",
+          "when": "view == newAzLogicApps && viewItem == azureextensionui.azureSubscription",
+          "group": "1@2"
         },
         {
           "command": "logicAppsExtension.openDesigner",
@@ -229,6 +239,8 @@
     "onCommand:logicAppsExtension.createCodeless",
     "onCommand:logicAppsExtension.deploy",
     "onCommand:logicAppsExtension.deploySlot",
+    "onCommand:logicAppsExtension.createLogicApp",
+    "onCommand:logicAppsExtension.createLogicAppAdvanced",
     "onView:newAzLogicApps",
     "onDebugInitialConfigurations"
   ],


### PR DESCRIPTION
### Main Code Changes
- Add command in package.json to be executed through command palette and azure tab context
- Register command 

### Tested scenarios
- Create logic app advanced through azure tab.
- Create logic app advanced through the command palette.
- Create logic app advanced while deploying.


### Implementation
https://user-images.githubusercontent.com/102700317/210393206-0de89b91-73bb-4afe-a7d4-39a634c516b7.mp4

