### PR TITLE
VSFeat: Add use sql storage command

### DIFF
--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -38,6 +38,7 @@ import { openDesigner } from './workflows/openDesigner/openDesigner';
 import { openOverview } from './workflows/openOverview';
 import { reviewValidation } from './workflows/reviewValidation';
 import { switchToDotnetProject } from './workflows/switchToDotnetProject';
+import { useSQLStorage } from './workflows/useSQLStorage';
 import { viewContent } from './workflows/viewContent';
 import { AppSettingsTreeItem, AppSettingTreeItem, registerSiteCommand } from '@microsoft/vscode-azext-azureappservice';
 import type { FileTreeItem } from '@microsoft/vscode-azext-azureappservice';
@@ -112,4 +113,5 @@ export function registerCommands(): void {
   registerCommand(extensionCommand.appSettingsRename, renameAppSetting);
   registerCommand(extensionCommand.appSettingsToggleSlotSetting, toggleSlotSetting);
   registerCommand(extensionCommand.appSettingsUpload, uploadAppSettings);
+  registerCommand(extensionCommand.useSQLStorage, useSQLStorage);
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/useSQLStorage.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/useSQLStorage.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { sqlStorageConnectionStringKey } from '../../../constants';
+import { localize } from '../../../localize';
+import { addOrUpdateLocalAppSettings } from '../../utils/appSettings/localSettings';
+import { getFunctionProjectRoot } from '../../utils/codeless/connection';
+import { getLocalSettingsFile } from '../appSettings/getLocalSettingsFile';
+import { validateSQLConnectionString } from '../deploy/storageAccountSteps/SQLStringNameStep';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+
+export async function useSQLStorage(context: IActionContext) {
+  const sqlConnectionString = await context.ui.showInputBox({
+    placeHolder: localize('sqlConnectionStringPlaceholder', 'SQL connection string'),
+    prompt: localize('sqlConnectionStringPrompt', 'Provide your SQL connection string'),
+    validateInput: async (connectionString: string): Promise<string | undefined> => await validateSQLConnectionString(connectionString),
+  });
+
+  const message: string = localize('selectLocalSettings', 'Select your local settings file.');
+  const localSettingsFile: string = await getLocalSettingsFile(context, message);
+  const projectPath = await getFunctionProjectRoot(context, localSettingsFile);
+
+  if (!projectPath) {
+    throw new Error(localize('FunctionRootFolderError', 'Unable to determine logic app project root folder.'));
+  }
+
+  const valuesToUpdateInSettings: Record<string, string> = {};
+  valuesToUpdateInSettings[sqlStorageConnectionStringKey] = sqlConnectionString;
+
+  await addOrUpdateLocalAppSettings(context, projectPath, valuesToUpdateInSettings);
+  await vscode.window.showInformationMessage(
+    localize('logicapp.sqlstorageupdate', 'The logic app project settings are updated to use SQL storage.')
+  );
+}

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -105,6 +105,7 @@ export enum extensionCommand {
   appSettingsUpload = 'logicAppsExtension.appSettings.upload',
   appSettingsToggleSlotSetting = 'logicAppsExtension.appSettings.toggleSlotSetting',
   toggleAppSettingVisibility = 'logicAppsExtension.toggleAppSettingVisibility',
+  useSQLStorage = 'logicAppsExtension.useSQLStorage',
 }
 
 // Context
@@ -168,3 +169,5 @@ export const kubernetesKind = 'kubernetes';
 export const functionAppKind = 'functionapp';
 export const logicAppKind = 'workflowapp';
 export const logicAppKindAppSetting = 'workflowApp';
+
+export const sqlStorageConnectionStringKey = 'Workflows.Sql.ConnectionString';

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -231,6 +231,11 @@
         "command": "logicAppsExtension.appSettings.upload",
         "title": "Upload Local Settings...",
         "category": "Azure Logic Apps"
+      },
+      {
+        "command": "logicAppsExtension.useSQLStorage",
+        "title": "Use SQL storage for your Logic App project",
+        "category": "Azure Logic Apps"
       }
     ],
     "viewsContainers": {
@@ -516,6 +521,11 @@
           "command": "logicAppsExtension.reviewValidation",
           "when": "resourceDirname=~/.logs/export && resourceFilename=~/exportValidation.json/",
           "group": "navigation@1"
+        },
+        {
+          "command": "logicAppsExtension.useSQLStorage",
+          "when": "explorerResourceIsRoot == true",
+          "group": "zzz_LogicApptools@3"
         }
       ],
       "commandPalette": [
@@ -672,6 +682,7 @@
     "onCommand:logicAppsExtension.appSettings.rename",
     "onCommand:logicAppsExtension.appSettings.toggleSlotSetting",
     "onCommand:logicAppsExtension.appSettings.upload",
+    "onCommand:logicAppsExtension.useSQLStorage",
     "onView:newAzLogicApps",
     "workspaceContains:host.json",
     "workspaceContains:*/host.json",


### PR DESCRIPTION
### Main Code Changes
- Add use sql storage command

### Tested Scenarios
- Use sql storage for logic app project through explorer context menu

### Implementation

https://user-images.githubusercontent.com/102700317/214369617-dbe9317b-3073-45a9-bf37-b24c6a794182.mov
