### PR TITLE
Export some panel state functions

### DIFF
--- a/libs/designer/src/lib/core/index.ts
+++ b/libs/designer/src/lib/core/index.ts
@@ -6,4 +6,5 @@ export type { RootState, AppDispatch } from './store';
 export { store } from './store';
 export { discardAllChanges } from './state/workflow/workflowSlice';
 export { serializeWorkflow } from './actions/bjsworkflow/serializer';
-export { switchToWorkflowParameters } from './state/panel/panelSlice';
+export { clearPanel, switchToWorkflowParameters } from './state/panel/panelSlice';
+export { useSelectedNodeId } from './state/panel/panelSelectors';


### PR DESCRIPTION
This PR exports `clearPanel` and `useSelectedNodeId` so that host services can consume them.