### PR TITLE
[DM/Feature] Starting tab nav

### DIFF
--- a/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
+++ b/libs/data-mapper/src/lib/components/tree/TreeBranch.tsx
@@ -63,6 +63,12 @@ const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
   const BundledChevronDownIcon = bundleIcon(ChevronDown12Filled, ChevronDown12Regular);
   const BundledChevronRightIcon = bundleIcon(ChevronRight12Filled, ChevronRight12Regular);
 
+  const selectionAreaKeydown = (e: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (e.code === 'Enter') {
+      handleItemClick();
+    }
+  };
+
   return (
     <>
       <Stack
@@ -101,7 +107,13 @@ const TreeBranch = <T extends ITreeNode<T>>(props: TreeBranchProps<T>) => {
           onMouseLeave={setChevronNotHovered}
         />
 
-        {nodeContent(node, isHovered)}
+        <span
+          style={{ width: '100%', height: '100%', paddingTop: '4px', paddingBottom: '4px' }}
+          tabIndex={0}
+          onKeyDown={selectionAreaKeydown}
+        >
+          {nodeContent(node, isHovered)}
+        </span>
       </Stack>
 
       {hasChildren &&

--- a/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
+++ b/libs/data-mapper/src/lib/ui/ReactFlowWrapper.tsx
@@ -203,6 +203,7 @@ export const ReactFlowWrapper = ({
       nodes={nodes}
       edges={edges}
       onPaneClick={onPaneClick}
+      nodesFocusable={false} // we handle keyboard focus from within the node
       // Not ideal, but it's this or useViewport that re-renders 3000 (due to x/y changes)
       onMove={(_e, viewport) => setCanvasZoom(viewport.zoom)}
       onKeyDown={keyDownHandler}


### PR DESCRIPTION
Tab nav for schema tree now works, as well as improvements in the tab nav for schema nodes. Tree nav might need to be revisited, to make sure that the interaction that we have is similar to other grouped list tab nav.