### PR TITLE
laFix: Small service cleanup

### DIFF
--- a/libs/services/designer-client-services/src/lib/appService.ts
+++ b/libs/services/designer-client-services/src/lib/appService.ts
@@ -3,7 +3,7 @@ import { AssertionErrorCode, AssertionException } from '@microsoft/utils-logic-a
 export interface IAppServiceService {
   [x: string]: any;
   fetchAppServices(): Promise<any>;
-  fetchAppServiceApiSwagger(appService: any): Promise<any>;
+  fetchAppServiceApiSwagger(swaggerUrl: string): Promise<any>;
   getOperationSchema(swaggerUrl: string, operationId: string, isInput: boolean): Promise<any>;
   getOperations(swaggerUrl: string): Promise<any>;
 }

--- a/libs/services/designer-client-services/src/lib/base/connection.ts
+++ b/libs/services/designer-client-services/src/lib/base/connection.ts
@@ -69,10 +69,6 @@ export abstract class BaseConnectionService implements IConnectionService {
     this._subscriptionResourceGroupWebUrl = `/subscriptions/${apiHubServiceDetails.subscriptionId}/resourceGroups/${apiHubServiceDetails.resourceGroup}/providers/Microsoft.Web`;
   }
 
-  dispose(): void {
-    return;
-  }
-
   async getConnectorAndSwagger(connectorId: string): Promise<ConnectorWithSwagger> {
     if (!isArmResourceId(connectorId)) {
       return { connector: await this.getConnector(connectorId), swagger: null as any };

--- a/libs/services/designer-client-services/src/lib/connection.ts
+++ b/libs/services/designer-client-services/src/lib/connection.ts
@@ -34,7 +34,6 @@ export interface CreateConnectionResult {
 }
 
 export interface IConnectionService {
-  dispose(): void;
   getConnector(connectorId: string): Promise<Connector>;
   getConnectorAndSwagger(connectorId: string): Promise<ConnectorWithSwagger>;
   getSwaggerFromUri(uri: string): Promise<OpenAPIV2.Document>;


### PR DESCRIPTION
### Main Fixes

- Fixed an issue with incorrect parameter name on interface method
- Removed an old unused `dispose` method