### PR TITLE
LaFix: SimpleQueryBuilder Serialization + Code Editor Fixes

### DIFF
--- a/__mocks__/workflows/Panel.json
+++ b/__mocks__/workflows/Panel.json
@@ -2,150 +2,79 @@
   "definition": {
     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
     "actions": {
-      "Initialize_variable": {
+      "Initialize_ArrayVariable": {
+        "type": "InitializeVariable",
         "inputs": {
           "variables": [
             {
-              "name": "stringvar",
-              "type": "string",
-              "value": "sdfsdf"
-            }
-          ]
-        },
-        "runAfter": {},
-        "type": "InitializeVariable"
-      },
-      "Initialize_variable_1": {
-        "inputs": {
-          "variables": [
-            {
-              "name": "IntegerVar",
-              "type": "integer",
-              "value": "test@{triggerOutputs()['headers']}@{variables('stringvar')}"
-            }
-          ]
-        },
-        "runAfter": {
-          "Initialize_variable": ["SUCCEEDED"]
-        },
-        "type": "InitializeVariable"
-      },
-      "Parse_JSON": {
-        "inputs": {
-          "content": "@triggerBody()",
-          "schema": {
-            "properties": {
-              "a": {
-                "type": "string"
-              },
-              "number": {
-                "type": "integer"
-              }
-            },
-            "type": "object"
-          }
-        },
-        "runAfter": {
-          "Initialize_variable_1": ["SUCCEEDED"]
-        },
-        "runtimeConfiguration": {
-          "secureData": {
-            "properties": ["inputs"]
-          },
-          "staticResult": {
-            "name": "Parse_JSON0",
-            "staticResultOptions": "Enabled"
-          }
-        },
-        "type": "ParseJson"
-      },
-      "HTTP": {
-        "type": "Http",
-        "inputs": {
-          "uri": "",
-          "method": ""
-        },
-        "runAfter": {
-          "Parse_JSON": ["SUCCEEDED"]
-        },
-        "runtimeConfiguration": {
-          "staticResult": {
-            "name": "HTTP0",
-            "staticResultOptions": "Enabled"
-          }
-        }
-      },
-      "HTTP2": {
-        "type": "Http",
-        "inputs": {
-          "uri": "",
-          "method": ""
-        },
-        "runAfter": {
-          "HTTP": ["SUCCEEDED"]
-        }
-      },
-      "For_each": {
-        "type": "Foreach",
-        "foreach": "@body('Parse_JSON')",
-        "actions": {
-          "Response": {
-            "type": "Response",
-            "kind": "Http",
-            "inputs": {
-              "statusCode": 200
-            }
-          }
-        },
-        "runAfter": {
-          "Parse_JSON": ["SUCCEEDED"]
-        }
-      },
-      "Until": {
-        "actions": {},
-        "expression": "@equals('test', 123)",
-        "limit": {
-          "count": 60,
-          "timeout": "PT1H"
-        },
-        "runAfter": {},
-        "type": "Until"
-      }
-    },
-    "staticResults": {
-      "Parse_JSON0": {
-        "status": "Failed",
-        "code": "this is a test",
-        "outputs": {
-          "body": "hi",
-          "errors": [
-            {
-              "message": "test message"
-            },
-            {
-              "errorType": "Dependencies",
-              "childErrors": [
+              "name": "ArrayVariable",
+              "type": "array",
+              "value": [
                 {
-                  "schema": "schemaHELLO",
-                  "childErrors": ["childerror1", "childerror2"]
+                  "document": "A",
+                  "min": 7500001,
+                  "policy": "X"
+                },
+                {
+                  "document": "B",
+                  "min": 7500001,
+                  "policy": "Y"
+                },
+                {
+                  "document": "C",
+                  "min": 7500001,
+                  "policy": "Z"
                 }
               ]
             }
           ]
+        },
+        "runAfter": {}
+      },
+      "Parse_JSON": {
+        "type": "ParseJson",
+        "inputs": {
+          "content": "@variables('ArrayVariable')",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "document": {
+                  "type": "string"
+                },
+                "min": {
+                  "type": "integer"
+                },
+                "policy": {
+                  "type": "string"
+                }
+              },
+              "required": ["document", "min", "policy"]
+            }
+          }
+        },
+        "runAfter": {
+          "Initialize_ArrayVariable": ["SUCCEEDED"]
         }
       },
-      "HTTP0": {
-        "outputs": {
-          "headers": {},
-          "statusCode": "OK"
+      "Filter_array": {
+        "type": "Query",
+        "inputs": {
+          "from": "@body('Parse_JSON')",
+          "where": "@equals(@item()?['policy'],'X')"
         },
-        "status": "Succeeded"
+        "runAfter": {
+          "Parse_JSON": ["SUCCEEDED"]
+        }
       }
     },
     "contentVersion": "1.0.0.0",
     "outputs": {},
     "triggers": {
       "manual": {
+        "type": "Request",
+        "kind": "Http",
         "inputs": {
           "schema": {
             "type": "object",
@@ -170,9 +99,7 @@
               }
             }
           }
-        },
-        "kind": "Http",
-        "type": "Request"
+        }
       }
     }
   },

--- a/libs/designer-ui/src/lib/code/index.tsx
+++ b/libs/designer-ui/src/lib/code/index.tsx
@@ -29,7 +29,6 @@ export function CodeEditor({
   const [getCurrentValue, setCurrentValue] = useFunctionalState(getInitialValue(initialValue));
   const [editorHeight, setEditorHeight] = useState(getEditorHeight(getInitialValue(initialValue)));
   const [showTokenPickerButton, setShowTokenPickerButton] = useState(false);
-  const [showTokenPicker, setShowTokenPicker] = useState(true);
   const [getInTokenPicker, setInTokenPicker] = useFunctionalState(false);
 
   const handleContentChanged = (e: EditorContentChangedEventArgs): void => {
@@ -41,9 +40,8 @@ export function CodeEditor({
 
   const handleBlur = (): void => {
     if (!getInTokenPicker()) {
-      setInTokenPicker(false);
+      setShowTokenPickerButton(false);
     }
-    setShowTokenPickerButton(false);
     onChange?.({ value: [{ id: 'key', type: ValueSegmentType.LITERAL, value: getCurrentValue() }] });
   };
 
@@ -54,10 +52,7 @@ export function CodeEditor({
   };
 
   const handleShowTokenPicker = () => {
-    if (showTokenPicker) {
-      setInTokenPicker(false);
-    }
-    setShowTokenPicker(!showTokenPicker);
+    setInTokenPicker(!getInTokenPicker());
   };
 
   const onClickTokenPicker = (b: boolean) => {
@@ -97,11 +92,14 @@ export function CodeEditor({
         onBlur={handleBlur}
       />
       {showTokenPickerButton || getInTokenPicker() ? (
-        <TokenPickerButton labelId={callOutLabelId} showTokenPicker={showTokenPicker} setShowTokenPicker={handleShowTokenPicker} />
+        <TokenPickerButton
+          labelId={callOutLabelId}
+          showTokenPicker={getInTokenPicker()}
+          setShowTokenPicker={handleShowTokenPicker}
+          codeEditor={codeEditorRef.current}
+        />
       ) : null}
-      {(showTokenPickerButton && showTokenPicker) || getInTokenPicker()
-        ? getTokenPicker?.(editorId, callOutLabelId, undefined, undefined, onClickTokenPicker, tokenClicked)
-        : null}
+      {getInTokenPicker() ? getTokenPicker?.(editorId, callOutLabelId, undefined, undefined, onClickTokenPicker, tokenClicked) : null}
     </div>
   );
 }

--- a/libs/designer-ui/src/lib/editor/base/plugins/TokenPickerButton.tsx
+++ b/libs/designer-ui/src/lib/editor/base/plugins/TokenPickerButton.tsx
@@ -1,6 +1,7 @@
 import { TokenNode } from '../nodes/tokenNode';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import type { LexicalEditor } from 'lexical';
+import type { editor } from 'monaco-editor';
 import { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 
@@ -14,6 +15,7 @@ export interface TokenPickerButtonProps {
   buttonOffset?: ButtonOffSet;
   customButton?: boolean;
   setShowTokenPicker?: () => void;
+  codeEditor?: editor.IStandaloneCodeEditor | null;
 }
 
 interface ButtonProps extends TokenPickerButtonProps {
@@ -28,6 +30,7 @@ export default function TokenPickerButton({
   labelId,
   customButton,
   setShowTokenPicker,
+  codeEditor,
 }: ButtonProps): JSX.Element {
   let editor: LexicalEditor | null;
   try {
@@ -58,6 +61,9 @@ export default function TokenPickerButton({
   });
 
   const handleClick = () => {
+    if (showTokenPicker && codeEditor) {
+      codeEditor.focus();
+    }
     setShowTokenPicker?.();
     if (editor) {
       editor.focus();

--- a/libs/designer-ui/src/lib/index.ts
+++ b/libs/designer-ui/src/lib/index.ts
@@ -52,7 +52,7 @@ export * from './monitoring';
 export * from './monitoring/statuspill/images';
 export * from './overview';
 export * from './querybuilder';
-export * from './querybuilder/Until';
+export * from './querybuilder/SimpleQueryBuilder';
 export * from './pager';
 export * from './peek';
 export * from './panel/panelcontainer';

--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -88,6 +88,7 @@ export const PanelContainer = ({
     (_props?: IPanelProps, _defaultrender?: IPanelHeaderRenderer, headerTextId?: string): JSX.Element => {
       return (
         <PanelHeader
+          nodeId={nodeId}
           cardIcon={cardIcon}
           isCollapsed={isCollapsed}
           headerLocation={panelLocation}
@@ -111,6 +112,7 @@ export const PanelContainer = ({
       );
     },
     [
+      nodeId,
       cardIcon,
       isCollapsed,
       panelLocation,

--- a/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
@@ -40,6 +40,7 @@ export interface PanelHeaderProps {
   showCommentBox?: boolean;
   title?: string;
   includeTitle: boolean;
+  nodeId: string;
   commentChange(panelCommentChangeEvent?: string): void;
   onDismissButtonClicked?(): void;
   onRenderWarningMessage?(): JSX.Element;
@@ -101,6 +102,7 @@ export const PanelHeader = ({
   showCommentBox,
   title,
   includeTitle,
+  nodeId,
   commentChange,
   onDismissButtonClicked,
   onRenderWarningMessage,
@@ -227,6 +229,7 @@ export const PanelHeader = ({
             {includeTitle ? (
               <div className="msla-panel-card-title-container" hidden={isCollapsed}>
                 <PanelHeaderTitle
+                  key={nodeId}
                   titleId={titleId}
                   readOnlyMode={readOnlyMode}
                   renameTitleDisabled={renameTitleDisabled}

--- a/libs/designer-ui/src/lib/panel/panelheader/panelheadertitle.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheadertitle.tsx
@@ -3,7 +3,7 @@ import { handleOnEscapeDown } from './panelheader';
 import type { ITextField, ITextFieldStyles } from '@fluentui/react/lib/TextField';
 import { TextField } from '@fluentui/react/lib/TextField';
 import { css } from '@fluentui/react/lib/Utilities';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
 
 const titleTextFieldStyle: Partial<ITextFieldStyles> = {
@@ -35,11 +35,10 @@ export const PanelHeaderTitle = ({
   const titleTextFieldRef = React.createRef<ITextField>();
 
   const [newTitleValue, setNewTitleValue] = useState(titleValue);
-  useEffect(() => setNewTitleValue(titleValue), [titleValue]);
 
   const onTitleChange = (_: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string): void => {
-    if (newValue || '') onChange(newValue || '');
-    else setNewTitleValue(newValue || '');
+    onChange(newValue || '');
+    setNewTitleValue(newValue || '');
   };
 
   const onTitleBlur = (): void => {

--- a/libs/designer-ui/src/lib/querybuilder/querybuilder.less
+++ b/libs/designer-ui/src/lib/querybuilder/querybuilder.less
@@ -162,7 +162,7 @@
   }
 }
 
-.msla-until-editor-container {
+.msla-simple-querybuilder-editor-container {
   width: 100%;
   border-radius: 2px;
   position: relative;

--- a/libs/designer-ui/src/lib/schemaeditor/index.tsx
+++ b/libs/designer-ui/src/lib/schemaeditor/index.tsx
@@ -120,7 +120,6 @@ export function SchemaEditor({ readonly, label, initialValue, onChange, onFocus 
 
   return (
     <div className="msla-schema-editor-body">
-      {label ? <div className="msla-schema-editor-title">{label}</div> : null}
       <Editor
         label={label}
         height={editorHeight}

--- a/libs/designer-ui/src/lib/schemaeditor/schemaeditor.less
+++ b/libs/designer-ui/src/lib/schemaeditor/schemaeditor.less
@@ -1,11 +1,6 @@
 @import (reference) '../variables.less';
 
 .msla-schema-editor-body {
-  .msla-schema-editor-title {
-    font-size: 18px;
-    padding-bottom: 8px;
-    color: @profile-text-color;
-  }
   .msla-monaco {
     border: 1px solid @defaultBorderColor;
     width: 100%;

--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -10,7 +10,7 @@ import type { CallbackHandler, ChangeHandler, GetTokenPickerHandler } from '../.
 import { EditorLanguage } from '../../editor/monaco';
 import { StringEditor } from '../../editor/string';
 import { QueryBuilderEditor } from '../../querybuilder';
-import { UntilEditor } from '../../querybuilder/Until';
+import { SimpleQueryBuilder } from '../../querybuilder/SimpleQueryBuilder';
 import { ScheduleEditor } from '../../recurrence';
 import { SchemaEditor } from '../../schemaeditor';
 import { TableEditor } from '../../table';
@@ -194,7 +194,7 @@ const TokenField = ({
 
     case 'condition':
       return editorViewModel.isOldFormat ? (
-        <UntilEditor
+        <SimpleQueryBuilder
           readonly={readOnly}
           items={JSON.parse(JSON.stringify(editorViewModel.items))}
           getTokenPicker={getTokenPicker}

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
@@ -2,6 +2,7 @@ import constants from '../constants';
 import type { Token } from '../editor';
 import { ValueSegmentType, TokenType } from '../editor';
 import { INSERT_TOKEN_NODE } from '../editor/base/plugins/InsertTokenNode';
+import { SINGLE_VALUE_SEGMENT } from '../editor/base/plugins/SingleValueSegment';
 import type { ExpressionEditorEvent } from '../expressioneditor';
 import { UPDATE_TOKEN_NODE } from './plugins/UpdateTokenNode';
 import { getExpressionTokenTitle } from './util';
@@ -76,6 +77,7 @@ export function TokenPickerFooter({ expression, expressionToBeUpdated, setExpres
         nodeKey: expressionToBeUpdated,
       });
     } else {
+      editor?.dispatchCommand(SINGLE_VALUE_SEGMENT, true);
       editor?.dispatchCommand(INSERT_TOKEN_NODE, {
         brandColor: token.brandColor,
         description: token.description,

--- a/libs/designer/src/lib/ui/panel/panelTabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/parametersTab/index.tsx
@@ -217,16 +217,19 @@ const ParameterSection = ({
     editorId: string,
     labelId: string,
     tokenPickerMode?: TokenPickerMode,
+    isCodeEditor?: boolean,
     closeTokenPicker?: () => void,
     tokenPickerClicked?: (b: boolean) => void,
     tokenClickedCallback?: (token: ValueSegment) => void
   ): JSX.Element => {
-    // check to see if there's a custom Token Picker
+    const codeEditorFilteredTokens = tokenGroup.filter((group) => {
+      return group.id !== 'workflowparameters' && group.id !== 'variables';
+    });
     return (
       <TokenPicker
         editorId={editorId}
         labelId={labelId}
-        tokenGroup={tokenGroup}
+        tokenGroup={isCodeEditor ? codeEditorFilteredTokens : tokenGroup}
         expressionGroup={expressionGroup}
         tokenPickerFocused={tokenPickerClicked}
         initialMode={tokenPickerMode}
@@ -252,6 +255,8 @@ const ParameterSection = ({
         param;
       const paramSubset = { id, label, required, showTokens, placeholder, editorViewModel, conditionalVisibility };
       const { editor, editorOptions } = getEditorAndOptions(param, upstreamNodeIds ?? [], variables);
+
+      const isCodeEditor = editor?.toLowerCase() === 'code';
 
       const remappedValues: ValueSegment[] = value.map((v: ValueSegment) => {
         if (v.type !== ValueSegmentType.TOKEN) return v;
@@ -290,7 +295,17 @@ const ParameterSection = ({
             closeTokenPicker?: () => void,
             tokenPickerClicked?: (b: boolean) => void,
             tokenClickedCallback?: (token: ValueSegment) => void
-          ) => getTokenPicker(id, editorId, labelId, tokenPickerMode, closeTokenPicker, tokenPickerClicked, tokenClickedCallback),
+          ) =>
+            getTokenPicker(
+              id,
+              editorId,
+              labelId,
+              tokenPickerMode,
+              isCodeEditor,
+              closeTokenPicker,
+              tokenPickerClicked,
+              tokenClickedCallback
+            ),
         },
       };
     });

--- a/libs/designer/src/lib/ui/panel/panelTabs/scratchTab.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/scratchTab.tsx
@@ -13,7 +13,7 @@ import {
   // GroupType,
   // GroupDropdownOptions,
   // QueryBuilderEditor, // DictionaryType, // EditorLanguage,
-  UntilEditor,
+  SimpleQueryBuilder,
   ValueSegmentType,
   CodeEditor,
   EditorLanguage, // HTMLEditor,
@@ -380,7 +380,7 @@ getTokenPicker={GetTokenPicker}
         /> */}
         {/* <HTMLEditor initialValue={[]} placeholder="Specify the body of the mail"           getTokenPicker={GetTokenPicker}*/}
         {
-          <UntilEditor
+          <SimpleQueryBuilder
             getTokenPicker={GetTokenPicker}
             items={{ type: GroupType.ROW, operand1: [], operand2: [], operator: RowDropdownOptions.EQUALS }}
           />


### PR DESCRIPTION
Some Accessibility Changes Broke Code Editor, so this PR fixes it
Removed Variables/Workflow parameters from code editor #1769
There was a bug where if we rename a node from the middle of it, our cursor would move to the end of the Title, should now be fixed

The Simple Query Builder Editor (previously known as until editor) was initializing (serializing/deserializing) incorrectly, which now should be fixed

Also the query editor was supporting more than one expression token, which it shouldn't have

![codeeditor](https://user-images.githubusercontent.com/95886809/230938770-d0261e4b-1100-4d9f-9d34-56c20770596c.gif)

