### PR TITLE
Export initializeServices for host services to update designer services

### DIFF
--- a/libs/designer/src/lib/core/index.ts
+++ b/libs/designer/src/lib/core/index.ts
@@ -9,3 +9,4 @@ export { useNodeDisplayName } from './state/workflow/workflowSelectors';
 export { serializeWorkflow } from './actions/bjsworkflow/serializer';
 export { clearPanel, switchToWorkflowParameters } from './state/panel/panelSlice';
 export { useSelectedNodeId } from './state/panel/panelSelectors';
+export { initializeServices } from './state/designerOptions/designerOptionsSlice';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.0.14",
+  "version": "2.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.0.14",
+      "version": "2.0.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.0.16",
+  "version": "2.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.0.16",
+      "version": "2.0.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Currently, designer services are initialized once in BJSWorkflowProvider and stored globally. They are not re-initialized on re-mounting the component. Exporting the function for host services to re-initialize the designer services as per need.