### PR TITLE
[Data Mapper] Major reworks to ReactFlow.utils.ts

### DIFF
--- a/libs/data-mapper/src/lib/components/mapOverview/MapOverview.stories.tsx
+++ b/libs/data-mapper/src/lib/components/mapOverview/MapOverview.stories.tsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 
 export default {
   component: MapOverview,
-  title: 'Data Mapper Components/Map Overview',
+  title: 'Data Mapper Components/Map Overview/Overview',
   decorators: [
     (Story) => (
       <Provider store={store}>

--- a/libs/data-mapper/src/lib/components/mapOverview/MapOverview.tsx
+++ b/libs/data-mapper/src/lib/components/mapOverview/MapOverview.tsx
@@ -50,9 +50,9 @@ const OverviewReactFlowWrapper = () => {
   const connectionDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.dataMapConnections);
   const targetSchemaDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.flattenedTargetSchema);
 
-  const tgtSchemaToggledStatesDictionary = useMemo<NodeToggledStateDictionary | undefined>(() => {
+  const targetSchemaStates = useMemo<NodeToggledStateDictionary>(() => {
     if (!targetSchema) {
-      return undefined;
+      return {};
     }
 
     // Find target schema nodes with connections
@@ -70,7 +70,7 @@ const OverviewReactFlowWrapper = () => {
     return newToggledStatesDictionary;
   }, [targetSchema, connectionDictionary, targetSchemaDictionary]);
 
-  const reactFlowNodes = useOverviewLayout(sourceSchema?.schemaTreeRoot, targetSchema?.schemaTreeRoot, tgtSchemaToggledStatesDictionary);
+  const reactFlowNodes = useOverviewLayout(sourceSchema?.schemaTreeRoot, targetSchema?.schemaTreeRoot, targetSchemaStates);
 
   // Fit the canvas view any time a schema changes
   useEffect(() => {

--- a/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.stories.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.stories.tsx
@@ -45,7 +45,7 @@ Standard.args = {
     schemaType: SchemaType.Source,
     displayHandle: true,
     isLeaf: false,
-    isChild: false,
+    width: 200,
     displayChevron: true,
     relatedConnections: [],
     onClick: () => console.log('Schema card clicked'),

--- a/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.stories.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.stories.tsx
@@ -47,7 +47,6 @@ Standard.args = {
     isLeaf: false,
     width: 200,
     displayChevron: true,
-    relatedConnections: [],
     onClick: () => console.log('Schema card clicked'),
     disabled: false,
     error: false,

--- a/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
@@ -4,7 +4,6 @@ import { removeSourceSchemaNodes, setCurrentTargetSchemaNode } from '../../core/
 import type { AppDispatch, RootState } from '../../core/state/Store';
 import type { SchemaNodeExtended } from '../../models';
 import { SchemaNodeProperty, SchemaType } from '../../models';
-import type { Connection } from '../../models/Connection';
 import { isTextUsingEllipsis } from '../../utils/Browser.Utils';
 import { flattenInputs } from '../../utils/Connection.Utils';
 import { iconForNormalizedDataType } from '../../utils/Icon.Utils';
@@ -153,7 +152,6 @@ export interface SchemaCardProps extends CardProps {
   displayChevron: boolean;
   isLeaf: boolean;
   width: number;
-  relatedConnections: Connection[];
   connectionStatus?: ItemToggledState;
 }
 

--- a/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/SchemaCard.tsx
@@ -1,4 +1,4 @@
-import { childTargetNodeCardWidth, schemaNodeCardDefaultWidth, schemaNodeCardHeight } from '../../constants/NodeConstants';
+import { schemaNodeCardDefaultWidth, schemaNodeCardHeight } from '../../constants/NodeConstants';
 import { ReactFlowNodeType } from '../../constants/ReactFlowConstants';
 import { removeSourceSchemaNodes, setCurrentTargetSchemaNode } from '../../core/state/DataMapSlice';
 import type { AppDispatch, RootState } from '../../core/state/Store';
@@ -148,20 +148,18 @@ const useStyles = makeStyles({
 
 export interface SchemaCardProps extends CardProps {
   schemaNode: SchemaNodeExtended;
-  maxWidth?: number;
   schemaType: SchemaType;
   displayHandle: boolean;
   displayChevron: boolean;
   isLeaf: boolean;
-  isChild: boolean;
+  width: number;
   relatedConnections: Connection[];
   connectionStatus?: ItemToggledState;
 }
 
 export const SchemaCard = (props: NodeProps<SchemaCardProps>) => {
   const reactFlowId = props.id;
-  const { schemaNode, maxWidth, schemaType, isLeaf, isChild, onClick, disabled, displayHandle, displayChevron, connectionStatus } =
-    props.data;
+  const { schemaNode, schemaType, isLeaf, onClick, disabled, displayHandle, displayChevron, connectionStatus, width } = props.data;
   const dispatch = useDispatch<AppDispatch>();
   const sharedStyles = getStylesForSharedState();
   const classes = useStyles();
@@ -262,19 +260,14 @@ export const SchemaCard = (props: NodeProps<SchemaCardProps>) => {
 
   const selectedNodeStyles = isCurrentNodeSelected || sourceNodeConnectionBeingDrawnFromId === reactFlowId ? selectedCardStyles : undefined;
 
-  const targetCardWidth = isChild ? childTargetNodeCardWidth : schemaNodeCardDefaultWidth;
-  const cardWidth = isSourceSchemaNode && schemaNode.width ? schemaNode.width : targetCardWidth;
-  const maxWidthCalculated = maxWidth || cardWidth;
-  const sourceCardMargin = isSourceSchemaNode ? maxWidthCalculated - cardWidth : 0;
-
   return (
-    <div className={classes.badgeContainer} style={{ marginLeft: sourceCardMargin }}>
+    <div className={classes.badgeContainer}>
       {isNBadgeRequired && !isSourceSchemaNode && <NBadge isOutput />}
 
       <div
         onContextMenu={contextMenu.handle}
         className={containerStyle}
-        style={{ ...selectedNodeStyles, width: cardWidth }}
+        style={{ ...selectedNodeStyles, width }}
         onMouseLeave={() => setIsCardHovered(false)}
         onMouseEnter={() => setIsCardHovered(true)}
       >
@@ -304,7 +297,7 @@ export const SchemaCard = (props: NodeProps<SchemaCardProps>) => {
             visible={shouldNameTooltipDisplay && isTooltipEnabled}
             onVisibleChange={(_ev, data) => setIsTooltipEnabled(data.visible)}
           >
-            <div ref={schemaNameTextRef} className={classes.cardText} style={{ width: `${cardWidth - 30}px` }}>
+            <div ref={schemaNameTextRef} className={classes.cardText} style={{ width: `${width - 30}px` }}>
               {schemaNode.name}
             </div>
           </Tooltip>

--- a/libs/data-mapper/src/lib/components/wholeView/WholeView.stories.tsx
+++ b/libs/data-mapper/src/lib/components/wholeView/WholeView.stories.tsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 
 export default {
   component: WholeMapOverview,
-  title: 'Data Mapper Components/Map Overview',
+  title: 'Data Mapper Components/Map Overview/Whole Overview',
   decorators: [
     (Story) => (
       <Provider store={store}>

--- a/libs/data-mapper/src/lib/components/wholeView/WholeView.stories.tsx
+++ b/libs/data-mapper/src/lib/components/wholeView/WholeView.stories.tsx
@@ -1,0 +1,19 @@
+import { store } from '../../core/state/Store';
+import { WholeMapOverview } from './WholeView';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+export default {
+  component: WholeMapOverview,
+  title: 'Data Mapper Components/Map Overview',
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <Story />
+      </Provider>
+    ),
+  ],
+} as ComponentMeta<typeof WholeMapOverview>;
+
+export const Standard: ComponentStory<typeof WholeMapOverview> = () => <WholeMapOverview />;

--- a/libs/data-mapper/src/lib/components/wholeView/WholeView.tsx
+++ b/libs/data-mapper/src/lib/components/wholeView/WholeView.tsx
@@ -4,9 +4,6 @@ import { SchemaType } from '../../models/';
 import { useWholeViewLayout } from '../../utils/ReactFlow.Util';
 import { SchemaCard } from '../nodeCard/SchemaCard';
 import { SchemaNameBadge } from '../schemaSelection/SchemaNameBadge';
-import type { TargetNodesWithConnectionsDictionary } from '../targetSchemaPane/TargetSchemaPane';
-import { checkNodeStatuses } from '../targetSchemaPane/TargetSchemaPane';
-import type { NodeToggledStateDictionary } from '../tree/TargetSchemaTreeItem';
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -45,30 +42,10 @@ const WholeOverviewReactFlowWrapper = () => {
 
   const sourceSchema = useSelector((state: RootState) => state.dataMap.curDataMapOperation.sourceSchema);
   const targetSchema = useSelector((state: RootState) => state.dataMap.curDataMapOperation.targetSchema);
-  const connectionDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.dataMapConnections);
-  const targetSchemaDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.flattenedTargetSchema);
+  // TODO will be used - const connectionDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.dataMapConnections);
+  // const targetSchemaDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.flattenedTargetSchema);
 
-  const tgtSchemaToggledStatesDictionary = useMemo<NodeToggledStateDictionary | undefined>(() => {
-    if (!targetSchema) {
-      return undefined;
-    }
-
-    // Find target schema nodes with connections
-    const tgtSchemaNodesWithConnections: TargetNodesWithConnectionsDictionary = {};
-    Object.values(connectionDictionary).forEach((connection) => {
-      if (connection.self.reactFlowKey in targetSchemaDictionary && connection.inputs[0] && connection.inputs[0].length > 0) {
-        tgtSchemaNodesWithConnections[connection.self.node.key] = true;
-      }
-    });
-
-    // Recursively traverse the schema tree to calculate connected statuses from the leaf nodes up
-    const newToggledStatesDictionary: NodeToggledStateDictionary = {};
-    checkNodeStatuses(targetSchema.schemaTreeRoot, newToggledStatesDictionary, tgtSchemaNodesWithConnections);
-
-    return newToggledStatesDictionary;
-  }, [targetSchema, connectionDictionary, targetSchemaDictionary]);
-
-  const reactFlowNodes = useWholeViewLayout(sourceSchema?.schemaTreeRoot, targetSchema?.schemaTreeRoot, tgtSchemaToggledStatesDictionary);
+  const reactFlowNodes = useWholeViewLayout(sourceSchema?.schemaTreeRoot, targetSchema?.schemaTreeRoot);
 
   // Fit the canvas view any time a schema changes
   useEffect(() => {

--- a/libs/data-mapper/src/lib/components/wholeView/WholeView.tsx
+++ b/libs/data-mapper/src/lib/components/wholeView/WholeView.tsx
@@ -1,0 +1,112 @@
+import { reactFlowFitViewOptions, ReactFlowNodeType } from '../../constants/ReactFlowConstants';
+import type { RootState } from '../../core/state/Store';
+import { SchemaType } from '../../models/';
+import { useWholeViewLayout } from '../../utils/ReactFlow.Util';
+import { SchemaCard } from '../nodeCard/SchemaCard';
+import { SchemaNameBadge } from '../schemaSelection/SchemaNameBadge';
+import type { TargetNodesWithConnectionsDictionary } from '../targetSchemaPane/TargetSchemaPane';
+import { checkNodeStatuses } from '../targetSchemaPane/TargetSchemaPane';
+import type { NodeToggledStateDictionary } from '../tree/TargetSchemaTreeItem';
+import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+// eslint-disable-next-line import/no-named-as-default
+import ReactFlow, { ReactFlowProvider, useReactFlow } from 'reactflow';
+
+const reactFlowStyle: React.CSSProperties = {
+  height: '100%',
+  position: 'relative',
+};
+
+const useStyles = makeStyles({
+  mapOverviewStyles: {
+    height: '100%',
+    width: '100%',
+    backgroundColor: tokens.colorNeutralBackground6,
+    minHeight: 0,
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+  },
+});
+
+export const WholeMapOverview = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.mapOverviewStyles}>
+      <ReactFlowProvider>
+        <WholeOverviewReactFlowWrapper />
+      </ReactFlowProvider>
+    </div>
+  );
+};
+
+const WholeOverviewReactFlowWrapper = () => {
+  const { fitView } = useReactFlow();
+
+  const sourceSchema = useSelector((state: RootState) => state.dataMap.curDataMapOperation.sourceSchema);
+  const targetSchema = useSelector((state: RootState) => state.dataMap.curDataMapOperation.targetSchema);
+  const connectionDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.dataMapConnections);
+  const targetSchemaDictionary = useSelector((state: RootState) => state.dataMap.curDataMapOperation.flattenedTargetSchema);
+
+  const tgtSchemaToggledStatesDictionary = useMemo<NodeToggledStateDictionary | undefined>(() => {
+    if (!targetSchema) {
+      return undefined;
+    }
+
+    // Find target schema nodes with connections
+    const tgtSchemaNodesWithConnections: TargetNodesWithConnectionsDictionary = {};
+    Object.values(connectionDictionary).forEach((connection) => {
+      if (connection.self.reactFlowKey in targetSchemaDictionary && connection.inputs[0] && connection.inputs[0].length > 0) {
+        tgtSchemaNodesWithConnections[connection.self.node.key] = true;
+      }
+    });
+
+    // Recursively traverse the schema tree to calculate connected statuses from the leaf nodes up
+    const newToggledStatesDictionary: NodeToggledStateDictionary = {};
+    checkNodeStatuses(targetSchema.schemaTreeRoot, newToggledStatesDictionary, tgtSchemaNodesWithConnections);
+
+    return newToggledStatesDictionary;
+  }, [targetSchema, connectionDictionary, targetSchemaDictionary]);
+
+  const reactFlowNodes = useWholeViewLayout(sourceSchema?.schemaTreeRoot, targetSchema?.schemaTreeRoot, tgtSchemaToggledStatesDictionary);
+
+  // Fit the canvas view any time a schema changes
+  useEffect(() => {
+    fitView(reactFlowFitViewOptions);
+  }, [fitView, sourceSchema?.schemaTreeRoot.key, targetSchema?.schemaTreeRoot.key]);
+
+  const schemaNodeTypes = useMemo(() => ({ [ReactFlowNodeType.SchemaNode]: SchemaCard }), []);
+
+  // Find first schema node (should be schemaTreeRoot) for source and target to use its xPos for schema name badge
+  const srcSchemaTreeRootXPos = useMemo(
+    () =>
+      reactFlowNodes.find((reactFlowNode) => reactFlowNode.data?.schemaType && reactFlowNode.data.schemaType === SchemaType.Source)
+        ?.position.x ?? 0,
+    [reactFlowNodes]
+  );
+
+  const tgtSchemaTreeRootXPos = useMemo(
+    () =>
+      reactFlowNodes.find((reactFlowNode) => reactFlowNode.data?.schemaType && reactFlowNode.data.schemaType === SchemaType.Target)
+        ?.position.x ?? 0,
+    [reactFlowNodes]
+  );
+
+  return (
+    <ReactFlow
+      nodeTypes={schemaNodeTypes}
+      nodes={reactFlowNodes}
+      nodesDraggable={false}
+      proOptions={{
+        account: 'paid-sponsor',
+        hideAttribution: true,
+      }}
+      style={reactFlowStyle}
+      fitViewOptions={reactFlowFitViewOptions}
+      fitView
+    >
+      {sourceSchema && <SchemaNameBadge schemaName={sourceSchema.name} schemaTreeRootXPos={srcSchemaTreeRootXPos} />}
+      {targetSchema && <SchemaNameBadge schemaName={targetSchema.name} schemaTreeRootXPos={tgtSchemaTreeRootXPos} />}
+    </ReactFlow>
+  );
+};

--- a/libs/data-mapper/src/lib/constants/NodeConstants.ts
+++ b/libs/data-mapper/src/lib/constants/NodeConstants.ts
@@ -1,7 +1,6 @@
 export const schemaNodeCardDefaultWidth = 200;
 export const schemaNodeCardWidthDifference = 24;
 export const schemaNodeCardHeight = 48;
-export const childTargetNodeCardWidth = 176;
-export const childTargetNodeCardIndent = schemaNodeCardDefaultWidth - childTargetNodeCardWidth;
+export const childTargetNodeCardIndent = schemaNodeCardWidthDifference;
 
 export const functionNodeCardSize = 64;

--- a/libs/data-mapper/src/lib/models/Schema.ts
+++ b/libs/data-mapper/src/lib/models/Schema.ts
@@ -60,7 +60,6 @@ export interface SchemaNodeExtended extends SchemaNode {
   nodeProperties: SchemaNodeProperty[];
   // Inclusive of the current node
   pathToRoot: PathItem[];
-  width?: number;
 }
 
 export interface PathItem {

--- a/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
+++ b/libs/data-mapper/src/lib/ui/DataMapperDesigner.tsx
@@ -308,7 +308,7 @@ export const DataMapperDesigner = ({
                     }}
                   >
                     {showMapOverview ? (
-                      <MapOverview />
+                      <MapOverview /> /* <WholeMapOverview /> */
                     ) : (
                       <ReactFlowProvider>
                         {/* TODO: Update width calculations once Code View becomes resizable */}

--- a/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
+++ b/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
@@ -162,8 +162,6 @@ export const ReactFlowWrapper = ({
     currentSourceSchemaNodes,
     currentFunctionNodes,
     currentTargetSchemaNode,
-    sourceSchema?.schemaTreeRoot,
-    targetSchema?.schemaTreeRoot,
     connections,
     selectedItemKey,
     sourceSchemaOrdering,

--- a/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
+++ b/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
@@ -162,6 +162,8 @@ export const ReactFlowWrapper = ({
     currentSourceSchemaNodes,
     currentFunctionNodes,
     currentTargetSchemaNode,
+    sourceSchema?.schemaTreeRoot,
+    targetSchema?.schemaTreeRoot,
     connections,
     selectedItemKey,
     sourceSchemaOrdering,

--- a/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
+++ b/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
@@ -331,7 +331,7 @@ export const useOverviewLayout = (
 
     // Source schema nodes
     if (srcSchemaTreeRoot) {
-      addChildNodes(srcSchemaTreeRoot, 0, 1, sourceReactFlowNodes, true, !!srcSchemaTreeRoot, 1);
+      addChildNodesForOverview(srcSchemaTreeRoot, 0, 1, sourceReactFlowNodes, true, !!srcSchemaTreeRoot, 1);
     }
 
     // Dummy target schema node
@@ -343,7 +343,7 @@ export const useOverviewLayout = (
 
     // Target schema nodes
     if (tgtSchemaTreeRoot) {
-      addChildNodes(tgtSchemaTreeRoot, 0, 1, targetReactFlowNodes, false, !!srcSchemaTreeRoot, 1);
+      addChildNodesForOverview(tgtSchemaTreeRoot, 0, 1, targetReactFlowNodes, false, !!srcSchemaTreeRoot, 1);
     }
 
     setReactFlowNodes([...sourceReactFlowNodes, ...targetReactFlowNodes]);
@@ -369,7 +369,7 @@ export const useWholeViewLayout = (
     // Source schema nodes
     if (srcSchemaTreeRoot) {
       const sourceDepth = nodeTreeDepth(srcSchemaTreeRoot);
-      addChildNodes(srcSchemaTreeRoot, 0, sourceDepth, sourceReactFlowNodes, !!srcSchemaTreeRoot, true);
+      addChildNodesForOverview(srcSchemaTreeRoot, 0, sourceDepth, sourceReactFlowNodes, true, !!srcSchemaTreeRoot);
     }
 
     // Dummy target schema node
@@ -382,7 +382,7 @@ export const useWholeViewLayout = (
     // Target schema nodes
     if (tgtSchemaTreeRoot) {
       const targetDepth = nodeTreeDepth(tgtSchemaTreeRoot);
-      addChildNodes(tgtSchemaTreeRoot, 0, targetDepth, targetReactFlowNodes, !!srcSchemaTreeRoot, false);
+      addChildNodesForOverview(tgtSchemaTreeRoot, 0, targetDepth, targetReactFlowNodes, false, !!srcSchemaTreeRoot);
     }
 
     setReactFlowNodes([...sourceReactFlowNodes, ...targetReactFlowNodes]);
@@ -406,7 +406,7 @@ const nodeArrayDepth = (nodes: SchemaNodeExtended[]): number[] => {
   return Array.from(depth);
 };
 
-const addChildNodes = (
+const addChildNodesForOverview = (
   curNode: SchemaNodeExtended,
   curDepth: number,
   maxDepth: number,
@@ -416,22 +416,18 @@ const addChildNodes = (
   generateToDepth?: number
 ): void => {
   const baseSchemaNodeData = {
+    schemaType: isSourceSchema ? SchemaType.Source : SchemaType.Target,
+    displayChevron: !isSourceSchema && sourceSchemaSpecified,
     displayHandle: false,
     disabled: false,
     error: false,
     relatedConnections: [],
   };
 
-  const baseSrcSchemaNodeData = {
-    ...baseSchemaNodeData,
-    schemaType: isSourceSchema ? SchemaType.Source : SchemaType.Target,
-    displayChevron: !isSourceSchema && sourceSchemaSpecified && curDepth !== 0,
-  };
-
   resultArray.push({
     id: isSourceSchema ? addSourceReactFlowPrefix(curNode.key) : addTargetReactFlowPrefix(curNode.key),
     data: {
-      ...baseSrcSchemaNodeData,
+      ...baseSchemaNodeData,
       schemaNode: curNode,
       width: calculateWidth(curDepth, maxDepth),
       isLeaf: isLeafNode(curNode),
@@ -445,15 +441,15 @@ const addChildNodes = (
 
   if (generateToDepth === undefined || curDepth < generateToDepth) {
     curNode.children.forEach((childNode) => {
-      addChildNodes(childNode, curDepth + 1, maxDepth, resultArray, isSourceSchema, sourceSchemaSpecified, generateToDepth);
+      addChildNodesForOverview(childNode, curDepth + 1, maxDepth, resultArray, isSourceSchema, sourceSchemaSpecified, generateToDepth);
     });
   }
 };
 
 const calculateWidth = (curDepth: number, maxDepth: number): number => {
-  const breakEvenDepth = 3;
+  const breakEvenDepth = 4;
 
-  if (maxDepth <= breakEvenDepth) {
+  if (maxDepth < breakEvenDepth) {
     return schemaNodeCardDefaultWidth - curDepth * schemaNodeCardWidthDifference;
   }
 

--- a/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
+++ b/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
@@ -179,7 +179,7 @@ const convertSourceSchemaToReactFlowNodes = (
   combinedSourceSchemaNodes: SchemaNodeExtended[],
   connections: ConnectionDictionary
 ): ReactFlowNode<SchemaCardProps>[] => {
-  return convertSchemaToReactFlowNodes(sourceSchemaElkTree, combinedSourceSchemaNodes, SchemaType.Source, false, connections);
+  return convertSchemaToReactFlowNodes(sourceSchemaElkTree, combinedSourceSchemaNodes, SchemaType.Source, connections);
 };
 
 const convertTargetSchemaToReactFlowNodes = (
@@ -191,7 +191,6 @@ const convertTargetSchemaToReactFlowNodes = (
     targetSchemaElkTree,
     [targetSchemaNode, ...targetSchemaNode.children],
     SchemaType.Target,
-    true,
     connections
   );
 };
@@ -200,7 +199,6 @@ export const convertSchemaToReactFlowNodes = (
   elkTree: ElkNode,
   schemaNodes: SchemaNodeExtended[],
   schemaType: SchemaType,
-  displayTargets: boolean,
   connections: ConnectionDictionary
 ): ReactFlowNode<SchemaCardProps>[] => {
   const reactFlowNodes: ReactFlowNode<SchemaCardProps>[] = [];
@@ -235,7 +233,7 @@ export const convertSchemaToReactFlowNodes = (
       data: {
         schemaNode,
         schemaType,
-        displayHandle: !!displayTargets,
+        displayHandle: true,
         displayChevron: !isSourceSchema && index !== 0, // The first target node is the parent
         isLeaf: isLeafNode(schemaNode),
         width: calculateWidth(curDepth, maxLocalDepth),
@@ -244,7 +242,7 @@ export const convertSchemaToReactFlowNodes = (
         relatedConnections: relatedConnections,
       },
       type: ReactFlowNodeType.SchemaNode,
-      targetPosition: !displayTargets ? undefined : isSourceSchema ? Position.Right : Position.Left,
+      targetPosition: isSourceSchema ? Position.Right : Position.Left,
       position: {
         x: elkTree.x + elkNode.x + curDepth * childTargetNodeCardIndent,
         y: elkNode.y,

--- a/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
+++ b/libs/data-mapper/src/lib/utils/ReactFlow.Util.ts
@@ -55,8 +55,6 @@ export const useLayout = (
   currentSourceSchemaNodes: SchemaNodeExtended[],
   currentFunctionNodes: FunctionDictionary,
   currentTargetSchemaNode: SchemaNodeExtended | undefined,
-  rootSourceNode: SchemaNodeExtended | undefined,
-  rootTargetNode: SchemaNodeExtended | undefined,
   connections: ConnectionDictionary,
   selectedItemKey: string | undefined,
   sourceSchemaOrdering: string[],
@@ -67,7 +65,7 @@ export const useLayout = (
   const [diagramSize, setDiagramSize] = useState<Size2D>({ width: 0, height: 0 });
 
   useEffect(() => {
-    if (currentTargetSchemaNode && rootTargetNode && rootSourceNode) {
+    if (currentTargetSchemaNode) {
       // Sort source schema nodes according to their order in the schema
       const sortedSourceSchemaNodes = [...currentSourceSchemaNodes].sort(
         (nodeA, nodeB) => sourceSchemaOrdering.indexOf(nodeA.key) - sourceSchemaOrdering.indexOf(nodeB.key)
@@ -149,8 +147,6 @@ export const useLayout = (
     sourceSchemaOrdering,
     selectedItemKey,
     useExpandedFunctionCards,
-    rootTargetNode,
-    rootSourceNode,
   ]);
 
   return [reactFlowNodes, reactFlowEdges, diagramSize];


### PR DESCRIPTION
* Added WholeMapOverview - tentative name. No connections, no functions yet
* Reworked how widths are calculated, should hopefully be sturdier and simpler to follow
* Fixed bug in minimap node sizes
* Refactored react flow node creation to go back to using 1 method for both source and target


Before Overview:
![image](https://user-images.githubusercontent.com/37600290/219158891-7c1d986e-40f8-4796-b2e3-54e1851dbb25.png)

After Overview (should be no difference):
![image](https://user-images.githubusercontent.com/37600290/219169460-8c65acb6-fcb0-4d8a-8b0d-afcbac4f96b2.png)


Before Mapping:
![image](https://user-images.githubusercontent.com/37600290/219159209-10bc99f3-b605-49a1-8867-3fad4c80f657.png)

After Mapping (should be no difference):
![image](https://user-images.githubusercontent.com/37600290/219163354-9b0769ac-451f-4eb2-8575-feb2dce86909.png)

Whole map:
![image](https://user-images.githubusercontent.com/37600290/219170816-b9c482bd-7db6-4804-aac3-e9d7adaf2da5.png)


AB#17192386