### PR TITLE
Allow manual nightly-release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,6 +1,7 @@
 name: Nightly Release
 
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: [release]
   schedule:


### PR DESCRIPTION
Allow manual release for the nightly-builds from the actions page