### PR TITLE
fix(designer): Revert my recent changes to `shouldAddForeach` due to double array regression

### DIFF
--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -59,16 +59,11 @@ export const shouldAddForeach = async (
   token: OutputToken,
   state: RootState
 ): Promise<ImplicitForeachDetails> => {
-  const operationInfo = state.operations.operationInfo[nodeId];
-  if (
-    token.outputInfo.type === TokenType.VARIABLE ||
-    token.outputInfo.type === TokenType.PARAMETER ||
-    !token.outputInfo?.arrayDetails ||
-    operationInfo.type.toLowerCase() === foreachOperationInfo.type.toLowerCase()
-  ) {
+  if (token.outputInfo.type === TokenType.VARIABLE || token.outputInfo.type === TokenType.PARAMETER || !token.outputInfo?.arrayDetails) {
     return { shouldAdd: false };
   }
 
+  const operationInfo = state.operations.operationInfo[nodeId];
   const parameter = getParameterFromId(state.operations.inputParameters[nodeId], parameterId);
   const manifest = OperationManifestService().isSupported(operationInfo.type, operationInfo.kind)
     ? await getOperationManifest(operationInfo)


### PR DESCRIPTION
double array should add a nested for each by default now. However, both foreach loops use the same foreach parameter, which is not the proper behavior. The fix for that is out of scope of this revert.

![image](https://user-images.githubusercontent.com/19804524/233754535-d2238f7c-e4d6-4423-aa39-95ae9179ce1e.png)
