### PR TITLE
VSFeat: Add create and delete slot command

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createSlot.ts
+++ b/apps/vs-code-designer/src/app/commands/createSlot.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../extensionVariables';
+import type { SlotTreeItem } from '../tree/slotsTree/SlotTreeItem';
+import { SlotsTreeItem } from '../tree/slotsTree/SlotsTreeItem';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+
+export async function createSlot(context: IActionContext, node?: SlotsTreeItem): Promise<string> {
+  if (!node) {
+    node = await ext.tree.showTreeItemPicker<SlotsTreeItem>(SlotsTreeItem.contextValue, context);
+  }
+
+  const slotNode: SlotTreeItem = await node.createChild(context);
+  return slotNode.fullId;
+}

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -6,10 +6,12 @@ import { extensionCommand } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { executeOnFunctions } from '../functionsExtension/executeOnFunctionsExt';
 import { ProductionSlotTreeItem } from '../tree/slotsTree/ProductionSlotTreeItem';
+import { SlotTreeItem } from '../tree/slotsTree/SlotTreeItem';
 import { browseWebsite } from './browseWebsite';
 import { createCodeless } from './createCodeless/createCodeless';
 import { createLogicApp, createLogicAppAdvanced } from './createLogicApp/createLogicApp';
 import { createNewProjectFromCommand } from './createNewProject/createNewProject';
+import { createSlot } from './createSlot';
 import { deleteNode } from './deleteNode';
 import { deployProductionSlot, deploySlot } from './deploy/deploy';
 import { redeployDeployment } from './deployments/redeployDeployment';
@@ -69,4 +71,9 @@ export function registerCommands(): void {
   registerCommand(extensionCommand.openInPortal, openInPortal);
   registerCommand(extensionCommand.browseWebsite, browseWebsite);
   registerCommand(extensionCommand.viewProperties, viewProperties);
+  registerCommand(extensionCommand.createSlot, createSlot);
+  registerCommand(
+    extensionCommand.deleteSlot,
+    async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, SlotTreeItem.contextValue, node)
+  );
 }

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -90,6 +90,8 @@ export enum extensionCommand {
   exportLogicApp = 'logicAppsExtension.exportLogicApp',
   browseWebsite = 'logicAppsExtension.browseWebsite',
   viewProperties = 'logicAppsExtension.viewProperties',
+  createSlot = 'logicAppsExtension.createSlot',
+  deleteSlot = 'logicAppsExtension.deleteSlot',
 }
 
 // Context

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -157,6 +157,11 @@
         "command": "logicAppsExtension.createSlot",
         "title": "Create Slot...",
         "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.deleteSlot",
+        "title": "Delete Slot...",
+        "category": "Azure Logic Apps"
       }
     ],
     "viewsContainers": {
@@ -350,6 +355,11 @@
           "command": "logicAppsExtension.createSlot",
           "when": "view == newAzLogicApps && viewItem == azLogicAppsSlots",
           "group": "1@1"
+        },
+        {
+          "command": "logicAppsExtension.deleteSlot",
+          "when": "view == newAzLogicApps && viewItem == azLogicAppsSlot",
+          "group": "2@5"
         }
       ],
       "explorer/context": [
@@ -511,6 +521,7 @@
     "onCommand:logicAppsExtension.browseWebsite",
     "onCommand:logicAppsExtension.viewProperties",
     "onCommand:logicAppsExtension.createSlot",
+    "onCommand:logicAppsExtension.deleteSlot",
     "onView:newAzLogicApps",
     "workspaceContains:host.json",
     "workspaceContains:*/host.json",

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -152,6 +152,11 @@
         "command": "logicAppsExtension.viewProperties",
         "title": "View Properties",
         "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.createSlot",
+        "title": "Create Slot...",
+        "category": "Azure Logic Apps"
       }
     ],
     "viewsContainers": {
@@ -340,6 +345,11 @@
           "command": "logicAppsExtension.viewProperties",
           "when": "view == newAzLogicApps && viewItem =~ /^azLogicApps(Production|)Slot$/",
           "group": "6@1"
+        },
+        {
+          "command": "logicAppsExtension.createSlot",
+          "when": "view == newAzLogicApps && viewItem == azLogicAppsSlots",
+          "group": "1@1"
         }
       ],
       "explorer/context": [
@@ -500,6 +510,7 @@
     "onCommand:logicAppsExtension.redeploy",
     "onCommand:logicAppsExtension.browseWebsite",
     "onCommand:logicAppsExtension.viewProperties",
+    "onCommand:logicAppsExtension.createSlot",
     "onView:newAzLogicApps",
     "workspaceContains:host.json",
     "workspaceContains:*/host.json",


### PR DESCRIPTION
### Main Code Changes
- Add delete and create command to be executed through azure item context menu

### Notes
- Didn't use functions extension command as they use different approach

### Tested Scenarios
- Create slot through azure item context menu
- Delete slot through azure item context menu

### Implementation
#### Create

https://user-images.githubusercontent.com/102700317/213760987-33d00b71-8986-4c59-a4d9-b0012f1a1539.mov


#### Delete

https://user-images.githubusercontent.com/102700317/213760952-67caeded-2655-446b-b15b-3e0d63f67a0d.mov

