### PR TITLE
laFix: Do-Until graph fix + Parameter sort fix

### DIFF
--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -238,9 +238,9 @@ const processScopeActions = (
       },
     };
 
-    // Connect scopeHeader to first child
-    if (graph.children?.[0]) {
-      edges.push(createWorkflowEdge(scopeCardNode.id, graph.children[0].id));
+    // Connect graph header to all top level nodes
+    for (const child of graph.children ?? []) {
+      if (metadata[child.id]?.isRoot) edges.push(createWorkflowEdge(scopeCardNode.id, child.id, WORKFLOW_EDGE_TYPES.HEADING_EDGE));
     }
 
     const footerId = `${graphId}-#footer`;

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -160,16 +160,16 @@ export interface RepetitionReference {
 export function getParametersSortedByVisibility(parameters: ParameterInfo[]): ParameterInfo[] {
   // Sorted by ( Required, Important, Advanced, Other )
   return parameters.sort((a, b) => {
-    if (a.required && !b.required) return 1;
-    if (!a.required && b.required) return -1;
+    if (a.required && !b.required) return -1;
+    if (!a.required && b.required) return 1;
 
     const aVisibility = getVisibility(a);
     const bVisibility = getVisibility(b);
     if (aVisibility === bVisibility) return 0;
-    if (aVisibility === Visibility.Important) return 1;
-    if (bVisibility === Visibility.Important) return -1;
-    if (aVisibility === Visibility.Advanced) return 1;
-    if (bVisibility === Visibility.Advanced) return -1;
+    if (aVisibility === Visibility.Important) return -1;
+    if (bVisibility === Visibility.Important) return 1;
+    if (aVisibility === Visibility.Advanced) return -1;
+    if (bVisibility === Visibility.Advanced) return 1;
     return 0;
   });
 }


### PR DESCRIPTION
### Fixes #1479 
First child of Until nodes would be disconnected if not first in the workflow.json file, root node is now order independent like the other scope nodes

![image](https://user-images.githubusercontent.com/25409734/211421287-84466eb9-e058-4687-b374-5a1dd4545f85.png)

---
### Fixes #1481 
Parameter order was reversed, now fixed to show optionals last

![image](https://user-images.githubusercontent.com/25409734/211421460-554c66a0-9c90-434f-81ed-975daa10281f.png)
