### PR TITLE
Add support for OpenAPI parameter types

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -94,7 +94,7 @@ const isApiConnectionType = (type: string): boolean => {
   );
 };
 
-const isOpenApiConnectionType = (type: string): boolean => {
+export const isOpenApiConnectionType = (type: string): boolean => {
   return (
     equals(type, Constants.NODE.TYPE.OPEN_API_CONNECTION) ||
     equals(type, Constants.NODE.TYPE.OPEN_API_CONNECTION_WEBHOOK) ||

--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -13,6 +13,8 @@ import { initializeParameters } from '../../state/workflowparameters/workflowpar
 import type { RootState } from '../../store';
 import { getBrandColorFromConnector, getIconUriFromConnector } from '../../utils/card';
 import { getTriggerNodeId, isRootNodeInGraph } from '../../utils/graph';
+import type { OpenApiConnectionSerializedInputs } from '../../utils/openapi/inputsbuilder';
+import { OpenApiOperationInputsBuilder } from '../../utils/openapi/inputsbuilder';
 import { getSplitOnOptions, getUpdatedManifestForSchemaDependency, getUpdatedManifestForSpiltOn, toOutputInfo } from '../../utils/outputs';
 import {
   addRecurrenceParametersInGroup,
@@ -29,6 +31,7 @@ import {
 import { createLiteralValueSegment } from '../../utils/parameters/segment';
 import { getOutputParametersFromSwagger } from '../../utils/swagger/operation';
 import { convertOutputsToTokens, getBuiltInTokens, getTokenNodeIds } from '../../utils/tokens';
+import { isOpenApiConnectionType } from './connections';
 import type { NodeInputsWithDependencies, NodeOutputsWithDependencies } from './operationdeserializer';
 import type { Settings } from './settings';
 import type {
@@ -95,37 +98,46 @@ export const getInputParametersFromManifest = (
   let primaryInputParametersInArray = unmap(primaryInputParameters);
 
   if (stepDefinition) {
-    const { inputsLocation } = manifest.properties;
-    const operationData = clone(stepDefinition);
+    const nodeType: string | undefined = stepDefinition.type;
+    if (nodeType && isOpenApiConnectionType(nodeType)) {
+      const stepDefinitionInputs: OpenApiConnectionSerializedInputs | undefined = stepDefinition.inputs;
 
-    // In the case of retry policy, it is treated as an input
-    // avoid pushing a parameter for it as it is already being
-    // handled in the settings store.
-    // NOTE: this could be expanded to more settings that are treated as inputs.
-    if (
-      manifest.properties.settings &&
-      manifest.properties.settings.retryPolicy &&
-      operationData.inputs &&
-      operationData.inputs[PropertyName.RETRYPOLICY]
-    ) {
-      delete operationData.inputs.retryPolicy;
+      primaryInputParametersInArray =
+        new OpenApiOperationInputsBuilder()
+          .loadStaticInputValuesFromDefinition(stepDefinitionInputs, primaryInputParametersInArray);
+    } else {
+      const { inputsLocation } = manifest.properties;
+      const operationData = clone(stepDefinition);
+
+      // In the case of retry policy, it is treated as an input
+      // avoid pushing a parameter for it as it is already being
+      // handled in the settings store.
+      // NOTE: this could be expanded to more settings that are treated as inputs.
+      if (
+        manifest.properties.settings &&
+        manifest.properties.settings.retryPolicy &&
+        operationData.inputs &&
+        operationData.inputs[PropertyName.RETRYPOLICY]
+      ) {
+        delete operationData.inputs.retryPolicy;
+      }
+
+      if (
+        manifest.properties.connectionReference &&
+        manifest.properties.connectionReference.referenceKeyFormat === ConnectionReferenceKeyFormat.Function
+      ) {
+        delete operationData.inputs.function;
+      }
+
+      primaryInputParametersInArray = updateParameterWithValues(
+        'inputs.$',
+        getInputsValueFromDefinitionForManifest(inputsLocation ?? ['inputs'], manifest, operationData, primaryInputParametersInArray),
+        '',
+        primaryInputParametersInArray,
+        (!inputsLocation || !!inputsLocation.length) && !manifest.properties.inputsLocationSwapMap /* createInvisibleParameter */,
+        false /* useDefault */
+      );
     }
-
-    if (
-      manifest.properties.connectionReference &&
-      manifest.properties.connectionReference.referenceKeyFormat === ConnectionReferenceKeyFormat.Function
-    ) {
-      delete operationData.inputs.function;
-    }
-
-    primaryInputParametersInArray = updateParameterWithValues(
-      'inputs.$',
-      getInputsValueFromDefinitionForManifest(inputsLocation ?? ['inputs'], manifest, operationData, primaryInputParametersInArray),
-      '',
-      primaryInputParametersInArray,
-      (!inputsLocation || !!inputsLocation.length) && !manifest.properties.inputsLocationSwapMap /* createInvisibleParameter */,
-      false /* useDefault */
-    );
   } else {
     loadParameterValuesFromDefault(primaryInputParameters);
   }

--- a/libs/designer/src/lib/core/utils/openapi/inputsbuilder.ts
+++ b/libs/designer/src/lib/core/utils/openapi/inputsbuilder.ts
@@ -1,0 +1,38 @@
+import type { InputParameter } from "@microsoft/parsers-logic-apps";
+
+export interface OpenApiConnectionSerializedInputs {
+  parameters: Record<string, unknown>;
+}
+
+export class OpenApiOperationInputsBuilder {
+  public loadStaticInputValuesFromDefinition(
+    inputsInDefinition: OpenApiConnectionSerializedInputs | undefined,
+    inputParameters: InputParameter[]
+  ): InputParameter[] {
+    return this._loadKnownParametersFromDefinition(inputsInDefinition, inputParameters);
+  }
+
+  private _loadKnownParametersFromDefinition(
+    inputsInDefinition: OpenApiConnectionSerializedInputs | undefined,
+    inputParameters: InputParameter[]
+  ): InputParameter[] {
+    if (!inputsInDefinition) {
+      return inputParameters;
+    }
+
+    const result: InputParameter[] = [];
+
+    for (const inputParameter of inputParameters) {
+      const inputParameterAlias =
+        inputParameter.alias ||
+        inputParameter.name;
+
+      result.push({
+        ...inputParameter,
+        value: inputsInDefinition.parameters[inputParameterAlias],
+      });
+    }
+
+    return result;
+  }
+}

--- a/libs/utils/src/lib/helpers/__test__/functions.spec.ts
+++ b/libs/utils/src/lib/helpers/__test__/functions.spec.ts
@@ -62,11 +62,31 @@ describe('lib/helpers/functions', () => {
     expect(arrayEqualsOrderInsensitive(['a', 'b'], ['b', 'a'])).toBeTruthy();
   });
 
-  it('equals', () => {
-    expect(equals('a', 'b')).toBeFalsy();
-    expect(equals('a', 'A')).toBeTruthy();
-    expect(equals('a', 'a', false)).toBeTruthy();
-    expect(equals('a', 'A', false)).toBeFalsy();
+  describe('equals', () => {
+    it.each([
+      ['a', 'b', false],
+      ['a', 'A', true],
+      ['a', 'a', true],
+      ['123', '123', true],
+      ['foo', 'FOO', true],
+      ['ßß', 'SSSS', true],
+      ['ς', 'Σ', true],
+    ])('returns the correct result for %p=%p, case-insensitive true/default', (a, b, expected) => {
+      expect(equals(a, b)).toBe(expected);
+      expect(equals(a, b, true)).toBe(expected);
+    });
+
+    it.each([
+      ['a', 'b', false],
+      ['a', 'A', false],
+      ['a', 'a', true],
+      ['123', '123', true],
+      ['foo', 'FOO', false],
+      ['ßß', 'SSSS', false],
+      ['ς', 'Σ', false],
+    ])('returns the correct result for %p=%p, case-insensitive false', (a, b, expected) => {
+      expect(equals(a, b, false)).toBe(expected);
+    });
   });
 
   describe('addPrefix', () => {

--- a/libs/utils/src/lib/helpers/functions.ts
+++ b/libs/utils/src/lib/helpers/functions.ts
@@ -96,7 +96,10 @@ export function arrayEqualsOrderInsensitive<T extends Primitive>(
  */
 export function equals(x: string | null | undefined, y: string | null | undefined, caseInsensitive = true) {
   if (caseInsensitive) {
-    return !isNullOrUndefined(x) && !isNullOrUndefined(y) && x.toLowerCase() === y.toLowerCase();
+    // NOTE: In some cases, the conversion of Latin or Greek characters to uppercase and then back to lowercase will result
+    // in a different evaluation, which means checking only 'toLowerCase' equivalence is insufficient. This should also return 'true'
+    // in the event that they share 'toUpperCase' equivalence. See work item One/#15505347 and incident 333040852 for details.
+    return !isNullOrUndefined(x) && !isNullOrUndefined(y) && (x.toLowerCase() === y.toLowerCase() || x.toUpperCase() === y.toUpperCase());
   } else {
     return !isNullOrUndefined(x) && !isNullOrUndefined(y) && x === y;
   }


### PR DESCRIPTION
## Primary changes

Currently, loading OpenAPI actions results in a duplicated set of parameters (and the duplicates are the ones populated with any previously saved data):

![image](https://user-images.githubusercontent.com/1350074/223586921-9328c023-2766-4ffd-a58a-dc46333d574b.png)

This change adds proper handling for OpenAPI actions so that they are not duplicated:

![image](https://user-images.githubusercontent.com/1350074/223587049-5f042030-7ddf-405e-9821-6d14d9769c26.png)

## Other changes

- Due to an issue we had in the past, I've updated the logic from `equals()` to handle Greek and Latin letters as well

AB#17466033