### PR TITLE
Fix(Designer): Update Token metadata for editorviewmodel editors/ other bugs

### DIFF
--- a/__mocks__/workflows/Panel.json
+++ b/__mocks__/workflows/Panel.json
@@ -34,7 +34,7 @@
       "Parse_JSON": {
         "type": "ParseJson",
         "inputs": {
-          "content": "@variables('ArrayVariable')",
+          "content": "@triggerBody()?['string']",
           "schema": {
             "type": "array",
             "items": {
@@ -62,7 +62,7 @@
         "type": "Query",
         "inputs": {
           "from": "@body('Parse_JSON')",
-          "where": "@equals(@item()?['policy'],'X')"
+          "where": "@equals(test,@triggerBody()?['string'])"
         },
         "runAfter": {
           "Parse_JSON": ["SUCCEEDED"]
@@ -103,5 +103,6 @@
       }
     }
   },
-  "kind": "Stateful"
+  "connectionReferences": {},
+  "parameters": {}
 }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -15,7 +15,12 @@ import type { NodesMetadata, Operations } from '../../state/workflow/workflowInt
 import type { RootState } from '../../store';
 import { getConnectionReference } from '../../utils/connectors/connections';
 import { isRootNodeInGraph } from '../../utils/graph';
-import { getAllInputParameters, updateDynamicDataInNode, updateTokenMetadata } from '../../utils/parameters/helper';
+import {
+  flattenAndUpdateViewModel,
+  getAllInputParameters,
+  updateDynamicDataInNode,
+  updateTokenMetadata,
+} from '../../utils/parameters/helper';
 import { isTokenValueSegment } from '../../utils/parameters/segment';
 import { initializeOperationDetailsForSwagger } from '../../utils/swagger/operation';
 import { convertOutputsToTokens, getBuiltInTokens, getTokenNodeIds } from '../../utils/tokens';
@@ -286,6 +291,20 @@ const updateTokenMetadataInParameters = (
 
           return segment;
         });
+      }
+
+      const viewModel = parameter.editorViewModel;
+      if (viewModel) {
+        flattenAndUpdateViewModel(
+          viewModel,
+          actionNodes,
+          triggerNodeId,
+          nodesData,
+          operations,
+          workflowParameters,
+          nodesMetadata,
+          parameter.type
+        );
       }
     }
   }

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -46,6 +46,7 @@ import {
   isOutputTokenValueSegment,
   isParameterToken,
   isTokenValueSegment,
+  isValueSegment,
   isVariableToken,
   ValueSegmentConvertor,
 } from './segment';
@@ -262,8 +263,7 @@ export function toParameterInfoMap(inputParameters: InputParameter[], stepDefini
 
 /**
  * Gets the parameter info object for UI elements from the resolved parameters from schema, swagger, definition, etc.
- * @arg {InputParameter} parameter - An object with metadata about a Swagger input parameter.
- * @arg {RepetitionContext} repetitionContext - An object contains the repetition related context data.
+ * @arg {ResolvedParameter} parameter - An object with metadata about a Swagger input parameter.
  * @arg {Record<string, string>} [metadata] - A hash mapping dynamic value lookup values to their display strings.
  * @arg {boolean} [shouldIgnoreDefaultValue=false] - True if should not populate with default value of dynamic parameter.
  * @return {ParameterInfo} - An object with the view model for an input parameter field.
@@ -383,7 +383,7 @@ export function getParameterEditorProps(
     editorViewModel = toAuthenticationViewModel(value);
     editorOptions = { ...editorOptions, identity: WorkflowService().getAppIdentity?.() };
   } else if (editor === constants.EDITOR.CONDITION) {
-    editorViewModel = editorOptions?.isOldFormat ? toUntilViewModel(value) : toConditionViewModel(value);
+    editorViewModel = editorOptions?.isOldFormat ? toSimpleQueryBuilderViewModel(value) : toConditionViewModel(value);
   } else if (dynamicValues && isLegacyDynamicValuesExtension(dynamicValues) && dynamicValues.extension.builtInOperation) {
     editor = undefined;
   } else if (isFilePicker) {
@@ -392,6 +392,38 @@ export function getParameterEditorProps(
   return { editor, editorOptions, editorViewModel, schema };
 }
 
+// Helper Functions for Creating Editor View Models
+const containsExpression = (operand: string): boolean => {
+  return operand.includes('(') && operand.includes(')');
+};
+
+const convertStringToInputParameter = (
+  value: string,
+  removeQuotesFromExpression?: boolean,
+  trimExpression?: boolean,
+  convertIfContainsExpression?: boolean
+): InputParameter => {
+  const hasExpression = containsExpression(value);
+  let newValue = value;
+  if (removeQuotesFromExpression) {
+    newValue = removeQuotes(newValue);
+  }
+  if (trimExpression) {
+    newValue = newValue.trim();
+  }
+  if (hasExpression && convertIfContainsExpression && !newValue.startsWith('@')) {
+    newValue = `@${newValue}`;
+  }
+  return {
+    key: guid(),
+    name: newValue,
+    type: 'any',
+    hideInUI: false,
+    value: newValue,
+  };
+};
+
+// Create Array Editor View Model
 const toArrayViewModel = (input: any): { schema: any } => {
   const schema: any = destructureSchema(input.itemSchema);
   return { schema };
@@ -414,18 +446,16 @@ const destructureSchema = (schema: any): any => {
   return newSchema;
 };
 
-const toUntilViewModel = (input: any): { isOldFormat: boolean; items: RowItemProps } => {
+// Create SimpleQueryBuilder Editor View Model
+const toSimpleQueryBuilderViewModel = (input: any): { isOldFormat: boolean; items: RowItemProps } => {
   let operand1: ValueSegment[], operand2: ValueSegment[], operation: string;
   try {
     operation = input.substring(input.indexOf('@') + 1, input.indexOf('('));
     const operations = input.split(',');
-    operand1 = loadParameterValue(
-      convertStringToInputParameter(removeQuotes(operations[0].substring(operations[0].indexOf('(') + 1)).trim())
-    );
-
-    operand2 = loadParameterValue(
-      convertStringToInputParameter(removeQuotes(operations[1].substring(0, operations[1].indexOf(')'))).trim())
-    );
+    const operand1String = operations[0].substring(operations[0].indexOf('(') + 1);
+    const operand2String = operations[1].substring(0, operations[1].lastIndexOf(')'));
+    operand1 = loadParameterValue(convertStringToInputParameter(operand1String, true, true, true));
+    operand2 = loadParameterValue(convertStringToInputParameter(operand2String, true, true, true));
   } catch {
     operation = 'equals';
     operand1 = [];
@@ -438,16 +468,7 @@ const toUntilViewModel = (input: any): { isOldFormat: boolean; items: RowItemPro
   };
 };
 
-const convertStringToInputParameter = (s: string): InputParameter => {
-  return {
-    key: s,
-    name: s,
-    type: 'any',
-    hideInUI: false,
-    value: s,
-  };
-};
-
+// Create QueryBuilder Editor View Model
 export const toConditionViewModel = (input: any): { items: GroupItemProps } => {
   const getConditionOption = getConditionalSelectedOption(input);
   const items: GroupItemProps = {
@@ -485,8 +506,12 @@ function recurseConditionalItems(input: any, selectedOption?: GroupDropdownOptio
         output.push({
           type: GroupType.ROW,
           operator: not + dropdownVal,
-          operand1: loadParameterValue({ value: not ? item[not][dropdownVal][0] : item[dropdownVal][0] } as InputParameter),
-          operand2: loadParameterValue({ value: not ? item[not][dropdownVal][1] : item[dropdownVal][1] } as InputParameter),
+          operand1: loadParameterValue(
+            convertStringToInputParameter(not ? item[not][dropdownVal][0] : item[dropdownVal][0], true, true, true)
+          ),
+          operand2: loadParameterValue(
+            convertStringToInputParameter(not ? item[not][dropdownVal][1] : item[dropdownVal][1], true, true, true)
+          ),
         });
       } else {
         output.push({ type: GroupType.GROUP, condition: condition, items: recurseConditionalItems(item, condition) });
@@ -496,6 +521,7 @@ function recurseConditionalItems(input: any, selectedOption?: GroupDropdownOptio
   return output;
 }
 
+// Create Dictionary Editor View Model
 function toDictionaryViewModel(value: any): { items: DictionaryEditorItemProps[] | undefined } {
   let items: DictionaryEditorItemProps[] | undefined = [];
   const valueToParse = value !== null ? value ?? {} : value;
@@ -505,8 +531,8 @@ function toDictionaryViewModel(value: any): { items: DictionaryEditorItemProps[]
     const keys = Object.keys(valueToParse);
     for (const itemKey of keys) {
       items.push({
-        key: loadParameterValue({ value: itemKey } as any),
-        value: loadParameterValue({ value: valueToParse[itemKey] } as any),
+        key: loadParameterValue(convertStringToInputParameter(itemKey)),
+        value: loadParameterValue(convertStringToInputParameter(valueToParse[itemKey])),
       });
     }
 
@@ -520,6 +546,7 @@ function toDictionaryViewModel(value: any): { items: DictionaryEditorItemProps[]
   return { items };
 }
 
+// Create Table Editor View Model
 function toTableViewModel(value: any, editorOptions: any): { items: DictionaryEditorItemProps[]; columnMode: ColumnMode } {
   const placeholderItem = { key: [createLiteralValueSegment('')], value: [createLiteralValueSegment('')] };
   if (Array.isArray(value)) {
@@ -527,8 +554,8 @@ function toTableViewModel(value: any, editorOptions: any): { items: DictionaryEd
     const items: DictionaryEditorItemProps[] = [];
     for (const item of value) {
       items.push({
-        key: loadParameterValue({ value: item[keys[0]] } as any),
-        value: loadParameterValue({ value: item[keys[1]] } as any),
+        key: loadParameterValue(convertStringToInputParameter(item[keys[0]])),
+        value: loadParameterValue(convertStringToInputParameter(item[keys[1]])),
       });
     }
 
@@ -538,6 +565,7 @@ function toTableViewModel(value: any, editorOptions: any): { items: DictionaryEd
   return { items: [placeholderItem], columnMode: ColumnMode.Automatic };
 }
 
+// Create Authentication Editor View Model
 function toAuthenticationViewModel(value: any): { type: AuthenticationType; authenticationValue: AuthProps } {
   const emptyValue = { type: AuthenticationType.NONE, authenticationValue: {} };
 
@@ -548,8 +576,8 @@ function toAuthenticationViewModel(value: any): { type: AuthenticationType; auth
           type: value.type,
           authenticationValue: {
             basic: {
-              basicUsername: loadParameterValue({ value: value.username } as InputParameter),
-              basicPassword: loadParameterValue({ value: value.password } as InputParameter),
+              basicUsername: loadParameterValue(convertStringToInputParameter(value.username)),
+              basicPassword: loadParameterValue(convertStringToInputParameter(value.password)),
             },
           },
         };
@@ -558,8 +586,8 @@ function toAuthenticationViewModel(value: any): { type: AuthenticationType; auth
           type: value.type,
           authenticationValue: {
             clientCertificate: {
-              clientCertificatePfx: loadParameterValue({ value: value.pfx } as InputParameter),
-              clientCertificatePassword: loadParameterValue({ value: value.password } as InputParameter),
+              clientCertificatePfx: loadParameterValue(convertStringToInputParameter(value.pfx)),
+              clientCertificatePassword: loadParameterValue(convertStringToInputParameter(value.password)),
             },
           },
         };
@@ -569,12 +597,12 @@ function toAuthenticationViewModel(value: any): { type: AuthenticationType; auth
           type: value.type,
           authenticationValue: {
             aadOAuth: {
-              oauthTenant: loadParameterValue({ value: value.tenant } as InputParameter),
-              oauthAudience: loadParameterValue({ value: value.audience } as InputParameter),
-              oauthClientId: loadParameterValue({ value: value.clientId } as InputParameter),
-              oauthTypeSecret: loadParameterValue({ value: value.secret } as InputParameter),
-              oauthTypeCertificatePfx: loadParameterValue({ value: value.pfx } as InputParameter),
-              oauthTypeCertificatePassword: loadParameterValue({ value: value.password } as InputParameter),
+              oauthTenant: loadParameterValue(convertStringToInputParameter(value.tenant)),
+              oauthAudience: loadParameterValue(convertStringToInputParameter(value.audience)),
+              oauthClientId: loadParameterValue(convertStringToInputParameter(value.clientId)),
+              oauthTypeSecret: loadParameterValue(convertStringToInputParameter(value.secret)),
+              oauthTypeCertificatePfx: loadParameterValue(convertStringToInputParameter(value.pfx)),
+              oauthTypeCertificatePassword: loadParameterValue(convertStringToInputParameter(value.password)),
             },
           },
         };
@@ -584,7 +612,7 @@ function toAuthenticationViewModel(value: any): { type: AuthenticationType; auth
           type: value.type,
           authenticationValue: {
             raw: {
-              rawValue: loadParameterValue({ value: value.value } as InputParameter),
+              rawValue: loadParameterValue(convertStringToInputParameter(value.value)),
             },
           },
         };
@@ -594,7 +622,7 @@ function toAuthenticationViewModel(value: any): { type: AuthenticationType; auth
           type: value.type,
           authenticationValue: {
             msi: {
-              msiAudience: loadParameterValue({ value: value.audience } as InputParameter),
+              msiAudience: loadParameterValue(convertStringToInputParameter(value.audience)),
               msiIdentity: value.identity,
             },
           },
@@ -1790,14 +1818,14 @@ function getStringifiedValueFromEditorViewModel(parameter: ParameterInfo, isDefi
       return undefined;
     case constants.EDITOR.CONDITION:
       return editorOptions?.isOldFormat
-        ? serializeUntil(editorViewModel)
+        ? serializeSimpleQueryBuilder(editorViewModel)
         : JSON.stringify(recurseSerializeCondition(parameter, editorViewModel.items, isDefinitionValue));
     default:
       return undefined;
   }
 }
 
-export const serializeUntil = (editorViewModel: any): string => {
+export const serializeSimpleQueryBuilder = (editorViewModel: any): string => {
   return editorViewModel.value;
 };
 
@@ -2115,8 +2143,69 @@ export function updateTokenMetadataInParameters(parameters: ParameterInfo[], roo
         return segment;
       });
     }
+    const viewModel = parameter.editorViewModel;
+    if (viewModel) {
+      flattenAndUpdateViewModel(viewModel, actionNodes, triggerNodeId, nodesData, operations, definitions, nodesMetadata, parameter.type);
+    }
   }
 }
+
+export const flattenAndUpdateViewModel = (
+  items: any,
+  actionNodes: Record<string, string>,
+  triggerNodeId: string,
+  nodes: Record<string, Partial<NodeDataWithOperationMetadata>>,
+  operations: Actions,
+  workflowParameters: Record<string, WorkflowParameter | WorkflowParameterDefinition>,
+  nodesMetadata: NodesMetadata,
+  parameterType?: string
+) => {
+  if (!items) return;
+  // check if on bottom-most level (array of valueSegments)
+  if (Array.isArray(items) && items.every((item) => isValueSegment(item))) {
+    return items.map((keyItem: ValueSegment) => {
+      if (!isTokenValueSegment(keyItem)) return keyItem;
+      const valueSegmentToUpdate = updateTokenMetadata(
+        keyItem,
+        actionNodes,
+        triggerNodeId,
+        nodes,
+        operations,
+        workflowParameters,
+        nodesMetadata,
+        parameterType
+      );
+      if (valueSegmentToUpdate) return valueSegmentToUpdate;
+      return keyItem;
+    }) as ValueSegment[];
+  }
+
+  const replacedItems: any = {};
+  Object.entries(items).forEach(([itemKey, itemValue]) => {
+    if (typeof itemValue === 'object') {
+      replacedItems[itemKey] = flattenAndUpdateViewModel(
+        itemValue,
+        actionNodes,
+        triggerNodeId,
+        nodes,
+        operations,
+        workflowParameters,
+        nodesMetadata,
+        parameterType
+      );
+    } else {
+      replacedItems[itemKey] = itemValue;
+    }
+  });
+  // Keep Array Format and preserve the order of the elements
+  return Array.isArray(items)
+    ? Object.keys(replacedItems)
+        .map(Number)
+        .sort((a, b) => a - b)
+        .map((key) => replacedItems[key])
+    : replacedItems;
+};
+
 export function updateTokenMetadata(
   valueSegment: ValueSegment,
   actionNodes: Record<string, string>,

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -211,6 +211,17 @@ export class ValueSegmentConvertor {
 }
 
 /**
+ * Checks whether the segment is a value segment.
+ * @arg {any} object - The value segment.
+ * @return {boolean}
+ */
+export function isValueSegment(object: any): boolean {
+  return (
+    object?.id && !isNullOrUndefined(object.value) && (object.type === ValueSegmentType.LITERAL || object.type === ValueSegmentType.TOKEN)
+  );
+}
+
+/**
  * Checks whether the segment is a literal value segment.
  * @arg {ValueSegment} segment - The value segment.
  * @return {boolean}


### PR DESCRIPTION
Reverted part of https://github.com/Azure/LogicAppsUX/pull/2027 because it would only work for Dictionary Editors, but cause other editorViewModel editors to crash. Should now be able to grab the token metadata before it populates the parameters

Before: 
![beforeTokens](https://user-images.githubusercontent.com/95886809/232238313-bb249db1-4237-4e55-965d-ec2272dfda86.gif)

After: 
![afterTokens](https://user-images.githubusercontent.com/95886809/232238321-91883e25-c70d-493e-9d69-b09f5a0588c7.gif)

Also Fixes #2012 
![trueDefault](https://user-images.githubusercontent.com/95886809/232239126-c98f0766-ba7d-4c2f-8381-f5cf3ba2fe73.gif)


Also hiding the placeholder editor tooltip if text does not overflow
