### PR TITLE
fix(powerautomate): Return empty schema object when manual trigger editor is initially loaded

### DIFF
--- a/libs/designer-ui/src/lib/dynamicallyaddedparameter/helper.ts
+++ b/libs/designer-ui/src/lib/dynamicallyaddedparameter/helper.ts
@@ -192,6 +192,24 @@ export function serialize(props: DynamicallyAddedParameterProps[]): ValueSegment
   ];
 }
 
+export function getEmptySchemaValueSegmentForInitialization() {
+  const rootObject = {
+    schema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  };
+
+  return [
+    {
+      id: guid(),
+      type: ValueSegmentType.LITERAL,
+      value: JSON.stringify(rootObject),
+    },
+  ];
+}
+
 export function createDynamicallyAddedParameterProperties(
   itemType: DynamicallyAddedParameterTypeType,
   schemaKey: string

--- a/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
+++ b/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
@@ -4,6 +4,7 @@ import {
   createDynamicallyAddedParameterProperties,
   deserialize,
   generateDynamicParameterKey,
+  getEmptySchemaValueSegmentForInitialization,
   serialize,
 } from '../dynamicallyaddedparameter/helper';
 import type { ValueSegment } from '../editor';
@@ -34,6 +35,15 @@ export const FloatingActionMenu = (props: FloatingActionMenuProps): JSX.Element 
     throw new ValidationException(ValidationErrorCode.INVALID_PARAMETERS, 'supportedTypes are necessary.');
   }
   const menuItems = getMenuItemsForDynamicAddedParameters(props.supportedTypes);
+
+  // Set an empty schema object in the value so that the object structure is what Flow-RP expects.
+  if (props.initialValue.length > 0 && !props.initialValue[0].value) {
+    const { onChange } = props;
+    if (onChange) {
+      const value = getEmptySchemaValueSegmentForInitialization();
+      onChange({ value });
+    }
+  }
 
   const intl = useIntl();
   const closeErrorButtonAriaLabel = intl.formatMessage({


### PR DESCRIPTION
Flow-RP expects there to be a schema object for the manual trigger when trying to save a flow. When there were no dynamic parameters added via manual trigger, this was causing flow save to fail.

This PR adds code to detect if the passed in valueSegment is empty, and creates and sets an empty schema object on it, if so.

Before:
![image](https://user-images.githubusercontent.com/10837129/234719452-f9d0cc39-b329-4ff4-a8a0-1955ac89843b.png)

After:
![image](https://user-images.githubusercontent.com/10837129/234719503-c1a2495e-d745-4e24-ba2c-62c9ae038227.png)
