### PR TITLE
VSFeat: Add swapslot command

### DIFF
--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -24,6 +24,7 @@ import { pickFuncProcess } from './pickFuncProcess';
 import { restartLogicApp } from './restartLogicApp';
 import { startLogicApp } from './startLogicApp';
 import { stopLogicApp } from './stopLogicApp';
+import { swapSlot } from './swapSlot';
 import { viewProperties } from './viewProperties';
 import { exportLogicApp } from './workflows/exportLogicApp';
 import { getDebugSymbolDll } from './workflows/getDebugSymbolDll';
@@ -81,6 +82,7 @@ export function registerCommands(): void {
     extensionCommand.deleteSlot,
     async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, SlotTreeItem.contextValue, node)
   );
+  registerCommand(extensionCommand.swapSlot, swapSlot);
   registerCommand(extensionCommand.startStreamingLogs, startStreamingLogs);
   registerCommand(extensionCommand.stopStreamingLogs, stopStreamingLogs);
   registerSiteCommand(extensionCommand.viewDeploymentLogs, viewDeploymentLogs);

--- a/apps/vs-code-designer/src/app/commands/swapSlot.ts
+++ b/apps/vs-code-designer/src/app/commands/swapSlot.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../extensionVariables';
+import { SlotTreeItem } from '../tree/slotsTree/SlotTreeItem';
+import * as appservice from '@microsoft/vscode-azext-azureappservice';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+
+export async function swapSlot(context: IActionContext, sourceSlotNode?: SlotTreeItem): Promise<void> {
+  if (!sourceSlotNode) {
+    sourceSlotNode = await ext.tree.showTreeItemPicker<SlotTreeItem>(SlotTreeItem.contextValue, context);
+  }
+
+  const deploymentSlots: SlotTreeItem[] = (await sourceSlotNode.parent.getCachedChildren(context)) as SlotTreeItem[];
+  await appservice.swapSlot(
+    context,
+    sourceSlotNode.site,
+    deploymentSlots.map((ds) => ds.site)
+  );
+  await sourceSlotNode.parent.parent.refresh(context);
+}

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -93,6 +93,7 @@ export enum extensionCommand {
   viewProperties = 'logicAppsExtension.viewProperties',
   createSlot = 'logicAppsExtension.createSlot',
   deleteSlot = 'logicAppsExtension.deleteSlot',
+  swapSlot = 'logicAppsExtension.swapSlot',
   startStreamingLogs = 'logicAppsExtension.startStreamingLogs',
   stopStreamingLogs = 'logicAppsExtension.stopStreamingLogs',
   viewDeploymentLogs = 'logicAppsExtension.viewDeploymentLogs',

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -182,6 +182,11 @@
         "command": "logicAppsExtension.reviewValidation",
         "title": "Review Validation",
         "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.swapSlot",
+        "title": "Swap Slot...",
+        "category": "Azure Logic Apps"
       }
     ],
     "viewsContainers": {
@@ -395,6 +400,11 @@
           "command": "logicAppsExtension.stopStreamingLogs",
           "when": "view == newAzLogicApps && viewItem =~ /^azLogicApps(Production|)Slot$/",
           "group": "4@2"
+        },
+        {
+          "command": "logicAppsExtension.swapSlot",
+          "when": "view == newAzLogicApps && viewItem == azLogicAppsSlot",
+          "group": "2@4"
         }
       ],
       "explorer/context": [
@@ -566,6 +576,7 @@
     "onCommand:logicAppsExtension.startStreamingLogs",
     "onCommand:logicAppsExtension.stopStreamingLogs",
     "onCommand:logicAppsExtension.viewDeploymentLogs",
+    "onCommand:logicAppsExtension.swapSlot",
     "onView:newAzLogicApps",
     "workspaceContains:host.json",
     "workspaceContains:*/host.json",


### PR DESCRIPTION
### Main Code Changes
- Add swap slot command to be executed through azure item context menu

### Notes
- Didn't use functions extension command as they use different approach

### Tested Scenarios
- Swap slot through azure item context menu for remote logic apps 


### Implementation


https://user-images.githubusercontent.com/102700317/214131894-2183dcc0-15c5-405f-9c73-c4a426a06a74.mp4

