### PR TITLE
Add redeploy command

### DIFF
--- a/apps/vs-code-designer/src/app/commands/deployments/redeployDeployment.ts
+++ b/apps/vs-code-designer/src/app/commands/deployments/redeployDeployment.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../../extensionVariables';
+import { DeploymentTreeItem } from '@microsoft/vscode-azext-azureappservice';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+
+export async function redeployDeployment(context: IActionContext, node?: DeploymentTreeItem): Promise<void> {
+  if (!node) {
+    node = await ext.tree.showTreeItemPicker<DeploymentTreeItem>(DeploymentTreeItem.contextValue, context);
+  }
+  await node.redeployDeployment(context);
+}

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -11,6 +11,7 @@ import { createLogicApp, createLogicAppAdvanced } from './createLogicApp/createL
 import { createNewProjectFromCommand } from './createNewProject/createNewProject';
 import { deleteNode } from './deleteNode';
 import { deployProductionSlot, deploySlot } from './deploy/deploy';
+import { redeployDeployment } from './deployments/redeployDeployment';
 import { openFile } from './openFile';
 import { pickFuncProcess } from './pickFuncProcess';
 import { restartLogicApp } from './restartLogicApp';
@@ -44,6 +45,7 @@ export function registerCommands(): void {
   registerCommand(extensionCommand.createLogicAppAdvanced, createLogicAppAdvanced);
   registerSiteCommand(extensionCommand.deploy, deployProductionSlot);
   registerSiteCommand(extensionCommand.deploySlot, deploySlot);
+  registerSiteCommand(extensionCommand.redeploy, redeployDeployment);
   registerCommand(extensionCommand.showOutputChannel, () => {
     ext.outputChannel.show();
   });

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -70,6 +70,7 @@ export enum extensionCommand {
   createLogicAppAdvanced = 'logicAppsExtension.createLogicAppAdvanced',
   deploy = 'logicAppsExtension.deploy',
   deploySlot = 'logicAppsExtension.deploySlot',
+  redeploy = 'logicAppsExtension.redeploy',
   showOutputChannel = 'logicAppsExtension.showOutputChannel',
   startLogicApp = 'logicAppsExtension.startLogicApp',
   stopLogicApp = 'logicAppsExtension.stopLogicApp',

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -123,6 +123,11 @@
         "command": "logicAppsExtension.switchToDotnetProject",
         "title": "Convert to NuGet-based Logic App project",
         "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.redeploy",
+        "title": "Redeploy",
+        "category": "Azure Logic Apps"
       }
     ],
     "viewsContainers": {
@@ -276,6 +281,11 @@
           "command": "logicAppsExtension.openOverview",
           "when": "view == newAzLogicApps && viewItem =~ /Remote;.*;Workflow;/i",
           "group": "1@1"
+        },
+        {
+          "command": "logicAppsExtension.redeploy",
+          "when": "view == newAzLogicApps && viewItem =~ /^deployment//",
+          "group": "1@2"
         }
       ],
       "explorer/context": [
@@ -431,6 +441,7 @@
     "onCommand:logicAppsExtension.openOverview",
     "onCommand:logicAppsExtension.refresh",
     "onCommand:logicAppsExtension.switchToDotnetProject",
+    "onCommand:logicAppsExtension.redeploy",
     "onView:newAzLogicApps",
     "workspaceContains:host.json",
     "workspaceContains:*/host.json",


### PR DESCRIPTION
### Main Code Changes
- Add redeploy command for deployments in remote logic apps

### Note
- Couldn't use functions extension as they open a different URL

### Tested scenarios
- Redeploy deployments through azure item context menu

### Implementation
![image](https://user-images.githubusercontent.com/102700317/213264800-b35e076b-7773-45bc-8360-4ba37ff658e0.png)
