### PR TITLE
laFix: Trigger Deletion to Operation Selection bugfix

### DIFF
--- a/libs/designer/src/lib/core/utils/tokens.ts
+++ b/libs/designer/src/lib/core/utils/tokens.ts
@@ -192,7 +192,7 @@ export const getOutputTokenSections = (
     });
 
     const outputTokenGroups = nodeTokens.upstreamNodeIds.map((upstreamNodeId) => {
-      let tokens = outputTokens[upstreamNodeId].tokens;
+      let tokens = outputTokens[upstreamNodeId]?.tokens ?? [];
       tokens = tokens.map((token) => {
         return {
           ...token,

--- a/libs/designer/src/lib/ui/connections/dropzone.tsx
+++ b/libs/designer/src/lib/ui/connections/dropzone.tsx
@@ -75,7 +75,7 @@ export const DropZone: React.FC<DropZoneProps> = ({ graphId, parentId, childId }
     toggleIsCalloutVisible();
   };
 
-  const buttonId = `msla-edge-button-${parentId}-${childId}`;
+  const buttonId = `msla-edge-button-${parentId}-${childId}`.replace(/\W/g, '-');
 
   return (
     <div

--- a/libs/designer/src/lib/ui/connections/dropzone.tsx
+++ b/libs/designer/src/lib/ui/connections/dropzone.tsx
@@ -1,7 +1,5 @@
-import type { RootState } from '../../core';
 import { expandDiscoveryPanel } from '../../core/state/panel/panelSlice';
 import { useAllGraphParents } from '../../core/state/workflow/workflowSelectors';
-import { getTriggerNode } from '../../core/utils/graph';
 import { AllowDropTarget } from './dynamicsvgs/allowdroptarget';
 import { BlockDropTarget } from './dynamicsvgs/blockdroptarget';
 import AddBranchIcon from './edgeContextMenuSvgs/addBranchIcon.svg';
@@ -10,11 +8,11 @@ import { ActionButton, Callout, DirectionalHint } from '@fluentui/react';
 import { useBoolean } from '@fluentui/react-hooks';
 import { css } from '@fluentui/utilities';
 import { ActionButtonV2 } from '@microsoft/designer-ui';
-import { guid, WORKFLOW_NODE_TYPES } from '@microsoft/utils-logic-apps';
+import { guid } from '@microsoft/utils-logic-apps';
 import { useCallback } from 'react';
 import { useDrop } from 'react-dnd';
 import { useIntl } from 'react-intl';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 export interface DropZoneProps {
   graphId: string;
@@ -25,10 +23,6 @@ export interface DropZoneProps {
 export const DropZone: React.FC<DropZoneProps> = ({ graphId, parentId, childId }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const isAddingTrigger = useSelector((state: RootState) => {
-    const triggerNode = getTriggerNode(state.workflow);
-    return triggerNode.type === WORKFLOW_NODE_TYPES.PLACEHOLDER_NODE;
-  });
   const [showCallout, { toggle: toggleIsCalloutVisible }] = useBoolean(false);
 
   const newActionText = intl.formatMessage({
@@ -81,7 +75,7 @@ export const DropZone: React.FC<DropZoneProps> = ({ graphId, parentId, childId }
     toggleIsCalloutVisible();
   };
 
-  const buttonId = `msla-edge-button-${parentId}-${childId}`.replace(/[^a-zA-Z-_ ]/g, '');
+  const buttonId = `msla-edge-button-${parentId}-${childId}`;
 
   return (
     <div
@@ -94,7 +88,7 @@ export const DropZone: React.FC<DropZoneProps> = ({ graphId, parentId, childId }
           {canDrop ? <AllowDropTarget fill="#0078D4" /> : <BlockDropTarget fill="#797775" />}
         </div>
       )}
-      {!isOver && !isAddingTrigger && (
+      {!isOver && (
         <>
           <ActionButtonV2 id={buttonId} title={tooltipText} onClick={actionButtonClick} />
           {showCallout && (


### PR DESCRIPTION
## Main Changes
- Fixes #1686 
  - Trigger can now be deleted and not crash when selecting a different Node
  - Fixes a related issue where when the trigger is deleted all other edge buttons become hidden
- Fixes #1689 
  - Callout now renders properly, was a regex issue with the edge button ID
