### PR TITLE
laFix: Fixed nightly release action

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -2,7 +2,7 @@
   "header": "# Logic Apps Designer",
   "infile": "CHANGELOG.md",
   "types": [
-  {
+    {
       "type": "feat",
       "section": "Features"
     },
@@ -74,6 +74,10 @@
     },
     {
       "filename": "libs/services/designer-client-services/package.json",
+      "type": "json"
+    },
+    {
+      "filename": "libs/vscode-extension/package.json",
       "type": "json"
     }
   ]

--- a/libs/vscode-extension/package.json
+++ b/libs/vscode-extension/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@microsoft/vscode-extension-logic-apps",
-  "version": "0.0.1"
+  "version": "0.2.60"
 }


### PR DESCRIPTION
The version for the vscode-extension was not getting bumped, so this just brings it up to match and adds it to the list of files to get version bumped.