### PR TITLE
fix(powerautomate): Fix DynamicallyAddedParameter menu getting collapsed on mouseenter

### DIFF
--- a/libs/designer-ui/src/lib/dynamicallyaddedparameter/index.tsx
+++ b/libs/designer-ui/src/lib/dynamicallyaddedparameter/index.tsx
@@ -1,6 +1,5 @@
 import type { IContextualMenuItem, IContextualMenuProps } from '@fluentui/react';
-import { ContextualMenuItemType, DirectionalHint, IconButton, TextField, TooltipHost } from '@fluentui/react';
-import { guid } from '@microsoft/utils-logic-apps';
+import { DirectionalHint, IconButton, TextField, TooltipHost } from '@fluentui/react';
 import React from 'react';
 import { useIntl } from 'react-intl';
 
@@ -49,8 +48,6 @@ export interface DynamicallyAddedParameterProps {
 }
 
 export const DynamicallyAddedParameter = (props: DynamicallyAddedParameterProps): JSX.Element => {
-  const menuRef = React.useRef(null);
-
   const intl = useIntl();
   const menuButtonTitle = intl.formatMessage({
     defaultMessage: 'Menu',
@@ -68,7 +65,7 @@ export const DynamicallyAddedParameter = (props: DynamicallyAddedParameterProps)
       items: [
         {
           iconProps: { iconName: 'Delete' },
-          key: guid(),
+          key: 'dynamicallyaddedparameter_menu_delete',
           text: deleteText,
           onClick: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, _item?: IContextualMenuItem) => {
             ev?.preventDefault();
@@ -77,7 +74,6 @@ export const DynamicallyAddedParameter = (props: DynamicallyAddedParameterProps)
             return true;
           },
         },
-        { key: 'divider_1', itemType: ContextualMenuItemType.Divider },
       ],
       gapSpace: 2,
       directionalHint: DirectionalHint.leftBottomEdge,
@@ -90,7 +86,6 @@ export const DynamicallyAddedParameter = (props: DynamicallyAddedParameterProps)
           iconProps={{ iconName: 'CollapseMenu' }}
           title={menuButtonTitle}
           aria-label={menuButtonTitle}
-          ref={menuRef}
           menuProps={menuProps}
         />
       </TooltipHost>


### PR DESCRIPTION
Bug: We were using a call to a guid() function to generate a key for the delete menu item. When the user mouses over the menu item, this causes a re-render which causes the guid() function to be called, and the menu item key to be changed -- this causes the menu to be collapsed.

Fix: This PR changes the menu item key to be a string constant. Also removes some dead code.

Before:
![GIF 4-25-2023 4-36-03 PM](https://user-images.githubusercontent.com/10837129/234430748-adffb1e6-01bd-4a07-8ff0-a9d625c90af0.gif)

After:
![GIF 4-25-2023 4-36-29 PM](https://user-images.githubusercontent.com/10837129/234430814-cb3ce8c6-fa19-4143-a66d-1e238125d3d4.gif)
