### PR TITLE
laBugfix: Fixed Until only child move and delete bug

### DIFF
--- a/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
@@ -24,7 +24,9 @@ export const deleteNodeFromWorkflow = (
   const isRoot = nodesMetadata[nodeId]?.isRoot;
   if (isRoot && !isTrigger) {
     const childIds = (workflowGraph.edges ?? []).filter((edge) => edge.source === nodeId).map((edge) => edge.target);
-    childIds.forEach((childId) => (nodesMetadata[childId].isRoot = true));
+    childIds.forEach((childId) => {
+      if (nodesMetadata[childId]) nodesMetadata[childId].isRoot = true;
+    });
   }
 
   // Nodes with multiple parents AND children are not allowed to be deleted

--- a/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
@@ -45,8 +45,8 @@ export const moveNodeInWorkflow = (
   if (isOldRoot) {
     const childIds = (oldWorkflowGraph.edges ?? []).filter((edge) => edge.source === nodeId).map((edge) => edge.target);
     childIds.forEach((childId) => {
-      nodesMetadata[childId].isRoot = true;
-      delete (state.operations[childId] as any).runAfter;
+      if (nodesMetadata[childId]) nodesMetadata[childId].isRoot = true;
+      delete (state.operations[childId] as any)?.runAfter;
     });
   }
 


### PR DESCRIPTION
Fixed an issue where deleting or moving the only child of an Until node caused nothing to happen. 
(Fixes #1520)