### PR TITLE
fix(designer): Update token picker location during scroll

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/plugins/tokenpickerbutton/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/plugins/tokenpickerbutton/index.tsx
@@ -31,6 +31,7 @@ export const TokenPickerButton = ({ showOnLeft, openTokenPicker }: TokenPickerBu
   const [editor] = useLexicalComposerContext();
   const [anchorKey, setAnchorKey] = useState<NodeKey | null>(null);
   const boxRef = useRef<HTMLDivElement>(null);
+  const panel = document.getElementsByClassName('ms-Panel-scrollableContent')[0];
 
   const updateAnchorPoint = useCallback(() => {
     editor.getEditorState().read(() => {
@@ -71,11 +72,13 @@ export const TokenPickerButton = ({ showOnLeft, openTokenPicker }: TokenPickerBu
 
   useEffect(() => {
     window.addEventListener('resize', updatePosition);
+    panel?.addEventListener('scroll', updatePosition);
 
     return () => {
       window.removeEventListener('resize', updatePosition);
+      panel?.removeEventListener('scroll', updatePosition);
     };
-  }, [editor, updatePosition]);
+  }, [editor, updatePosition, panel]);
 
   useLayoutEffect(() => {
     updatePosition();


### PR DESCRIPTION
Add Event Listener for scroll action on the side panel, so the token picker button will have updated location when the panel is scrolled.
Current behavior:
![tok](https://user-images.githubusercontent.com/84426548/235198231-9c5eeaf4-b435-44c0-8869-860ff8b35200.gif)
Behavior after fix;
![token_afterFix](https://user-images.githubusercontent.com/84426548/235198772-577e7f35-ddc2-48ee-9ac2-e156c31abd02.gif)
