### PR TITLE
fix(vscode): Fix an issue with switching to NuGet-based project when executed from Command menu

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/switchToDotnetProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/switchToDotnetProject.ts
@@ -32,6 +32,18 @@ import * as vscode from 'vscode';
 
 export async function switchToDotnetProject(context: IProjectWizardContext, target: vscode.Uri) {
   await validateDotnetInstalled(context);
+
+  if (target === undefined) {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders === undefined || workspaceFolders.length === 0) {
+      throw new Error(localize('noWorkspace', 'No workspace is open.'));
+    } else if (workspaceFolders.length > 1) {
+      throw new Error(localize('multipleWorkspaces', 'Multiple workspaces are open.'));
+    } else {
+      target = workspaceFolders[0].uri;
+    }
+  }
+
   let version: FuncVersion | undefined = tryParseFuncVersion(getWorkspaceSetting(funcVersionSetting, target.fsPath));
 
   const projectFiles = await getProjFiles(context, ProjectLanguage.CSharp, target.fsPath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.0.24",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.0.24",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -180,8 +180,8 @@
         "yalc": "1.0.0-pre.53"
       },
       "engines": {
-        "node": "16",
-        "npm": "8"
+        "node": ">=16",
+        "npm": ">=8"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
Fixes #1969 

This change checks whether the target URL is provided ([when right-clicking in the folder view](https://learn.microsoft.com/en-us/azure/logic-apps/create-single-tenant-workflows-visual-studio-code#enable-built-in-connector-authoring)), and if not, it attempts to take the target from current workspace. Two error cases are handled - no open workspace and multiple workspaces open.

**EDIT:** I am not sure why version got bumped in package.json, but it seems like it is some sort of a commit action adding it automatically. If you want to revert the change, let me know.