### PR TITLE
fix(designer): Panel should validate params onBlur + Foreach shouldn't add another when selecting a token

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -9,7 +9,7 @@ import { PanelHeader } from './panelheader/panelheader';
 import { PanelPivot } from './panelpivot';
 import type { ILayerProps } from '@fluentui/react';
 import { MessageBar, MessageBarType, Spinner, SpinnerSize } from '@fluentui/react';
-import type { IPanelHeaderRenderer, IPanelProps, IPanelStyles } from '@fluentui/react/lib/Panel';
+import type { IPanelHeaderRenderer, IPanelProps, IPanelStyles, PanelBase } from '@fluentui/react/lib/Panel';
 import { Panel, PanelType } from '@fluentui/react/lib/Panel';
 import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
@@ -50,6 +50,7 @@ export type PanelContainerProps = {
   onCommentChange: (panelCommentChangeEvent?: string) => void;
   renderHeader?: (props?: IPanelProps, defaultrender?: IPanelHeaderRenderer, headerTextId?: string) => JSX.Element;
   onTitleChange: (newValue: string) => void;
+  onBlur?: React.FocusEventHandler<PanelBase> | undefined;
 } & CommonPanelProps;
 
 export const PanelContainer = ({
@@ -78,6 +79,7 @@ export const PanelContainer = ({
   renderHeader,
   onCommentChange,
   onTitleChange,
+  onBlur,
 }: PanelContainerProps) => {
   const intl = useIntl();
   const onTabChange = (itemKey: string): void => {
@@ -158,6 +160,7 @@ export const PanelContainer = ({
       customWidth={width}
       styles={isCollapsed ? panelStylesCollapsed : panelStyles}
       layerProps={layerProps}
+      onBlur={onBlur}
     >
       {!isCollapsed && (
         <>

--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -59,11 +59,16 @@ export const shouldAddForeach = async (
   token: OutputToken,
   state: RootState
 ): Promise<ImplicitForeachDetails> => {
-  if (token.outputInfo.type === TokenType.VARIABLE || token.outputInfo.type === TokenType.PARAMETER || !token.outputInfo?.arrayDetails) {
+  const operationInfo = state.operations.operationInfo[nodeId];
+  if (
+    token.outputInfo.type === TokenType.VARIABLE ||
+    token.outputInfo.type === TokenType.PARAMETER ||
+    !token.outputInfo?.arrayDetails ||
+    operationInfo.type.toLowerCase() === foreachOperationInfo.type.toLowerCase()
+  ) {
     return { shouldAdd: false };
   }
 
-  const operationInfo = state.operations.operationInfo[nodeId];
   const parameter = getParameterFromId(state.operations.inputParameters[nodeId], parameterId);
   const manifest = OperationManifestService().isSupported(operationInfo.type, operationInfo.kind)
     ? await getOperationManifest(operationInfo)

--- a/libs/designer/src/lib/ui/panel/panelroot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelroot.tsx
@@ -249,6 +249,15 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
     // TODO: 12798935 Analytics (event logging)
   };
 
+  const validateAllParams = (): void => {
+    Object.keys(inputs?.parameterGroups ?? {}).forEach((parameterGroup) => {
+      inputs.parameterGroups[parameterGroup].parameters.forEach((parameter) => {
+        const validationErrors = validateParameter(parameter, parameter.value);
+        dispatch(updateParameterValidation({ nodeId: selectedNode, groupId: parameterGroup, parameterId: parameter.id, validationErrors }));
+      });
+    });
+  };
+
   const togglePanel = (): void => (!collapsed ? collapse() : expand());
   const dismissPanel = () => dispatch(clearPanel());
 
@@ -298,17 +307,11 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
       toggleCollapse={() => {
         //only run validation when collapsing the panel
         if (!collapsed) {
-          Object.keys(inputs?.parameterGroups ?? {}).forEach((parameterGroup) => {
-            inputs.parameterGroups[parameterGroup].parameters.forEach((parameter) => {
-              const validationErrors = validateParameter(parameter, parameter.value);
-              dispatch(
-                updateParameterValidation({ nodeId: selectedNode, groupId: parameterGroup, parameterId: parameter.id, validationErrors })
-              );
-            });
-          });
+          validateAllParams();
         }
         togglePanel();
       }}
+      onBlur={() => validateAllParams()}
       trackEvent={handleTrackEvent}
       onCommentChange={(value) => {
         dispatch(setNodeDescription({ nodeId: selectedNode, description: value }));


### PR DESCRIPTION
* Validate parameters when the panel gets onBlur:
![image](https://user-images.githubusercontent.com/19804524/233510012-ac6784f1-1c7a-4f2e-a039-beeeb8417c98.png)


* This commit allows us to have an apply to each loop with an array token without adding a parent loop:
![image](https://user-images.githubusercontent.com/19804524/233509916-7538dbad-2476-477d-a6a4-42a98e4017be.png)
