### PR TITLE
Designer Crashes when editing Javascript editor

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -44,7 +44,7 @@ export type GetTokenPickerHandler = (
   tokenPickerMode?: TokenPickerMode,
   closeTokenPicker?: () => void,
   tokenPickerClicked?: (b: boolean) => void,
-  tokenClicked?: (token: ValueSegment) => void
+  tokenClickedCallback?: (token: ValueSegment) => void
 ) => JSX.Element;
 
 export type ChangeHandler = (newState: ChangeState) => void;

--- a/libs/designer-ui/src/lib/token/inputToken.tsx
+++ b/libs/designer-ui/src/lib/token/inputToken.tsx
@@ -1,9 +1,11 @@
 import { getBrandColorRgbA } from '../card/utils';
+import { TokenType } from '../editor';
 import { DELETE_TOKEN_NODE } from '../editor/base/plugins/DeleteTokenNode';
 import { OPEN_TOKEN_PICKER } from '../editor/base/plugins/OpenTokenPicker';
 import iconSvg from './icon/icon.svg';
 import { Icon } from '@fluentui/react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $getNodeByKey } from 'lexical';
 import type { NodeKey } from 'lexical';
 import { useIntl } from 'react-intl';
 
@@ -27,7 +29,11 @@ export const InputToken: React.FC<InputTokenProps> = ({ value, brandColor, icon,
 
   const handleTokenClicked = () => {
     if (nodeKey) {
-      editor.dispatchCommand(OPEN_TOKEN_PICKER, nodeKey);
+      editor.getEditorState().read(() => {
+        if ($getNodeByKey(nodeKey)?.['__data']?.token?.tokenType === TokenType.FX) {
+          editor.dispatchCommand(OPEN_TOKEN_PICKER, nodeKey);
+        }
+      });
     }
   };
 

--- a/libs/designer-ui/src/lib/tokenpicker/plugins/TokenPickerHandler.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/plugins/TokenPickerHandler.tsx
@@ -20,8 +20,6 @@ export default function TokenPickerHandler({ handleUpdateExpressionToken }: Toke
       (payload: string) => {
         const node = findChildNode($getRoot(), payload, TokenType.FX);
         if (node?.token?.tokenType === TokenType.FX) {
-          console.log(node?.token?.value);
-          console.log(handleUpdateExpressionToken);
           handleUpdateExpressionToken?.(node?.token?.value ?? '', payload);
         } else {
           editor.focus();

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
@@ -10,7 +10,7 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import type { Expression } from '@microsoft/parsers-logic-apps';
 import { ExpressionParser } from '@microsoft/parsers-logic-apps';
 import { guid } from '@microsoft/utils-logic-apps';
-import type { NodeKey } from 'lexical';
+import type { LexicalEditor, NodeKey } from 'lexical';
 import { useIntl } from 'react-intl';
 
 const FxIcon =
@@ -23,7 +23,12 @@ interface TokenPickerFooterProps {
 }
 
 export function TokenPickerFooter({ expression, expressionToBeUpdated, setExpressionEditorError }: TokenPickerFooterProps) {
-  const [editor] = useLexicalComposerContext();
+  let editor: LexicalEditor | null;
+  try {
+    [editor] = useLexicalComposerContext();
+  } catch {
+    editor = null;
+  }
   const intl = useIntl();
 
   const tokenPickerAdd = intl.formatMessage({

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickerheader.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickerheader.tsx
@@ -2,6 +2,7 @@ import constants from '../constants';
 import type { IButtonStyles } from '@fluentui/react';
 import { IconButton } from '@fluentui/react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import type { LexicalEditor } from 'lexical';
 import { useIntl } from 'react-intl';
 
 const buttonStyles: IButtonStyles = {
@@ -24,7 +25,12 @@ interface TokenPickerHeaderProps {
 }
 
 export function TokenPickerHeader({ fullScreen, closeTokenPicker, setFullScreen }: TokenPickerHeaderProps) {
-  const [editor] = useLexicalComposerContext();
+  let editor: LexicalEditor | null;
+  try {
+    [editor] = useLexicalComposerContext();
+  } catch {
+    editor = null;
+  }
   const intl = useIntl();
 
   const closeMessage = intl.formatMessage({
@@ -47,7 +53,7 @@ export function TokenPickerHeader({ fullScreen, closeTokenPicker, setFullScreen 
   });
 
   const handleCloseTokenPicker = () => {
-    editor.focus();
+    editor?.focus();
     closeTokenPicker?.();
   };
   return (

--- a/libs/designer/src/lib/ui/panel/panelTabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/parametersTab/index.tsx
@@ -215,7 +215,7 @@ const ParameterSection = ({
     tokenPickerMode?: TokenPickerMode,
     closeTokenPicker?: () => void,
     tokenPickerClicked?: (b: boolean) => void,
-    tokenClicked?: (token: ValueSegment) => void
+    tokenClickedCallback?: (token: ValueSegment) => void
   ): JSX.Element => {
     // check to see if there's a custom Token Picker
     return (
@@ -229,7 +229,7 @@ const ParameterSection = ({
         getValueSegmentFromToken={(token: OutputToken, addImplicitForeach: boolean) =>
           getValueSegmentFromToken(parameterId, token, addImplicitForeach)
         }
-        tokenClickedCallback={tokenClicked}
+        tokenClickedCallback={tokenClickedCallback}
         closeTokenPicker={closeTokenPicker}
       />
     );
@@ -284,8 +284,9 @@ const ParameterSection = ({
             labelId: string,
             tokenPickerMode?: TokenPickerMode,
             closeTokenPicker?: () => void,
-            tokenPickerClicked?: (b: boolean) => void
-          ) => getTokenPicker(id, editorId, labelId, tokenPickerMode, closeTokenPicker, tokenPickerClicked),
+            tokenPickerClicked?: (b: boolean) => void,
+            tokenClickedCallback?: (token: ValueSegment) => void
+          ) => getTokenPicker(id, editorId, labelId, tokenPickerMode, closeTokenPicker, tokenPickerClicked, tokenClickedCallback),
         },
       };
     });


### PR DESCRIPTION
Bug happening because Code Editor still uses the legacy token picker button and requires a callback, forgot to include that callback with getting the tokenpicker in the parameters tab

Fixes #1767 

Also Fixes a bug that unintentionally opens the token picker on clicking a dynamic content token 

![bugWithCodeEditor](https://user-images.githubusercontent.com/95886809/225743330-097901d5-f95a-4d61-b92d-ab892bf29b1d.gif)
