### PR TITLE
laFix: Fix for code view breaking on empty workflows

### DIFF
--- a/libs/designer/src/lib/core/utils/graph.ts
+++ b/libs/designer/src/lib/core/utils/graph.ts
@@ -20,7 +20,7 @@ export const getTriggerNode = (state: WorkflowState): WorkflowNode => {
 };
 
 export const getTriggerNodeId = (state: WorkflowState): string => {
-  return getTriggerNode(state).id;
+  return getTriggerNode(state)?.id;
 };
 
 export const isLeafNodeFromEdges = (edges: WorkflowEdge[]) => {


### PR DESCRIPTION
We were just missing a single optional, the rest of the logic was already in place to support serializing empty workflows.
Fixes #1185 