### PR TITLE
Adding swift mt operations to list of supported manifests

### DIFF
--- a/libs/services/designer-client-services/src/lib/base/operationmanifest.ts
+++ b/libs/services/designer-client-services/src/lib/base/operationmanifest.ts
@@ -75,6 +75,8 @@ const flatfiledecoding = 'flatfiledecoding';
 const flatfileencoding = 'flatfileencoding';
 const swiftdecode = 'swiftdecode';
 const swiftencode = 'swiftencode';
+const swiftmtdecode = 'swiftmtdecode';
+const swiftmtencode = 'swiftmtencode';
 const scope = 'scope';
 const foreach = 'foreach';
 const condition = 'if';
@@ -157,6 +159,8 @@ const supportedManifestTypes = [
   scope,
   swiftdecode,
   swiftencode,
+  swiftmtdecode,
+  swiftmtencode,
   terminate,
   until,
   wait,
@@ -317,6 +321,8 @@ export function isBuiltInOperation(definition: any): boolean {
     case scope:
     case swiftdecode:
     case swiftencode:
+    case swiftmtdecode:
+    case swiftmtencode:
     case table:
     case terminate:
     case until:
@@ -562,6 +568,14 @@ const builtInOperationsMetadata: Record<string, OperationInfo> = {
   [swiftencode]: {
     connectorId: 'connectionProviders/swiftOperations',
     operationId: 'swiftEncode',
+  },
+  [swiftmtdecode]: {
+    connectorId: 'connectionProviders/swiftOperations',
+    operationId: 'swiftMTDecode',
+  },
+  [swiftmtencode]: {
+    connectorId: 'connectionProviders/swiftOperations',
+    operationId: 'swiftMTEncode',
   },
   [terminate]: {
     connectorId: controlConnectorId,


### PR DESCRIPTION
The new designer is unable to load the card for the SWIFT MT Decode and Encode actions because these operations are not present in the list of supported manifests. Old designer recognizes these already and is able to display the cards.

AB#16907547