### PR TITLE
[DM | Expanded function cards] Set a maxWidth, and utilize in layouting

### DIFF
--- a/libs/data-mapper/src/lib/components/nodeCard/functionCard/ExpandedFunctionCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/functionCard/ExpandedFunctionCard.tsx
@@ -1,3 +1,4 @@
+import { expandedFunctionCardMaxWidth } from '../../../constants/NodeConstants';
 import { customTokens } from '../../../core';
 import { deleteCurrentlySelectedItem, setSelectedItem } from '../../../core/state/DataMapSlice';
 import type { RootState } from '../../../core/state/Store';
@@ -84,7 +85,17 @@ export const ExpandedFunctionCard = (props: NodeProps<FunctionCardProps>) => {
         fileName={functionData.iconFileName}
         color={tokens.colorNeutralForegroundInverted}
       />
-      <Text style={{ margin: '0px 12px', color: tokens.colorNeutralForegroundInverted }}>{functionData.displayName}</Text>
+      <Text
+        style={{
+          margin: '0px 12px',
+          color: tokens.colorNeutralForegroundInverted,
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {functionData.displayName}
+      </Text>
       <Divider vertical style={{ height: '100%' }} />
       <OutputIcon style={{ margin: '0px 6px 0px 10px', color: tokens.colorNeutralForegroundInverted }} />
       <Handle
@@ -96,12 +107,19 @@ export const ExpandedFunctionCard = (props: NodeProps<FunctionCardProps>) => {
     </Button>
   );
 
-  const inputBodyStyles = {
+  const inputBodyStyles: React.CSSProperties = {
     padding: '0px 10px',
     backgroundColor: tokens.colorNeutralBackground1,
     borderRadius: tokens.borderRadiusMedium,
   };
-  const inputTextStyles = { alignItems: 'center', height: '30px', display: 'flex' };
+  const inputTextStyles: React.CSSProperties = {
+    alignItems: 'center',
+    height: '30px',
+    display: 'flex',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  };
   const handleIndexOffset = 34;
   const handleBaseOffset = 58;
 
@@ -161,7 +179,8 @@ export const ExpandedFunctionCard = (props: NodeProps<FunctionCardProps>) => {
     }
   }
 
-  let divStyle = {
+  let divStyle: React.CSSProperties = {
+    maxWidth: expandedFunctionCardMaxWidth,
     borderRadius: tokens.borderRadiusMedium,
     backgroundColor: customTokens[functionBranding.colorTokenName],
   };

--- a/libs/data-mapper/src/lib/components/nodeCard/functionCard/FunctionCard.ts
+++ b/libs/data-mapper/src/lib/components/nodeCard/functionCard/FunctionCard.ts
@@ -1,21 +1,21 @@
 import type { FunctionGroupBranding } from '../../../constants/FunctionConstants';
-import { functionNodeCardSize } from '../../../constants/NodeConstants';
+import { simpleFunctionCardDiameter } from '../../../constants/NodeConstants';
 import type { ConnectionDictionary } from '../../../models/Connection';
 import type { FunctionData } from '../../../models/Function';
 import { areInputTypesValidForFunction } from '../../../utils/MapChecker.Utils';
 import type { CardProps } from '../NodeCard';
 import { createFocusOutlineStyle, makeStyles, shorthands, tokens } from '@fluentui/react-components';
 
-const sharedHalfCardSize = functionNodeCardSize / 2;
+const simpleFunctionCardRadius = simpleFunctionCardDiameter / 2;
 
 export const useFunctionCardStyles = makeStyles({
   root: {
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
     color: tokens.colorNeutralBackground1,
     fontSize: '20px',
-    height: `${sharedHalfCardSize}px`,
-    width: `${sharedHalfCardSize}px`,
-    minWidth: `${sharedHalfCardSize}px`,
+    height: `${simpleFunctionCardRadius}px`,
+    width: `${simpleFunctionCardRadius}px`,
+    minWidth: `${simpleFunctionCardRadius}px`,
     textAlign: 'center',
     position: 'relative',
     justifyContent: 'center',

--- a/libs/data-mapper/src/lib/constants/NodeConstants.ts
+++ b/libs/data-mapper/src/lib/constants/NodeConstants.ts
@@ -3,4 +3,5 @@ export const schemaNodeCardWidthDifference = 24;
 export const schemaNodeCardHeight = 48;
 export const childTargetNodeCardIndent = schemaNodeCardWidthDifference;
 
-export const functionNodeCardSize = 64;
+export const simpleFunctionCardDiameter = 64;
+export const expandedFunctionCardMaxWidth = 200;

--- a/libs/data-mapper/src/lib/utils/Layout.Utils.ts
+++ b/libs/data-mapper/src/lib/utils/Layout.Utils.ts
@@ -1,4 +1,9 @@
-import { functionNodeCardSize, schemaNodeCardDefaultWidth, schemaNodeCardHeight } from '../constants/NodeConstants';
+import {
+  simpleFunctionCardDiameter,
+  schemaNodeCardDefaultWidth,
+  schemaNodeCardHeight,
+  expandedFunctionCardMaxWidth,
+} from '../constants/NodeConstants';
 import { targetPrefix } from '../constants/ReactFlowConstants';
 import type { SchemaNodeDictionary, SchemaNodeExtended } from '../models';
 import type { ConnectionDictionary } from '../models/Connection';
@@ -178,12 +183,12 @@ export const applyCustomLayout = async (
   isOverview?: boolean
 ): Promise<RootLayoutNode> => {
   const schemaNodeCardVGap = 8;
-  const xInterval = functionNodeCardSize * (useExpandedFunctionCards ? 5 : 2);
-  const yInterval = functionNodeCardSize * 1.5;
+  const xInterval = (useExpandedFunctionCards ? expandedFunctionCardMaxWidth : simpleFunctionCardDiameter) * 1.5;
+  const yInterval = simpleFunctionCardDiameter * 1.5;
   const maxFunctionsPerToolbarRow = 4;
-  const functionToolbarStartY = -1 * functionNodeCardSize * 2;
-  const nodeCollisionXThreshold = functionNodeCardSize * (useExpandedFunctionCards ? 3 : 1.5);
-  const nodeCollisionYThreshold = functionNodeCardSize * 1.2;
+  const functionToolbarStartY = -1 * simpleFunctionCardDiameter * 2;
+  const nodeCollisionXThreshold = (useExpandedFunctionCards ? expandedFunctionCardMaxWidth : simpleFunctionCardDiameter) * 1.25;
+  const nodeCollisionYThreshold = simpleFunctionCardDiameter * 1.2;
 
   const getSchemaNodeYPos = (nodeIdx: number) => nodeIdx * (schemaNodeCardHeight + (nodeIdx === 0 ? 0 : schemaNodeCardVGap));
 


### PR DESCRIPTION
New const maxWidth for expanded function cards (should allow everything as long as ‘Direct Access’ and some to be one line still, ellipsis is just a failsafe in case we add a function out of nowhere with a ridiculously long name): *Should be no change here
![image](https://user-images.githubusercontent.com/49288482/221697807-5b634d0b-cea4-41b7-a5f1-2471458ccc30.png)


Temporarily reduced width just for a screenshot to show the ellipsis:
![image](https://user-images.githubusercontent.com/49288482/221697855-13b42999-71da-40da-9795-a0365076092f.png)
