### PR TITLE
fix(vscode): Set functions worker runtime according to OS

### DIFF
--- a/apps/vs-code-designer-react/src/app/app.tsx
+++ b/apps/vs-code-designer-react/src/app/app.tsx
@@ -109,7 +109,7 @@ export const App = () => {
     setStandardApp(undefined);
   };
 
-  const { refetch, isError, isFetching, isLoading, isRefetching } = useQuery<any>(['runInstance'], getRunInstance, {
+  const { refetch, isError, isFetching, isLoading, isRefetching } = useQuery<any>(['runInstance', { runId }], getRunInstance, {
     refetchOnWindowFocus: false,
     initialData: null,
     onSuccess: onRunInstanceSuccess,

--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -46,7 +46,7 @@ export async function startDesignTimeApi(projectPath: string): Promise<void> {
     IsEncrypted: false,
     Values: {
       AzureWebJobsSecretStorageType: 'Files',
-      FUNCTIONS_WORKER_RUNTIME: WorkerRuntime.DotnetIsolated,
+      FUNCTIONS_WORKER_RUNTIME: os.platform() === 'win32' ? WorkerRuntime.DotnetIsolated : WorkerRuntime.Node,
     },
   };
   if (!ext.workflowDesignTimePort) {


### PR DESCRIPTION
### Main Code Changes
- Change functions worker runtime by OS

### Implementation
#### New workflow-designtime in Mac OS
<img width="1920" alt="Screenshot 2023-04-11 at 2 02 58 PM" src="https://user-images.githubusercontent.com/102700317/231289893-f489ea87-494b-4605-aea3-78d9efc978a9.png">

#### New workflow-designtime in Windows OS
<img width="1907" alt="Screenshot 2023-04-11 at 2 23 26 PM" src="https://user-images.githubusercontent.com/102700317/231291375-8996112e-ab66-4c3a-b64c-d96441187618.png">
