### PR TITLE
fix(Services): Gateway service now works in VSCode/Standalone

### DIFF
--- a/apps/designer-standalone/src/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/designer-standalone/src/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -325,7 +325,7 @@ const getDesignerServices = (
     workflowReferenceId: '',
   });
   const gatewayService = new BaseGatewayService({
-    baseUrl,
+    baseUrl: armUrl,
     httpClient,
     apiVersions: {
       subscription: apiVersion,

--- a/apps/vs-code-designer-react/src/app/servicesHelper.ts
+++ b/apps/vs-code-designer-react/src/app/servicesHelper.ts
@@ -56,6 +56,8 @@ export const getDesignerServices = (
 
   const { subscriptionId = 'subscriptionId', resourceGroup, location } = apiHubServiceDetails;
 
+  const armUrl = 'https://management.azure.com';
+
   if (panelMetadata) {
     authToken = panelMetadata.accessToken ?? '';
     panelId = panelMetadata.panelId;
@@ -203,7 +205,7 @@ export const getDesignerServices = (
   });
 
   const gatewayService = new BaseGatewayService({
-    baseUrl,
+    baseUrl: armUrl,
     httpClient,
     apiVersions: {
       subscription: apiVersion,

--- a/libs/services/designer-client-services/src/lib/base/gateway.ts
+++ b/libs/services/designer-client-services/src/lib/base/gateway.ts
@@ -34,9 +34,9 @@ export class BaseGatewayService implements IGatewayService {
 
   private async fetchGatewaysList(subscriptionId: string, apiName: string): Promise<Gateway[]> {
     const filter = `apiName eq '${apiName}'`;
-    const { apiVersions } = this.options;
+    const { baseUrl, apiVersions } = this.options;
     const request: HttpRequestOptions<any> = {
-      uri: `${subscriptionId}/providers/Microsoft.Web/connectionGateways`,
+      uri: `${baseUrl}${subscriptionId}/providers/Microsoft.Web/connectionGateways`,
       queryParameters: {
         'api-version': apiVersions.gateway,
         $filter: filter,
@@ -56,9 +56,9 @@ export class BaseGatewayService implements IGatewayService {
   }
 
   private async fetchSubscriptions(): Promise<Subscription[]> {
-    const { apiVersions } = this.options;
+    const { baseUrl, apiVersions } = this.options;
     const request: HttpRequestOptions<SubscriptionsResponse> = {
-      uri: '/subscriptions',
+      uri: `${baseUrl}/subscriptions/`,
       queryParameters: {
         'api-version': apiVersions.subscription,
       },


### PR DESCRIPTION
## Main Changes
- Base url is now applied to gateway requests, enabling it in VSCode and Standalone
- VSCode no longer strips gateway requests of auth