### PR TITLE
VSFeat: Add view deployments logs command

### DIFF
--- a/apps/vs-code-designer/src/app/commands/deployments/viewDeploymentLogs.ts
+++ b/apps/vs-code-designer/src/app/commands/deployments/viewDeploymentLogs.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../../extensionVariables';
+import { DeploymentTreeItem } from '@microsoft/vscode-azext-azureappservice';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+
+export async function viewDeploymentLogs(context: IActionContext, node?: DeploymentTreeItem): Promise<void> {
+  if (!node) {
+    node = await ext.tree.showTreeItemPicker<DeploymentTreeItem>(DeploymentTreeItem.contextValue, context);
+  }
+  await node.viewDeploymentLogs(context);
+}

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -15,6 +15,7 @@ import { createSlot } from './createSlot';
 import { deleteNode } from './deleteNode';
 import { deployProductionSlot, deploySlot } from './deploy/deploy';
 import { redeployDeployment } from './deployments/redeployDeployment';
+import { viewDeploymentLogs } from './deployments/viewDeploymentLogs';
 import { openFile } from './openFile';
 import { openInPortal } from './openInPortal';
 import { pickFuncProcess } from './pickFuncProcess';
@@ -76,4 +77,5 @@ export function registerCommands(): void {
     extensionCommand.deleteSlot,
     async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, SlotTreeItem.contextValue, node)
   );
+  registerSiteCommand(extensionCommand.viewDeploymentLogs, viewDeploymentLogs);
 }

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -92,6 +92,7 @@ export enum extensionCommand {
   viewProperties = 'logicAppsExtension.viewProperties',
   createSlot = 'logicAppsExtension.createSlot',
   deleteSlot = 'logicAppsExtension.deleteSlot',
+  viewDeploymentLogs = 'logicAppsExtension.viewDeploymentLogs',
 }
 
 // Context

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -162,6 +162,11 @@
         "command": "logicAppsExtension.deleteSlot",
         "title": "Delete Slot...",
         "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.viewDeploymentLogs",
+        "title": "View Deployment Logs",
+        "category": "Azure Logic Apps"
       }
     ],
     "viewsContainers": {
@@ -360,6 +365,11 @@
           "command": "logicAppsExtension.deleteSlot",
           "when": "view == newAzLogicApps && viewItem == azLogicAppsSlot",
           "group": "2@5"
+        },
+        {
+          "command": "logicAppsExtension.viewDeploymentLogs",
+          "when": "view == newAzLogicApps && viewItem =~ /^deployment//",
+          "group": "1@1"
         }
       ],
       "explorer/context": [
@@ -522,6 +532,7 @@
     "onCommand:logicAppsExtension.viewProperties",
     "onCommand:logicAppsExtension.createSlot",
     "onCommand:logicAppsExtension.deleteSlot",
+    "onCommand:logicAppsExtension.viewDeploymentLogs",
     "onView:newAzLogicApps",
     "workspaceContains:host.json",
     "workspaceContains:*/host.json",


### PR DESCRIPTION
### Main Code Changes
- Add view deployment logs command to be executed through azure item context menu

### Notes
- Didn't use functions extension command as they use different approach

### Tested Scenarios
- View deployment logs through azure item context menu for remote deployment

### Implementation

https://user-images.githubusercontent.com/102700317/213805255-35b0b0eb-f001-4a5b-8344-e133d5bc0b87.mov

