### PR TITLE
laFix: Allow parallel node addition on all valid edge buttons

### DIFF
--- a/libs/designer/src/lib/ui/connections/dropzone.tsx
+++ b/libs/designer/src/lib/ui/connections/dropzone.tsx
@@ -110,7 +110,7 @@ export const DropZone: React.FC<DropZoneProps> = ({ graphId, parentId, childId }
                 <ActionButton iconProps={{ imageProps: { src: AddNodeIcon } }} onClick={openAddNodePanel}>
                   {newActionText}
                 </ActionButton>
-                {childId && parentId ? (
+                {parentId ? (
                   <ActionButton iconProps={{ imageProps: { src: AddBranchIcon } }} onClick={addParallelBranch}>
                     {newBranchText}
                   </ActionButton>


### PR DESCRIPTION
Allow parallel node addition on all valid edge buttons, any edge with one parent node.
Fixes #1612