### PR TITLE
fix(designer): Fix incorrect type when creating new DynamicallyAddedParameter to unblock Save Flow

### DIFF
--- a/libs/designer-ui/src/lib/dynamicallyaddedparameter/helper.ts
+++ b/libs/designer-ui/src/lib/dynamicallyaddedparameter/helper.ts
@@ -2,6 +2,7 @@ import type { DynamicallyAddedParameterProps, DynamicallyAddedParameterTypeType,
 import { DynamicallyAddedParameterType } from '.';
 import type { ValueSegment } from '../editor';
 import { ValueSegmentType } from '../editor';
+import { getIntl } from '@microsoft/intl-logic-apps';
 import { guid } from '@microsoft/utils-logic-apps';
 
 export type DynamicallyAddedParameterIcon = string;
@@ -116,4 +117,51 @@ export function serialize(props: DynamicallyAddedParameterProps[]): ValueSegment
       value: JSON.stringify(rootObject),
     },
   ];
+}
+
+export function createDynamicallyAddedParameterProperties(
+  itemType: DynamicallyAddedParameterTypeType,
+  description: string
+): IDynamicallyAddedParameterProperties {
+  let format, fileProperties;
+  let type = '';
+  switch (itemType) {
+    case DynamicallyAddedParameterType.Date:
+      type = 'string';
+      format = itemType.toLowerCase();
+      break;
+    case DynamicallyAddedParameterType.Email:
+      type = 'string';
+      format = itemType.toLowerCase();
+      break;
+    case DynamicallyAddedParameterType.Text:
+      type = 'string';
+      break;
+    case DynamicallyAddedParameterType.File:
+      type = 'object';
+      fileProperties = { contentBytes: { type: 'string', format: 'byte' }, name: { type: 'string' } };
+      break;
+    case DynamicallyAddedParameterType.Boolean:
+      type = 'boolean';
+      break;
+    case DynamicallyAddedParameterType.Number:
+      type = 'number';
+      break;
+  }
+
+  const intl = getIntl();
+  const titlePlaceholder = intl.formatMessage({
+    defaultMessage: 'Enter title',
+    description: 'Placeholder for variable name for new dynamically added parameter',
+  });
+
+  return {
+    description,
+    format,
+    title: titlePlaceholder, // TODO: generate title based on schemaKey
+    type,
+    properties: fileProperties,
+    'x-ms-content-hint': itemType,
+    'x-ms-dynamically-added': true,
+  };
 }

--- a/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
+++ b/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
@@ -1,6 +1,6 @@
 import type { DynamicallyAddedParameterTypeType } from '../dynamicallyaddedparameter';
-import { DynamicallyAddedParameter, DynamicallyAddedParameterType } from '../dynamicallyaddedparameter';
-import { deserialize, serialize } from '../dynamicallyaddedparameter/helper';
+import { DynamicallyAddedParameter } from '../dynamicallyaddedparameter';
+import { createDynamicallyAddedParameterProperties, deserialize, serialize } from '../dynamicallyaddedparameter/helper';
 import type { ValueSegment } from '../editor';
 import type { ChangeHandler } from '../editor/base';
 import { getMenuItemsForDynamicAddedParameters } from './helper';
@@ -156,26 +156,13 @@ export const FloatingActionMenu = (props: FloatingActionMenuProps): JSX.Element 
     }
   };
 
-  const titlePlaceholder = intl.formatMessage({
-    defaultMessage: 'Enter title',
-    description: 'Placeholder for variable name for new dynamically added parameter',
-  });
-
   const addNewDynamicallyAddedParameter = (item: FloatingActionMenuItem) => {
-    const { icon, type, placeholder } = item;
-    const format =
-      type === DynamicallyAddedParameterType.Date || type === DynamicallyAddedParameterType.Email ? type.toLowerCase() : undefined;
+    const { icon, type: floatingActionMenuItemType, placeholder } = item;
+
     dynamicParameterProps.push({
       icon,
       schemaKey: guid(), // TODO: generate schemaKey
-      properties: {
-        description: placeholder,
-        format,
-        title: titlePlaceholder, // TODO: generate title based on schemaKey
-        type,
-        'x-ms-content-hint': type,
-        'x-ms-dynamically-added': true,
-      },
+      properties: createDynamicallyAddedParameterProperties(floatingActionMenuItemType, placeholder),
       required: true, // TODO: add functionality to allow making parameters optional
       onChange: onDynamicallyAddedParameterChange,
       onDelete: onDynamicallyAddedParameterDelete,


### PR DESCRIPTION
As part of the implementation of DynamicallyAddedParameter, we are passing the incorrect 'type' for its properties. The correct type is a swagger data type; instead we're passing in the 'floating action menu type'. This PR fixes that.

We now mimic the logic from V1 designer [operationoutputs.ts](https://msazure.visualstudio.com/One/_git/AzureUX-BPMUX?path=/src/core/stores/operationoutputs.ts&version=GBmaster&line=344&lineEnd=369&lineStartColumn=1&lineEndColumn=22&lineStyle=plain&_a=contents).

![GIF 4-24-2023 2-11-25 PM](https://user-images.githubusercontent.com/10837129/234118158-5ae8736f-06ad-4cdf-a4d1-e0ec84ed237e.gif)

