### PR TITLE
laFix: Custom Connectors - sped up operations, fixed too many connectors

### DIFF
--- a/libs/services/designer-client-services/src/lib/standard/search.ts
+++ b/libs/services/designer-client-services/src/lib/standard/search.ts
@@ -47,7 +47,7 @@ export class StandardSearchService extends BaseSearchService {
         'api-version': apiVersion,
         $filter: `properties/trigger eq null and type eq 'Microsoft.Web/customApis/apiOperations' and ${ISE_RESOURCE_ID} eq null`,
       };
-      const response = await this.pagedBatchAzureResourceRequests(page, uri, queryParameters);
+      const response = await this.pagedBatchAzureResourceRequests(page, uri, queryParameters, 1);
       return response;
     } catch (error) {
       return [];
@@ -68,14 +68,17 @@ export class StandardSearchService extends BaseSearchService {
     try {
       const {
         httpClient,
-        apiHubServiceDetails: { apiVersion, subscriptionId },
+        apiHubServiceDetails: { apiVersion, subscriptionId, location },
       } = this.options;
       const filter = `$filter=${ISE_RESOURCE_ID} eq null`;
       const startUri = `/subscriptions/${subscriptionId}/providers/Microsoft.Web/customApis?api-version=${apiVersion}`;
       const uri = `${prevNextlink ?? startUri}&${filter}`;
 
       const { nextLink, value } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri });
-      return { nextlink: nextLink, value: value.filter((connector) => connector.properties?.supportedConnectionKinds?.includes('V2')) };
+      const filteredValue = value
+        .filter((connector) => connector.properties?.supportedConnectionKinds?.includes('V2'))
+        .filter((connector) => connector?.location === location);
+      return { nextlink: nextLink, value: filteredValue };
     } catch (error) {
       return { value: [] };
     }


### PR DESCRIPTION
### Main Changes
- Operations are now searched one page at a time, we were not getting enough to warrant batching multiple pages at once
  - This leads to much less waiting for doomed requests
- We were showing all custom connectors before, we now filter by location to show relevant connectors