### PR TITLE
laBugfix: Empty schema value catch found on `Filter Array`

### DIFF
--- a/libs/designer-ui/src/lib/workflow/schema/generator.ts
+++ b/libs/designer-ui/src/lib/workflow/schema/generator.ts
@@ -21,7 +21,7 @@ type SchemaObject = OpenAPIV2.SchemaObject;
  * @return {Swagger.Schema}
  */
 export function generateSchemaFromJsonString(jsonString: string): SchemaObject {
-  const value = JSON.parse(jsonString);
+  const value = JSON.parse(jsonString ? jsonString : '{}');
   return generateSchemaFromValue(value);
 }
 


### PR DESCRIPTION
## Main Changes
- Fixed an issue where operations with empty schema values would error out, now passing `{}` instead of empty string
  - Fixes #1523