### PR TITLE
laFix: Reverting an OperationManifest change

### DIFF
--- a/libs/designer/src/lib/core/state/selectors/actionMetadataSelector.ts
+++ b/libs/designer/src/lib/core/state/selectors/actionMetadataSelector.ts
@@ -63,7 +63,10 @@ export const useOperationManifest = (operationInfo: NodeOperation) => {
   const operationId = operationInfo?.operationId?.toLowerCase();
   return useQuery(
     ['manifest', { connectorId }, { operationId }],
-    () => operationManifestService.getOperationManifest(connectorId, operationId),
+    () =>
+      operationManifestService.isSupported(operationInfo.type, operationInfo.kind)
+        ? operationManifestService.getOperationManifest(connectorId, operationId)
+        : undefined,
     {
       enabled: !!connectorId && !!operationId,
       placeholderData: undefined,


### PR DESCRIPTION
Just a quick reversion of a change I made in my last operation manifest PR.
This line looked irrelevant with the checks inside the method to get the manifest, but it's actually a little different.