### PR TITLE
fix(designer): Don't validate parameters and dispatch on blur if the user is still editing on the panel

### DIFF
--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -38,6 +38,8 @@ const calloutStyles: Partial<ICalloutContentStyles> = {
 
 export type SearchTextChangedEventHandler = (e: string) => void;
 
+const tokenPickerClassName = 'msla-token-picker';
+
 export interface TokenPickerProps {
   editorId: string;
   labelId: string;
@@ -193,7 +195,7 @@ export function TokenPicker({
               : { maxHeight: '550px', width: '400px' }
           }
         >
-          <div className="msla-token-picker">
+          <div className={tokenPickerClassName}>
             {initialMode ? (
               <TokenPickerHeader fullScreen={fullScreen} closeTokenPicker={closeTokenPicker} setFullScreen={setFullScreen} />
             ) : null}
@@ -263,4 +265,13 @@ export function getWindowDimensions() {
     width,
     height,
   };
+}
+
+export function isTokenPickerElement(element: HTMLElement | null) {
+  for (let e = element; e !== null; e = e.parentElement) {
+    if (e.className.includes(tokenPickerClassName)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -269,7 +269,7 @@ export function getWindowDimensions() {
 
 export function isTokenPickerElement(element: HTMLElement | null) {
   for (let e = element; e !== null; e = e.parentElement) {
-    if (e.className.includes(tokenPickerClassName)) {
+    if (e.className?.includes(tokenPickerClassName)) {
       return true;
     }
   }

--- a/libs/designer/src/lib/ui/panel/panelroot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelroot.tsx
@@ -41,8 +41,17 @@ import { settingsTab } from './panelTabs/settingsTab';
 import { testingTab } from './panelTabs/testingTab';
 import { RecommendationPanelContext } from './recommendation/recommendationPanelContext';
 import { WorkflowParametersPanel } from './workflowparameterspanel';
+import type { PanelBase } from '@fluentui/react/lib/components/Panel/Panel.base';
 import type { CommonPanelProps, MenuItemOption, PageActionTelemetryData } from '@microsoft/designer-ui';
-import { MenuItemType, PanelContainer, PanelHeaderControlType, PanelLocation, PanelScope, PanelSize } from '@microsoft/designer-ui';
+import {
+  isTokenPickerElement,
+  MenuItemType,
+  PanelContainer,
+  PanelHeaderControlType,
+  PanelLocation,
+  PanelScope,
+  PanelSize,
+} from '@microsoft/designer-ui';
 import { isNullOrUndefined, SUBGRAPH_TYPES } from '@microsoft/utils-logic-apps';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -312,7 +321,16 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
         }
         togglePanel();
       }}
-      onBlur={() => validateAllParams()}
+      onBlur={(event: React.FocusEvent<PanelBase>) => {
+        // ignore if the focus is moving to a child element, or if the focus is moving to the token picker (so the user is still editing the same panel)
+        if (
+          (event.currentTarget as unknown as Element).contains(event.relatedTarget) ||
+          isTokenPickerElement(event.relatedTarget as HTMLElement)
+        ) {
+          return;
+        }
+        validateAllParams();
+      }}
       trackEvent={handleTrackEvent}
       onCommentChange={(value) => {
         dispatch(setNodeDescription({ nodeId: selectedNode, description: value }));


### PR DESCRIPTION
Don't validate parameters and dispatch on blur if the user is still editing on the panel. This prevents the issue where the token picker for drop down list custom value would immediately get dismissed on click.

![image](https://user-images.githubusercontent.com/19804524/234347956-32070e6b-2dce-40e7-aa71-3eb1da6f6b01.png)
