### PR TITLE
docs(vscode): Remove development notes from readme

### DIFF
--- a/apps/vs-code-data-mapper/src/README.md
+++ b/apps/vs-code-data-mapper/src/README.md
@@ -4,10 +4,6 @@ In Visual Studio Code, you can use the Azure Logic Apps - Data Mapper extension 
 
 > Sign up today for your free Azure account and receive 12 months of free popular services, $200 free credit and 25+ always free services 👉 [Start Free](https://azure.microsoft.com/free/open-source).
 
-## Development Notes
-
-If building the extension make sure you are using node version 14. If you are using [NVM](https://github.com/nvm-sh/nvm) or [NVM Windows](https://github.com/coreybutler/nvm-windows) you can just use 'nvm use' in this repo to switch to the supported version.
-
 ## Known issues
 
 You can see known issues [here](https://github.com/Azure/LogicAppsUX/issues).

--- a/apps/vs-code-designer/src/README.md
+++ b/apps/vs-code-designer/src/README.md
@@ -4,10 +4,6 @@ In Visual Studio Code, you can use the Azure Logic Apps (Standard) extension to 
 
 > Sign up today for your free Azure account and receive 12 months of free popular services, $200 free credit and 25+ always free services 👉 [Start Free](https://azure.microsoft.com/free/open-source).
 
-## Development Notes
-
-If building the extension make sure you are using node version 14. If you are using [NVM](https://github.com/nvm-sh/nvm) or [NVM Windows](https://github.com/coreybutler/nvm-windows) you can just use 'nvm use' in this repo to switch to the supported version.
-
 ## Known issues
 
 You can see known issues [here](https://github.com/Azure/LogicAppsUX/issues).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.2.1",
+  "version": "2.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.2.1",
+      "version": "2.4.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This is confusing when included in the marketplace readme. We have better and more up to date docs in our docs.