### PR TITLE
VSFeat: Add streaming logs

### DIFF
--- a/apps/vs-code-designer/src/app/commands/logstream/stopStreamingLogs.ts
+++ b/apps/vs-code-designer/src/app/commands/logstream/stopStreamingLogs.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../../extensionVariables';
+import { ProductionSlotTreeItem } from '../../tree/slotsTree/ProductionSlotTreeItem';
+import type { SlotTreeItemBase } from '../../tree/slotsTree/SlotTreeItemBase';
+import * as appservice from '@microsoft/vscode-azext-azureappservice';
+import type { ParsedSite } from '@microsoft/vscode-azext-azureappservice';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+
+export async function stopStreamingLogs(context: IActionContext, node?: SlotTreeItemBase): Promise<void> {
+  if (!node) {
+    node = await ext.tree.showTreeItemPicker<SlotTreeItemBase>(ProductionSlotTreeItem.contextValue, context);
+  }
+
+  const site: ParsedSite = node.site;
+  await appservice.stopStreamingLogs(site, node.logStreamPath);
+}

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -15,6 +15,8 @@ import { createSlot } from './createSlot';
 import { deleteNode } from './deleteNode';
 import { deployProductionSlot, deploySlot } from './deploy/deploy';
 import { redeployDeployment } from './deployments/redeployDeployment';
+import { startStreamingLogs } from './logstream/startStreamingLogs';
+import { stopStreamingLogs } from './logstream/stopStreamingLogs';
 import { openFile } from './openFile';
 import { openInPortal } from './openInPortal';
 import { pickFuncProcess } from './pickFuncProcess';
@@ -76,4 +78,6 @@ export function registerCommands(): void {
     extensionCommand.deleteSlot,
     async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, SlotTreeItem.contextValue, node)
   );
+  registerCommand(extensionCommand.startStreamingLogs, startStreamingLogs);
+  registerCommand(extensionCommand.stopStreamingLogs, stopStreamingLogs);
 }

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -92,6 +92,8 @@ export enum extensionCommand {
   viewProperties = 'logicAppsExtension.viewProperties',
   createSlot = 'logicAppsExtension.createSlot',
   deleteSlot = 'logicAppsExtension.deleteSlot',
+  startStreamingLogs = 'logicAppsExtension.startStreamingLogs',
+  stopStreamingLogs = 'logicAppsExtension.stopStreamingLogs',
 }
 
 // Context

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -162,6 +162,16 @@
         "command": "logicAppsExtension.deleteSlot",
         "title": "Delete Slot...",
         "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.startStreamingLogs",
+        "title": "Start Streaming Logs",
+        "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.stopStreamingLogs",
+        "title": "Stop Streaming Logs",
+        "category": "Azure Logic Apps"
       }
     ],
     "viewsContainers": {
@@ -360,6 +370,26 @@
           "command": "logicAppsExtension.deleteSlot",
           "when": "view == newAzLogicApps && viewItem == azLogicAppsSlot",
           "group": "2@5"
+        },
+        {
+          "command": "logicAppsExtension.startStreamingLogs",
+          "when": "view == newAzLogicApps && viewItem =~ /^azLogicApps(Production|)Slot$/",
+          "group": "4@1"
+        },
+        {
+          "command": "logicAppsExtension.startStreamingLogs",
+          "when": "view == newAzLogicApps && viewItem =~ /Remote;.*;Workflow;/i",
+          "group": "3@1"
+        },
+        {
+          "command": "logicAppsExtension.stopStreamingLogs",
+          "when": "view == newAzLogicApps && viewItem =~ /^azLogicApps(Production|)Slot$/",
+          "group": "4@2"
+        },
+        {
+          "command": "logicAppsExtension.stopStreamingLogs",
+          "when": "view == newAzLogicApps && viewItem =~ /Remote;.*;Workflow;/i",
+          "group": "3@2"
         }
       ],
       "explorer/context": [
@@ -522,6 +552,8 @@
     "onCommand:logicAppsExtension.viewProperties",
     "onCommand:logicAppsExtension.createSlot",
     "onCommand:logicAppsExtension.deleteSlot",
+    "onCommand:logicAppsExtension.startStreamingLogs",
+    "onCommand:logicAppsExtension.stopStreamingLogs",
     "onView:newAzLogicApps",
     "workspaceContains:host.json",
     "workspaceContains:*/host.json",

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -377,19 +377,9 @@
           "group": "4@1"
         },
         {
-          "command": "logicAppsExtension.startStreamingLogs",
-          "when": "view == newAzLogicApps && viewItem =~ /Remote;.*;Workflow;/i",
-          "group": "3@1"
-        },
-        {
           "command": "logicAppsExtension.stopStreamingLogs",
           "when": "view == newAzLogicApps && viewItem =~ /^azLogicApps(Production|)Slot$/",
           "group": "4@2"
-        },
-        {
-          "command": "logicAppsExtension.stopStreamingLogs",
-          "when": "view == newAzLogicApps && viewItem =~ /Remote;.*;Workflow;/i",
-          "group": "3@2"
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
### Main Code Changes
- Add start and stop streaming logs command to be executed through azure item context menu

### Notes
- Didn't use functions extension command as they use different approach for start and stop

### Tested Scenarios
- Start streaming logs through azure item context menu for remote logic apps and slots
- Stop streaming logs through azure item context menu for remote logic apps and slots


### Implementation

https://user-images.githubusercontent.com/102700317/213800218-c7d5593d-a7ad-48b2-8bbb-0e2fb0932093.mov

