### PR TITLE
fix(designer): Remove double quotation marks in parameters panel

### DIFF
--- a/libs/designer-ui/src/lib/workflowparameters/workflowparametersField.tsx
+++ b/libs/designer-ui/src/lib/workflowparameters/workflowparametersField.tsx
@@ -91,8 +91,8 @@ export const WorkflowparameterField = ({
 }: WorkflowparameterFieldProps): JSX.Element => {
   const [valueWarningMessage, setValueWarningMessage] = useState(getValueWarningMessage(definition.value, definition.type));
   const [type, setType] = useState(definition.type);
-  const [value, setValue] = useState<string | undefined>(stringifyValue(definition.value, definition.type));
-  const [defaultValue, setDefaultValue] = useState<string | undefined>(stringifyValue(definition.defaultValue, definition.type));
+  const [value, setValue] = useState<string | undefined>(definition.value);
+  const [defaultValue, setDefaultValue] = useState<string | undefined>(definition.defaultValue);
 
   const intl = useIntl();
 
@@ -359,8 +359,4 @@ function isSecureParameter(type?: string): boolean {
 
 function getValueWarningMessage(value?: string, type?: string): string | undefined {
   return isSecureParameter(type) && !!value ? format('Warning Message', type) : undefined;
-}
-
-function stringifyValue(value?: string, type?: string): string | undefined {
-  return type !== Constants.WORKFLOW_PARAMETER_SERIALIZED_TYPE.STRING ? JSON.stringify(value) : value;
 }


### PR DESCRIPTION
### Main Code Changes
- Remove `stringifyValue` function. It seems that the value is already a string, as a result JSON.stringify() was adding double quotation marks 
- Tried with all the data types

Closes #1892 

### Implementation

https://user-images.githubusercontent.com/102700317/235012103-d7bda150-d895-40cb-a4e9-688da258ad83.mov

