### PR TITLE
[DM | Overview] Fix source schema name badge offset

### DIFF
--- a/libs/data-mapper/src/lib/components/mapOverview/MapOverview.tsx
+++ b/libs/data-mapper/src/lib/components/mapOverview/MapOverview.tsx
@@ -1,7 +1,7 @@
 import { reactFlowFitViewOptions, ReactFlowNodeType } from '../../constants/ReactFlowConstants';
 import type { RootState } from '../../core/state/Store';
 import { SchemaType } from '../../models/';
-import { overviewTgtSchemaX, useOverviewLayout } from '../../utils/ReactFlow.Util';
+import { useOverviewLayout } from '../../utils/ReactFlow.Util';
 import { SchemaCard } from '../nodeCard/SchemaCard';
 import { SchemaNameBadge } from '../schemaSelection/SchemaNameBadge';
 import { SelectSchemaCard } from '../schemaSelection/SelectSchemaCard';
@@ -79,6 +79,21 @@ const OverviewReactFlowWrapper = () => {
 
   const schemaNodeTypes = useMemo(() => ({ [ReactFlowNodeType.SchemaNode]: SchemaCard }), []);
 
+  // Find first schema node (should be schemaTreeRoot) for source and target to use its xPos for schema name badge
+  const srcSchemaTreeRootXPos = useMemo(
+    () =>
+      reactFlowNodes.find((reactFlowNode) => reactFlowNode.data?.schemaType && reactFlowNode.data.schemaType === SchemaType.Source)
+        ?.position.x ?? 0,
+    [reactFlowNodes]
+  );
+
+  const tgtSchemaTreeRootXPos = useMemo(
+    () =>
+      reactFlowNodes.find((reactFlowNode) => reactFlowNode.data?.schemaType && reactFlowNode.data.schemaType === SchemaType.Target)
+        ?.position.x ?? 0,
+    [reactFlowNodes]
+  );
+
   return (
     <ReactFlow
       nodeTypes={schemaNodeTypes}
@@ -98,8 +113,8 @@ const OverviewReactFlowWrapper = () => {
         <SelectSchemaCard schemaType={SchemaType.Target} style={{ visibility: !targetSchema ? 'visible' : 'hidden' }} />
       </Stack>
 
-      {sourceSchema && <SchemaNameBadge schemaName={sourceSchema.name} />}
-      {targetSchema && <SchemaNameBadge schemaName={targetSchema.name} tgtSchemaTreeRootXPos={overviewTgtSchemaX} />}
+      {sourceSchema && <SchemaNameBadge schemaName={sourceSchema.name} schemaTreeRootXPos={srcSchemaTreeRootXPos} />}
+      {targetSchema && <SchemaNameBadge schemaName={targetSchema.name} schemaTreeRootXPos={tgtSchemaTreeRootXPos} />}
     </ReactFlow>
   );
 };

--- a/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
@@ -281,7 +281,7 @@ export const SchemaCard = (props: NodeProps<SchemaCardProps>) => {
 
   const targetCardWidth = isChild ? childTargetNodeCardWidth : schemaNodeCardDefaultWidth;
   const cardWidth = isSourceSchemaNode && schemaNode.width ? schemaNode.width : targetCardWidth;
-  const maxWidthCalculated = maxWidth || 0;
+  const maxWidthCalculated = maxWidth || cardWidth;
   const sourceCardMargin = isSourceSchemaNode ? maxWidthCalculated - cardWidth : 0;
 
   return (

--- a/libs/data-mapper/src/lib/components/schemaSelection/SchemaNameBadge.tsx
+++ b/libs/data-mapper/src/lib/components/schemaSelection/SchemaNameBadge.tsx
@@ -13,10 +13,10 @@ const useStyles = makeStyles({
 
 interface SchemaNameBadgeProps {
   schemaName: string;
-  tgtSchemaTreeRootXPos?: number;
+  schemaTreeRootXPos?: number;
 }
 
-export const SchemaNameBadge = ({ schemaName, tgtSchemaTreeRootXPos }: SchemaNameBadgeProps) => {
+export const SchemaNameBadge = ({ schemaName, schemaTreeRootXPos }: SchemaNameBadgeProps) => {
   const styles = useStyles();
   const reactFlowViewport = useViewport();
 
@@ -27,8 +27,8 @@ export const SchemaNameBadge = ({ schemaName, tgtSchemaTreeRootXPos }: SchemaNam
     y: reactFlowViewport.y - scaledBadgeDistanceAboveNodes,
   };
 
-  if (tgtSchemaTreeRootXPos) {
-    schemaNameBadgeCoords.x += reactFlowViewport.zoom * tgtSchemaTreeRootXPos;
+  if (schemaTreeRootXPos) {
+    schemaNameBadgeCoords.x += reactFlowViewport.zoom * schemaTreeRootXPos;
   }
 
   return (

--- a/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
+++ b/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
@@ -157,7 +157,13 @@ export const ReactFlowWrapper = ({ canvasBlockHeight, canvasBlockWidth, useExpan
     sourceSchemaOrdering
   );
 
-  // Find first target schema node (should be schemaTreeRoot) to use its xPos for schema name badge
+  // Find first schema node (should be schemaTreeRoot) for source and target to use its xPos for schema name badge
+  const srcSchemaTreeRootXPos = useMemo(
+    () =>
+      nodes.find((reactFlowNode) => reactFlowNode.data?.schemaType && reactFlowNode.data.schemaType === SchemaType.Source)?.position.x ?? 0,
+    [nodes]
+  );
+
   const tgtSchemaTreeRootXPos = useMemo(
     () =>
       nodes.find((reactFlowNode) => reactFlowNode.data?.schemaType && reactFlowNode.data.schemaType === SchemaType.Target)?.position.x ?? 0,
@@ -229,8 +235,8 @@ export const ReactFlowWrapper = ({ canvasBlockHeight, canvasBlockWidth, useExpan
         <SourceSchemaPlaceholder onClickSelectElement={() => dispatch(setCanvasToolboxTabToDisplay(ToolboxPanelTabs.sourceSchemaTree))} />
       )}
 
-      {sourceSchema && <SchemaNameBadge schemaName={sourceSchema.name} />}
-      {targetSchema && <SchemaNameBadge schemaName={targetSchema.name} tgtSchemaTreeRootXPos={tgtSchemaTreeRootXPos} />}
+      {sourceSchema && <SchemaNameBadge schemaName={sourceSchema.name} schemaTreeRootXPos={srcSchemaTreeRootXPos} />}
+      {targetSchema && <SchemaNameBadge schemaName={targetSchema.name} schemaTreeRootXPos={tgtSchemaTreeRootXPos} />}
     </ReactFlow>
   );
 };


### PR DESCRIPTION
Fixes #16943884

Also incidentally upgrades name badges to always be positioned based on source and target schemaTreeRoots on both the editing canvas and the overview

![image](https://user-images.githubusercontent.com/49288482/215513565-f1acbe4f-b8f2-4656-b414-e429d0bf71dd.png)

![image](https://user-images.githubusercontent.com/49288482/215513450-5c4a342f-5408-4afb-a666-16afd419bc8c.png)

![image](https://user-images.githubusercontent.com/49288482/215513486-5ae65f5f-ac3e-423b-8048-20edc6d9992a.png)
