### PR TITLE
Remove fuse.js as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,6 @@
     "eslint-plugin-jsx-a11y": "6.6.1",
     "eslint-plugin-react": "7.31.8",
     "eslint-plugin-react-hooks": "4.6.0",
-    "fuse.js": "6.6.2",
     "husky": "8.0.1",
     "jest": "28.1.3",
     "jest-junit": "13.2.0",


### PR DESCRIPTION
The `fuse.js` library is set as both a dependency and dev dependency, which causes Nx to get confused and not bundle it in `package.json`.

I made the change locally and did a full clean and rebuild before and after. Below is the `dist/libs/designer/package.json` content before and after.

## Before

![image](https://user-images.githubusercontent.com/1350074/223883266-9e73d742-5a01-43fa-bfc5-4bff32ac7448.png)


## After

![image](https://user-images.githubusercontent.com/1350074/223883305-2172739f-5420-4d15-8366-520ed1e05596.png)

AB#17490406