### PR TITLE
laFix: Fixed run-after-trigger bug

### DIFF
--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -51,7 +51,8 @@ export const addNodeToWorkflow = (
   state.operations[newNodeId] = { ...state.operations[newNodeId], type: payload.operation.type };
   state.newlyAddedOperations[newNodeId] = newNodeId;
 
-  const shouldAddRunAfters = !isRoot;
+  const isAfterTrigger = nodesMetadata[parentId ?? '']?.isRoot && graphId === 'root';
+  const shouldAddRunAfters = !isRoot && !isAfterTrigger;
 
   // Parallel Branch creation, just add the singular node
   if (payload.isParallelBranch && parentId) {

--- a/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
@@ -86,7 +86,9 @@ export const moveNodeInWorkflow = (
   nodesMetadata[nodeId] = { ...nodesMetadata[nodeId], graphId: newGraphId, parentNodeId, isRoot: isNewRoot };
   if (nodesMetadata[nodeId].isRoot === false) delete nodesMetadata[nodeId].isRoot;
 
-  const shouldAddRunAfters = parentId ? !isRootNodeInGraph(parentId, 'root', state.nodesMetadata) : true;
+  const isAfterTrigger = nodesMetadata[parentId ?? '']?.isRoot && newGraphId === 'root';
+  const shouldAddRunAfters = !isNewRoot && !isAfterTrigger;
+
   // X parents, 1 child
   if (childId) {
     reassignEdgeTargets(state, childId, nodeId, newWorkflowGraph);


### PR DESCRIPTION
Fixes an issue where nodes placed after the workflow trigger will have incorrect run-after settings, preventing saving the workflow.