### PR TITLE
Update parameter validation to use OpenAPI display names

### DIFF
--- a/libs/designer/src/lib/core/utils/openapi/__test__/schema.test.ts
+++ b/libs/designer/src/lib/core/utils/openapi/__test__/schema.test.ts
@@ -1,0 +1,32 @@
+import { getTitleOrSummary, isOneOf } from "../schema";
+
+describe('OpenAPI schema utilities', () => {
+  describe('getTitleOrSummary', () => {
+    test.each<[OpenAPIV2.Schema, string | undefined]>([
+      [{}, undefined],
+      [{ id: 'foo' }, undefined],
+      [{ title: 'bar' }, 'bar'],
+      [{ 'x-ms-summary': 'baz' }, 'baz'],
+      [{ title: 'bar', 'x-ms-summary': 'baz' }, 'bar'],
+    ])(
+      'returns the correct value',
+      (schema, expected) => {
+        expect(getTitleOrSummary(schema)).toBe(expected);
+      },
+    )
+  });
+
+  describe('isOneOf', () => {
+    test.each<[OpenAPIV2.Schema, boolean]>([
+      [{}, false],
+      [{ oneOf: undefined }, false],
+      [{ oneOf: [] }, true],
+      [{ oneOf: [{}, {}] }, true],
+    ])(
+      'returns the correct value',
+      (schema, expected) => {
+        expect(isOneOf(schema)).toBe(expected);
+      },
+    )
+  });
+});

--- a/libs/designer/src/lib/core/utils/openapi/schema.ts
+++ b/libs/designer/src/lib/core/utils/openapi/schema.ts
@@ -1,0 +1,13 @@
+import { ExtensionProperties as SwaggerExtensionProperties } from '@microsoft/parsers-logic-apps';
+
+export const getTitleOrSummary = (schema: OpenAPIV2.SchemaObject): string | undefined => {
+    if (!schema) {
+        return undefined;
+    }
+
+    return schema.title || schema[SwaggerExtensionProperties.Summary];
+};
+
+export const isOneOf = (schema: OpenAPIV2.SchemaObject): boolean => {
+    return !!schema?.oneOf;
+};

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -131,6 +131,7 @@ import {
   ValidationException,
 } from '@microsoft/utils-logic-apps';
 import type { Dispatch } from '@reduxjs/toolkit';
+import { isOneOf } from '../openapi/schema';
 
 // import { debounce } from 'lodash';
 
@@ -2431,7 +2432,7 @@ export function parameterValueToString(
   if (
     parameterType === constants.SWAGGER.TYPE.OBJECT ||
     parameterType === constants.SWAGGER.TYPE.ARRAY ||
-    (parameter.schema && parameter.schema['oneOf'])
+    isOneOf(parameter.schema)
   ) {
     return parameterValueToJSONString(value, /* applyCasting */ !parameterSuppressesCasting);
   }

--- a/libs/designer/src/lib/core/utils/validation.ts
+++ b/libs/designer/src/lib/core/utils/validation.ts
@@ -1,4 +1,5 @@
 import Constants from '../../common/constants';
+import { getTitleOrSummary } from './openapi/schema';
 import { isParameterRequired, parameterValueToJSONString, recurseSerializeCondition } from './parameters/helper';
 import { isTokenValueSegment } from './parameters/segment';
 import type { ParameterInfo, ValueSegment } from '@microsoft/designer-ui';
@@ -41,8 +42,9 @@ export function validateStaticParameterInfo(
 ): string[] {
   const intl = getIntl();
 
+  const parameterTitle = getTitleOrSummary(parameterMetadata.schema) || parameterMetadata.parameterName;
   const parameterFormat = parameterMetadata.info.format,
-    parameterName = formatParameterName(parameterMetadata.parameterName),
+    parameterName = formatParameterName(parameterTitle),
     pattern = parameterMetadata.pattern,
     type = parameterMetadata.type,
     required = isParameterRequired(parameterMetadata),
@@ -249,7 +251,8 @@ export function validateJSONParameter(parameterMetadata: ParameterInfo, paramete
     : parameterValueToJSONString(parameterValue, false, true);
 
   const errors: string[] = [];
-  const parameterName = formatParameterName(parameterMetadata.parameterName);
+  const parameterTitle = getTitleOrSummary(parameterMetadata.schema) || parameterMetadata.parameterName;
+  const parameterName = formatParameterName(parameterTitle);
   const required = isParameterRequired(parameterMetadata);
   if (required && !value) {
     return [


### PR DESCRIPTION
Currently, OpenAPI parameters which do not validate (i.e., have error messages) show the incorrect display name for the parameter:

![image](https://user-images.githubusercontent.com/1350074/228070217-d1248740-c427-4f9b-b595-179321348399.png)

This PR updates the logic to check if there is a schema associated with the parameter first and, if so, use that schema's title or summary fields to fill in the display name. Otherwise, fall back to the current logic.

Result:

![image](https://user-images.githubusercontent.com/1350074/228081821-bc396051-8ad9-4252-a68d-05d253a3e457.png)