### PR TITLE
laFix: Many RunAfter bug fixes

### DIFF
--- a/__mocks__/workflows/RunAfter.json
+++ b/__mocks__/workflows/RunAfter.json
@@ -18,8 +18,7 @@
       "Compose": {
         "inputs": "a",
         "runAfter": {
-          "Init_all": ["SUCCEEDED"],
-          "Http": ["SUCCEEDED"]
+          "Init_all": ["SUCCEEDED"]
         },
         "type": "Compose"
       },

--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -44,7 +44,8 @@ export const addNodeToWorkflow = (
   state.operations[newNodeId] = { ...state.operations[newNodeId], type: payload.operation.type };
   state.newlyAddedOperations[newNodeId] = newNodeId;
 
-  const shouldAddRunAfters = !isRoot;
+  const isAfterTrigger = nodesMetadata[parentId ?? '']?.isRoot && graphId === 'root';
+  const shouldAddRunAfters = !isRoot && !isAfterTrigger;
 
   // Parallel Branch creation, just add the singular node
   if (payload.isParallelBranch && parentId) {
@@ -54,9 +55,9 @@ export const addNodeToWorkflow = (
   else if (parentId && childId) {
     const childRunAfter = (state.operations?.[childId] as any)?.runAfter;
     addNewEdge(state, parentId, newNodeId, workflowGraph, shouldAddRunAfters);
-    addNewEdge(state, newNodeId, childId, workflowGraph, shouldAddRunAfters);
+    addNewEdge(state, newNodeId, childId, workflowGraph, true);
     removeEdge(state, parentId, childId, workflowGraph);
-    if (childRunAfter) (state.operations?.[newNodeId] as any).runAfter[parentId] = childRunAfter[parentId];
+    if (childRunAfter && shouldAddRunAfters) (state.operations?.[newNodeId] as any).runAfter[parentId] = childRunAfter[parentId];
   }
   // X parents, 1 child
   else if (childId) {

--- a/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
@@ -36,8 +36,14 @@ export const deleteNodeFromWorkflow = (
     workflowGraph.edges = (workflowGraph.edges ?? []).filter((edge) => edge.source !== nodeId);
   } else if (multipleParents) {
     const childId = (workflowGraph.edges ?? []).find((edge) => edge.source === nodeId)?.target ?? '';
-    reassignEdgeTargets(state, nodeId, childId, workflowGraph);
-    removeEdge(state, nodeId, childId, workflowGraph);
+    if (childId) {
+      reassignEdgeTargets(state, nodeId, childId, workflowGraph);
+      removeEdge(state, nodeId, childId, workflowGraph);
+    } else {
+      Object.keys(currentRunAfter ?? {}).forEach((_parentId: string) => {
+        removeEdge(state, _parentId, nodeId, workflowGraph);
+      });
+    }
   } else {
     const parentId = (workflowGraph.edges ?? []).find((edge) => edge.target === nodeId)?.source ?? '';
     const isNewSourceTrigger = isRootNodeInGraph(parentId, 'root', state.nodesMetadata);

--- a/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
@@ -86,8 +86,7 @@ export const moveNodeInWorkflow = (
   nodesMetadata[nodeId] = { ...nodesMetadata[nodeId], graphId: newGraphId, parentNodeId, isRoot: isNewRoot };
   if (nodesMetadata[nodeId].isRoot === false) delete nodesMetadata[nodeId].isRoot;
 
-  const isAfterTrigger = nodesMetadata[parentId ?? '']?.isRoot && newGraphId === 'root';
-  const shouldAddRunAfters = !isNewRoot && !isAfterTrigger;
+  const shouldAddRunAfters = !isNewRoot;
 
   // X parents, 1 child
   if (childId) {

--- a/libs/designer/src/lib/core/parsers/restructuringHelpers.ts
+++ b/libs/designer/src/lib/core/parsers/restructuringHelpers.ts
@@ -17,14 +17,16 @@ export const addNewEdge = (state: WorkflowState, source: string, target: string,
   graph?.edges.push(workflowEdge);
 
   const targetOp = state.operations?.[target] as any;
-  if (targetOp && addRunAfter) (state.operations?.[target] as any).runAfter = { [source]: [RUN_AFTER_STATUS.SUCCEEDED] };
+  if (targetOp && addRunAfter) {
+    targetOp.runAfter = { ...targetOp.runAfter, [source]: [RUN_AFTER_STATUS.SUCCEEDED] };
+  }
 };
 
 export const removeEdge = (state: WorkflowState, sourceId: string, targetId: string, graph: WorkflowNode) => {
   if (!state) return;
   graph.edges = graph.edges?.filter((edge) => !(edge.source === sourceId && edge.target === targetId));
   const targetRunAfter = (state.operations?.[targetId] as any)?.runAfter;
-  if (targetRunAfter) delete targetRunAfter.runAfter?.[sourceId as any];
+  if (targetRunAfter) delete targetRunAfter?.[sourceId as any];
 };
 
 const setEdgeSource = (edge: WorkflowEdge, newSource: string) => {
@@ -94,7 +96,7 @@ export const moveRunAfterTarget = (state: WorkflowState | undefined, oldTargetId
   }
 };
 
-const moveRunAfterSource = (
+export const moveRunAfterSource = (
   state: WorkflowState | undefined,
   nodeId: string,
   oldSourceId: string,

--- a/libs/designer/src/lib/ui/settings/sections/runafter.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/runafter.tsx
@@ -1,26 +1,23 @@
 import type { SectionProps } from '../';
 import constants from '../../../common/constants';
 import type { AppDispatch, RootState } from '../../../core';
-import type { WorkflowEdge } from '../../../core/parsers/models/workflowNode';
 import { type ValidationError, ValidationWarningKeys } from '../../../core/state/setting/settingSlice';
 import { addEdgeFromRunAfter, removeEdgeFromRunAfter, updateRunAfter } from '../../../core/state/workflow/workflowSlice';
 import type { SettingsSectionProps } from '../settingsection';
 import { SettingsSection } from '../settingsection';
 import type { RunAfterActionDetailsProps } from './runafterconfiguration';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 
-// TODO: 14714481 We need to support all incoming edges and runAfterConfigMenu
-
-interface RunAfterProps extends SectionProps {
-  allEdges: WorkflowEdge[];
-}
-
-export const RunAfter = ({ runAfter, readOnly = false, expanded, onHeaderClick, nodeId }: RunAfterProps): JSX.Element | null => {
+export const RunAfter = ({ readOnly = false, expanded, onHeaderClick, nodeId }: SectionProps): JSX.Element | null => {
   const nodeData = useSelector((state: RootState) => state.workflow.operations[nodeId] as LogicAppsV2.ActionDefinition);
   const dispatch = useDispatch<AppDispatch>();
   const [errors, setErrors] = useState<ValidationError[]>([]);
+
+  const showRunAfter = useMemo(() => {
+    return Object.keys(nodeData?.runAfter ?? {}).length > 0;
+  }, [nodeData?.runAfter]);
 
   const intl = useIntl();
   const runAfterTitle = intl.formatMessage({
@@ -125,7 +122,7 @@ export const RunAfter = ({ runAfter, readOnly = false, expanded, onHeaderClick, 
             );
           },
         },
-        visible: runAfter?.isSupported,
+        visible: showRunAfter,
       },
     ],
     validationErrors: errors,

--- a/libs/designer/src/lib/ui/settings/sections/runafterconfiguration/runaftertrafficlights.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/runafterconfiguration/runaftertrafficlights.tsx
@@ -7,7 +7,7 @@ export interface RunAfterTrafficLightsProps {
   statuses: string[];
 }
 
-export function RunAfterTrafficLights({ statuses }: RunAfterTrafficLightsProps): JSX.Element {
+export function RunAfterTrafficLights({ statuses = [] }: RunAfterTrafficLightsProps): JSX.Element {
   const { isInverted } = useTheme();
   const themeName = isInverted ? 'dark' : 'light';
   const normalizedStatuses = statuses.map((status) => status.toUpperCase());


### PR DESCRIPTION
## Main Changes
Fixed multiple niche run-after bugs.
Should now have valid run-afters for every state of adding / moving / deleting nodes, specifically:
  - Nodes that used to have no run-after settings (under a trigger or was the root of a subgraph)
  - Parallel branch nodes work as expected
  - Removing/Moving leaf nodes (this used to sometimes error out silently)

Should serialize exactly the same as is visible in the UX
  - I think this was an issue with setting visibility, this has been adjusted
  - Tested changing + saving as many configurations as I could (and verified the source issue was fixed)
  - Fixes #1838