### PR TITLE
fix: updating Panel z-Index so that it does not overlap external components

### DIFF
--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -229,7 +229,6 @@ export const Designer = (props: DesignerProps) => {
           id={'msla-layer-host'}
           style={{
             position: 'absolute',
-            zIndex: 1000000,
             inset: '0px',
             visibility: 'hidden',
           }}

--- a/libs/designer/src/lib/ui/styles.less
+++ b/libs/designer/src/lib/ui/styles.less
@@ -78,7 +78,8 @@
 }
 
 .react-flow__panel {
-  margin: 0px !important;
+  margin: 0px;
+  z-index: 0 !important;
 }
 
 .react-flow__minimap {


### PR DESCRIPTION
fix: updating Panel z-Index so that it does not overlap external components

Panel continues to be on top of the Designer
![image](https://user-images.githubusercontent.com/12244548/234050684-bfc7166e-4fe9-40cf-94e2-fc27bdc9c153.png)

Parameters tab:
![image](https://user-images.githubusercontent.com/12244548/234050434-f378c55d-66f2-497d-a00a-7d07f0159956.png)

Settings tab:
![image](https://user-images.githubusercontent.com/12244548/234051766-644651bd-d886-48cf-9973-1997d8af4fd9.png)

Code View tab:
![image](https://user-images.githubusercontent.com/12244548/234051528-aa04ab32-107b-41e9-a9f4-58acb7cf59dd.png)

Testing tab:
![image](https://user-images.githubusercontent.com/12244548/234051069-9cb5d4cc-ba76-45e1-ad63-74423c729b02.png)

About tab:
![image](https://user-images.githubusercontent.com/12244548/234051386-cdcf24d2-072d-4b06-a054-8bf4658d6afc.png)

Scratch tab

