### PR TITLE
feat(designer): Expose `validateParameter` helper function

### DIFF
--- a/libs/designer/src/lib/core/index.ts
+++ b/libs/designer/src/lib/core/index.ts
@@ -13,3 +13,4 @@ export { changePanelNode, clearPanel, switchToWorkflowParameters } from './state
 export { useSelectedNodeId } from './state/panel/panelSelectors';
 export { initializeServices } from './state/designerOptions/designerOptionsSlice';
 export { resetWorkflowState } from './state/global';
+export { validateParameter } from './utils/parameters/helper';


### PR DESCRIPTION
Power Automate needs to use the validateParameter helper function to validate the parameters before save.