### PR TITLE
laFix: Azure Blob connector - Auth options fix

### DIFF
--- a/libs/designer-ui/src/lib/createConnection/index.tsx
+++ b/libs/designer-ui/src/lib/createConnection/index.tsx
@@ -446,7 +446,7 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
               options={
                 connectionParameterSets?.values.map((paramSet, index) => ({
                   key: index,
-                  text: paramSet?.uiDefinition?.displayName,
+                  text: paramSet?.uiDefinition?.displayName ?? paramSet?.name,
                 })) ?? []
               }
             />

--- a/libs/designer-ui/src/lib/createConnection/universalConnectionParameter.tsx
+++ b/libs/designer-ui/src/lib/createConnection/universalConnectionParameter.tsx
@@ -57,14 +57,14 @@ export const UniversalConnectionParameter = (props: ConnectionParameterProps) =>
 
   // Dropdown Parameter
   else if ((constraints?.allowedValues?.length ?? 0) > 0) {
+    const selectedKey = constraints?.allowedValues?.findIndex((_value) => _value.text === value);
+    if (selectedKey === -1) setValue(constraints?.allowedValues?.[0].text);
     inputComponent = (
       <Dropdown
         id={`connection-param-${parameterKey}`}
         className="connection-parameter-input"
-        selectedKey={constraints?.allowedValues?.findIndex((_value) => _value.text === value)}
-        onChange={(e: any, newVal?: IDropdownOption) => {
-          setValue(newVal?.text);
-        }}
+        selectedKey={selectedKey}
+        onChange={(e: any, newVal?: IDropdownOption) => setValue(newVal?.text)}
         disabled={isLoading}
         ariaLabel={description}
         placeholder={description}

--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -1,6 +1,5 @@
 import type { ConnectionReference } from '../../../common/models/workflow';
 import type { RootState } from '../../store';
-import { useOperationManifest, useOperationInfo } from '../selectors/actionMetadataSelector';
 import { ConnectionService, GatewayService } from '@microsoft/designer-client-services-logic-apps';
 import type { Connector } from '@microsoft/utils-logic-apps';
 import { useQuery } from 'react-query';
@@ -39,11 +38,9 @@ export const useGateways = (subscriptionId: string, connectorName: string) => {
 export const useSubscriptions = () => useQuery('subscriptions', async () => GatewayService().getSubscriptions());
 
 export const useConnectorByNodeId = (nodeId: string): Connector | undefined => {
-  // TODO: Revisit trying to conditionally ask for the connector from the service
-  const connectorFromManifest = useOperationManifest(useOperationInfo(nodeId)).data?.properties.connector;
   const storeConnectorId = useSelector((state: RootState) => state.operations.operationInfo[nodeId]?.connectorId);
   const connectorFromService = useConnector(storeConnectorId)?.data;
-  return connectorFromManifest ?? connectorFromService;
+  return connectorFromService;
 };
 
 export const useConnectionRefsByConnectorId = (connectorId?: string) => {

--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -39,8 +39,7 @@ export const useSubscriptions = () => useQuery('subscriptions', async () => Gate
 
 export const useConnectorByNodeId = (nodeId: string): Connector | undefined => {
   const storeConnectorId = useSelector((state: RootState) => state.operations.operationInfo[nodeId]?.connectorId);
-  const connectorFromService = useConnector(storeConnectorId)?.data;
-  return connectorFromService;
+  return useConnector(storeConnectorId)?.data;
 };
 
 export const useConnectionRefsByConnectorId = (connectorId?: string) => {


### PR DESCRIPTION
## Main Changes
- Azure Blob connection creation now displays all auth options correctly
  - Fixes #1893 
- Connection dropdown parameters now start with first option selected
  - Old designer required one of the options to be selected, this matches that design