### PR TITLE
fix: add logic to fallback to connector data from Operation Manifest when Connection Service data is undefined

### DIFF
--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -1,5 +1,6 @@
 import type { ConnectionReference, ConnectionReferences } from '../../../common/models/workflow';
 import type { RootState } from '../../store';
+import { useOperationManifest, useOperationInfo } from '../selectors/actionMetadataSelector';
 import type { ConnectionMapping } from './connectionSlice';
 import { ConnectionService, GatewayService } from '@microsoft/designer-client-services-logic-apps';
 import type { Connector } from '@microsoft/utils-logic-apps';
@@ -39,8 +40,11 @@ export const useGateways = (subscriptionId: string, connectorName: string) => {
 export const useSubscriptions = () => useQuery('subscriptions', async () => GatewayService().getSubscriptions());
 
 export const useConnectorByNodeId = (nodeId: string): Connector | undefined => {
+  // TODO: Revisit trying to conditionally ask for the connector from the service
+  const connectorFromManifest = useOperationManifest(useOperationInfo(nodeId)).data?.properties.connector;
   const storeConnectorId = useSelector((state: RootState) => state.operations.operationInfo[nodeId]?.connectorId);
-  return useConnector(storeConnectorId)?.data;
+  const connectorFromService = useConnector(storeConnectorId)?.data;
+  return connectorFromService ?? connectorFromManifest;
 };
 
 export const useConnectionMapping = (): ConnectionMapping => {


### PR DESCRIPTION
Reintroducing logic that uses Operation Manifest connector data that was removed as part of https://github.com/Azure/LogicAppsUX/commit/22d6c30d7977a9fb7ef17e10095084bf9e77c1aa#diff-ea2d1be19c1bdc8a7105f83da7156578f002d4dd84fcf9cc702d6c925d280bf9. The main change is that useConnectorByNodeId will give priority to Connection Service and then fallback to Operation manifest to avoid reintroducing a regression.