### PR TITLE
VSFeat: Add view properties command

### DIFF
--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -19,6 +19,7 @@ import { pickFuncProcess } from './pickFuncProcess';
 import { restartLogicApp } from './restartLogicApp';
 import { startLogicApp } from './startLogicApp';
 import { stopLogicApp } from './stopLogicApp';
+import { viewProperties } from './viewProperties';
 import { exportLogicApp } from './workflows/exportLogicApp';
 import { getDebugSymbolDll } from './workflows/getDebugSymbolDll';
 import { openDesigner } from './workflows/openDesigner/openDesigner';
@@ -67,4 +68,5 @@ export function registerCommands(): void {
   registerCommand(extensionCommand.switchToDotnetProject, switchToDotnetProject);
   registerCommand(extensionCommand.openInPortal, openInPortal);
   registerCommand(extensionCommand.browseWebsite, browseWebsite);
+  registerCommand(extensionCommand.viewProperties, viewProperties);
 }

--- a/apps/vs-code-designer/src/app/commands/viewProperties.ts
+++ b/apps/vs-code-designer/src/app/commands/viewProperties.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../extensionVariables';
+import { ProductionSlotTreeItem } from '../tree/slotsTree/ProductionSlotTreeItem';
+import type { SlotTreeItemBase } from '../tree/slotsTree/SlotTreeItemBase';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import { openReadOnlyJson } from '@microsoft/vscode-azext-utils';
+
+export async function viewProperties(context: IActionContext, node?: SlotTreeItemBase | ProductionSlotTreeItem): Promise<void> {
+  if (!node) {
+    node = await ext.tree.showTreeItemPicker<ProductionSlotTreeItem>(ProductionSlotTreeItem.contextValue, context);
+  }
+
+  const data = node.site;
+
+  await openReadOnlyJson(node, data);
+}

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -89,6 +89,7 @@ export enum extensionCommand {
   openOverview = 'logicAppsExtension.openOverview',
   exportLogicApp = 'logicAppsExtension.exportLogicApp',
   browseWebsite = 'logicAppsExtension.browseWebsite',
+  viewProperties = 'logicAppsExtension.viewProperties',
 }
 
 // Context

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -147,6 +147,11 @@
         "command": "logicAppsExtension.browseWebsite",
         "title": "Browse Website",
         "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.viewProperties",
+        "title": "View Properties",
+        "category": "Azure Logic Apps"
       }
     ],
     "viewsContainers": {
@@ -330,6 +335,16 @@
           "command": "logicAppsExtension.browseWebsite",
           "when": "view == newAzLogicApps && viewItem =~ /^azLogicApps(Production|)Slot$/",
           "group": "1@2"
+        },
+        {
+          "command": "logicAppsExtension.viewProperties",
+          "when": "view == newAzLogicApps && viewItem =~ /^azLogicApps(Production|)Slot$/",
+          "group": "6@1"
+        },
+        {
+          "command": "logicAppsExtension.viewProperties",
+          "when": "view == newAzLogicApps && viewItem =~ /Remote;.*;Workflow;/i",
+          "group": "4@1"
         }
       ],
       "explorer/context": [
@@ -489,6 +504,7 @@
     "onCommand:logicAppsExtension.openInPortal",
     "onCommand:logicAppsExtension.redeploy",
     "onCommand:logicAppsExtension.browseWebsite",
+    "onCommand:logicAppsExtension.viewProperties",
     "onView:newAzLogicApps",
     "workspaceContains:host.json",
     "workspaceContains:*/host.json",

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -340,11 +340,6 @@
           "command": "logicAppsExtension.viewProperties",
           "when": "view == newAzLogicApps && viewItem =~ /^azLogicApps(Production|)Slot$/",
           "group": "6@1"
-        },
-        {
-          "command": "logicAppsExtension.viewProperties",
-          "when": "view == newAzLogicApps && viewItem =~ /Remote;.*;Workflow;/i",
-          "group": "4@1"
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
### Main Code Changes
- Add command to package.json to be executed through azure item context menu
- Add logit to open the properties JSON

### Note
- Didn't use functions extension command as they have a different azure tree structure, therefore when trying to view properties it results in an error. 

### Tested Scenarios
- View production logic app properties through azure item context menu
- View production slot properties through azure item context menu

### Implementation
https://user-images.githubusercontent.com/102700317/213748532-98f219ff-8de7-4217-8e36-0e4550946676.mov

