### PR TITLE
fix(designer): ensure all operations and connectors pages are fetched on fisrt search

### DIFF
--- a/libs/designer/src/lib/core/queries/browse.ts
+++ b/libs/designer/src/lib/core/queries/browse.ts
@@ -23,8 +23,32 @@ const pagedOpts = {
 /// Operations ///
 
 export const useAllOperations = () => {
-  const { data: azureOperations, isLoading: azureLoading, hasNextPage: azureHasNextPage } = useAzureOperationsLazyQuery();
-  const { data: customOperations, isLoading: customLoading, hasNextPage: customHasNextPage } = useCustomOperationsLazyQuery();
+  const {
+    data: azureOperations,
+    isLoading: azureLoading,
+    hasNextPage: azureHasNextPage,
+    fetchNextPage: fetchNextAzurePage,
+    isFetchingNextPage: isFetchingNextAzurePage,
+  } = useAzureOperationsLazyQuery();
+  useEffect(() => {
+    if (azureLoading || isFetchingNextAzurePage) return;
+    if (!azureHasNextPage) return;
+    fetchNextAzurePage();
+  }, [azureLoading, fetchNextAzurePage, azureHasNextPage, isFetchingNextAzurePage]);
+
+  const {
+    data: customOperations,
+    isLoading: customLoading,
+    hasNextPage: customHasNextPage,
+    fetchNextPage: fetchNextCustomPage,
+    isFetchingNextPage: isFetchingNextCustomPage,
+  } = useCustomOperationsLazyQuery();
+  useEffect(() => {
+    if (customLoading || isFetchingNextCustomPage) return;
+    if (!customHasNextPage) return;
+    fetchNextCustomPage();
+  }, [customLoading, fetchNextCustomPage, customHasNextPage, isFetchingNextCustomPage]);
+
   const { data: builtinOperations, isLoading: builtinLoading } = useBuiltInOperationsQuery();
 
   const data = useMemo(() => {
@@ -119,8 +143,32 @@ const useBuiltInOperationsQuery = () =>
 /// Connectors ///
 
 export const useAllConnectors = () => {
-  const { data: azureData, isLoading: azureLoading, hasNextPage: azureHasNextPage } = useAzureConnectorsLazyQuery();
-  const { data: customData, isLoading: customLoading, hasNextPage: customHasNextPage } = useCustomConnectorsLazyQuery();
+  const {
+    data: azureData,
+    isLoading: azureLoading,
+    hasNextPage: azureHasNextPage,
+    fetchNextPage: fetchNextAzurePage,
+    isFetchingNextPage: isFetchingNextAzurePage,
+  } = useAzureConnectorsLazyQuery();
+  useEffect(() => {
+    if (azureLoading || isFetchingNextAzurePage) return;
+    if (!azureHasNextPage) return;
+    fetchNextAzurePage();
+  }, [azureLoading, fetchNextAzurePage, azureHasNextPage, isFetchingNextAzurePage]);
+
+  const {
+    data: customData,
+    isLoading: customLoading,
+    hasNextPage: customHasNextPage,
+    fetchNextPage: fetchNextCustomPage,
+    isFetchingNextPage: isFetchingNextCustomPage,
+  } = useCustomConnectorsLazyQuery();
+  useEffect(() => {
+    if (customLoading || isFetchingNextCustomPage) return;
+    if (!customHasNextPage) return;
+    fetchNextCustomPage();
+  }, [customLoading, fetchNextCustomPage, customHasNextPage, isFetchingNextCustomPage]);
+
   const { data: builtinData, isLoading: builtinLoading } = useBuiltInConnectorsQuery();
 
   const hasNextPage = useMemo(() => azureHasNextPage || customHasNextPage, [azureHasNextPage, customHasNextPage]);

--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -1,5 +1,6 @@
 import type { ConnectionReference, ConnectionReferences } from '../../../common/models/workflow';
 import type { RootState } from '../../store';
+import { useOperationManifest, useOperationInfo } from '../selectors/actionMetadataSelector';
 import type { ConnectionMapping } from './connectionSlice';
 import { ConnectionService, GatewayService } from '@microsoft/designer-client-services-logic-apps';
 import type { Connector } from '@microsoft/utils-logic-apps';
@@ -39,8 +40,11 @@ export const useGateways = (subscriptionId: string, connectorName: string) => {
 export const useSubscriptions = () => useQuery('subscriptions', async () => GatewayService().getSubscriptions());
 
 export const useConnectorByNodeId = (nodeId: string): Connector | undefined => {
+  // TODO: Revisit trying to conditionally ask for the connector from the service
+  const connectorFromManifest = useOperationManifest(useOperationInfo(nodeId)).data?.properties.connector;
   const storeConnectorId = useSelector((state: RootState) => state.operations.operationInfo[nodeId]?.connectorId);
-  return useConnector(storeConnectorId)?.data;
+  const connectorFromService = useConnector(storeConnectorId)?.data;
+  return connectorFromService ?? connectorFromManifest;
 };
 
 export const useConnectionMapping = (): ConnectionMapping => {

--- a/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
@@ -6,7 +6,7 @@ import { isCustomConnector, isBuiltInConnector } from '@microsoft/utils-logic-ap
 import { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
-export const BrowseView = ({ filters }: { filters: Record<string, string> }) => {
+export const BrowseView = ({ filters, isLoadingOperations }: { filters: Record<string, string>; isLoadingOperations: boolean }) => {
   const dispatch = useDispatch();
 
   const { data: allConnectors, isLoading } = useAllConnectors();
@@ -45,5 +45,7 @@ export const BrowseView = ({ filters }: { filters: Record<string, string> }) => 
     [dispatch]
   );
 
-  return <BrowseGrid onConnectorSelected={onConnectorCardSelected} connectors={sortedConnectors} isLoading={isLoading} />;
+  return (
+    <BrowseGrid onConnectorSelected={onConnectorCardSelected} connectors={sortedConnectors} isLoading={isLoading || isLoadingOperations} />
+  );
 };

--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -168,7 +168,7 @@ export const RecommendationPanelContext = (props: CommonPanelProps) => {
                   onOperationClick={onOperationClick}
                 />
               ) : (
-                <BrowseView filters={filters} />
+                <BrowseView filters={filters} isLoadingOperations={isLoadingOperations} />
               )}
             </>
           ),


### PR DESCRIPTION
When adding an action for first time all Operations and Connectors should be fetched, if there is another page to be fetched a subsequent call needs to be made to fetch that page and continue until there are no more pages to fetch.

After https://github.com/Azure/LogicAppsUX/pull/1983 this behavior regressed and only one page is fetched resulting in three network calls (1 for Azure, 1 for Custom and 1 for BuiltIn), and subsequent pages are not fetched even though there is a next link. This change fixes that regression.

Current behavior:
![image](https://user-images.githubusercontent.com/12244548/233460194-4a9f3393-1d4e-4ed6-8e7e-144d9a13e10d.png)

New behavior:
<img width="667" alt="image" src="https://user-images.githubusercontent.com/12244548/233462853-0fc9a9bc-85ab-41bb-bf58-9daf746bb3af.png">

Fixes #2081 