### PR TITLE
Add redux action to revert workflow state to initial

### DIFF
--- a/libs/designer/src/lib/core/index.ts
+++ b/libs/designer/src/lib/core/index.ts
@@ -10,3 +10,4 @@ export { serializeWorkflow } from './actions/bjsworkflow/serializer';
 export { clearPanel, switchToWorkflowParameters } from './state/panel/panelSlice';
 export { useSelectedNodeId } from './state/panel/panelSelectors';
 export { initializeServices } from './state/designerOptions/designerOptionsSlice';
+export { resetWorkflowState } from './state/global';

--- a/libs/designer/src/lib/core/state/connection/connectionSlice.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSlice.ts
@@ -1,4 +1,5 @@
 import type { ConnectionReferences } from '../../../common/models/workflow';
+import { resetWorkflowState } from '../global';
 import { equals, getUniqueName } from '@microsoft/utils-logic-apps';
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
@@ -53,6 +54,9 @@ export const connectionSlice = createSlice({
       const { nodeId } = action.payload;
       delete state.connectionsMapping[nodeId];
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(resetWorkflowState, () => initialConnectionsState);
   },
 });
 

--- a/libs/designer/src/lib/core/state/designerView/designerViewSlice.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewSlice.ts
@@ -1,3 +1,4 @@
+import { resetWorkflowState } from '../global';
 import type { DesignerViewState } from './designerViewInterfaces';
 import { createSlice } from '@reduxjs/toolkit';
 
@@ -16,6 +17,9 @@ export const designerViewSlice = createSlice({
     toggleClampPan: (state: DesignerViewState) => {
       state.clampPan = !state.clampPan;
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(resetWorkflowState, () => initialState);
   },
 });
 

--- a/libs/designer/src/lib/core/state/global.ts
+++ b/libs/designer/src/lib/core/state/global.ts
@@ -1,0 +1,3 @@
+import { createAction } from "@reduxjs/toolkit";
+
+export const resetWorkflowState = createAction('resetWorkflowState');

--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -2,6 +2,7 @@ import { getInputDependencies } from '../../actions/bjsworkflow/initialize';
 import type { Settings } from '../../actions/bjsworkflow/settings';
 import type { NodeStaticResults } from '../../actions/bjsworkflow/staticresults';
 import { StaticResultOption } from '../../actions/bjsworkflow/staticresults';
+import { resetWorkflowState } from '../global';
 import type { ParameterInfo } from '@microsoft/designer-ui';
 import type { InputParameter, OutputParameter } from '@microsoft/parsers-logic-apps';
 import type { OperationInfo } from '@microsoft/utils-logic-apps';
@@ -333,6 +334,9 @@ export const operationMetadataSlice = createSlice({
         delete state.actionMetadata[id];
       }
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(resetWorkflowState, () => initialState);
   },
 });
 

--- a/libs/designer/src/lib/core/state/setting/settingSlice.ts
+++ b/libs/designer/src/lib/core/state/setting/settingSlice.ts
@@ -1,3 +1,4 @@
+import { resetWorkflowState } from '../global';
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
@@ -50,6 +51,9 @@ export const settingsSlice = createSlice({
         state.expandedSections = [...state.expandedSections, sectionName];
       }
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(resetWorkflowState, () => initialState);
   },
 });
 

--- a/libs/designer/src/lib/core/state/staticresultschema/staticresultsSlice.ts
+++ b/libs/designer/src/lib/core/state/staticresultschema/staticresultsSlice.ts
@@ -1,3 +1,4 @@
+import { resetWorkflowState } from '../global';
 import type { Schema } from '@microsoft/parsers-logic-apps';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
@@ -34,6 +35,9 @@ export const staticResultsSlice = createSlice({
     updateStaticResultProperties: (state, action: PayloadAction<{ name: string; properties: any }>) => {
       state.properties[action.payload.name] = action.payload.properties;
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(resetWorkflowState, () => initialState);
   },
 });
 

--- a/libs/designer/src/lib/core/state/tokensSlice.ts
+++ b/libs/designer/src/lib/core/state/tokensSlice.ts
@@ -1,3 +1,4 @@
+import { resetWorkflowState } from './global';
 import type { OutputToken as Token } from '@microsoft/designer-ui';
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
@@ -98,6 +99,9 @@ export const tokensSlice = createSlice({
         state.outputTokens[nodeId].upstreamNodeIds = action.payload[nodeId];
       }
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(resetWorkflowState, () => initialState);
   },
 });
 

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -9,6 +9,7 @@ import type { MoveNodePayload } from '../../parsers/moveNodeInWorkflow';
 import { moveNodeInWorkflow } from '../../parsers/moveNodeInWorkflow';
 import { addNewEdge } from '../../parsers/restructuringHelpers';
 import { getImmediateSourceNodeIds } from '../../utils/graph';
+import { resetWorkflowState } from '../global';
 import type { SpecTypes, WorkflowState } from './workflowInterfaces';
 import { getWorkflowNodeFromGraphState } from './workflowSelectors';
 import { LogEntryLevel, LoggerService } from '@microsoft/designer-client-services-logic-apps';
@@ -324,6 +325,7 @@ export const workflowSlice = createSlice({
         ([, value]) => !(value as LogicAppsV2.ActionDefinition).runAfter
       )?.[0];
     });
+    builder.addCase(resetWorkflowState, () => initialWorkflowState);
   },
 });
 

--- a/libs/designer/src/lib/core/state/workflowparameters/workflowparametersSlice.ts
+++ b/libs/designer/src/lib/core/state/workflowparameters/workflowparametersSlice.ts
@@ -2,6 +2,7 @@ import Constants from '../../../common/constants';
 import type { WorkflowParameter } from '../../../common/models/workflow';
 import { convertWorkflowParameterTypeToSwaggerType } from '../../utils/tokens';
 import { validateType } from '../../utils/validation';
+import { resetWorkflowState } from '../global';
 import type { WorkflowParameterUpdateEvent } from '@microsoft/designer-ui';
 import { UIConstants } from '@microsoft/designer-ui';
 import { getIntl } from '@microsoft/intl-logic-apps';
@@ -194,6 +195,9 @@ export const workflowParametersSlice = createSlice({
         ...validationErrors,
       };
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(resetWorkflowState, () => initialState);
   },
 });
 


### PR DESCRIPTION
This PR adds an exported dispatch function, `resetWorkflowState()`, which allows the redux state for LAUX to be reset. This allows apps which retain the redux state across mounts to clear the cached redux state data and prevent cross-pollination. (Primary issue is that parameter validation errors do not get cleared when a new workflow is loaded.)

Before the fix, if I loaded a workflow and then remounted the component with a second workflow, this would happen:

![image](https://user-images.githubusercontent.com/1350074/232872729-07919cde-c7a0-4f4d-bad1-7384c6a2366d.png)

With the fix and invoking `dispatch(resetWorkflowState())`, only the green-highlighted keys remain in the array.