### PR TITLE
fix(designer): Add refetch for failed iterations

### DIFF
--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -25,7 +25,6 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
   const forEachItemsCount = getForeachItemsCount(metadata?.runData);
 
   const getFailedRunScopeRepetitions = () => {
-    console.log('getFailedRunScopeRepetitions', scopeId, runInstance?.id);
     return RunService().getScopeRepetitions({ nodeId: scopeId, runId: runInstance?.id }, constants.FLOW_STATUS.FAILED);
   };
 

--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -6,7 +6,7 @@ import { getForeachItemsCount } from './helper';
 import { RunService } from '@microsoft/designer-client-services-logic-apps';
 import type { PageChangeEventArgs, PageChangeEventHandler } from '@microsoft/designer-ui';
 import { Pager } from '@microsoft/designer-ui';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import { useDispatch } from 'react-redux';
 
@@ -25,6 +25,7 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
   const forEachItemsCount = getForeachItemsCount(metadata?.runData);
 
   const getFailedRunScopeRepetitions = () => {
+    console.log('getFailedRunScopeRepetitions', scopeId, runInstance?.id);
     return RunService().getScopeRepetitions({ nodeId: scopeId, runId: runInstance?.id }, constants.FLOW_STATUS.FAILED);
   };
 
@@ -44,12 +45,20 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
     setFailedRepetitions([]);
   };
 
-  const { isError } = useQuery<any>(['runRepetitions'], getFailedRunScopeRepetitions, {
-    refetchOnWindowFocus: false,
-    initialData: null,
-    onSuccess: onRunRepetitionsSuccess,
-    onError: onRunRepetitionsError,
-  });
+  const { isError, refetch } = useQuery<any>(
+    ['runRepetitions', { nodeId: scopeId, runId: runInstance?.id }],
+    getFailedRunScopeRepetitions,
+    {
+      refetchOnWindowFocus: false,
+      initialData: null,
+      onSuccess: onRunRepetitionsSuccess,
+      onError: onRunRepetitionsError,
+    }
+  );
+
+  useEffect(() => {
+    refetch();
+  }, [runInstance?.id, refetch, scopeId]);
 
   if (!forEachItemsCount || isError || collapsed) {
     return null;


### PR DESCRIPTION
### Main Code Changes
- Add UseEffect for refetch
- Add scope and run ids for query id

### Implementation
- Able to display the previous/next error pager when loop scope has error
![Screenshot 2023-04-19 at 2 34 43 PM](https://user-images.githubusercontent.com/102700317/233206387-186e7402-38c8-4eed-992c-ebea0ca97325.png)
