### PR TITLE
[VSBug] Export tool selecting/deselecting workflows bug fix

### DIFF
--- a/apps/vs-code-react/src/app/export/workflowsSelection/selectedList.tsx
+++ b/apps/vs-code-react/src/app/export/workflowsSelection/selectedList.tsx
@@ -1,26 +1,22 @@
-import type { SelectedWorkflowsList, WorkflowsList } from '../../../run-service';
+import type { WorkflowsList } from '../../../run-service';
 import type { RootState } from '../../../state/store';
 import type { InitializedVscodeState } from '../../../state/vscodeSlice';
-import { updateSelectedItems } from './helper';
 import { IconButton, Shimmer, Text } from '@fluentui/react';
 import type { IIconProps } from '@fluentui/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
 export interface ISelectedListProps {
   isLoading: boolean;
-  allWorkflows: WorkflowsList[];
-  renderWorkflows: WorkflowsList[] | null;
   deselectWorkflow: (workflowKey: string) => void;
 }
 
-export const SelectedList: React.FC<ISelectedListProps> = ({ isLoading, allWorkflows, renderWorkflows, deselectWorkflow }) => {
+export const SelectedList: React.FC<ISelectedListProps> = ({ isLoading, deselectWorkflow }) => {
   const intl = useIntl();
   const vscodeState = useSelector((state: RootState) => state.vscode);
   const { exportData } = vscodeState as InitializedVscodeState;
   const { selectedWorkflows } = exportData;
-  const [allItems, setAllItems] = useState<SelectedWorkflowsList[]>(allWorkflows as SelectedWorkflowsList[]);
 
   const intlText = {
     SELECTED_APPS: intl.formatMessage({
@@ -35,18 +31,9 @@ export const SelectedList: React.FC<ISelectedListProps> = ({ isLoading, allWorkf
     });
   }, []);
 
-  useEffect(() => {
-    const items = !allItems.length ? allWorkflows : allItems;
-    const updatedItems = updateSelectedItems(items, renderWorkflows, selectedWorkflows);
-
-    setAllItems(updatedItems);
-  }, [selectedWorkflows, renderWorkflows, allItems, allWorkflows]);
-
   const renderItems = useMemo(() => {
-    const selectedItems = [...allItems.filter((item) => item.selected)];
-
-    const getList = (list: SelectedWorkflowsList[]) => {
-      return list.map((workflow: SelectedWorkflowsList) => {
+    const getList = (list: WorkflowsList[]) => {
+      return list.map((workflow: WorkflowsList) => {
         const { name, resourceGroup } = workflow;
         const deselectIcon: IIconProps = { iconName: 'Cancel' };
         const deselectButton = <IconButton iconProps={deselectIcon} aria-label="cancel" onClick={() => deselectWorkflow(workflow.key)} />;
@@ -69,8 +56,8 @@ export const SelectedList: React.FC<ISelectedListProps> = ({ isLoading, allWorkf
       });
     };
 
-    return isLoading ? shimmerList : getList(selectedItems);
-  }, [isLoading, shimmerList, allItems, deselectWorkflow]);
+    return isLoading ? shimmerList : getList(selectedWorkflows);
+  }, [isLoading, shimmerList, selectedWorkflows, deselectWorkflow]);
 
   return (
     <div className="msla-export-workflows-panel-selected">

--- a/apps/vs-code-react/src/app/export/workflowsSelection/workflowsSelection.tsx
+++ b/apps/vs-code-react/src/app/export/workflowsSelection/workflowsSelection.tsx
@@ -133,7 +133,7 @@ export const WorkflowsSelection: React.FC = () => {
       onSelectionChanged: onSelectionChanged,
       onItemsChanged: onItemsChange,
     });
-  }, [dispatch, selectedWorkflows]);
+  }, [dispatch]);
 
   const workflowsList = useMemo(() => {
     const emptyText = (
@@ -283,12 +283,7 @@ export const WorkflowsSelection: React.FC = () => {
           {workflowsList}
         </div>
         <Separator vertical className="msla-export-workflows-panel-divider" />
-        <SelectedList
-          isLoading={isWorkflowsLoading || renderWorkflows === null}
-          allWorkflows={allWorkflows.current}
-          renderWorkflows={renderWorkflows}
-          deselectWorkflow={deselectWorkflow}
-        />
+        <SelectedList isLoading={isWorkflowsLoading || renderWorkflows === null} deselectWorkflow={deselectWorkflow} />
       </div>
       <AdvancedOptions />
     </div>

--- a/apps/vs-code-react/src/app/export/workflowsSelection/workflowsSelection.tsx
+++ b/apps/vs-code-react/src/app/export/workflowsSelection/workflowsSelection.tsx
@@ -89,6 +89,12 @@ export const WorkflowsSelection: React.FC = () => {
     allItemsSelected.current = workflows.map((workflow) => {
       return { ...workflow, selected: false, rendered: true };
     });
+    selectedWorkflows.forEach((workflow: WorkflowsList) => {
+      const selectedIndex = allItemsSelected.current.findIndex((selectedItem: SelectedWorkflowsList) => selectedItem.key === workflow.key);
+      if (selectedIndex !== -1) {
+        allItemsSelected.current[selectedIndex].selected = true;
+      }
+    });
   };
 
   const { isLoading: isWorkflowsLoading } = useQuery<any>([QueryKeys.workflowsData, { location, iseId: selectedIse }], loadWorkflows, {
@@ -105,11 +111,9 @@ export const WorkflowsSelection: React.FC = () => {
   const selection: Selection = useMemo(() => {
     const onItemsChange = () => {
       const selectedItems = [...allItemsSelected.current.filter((item) => item.selected)];
-      const currentSelection = !selectedItems.length && selectedWorkflows.length ? selectedWorkflows : selectedItems;
-      if (selection && selection.getItems().length > 0 && currentSelection.length > 0) {
-        selection.setAllSelected(false);
-        currentSelection.forEach((workflow: WorkflowsList) => {
-          selection.setKeySelected(workflow.key, true, true);
+      if (selection && selection.getItems().length > 0) {
+        selectedItems.forEach((workflow: WorkflowsList) => {
+          selection.setKeySelected(workflow.key, true, false);
         });
       }
     };


### PR DESCRIPTION
### Main Code Change
- Remove extra useStates in selectedList component, avoiding extra rendering and render workflows from the redux state
- Initialize current selection of workflows with the general selected workflows

### Implementation

#### Fixed issued - When filtering by resource group and click in removing workflow, workflow was deselecting
https://user-images.githubusercontent.com/102700317/226460032-23363d05-71d3-40f4-821a-dc9f92277671.mov

#### Fixed issued - When moving forward after selecting workflows and coming back, removing all workflows one by one didn't work
https://user-images.githubusercontent.com/102700317/226460033-f55fe92c-b82f-45e4-9cfa-6564d414ea8e.mov

