### PR TITLE
fix(designer): Change V3 token picker classname diff from V1

### DIFF
--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -186,7 +186,7 @@ export function TokenPicker({
         }}
       >
         <div
-          className="msla-token-picker-container"
+          className="msla-token-picker-container-v3"
           style={
             fullScreen
               ? { height: windowDimensions.height - 100, width: windowDimensions.width - (parseInt(PanelSize.Medium, 10) + 40) }


### PR DESCRIPTION
Need to distinguish the V3 token picker classname from V1 classname.
When we are support both V1 and V3, we are seeing [V1 styling](https://msazure.visualstudio.com/One/_git/AzureUX-BPMUX?path=/src/ui/tokenpicker/tokenpicker.less&version=GBmaster&line=55&lineEnd=58&lineStartColumn=1&lineEndColumn=32&lineStyle=plain&_a=contents) getting applied to V3 token picker.
![image](https://user-images.githubusercontent.com/84426548/234349068-158f7234-9cb8-4a10-82ff-828cdff4659a.png)
