### PR TITLE
Add `serializeHost` case for OpenAPI

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -455,6 +455,14 @@ interface FunctionConnectionInfo {
   };
 }
 
+interface OpenApiConnectionInfo {
+  host: {
+    apiId: string;
+    connectionName: string;
+    operationId: string;
+  };
+}
+
 interface ServiceProviderConnectionConfigInfo {
   serviceProviderConfiguration: {
     connectionName: string;
@@ -467,7 +475,7 @@ const serializeHost = (
   nodeId: string,
   manifest: OperationManifest,
   rootState: RootState
-): FunctionConnectionInfo | ApiManagementConnectionInfo | ServiceProviderConnectionConfigInfo | undefined => {
+): FunctionConnectionInfo | ApiManagementConnectionInfo | OpenApiConnectionInfo | ServiceProviderConnectionConfigInfo | undefined => {
   if (!manifest.properties.connectionReference) {
     return undefined;
   }
@@ -489,6 +497,14 @@ const serializeHost = (
         apiManagement: {
           connection: referenceKey,
         },
+      };
+    case ConnectionReferenceKeyFormat.OpenApi:
+      return {
+        host: {
+          apiId: connectorId,
+          connectionName: referenceKey,
+          operationId,
+        }
       };
     case ConnectionReferenceKeyFormat.ServiceProvider:
       return {


### PR DESCRIPTION
Currently, serialization of OpenAPI actions fails due to it not being handled by `serializeHost`. This PR adds a case to that method for handling OpenAPI.