### PR TITLE
Add props for host layer to add custom background

### DIFF
--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -22,15 +22,15 @@ import { setLayerHostSelector } from '@fluentui/react';
 import type { WorkflowNodeType } from '@microsoft/utils-logic-apps';
 import { useWindowDimensions, WORKFLOW_NODE_TYPES, useThrottledEffect } from '@microsoft/utils-logic-apps';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import KeyboardBackend, { isKeyboardDragTrigger } from 'react-dnd-accessible-backend';
+import KeyboardBackendFactory, { isKeyboardDragTrigger } from 'react-dnd-accessible-backend';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { DndProvider, createTransition, MouseTransition } from 'react-dnd-multi-backend';
 import { useDispatch, useSelector } from 'react-redux';
-import { ReactFlow, ReactFlowProvider, useNodes, useReactFlow, useStore, BezierEdge } from 'reactflow';
-import type { NodeChange } from 'reactflow';
+import { Background, ReactFlow, ReactFlowProvider, useNodes, useReactFlow, useStore, BezierEdge } from 'reactflow';
+import type { BackgroundProps, NodeChange } from 'reactflow';
 
 export interface DesignerProps {
-  graphId?: string;
+  backgroundProps?: BackgroundProps;
 }
 
 type NodeTypesObj = {
@@ -106,7 +106,9 @@ export const CanvasFinder = () => {
   return null;
 };
 
-export const Designer = () => {
+export const Designer = (props: DesignerProps) => {
+  const { backgroundProps } = props;
+
   const [nodes, edges, flowSize] = useLayout();
   const isEmpty = useIsGraphEmpty();
   const isReadOnly = useReadOnly();
@@ -143,7 +145,7 @@ export const Designer = () => {
 
   const [zoom, setZoom] = useState(1);
 
-  const tranlsateExtent = useMemo((): [[number, number], [number, number]] => {
+  const translateExtent = useMemo((): [[number, number], [number, number]] => {
     const padding = 64 + 24;
     const [flowWidth, flowHeight] = flowSize;
 
@@ -172,7 +174,7 @@ export const Designer = () => {
       },
       {
         id: 'keyboard',
-        backend: KeyboardBackend,
+        backend: KeyboardBackendFactory,
         context: { window, document },
         preview: true,
         transition: KeyboardTransition,
@@ -195,7 +197,7 @@ export const Designer = () => {
             panOnScroll={true}
             deleteKeyCode={['Backspace', 'Delete']}
             zoomActivationKeyCode={['Ctrl', 'Meta', 'Alt', 'Control']}
-            translateExtent={clampPan ? tranlsateExtent : undefined}
+            translateExtent={clampPan ? translateExtent : undefined}
             onMove={(_e, viewport) => setZoom(viewport.zoom)}
             proOptions={{
               account: 'paid-sponsor',
@@ -203,6 +205,7 @@ export const Designer = () => {
             }}
           >
             <PanelRoot />
+            {backgroundProps ? <Background {...backgroundProps} /> : null}
           </ReactFlow>
           <div className="msla-designer-tools">
             <Controls />


### PR DESCRIPTION
Currently, host layer has no access to the `<ReactFlow>` component to customize it. This PR adds the ability to customize the `<ReactFlow>` background via the `<Background>` component using an optional props bundle.