### PR TITLE
[DM | Layouting] Stop expanded function card edges from routing past target schema nodes

### DIFF
--- a/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
+++ b/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
@@ -164,7 +164,8 @@ export const ReactFlowWrapper = ({
     currentTargetSchemaNode,
     connections,
     selectedItemKey,
-    sourceSchemaOrdering
+    sourceSchemaOrdering,
+    useExpandedFunctionCards
   );
 
   // Find first schema node (should be schemaTreeRoot) for source and target to use its xPos for schema name badge

--- a/libs/data-mapper/src/lib/utils/Layout.Utils.ts
+++ b/libs/data-mapper/src/lib/utils/Layout.Utils.ts
@@ -10,6 +10,9 @@ import ELK from 'elkjs/lib/elk.bundled';
 
 const elk = new ELK();
 
+const defaultNodeGroupSpacing = '120.0';
+const expandedNodeGroupSpacing = '160.0';
+
 const defaultTreeLayoutOptions: Record<string, string> = {
   // General layout settings
   direction: 'RIGHT',
@@ -18,7 +21,7 @@ const defaultTreeLayoutOptions: Record<string, string> = {
   hierarchyHandling: 'INCLUDE_CHILDREN',
   'partitioning.activate': 'true', // Allows blocks/node-groups to be forced into specific "slots"
   'edge.thickness': '8.0',
-  'spacing.nodeNodeBetweenLayers': '120.0', // Spacing between node groups (Source schema/Functions/Target schema)
+  'spacing.nodeNodeBetweenLayers': defaultNodeGroupSpacing, // Spacing between node groups (Source schema/Functions/Target schema)
   // Settings related to node ordering (when attempting to minimize edge crossing)
   'crossingMinimization.semiInteractive': 'true',
   'considerModelOrder.strategy': 'NODES_AND_EDGES',
@@ -51,7 +54,8 @@ export const convertDataMapNodesToElkGraph = (
   currentSourceSchemaNodes: SchemaNodeExtended[],
   currentFunctionNodes: FunctionDictionary,
   currentTargetSchemaNode: SchemaNodeExtended,
-  connections: ConnectionDictionary
+  connections: ConnectionDictionary,
+  useExpandedFunctionCards: boolean
 ): ElkNode => {
   // NOTE: Sub-block edges[] only contain edges between nodes *within that block*
   // - the root edges[] will contain all multi-block edges (thus, src/tgt schemas should never have edges)
@@ -102,7 +106,10 @@ export const convertDataMapNodesToElkGraph = (
 
   const elkTree: ElkNode = {
     id: 'root',
-    layoutOptions: defaultTreeLayoutOptions,
+    layoutOptions: {
+      ...defaultTreeLayoutOptions,
+      'spacing.nodeNodeBetweenLayers': useExpandedFunctionCards ? expandedNodeGroupSpacing : defaultNodeGroupSpacing,
+    },
     children: [
       {
         id: 'sourceSchemaBlock',

--- a/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
+++ b/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
@@ -57,7 +57,8 @@ export const useLayout = (
   currentTargetSchemaNode: SchemaNodeExtended | undefined,
   connections: ConnectionDictionary,
   selectedItemKey: string | undefined,
-  sourceSchemaOrdering: string[]
+  sourceSchemaOrdering: string[],
+  useExpandedFunctionCards: boolean
 ): [ReactFlowNode[], ReactFlowEdge[], Size2D] => {
   const [reactFlowNodes, setReactFlowNodes] = useState<ReactFlowNode[]>([]);
   const [reactFlowEdges, setReactFlowEdges] = useState<ReactFlowEdge[]>([]);
@@ -75,7 +76,8 @@ export const useLayout = (
         sortedSourceSchemaNodes,
         currentFunctionNodes,
         currentTargetSchemaNode,
-        connections
+        connections,
+        useExpandedFunctionCards
       );
 
       // Apply ELK layout
@@ -137,7 +139,15 @@ export const useLayout = (
       setReactFlowEdges([]);
       setDiagramSize({ width: 0, height: 0 });
     }
-  }, [currentTargetSchemaNode, currentSourceSchemaNodes, currentFunctionNodes, connections, sourceSchemaOrdering, selectedItemKey]);
+  }, [
+    currentTargetSchemaNode,
+    currentSourceSchemaNodes,
+    currentFunctionNodes,
+    connections,
+    sourceSchemaOrdering,
+    selectedItemKey,
+    useExpandedFunctionCards,
+  ]);
 
   return [reactFlowNodes, reactFlowEdges, diagramSize];
 };


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/49288482/217370956-5b2c1f2d-c45c-4f42-8e65-83c9eee78c35.png)

After:
![image](https://user-images.githubusercontent.com/49288482/217370968-ec2ce224-a201-4fd6-9317-d58fcf66ba51.png)