### PR TITLE
Minor updates to operationManifest isSupported and map export

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -80,7 +80,7 @@ const initializeOperationDetails = async (
 ): Promise<void> => {
   const state = getState();
   const isTrigger = isRootNodeInGraph(nodeId, 'root', state.workflow.nodesMetadata);
-  const { type, connectorId } = operationInfo;
+  const { type, kind, connectorId } = operationInfo;
   let isConnectionRequired = true;
   const operationManifestService = OperationManifestService();
 
@@ -90,7 +90,7 @@ const initializeOperationDetails = async (
   let initData: NodeData;
   let manifest: OperationManifest | undefined = undefined;
   let swagger: SwaggerParser | undefined = undefined;
-  if (operationManifestService.isSupported(type)) {
+  if (operationManifestService.isSupported(type, kind)) {
     manifest = await getOperationManifest(operationInfo);
     isConnectionRequired = isConnectionRequiredForOperation(manifest);
 

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -68,7 +68,7 @@ export const initializeOperationMetadata = async (
     if (isTrigger) {
       triggerNodeId = operationId;
     }
-    if (operationManifestService.isSupported(operation.type)) {
+    if (operationManifestService.isSupported(operation.type, operation.kind)) {
       promises.push(initializeOperationDetailsForManifest(operationId, operation, !!isTrigger, dispatch));
     } else {
       promises.push(initializeOperationDetailsForSwagger(operationId, operation, references, !!isTrigger, dispatch) as any);

--- a/libs/services/designer-client-services/src/lib/base/index.ts
+++ b/libs/services/designer-client-services/src/lib/base/index.ts
@@ -2,7 +2,7 @@
 export { BaseSearchService, getClientBuiltInOperations, getClientBuiltInConnectors } from './search';
 export type { BaseSearchServiceOptions } from './search';
 // Manifests
-export { BaseOperationManifestService, foreachOperationInfo } from './operationmanifest';
+export { BaseOperationManifestService, foreachOperationInfo, supportedBaseManifestObjects } from './operationmanifest';
 export type { BaseOperationManifestServiceOptions } from './operationmanifest';
 export { frequencyValues } from './manifests/schedule';
 // Connector


### PR DESCRIPTION
Passing operationKind in to isSupported in places where that was not done before and exporting supportedBaseManifestObjects to avoid duplicating operation manifests for shared builtins.

AB#17530575