### PR TITLE
Fix rendering of OpenAPI token titles

### DIFF
--- a/libs/designer/src/lib/core/utils/__test__/outputs.spec.ts
+++ b/libs/designer/src/lib/core/utils/__test__/outputs.spec.ts
@@ -1,0 +1,80 @@
+import { getUpdatedManifestForSpiltOn } from '../outputs';
+import type { OperationManifest } from '@microsoft/utils-logic-apps';
+import { ConnectionReferenceKeyFormat } from '@microsoft/utils-logic-apps';
+
+describe('Outputs Utilities', () => {
+  describe('getUpdatedManifestForSpiltOn', () => {
+    it('properly deserializes OpenAPI property aliases', () => {
+      const sampleManifest: OperationManifest = {
+        properties: {
+          iconUri: 'https://example.com/icon.png',
+          brandColor: '#4B53BC',
+          summary: 'When a new channel message is added',
+          inputs: {
+            type: 'object',
+            properties: {
+              groupId: {
+                type: 'string',
+                title: 'Team',
+                'x-ms-dynamic-list': {
+                  itemValuePath: 'id',
+                  dynamicState: {
+                    operationId: 'GetAllTeams',
+                    parameters: {},
+                    itemsPath: 'value',
+                    itemValuePath: 'id',
+                    itemTitlePath: 'displayName',
+                  },
+                  parameters: {},
+                },
+                description: 'Add team ID',
+                minLength: 1,
+                'x-ms-property-name-alias': 'groupId',
+              },
+            },
+            required: ['channelId', 'groupId'],
+          },
+          outputs: {
+            type: 'object',
+            properties: {
+              body: {
+                type: 'array',
+                title: 'Message List',
+                items: {
+                  type: 'object',
+                  title: 'Message',
+                  properties: {
+                    importance: {
+                      type: 'string',
+                      title: 'importance',
+                      description: 'importance',
+                      'x-ms-visibility': 'advanced',
+                      'x-ms-property-name-alias': 'importance',
+                    },
+                  },
+                  required: [],
+                  description: 'Properties associated with a single message.',
+                },
+                description: 'List of one or more messages for a specific channel in a Team.',
+                'x-ms-visibility': 'advanced',
+                'x-ms-property-name-alias': 'body',
+              },
+            },
+          },
+          connectionReference: {
+            referenceKeyFormat: ConnectionReferenceKeyFormat.OpenApi,
+          },
+        },
+      };
+      const splitOn = "@triggerOutputs()?['body']";
+
+      const result = getUpdatedManifestForSpiltOn(sampleManifest, splitOn);
+
+      // Ensure the original is not modified.
+      expect(sampleManifest.properties.outputs.properties.body.items.properties.importance['x-ms-property-name-alias']).toBe('importance');
+
+      // Ensure the result has the correct format for alias.
+      expect(result.properties.outputs.properties.body.properties.importance['x-ms-property-name-alias']).toBe('body/importance');
+    });
+  });
+});

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -144,7 +144,6 @@ export const getUpdatedManifestForSpiltOn = (manifest: OperationManifest, splitO
     if (clonedManifestProperties) {
       for (const itemName of Object.keys(clonedManifestProperties)) {
         const splitOnItem = clonedManifestProperties[itemName];
-
         convertSchemaAliasesForSplitOn(splitOnItem);
       }
     }


### PR DESCRIPTION
Currently, OpenAPI properties used as outputs on a trigger (which are split-on properties) are loaded with `x-ms-property-name-alias` as their leaf node name rather than their proper reference name. For example, `outputs.$.body.body/importance` is loaded as `importance` instead of `body/importance`. This means that there is a mismatch between the outputs in the schema and the tokens that are loaded into memory.

As a result, the current setup looks like this:

![image](https://user-images.githubusercontent.com/1350074/223886772-d6292edc-c8f1-4889-af9e-aa7736dd58d7.png)

*(Note: The last item is an action output, not a trigger output.)*

With the fix, it looks like this:

![image](https://user-images.githubusercontent.com/1350074/223886865-ba0c62b1-d59e-4f6f-95c0-48574c7affab.png)