### PR TITLE
fix(powerautomate): Update manual trigger serialization to match manifest and render only dynamically added parameters

### DIFF
--- a/libs/designer-ui/src/lib/dynamicallyaddedparameter/helper.ts
+++ b/libs/designer-ui/src/lib/dynamicallyaddedparameter/helper.ts
@@ -136,11 +136,11 @@ export function deserialize(value: ValueSegment[]): DynamicallyAddedParameterPro
   const rootObject = JSON.parse(value[0].value);
 
   const retval: DynamicallyAddedParameterProps[] = [];
-  for (const [schemaKey, propertiesUnknown] of Object.entries(rootObject?.schema?.properties)) {
+  for (const [schemaKey, propertiesUnknown] of Object.entries(rootObject?.properties)) {
     const properties = propertiesUnknown as IDynamicallyAddedParameterProperties;
     if (properties) {
       const icon = getIconForDynamicallyAddedParameterType(properties['x-ms-content-hint'] as DynamicallyAddedParameterTypeType);
-      const required = rootObject?.schema?.required?.includes(schemaKey);
+      const required = rootObject?.required?.includes(schemaKey);
       retval.push({
         icon,
         schemaKey,
@@ -176,11 +176,9 @@ export function serialize(props: DynamicallyAddedParameterProps[]): ValueSegment
     }, {});
 
   const rootObject = {
-    schema: {
-      type: 'object',
-      properties,
-      required: requiredArray,
-    },
+    type: 'object',
+    properties,
+    required: requiredArray,
   };
 
   return [
@@ -194,11 +192,9 @@ export function serialize(props: DynamicallyAddedParameterProps[]): ValueSegment
 
 export function getEmptySchemaValueSegmentForInitialization() {
   const rootObject = {
-    schema: {
-      type: 'object',
-      properties: {},
-      required: [],
-    },
+    type: 'object',
+    properties: {},
+    required: [],
   };
 
   return [

--- a/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
+++ b/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
@@ -209,12 +209,12 @@ export const FloatingActionMenu = (props: FloatingActionMenuProps): JSX.Element 
     <>
       <div className="msla-dynamic-added-params-container">
         {dynamicParameterProps.map((props) =>
-          props.properties['x-ms-dynamically-added'] === true ? <DynamicallyAddedParameter {...props} key={props.schemaKey} /> : undefined
+          props.properties['x-ms-dynamically-added'] === true ? <DynamicallyAddedParameter {...props} key={props.schemaKey} /> : null
         )}
       </div>
       <div className="msla-floating-action-menu-container">
-        {!expanded ? renderMenuButton() : undefined}
-        {expanded ? renderMenuItems() : undefined}
+        {!expanded ? renderMenuButton() : null}
+        {expanded ? renderMenuItems() : null}
       </div>
     </>
   );

--- a/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
+++ b/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
@@ -208,9 +208,9 @@ export const FloatingActionMenu = (props: FloatingActionMenuProps): JSX.Element 
   return (
     <>
       <div className="msla-dynamic-added-params-container">
-        {dynamicParameterProps.map((props) => (
-          <DynamicallyAddedParameter {...props} key={props.schemaKey} />
-        ))}
+        {dynamicParameterProps.map((props) =>
+          props.properties['x-ms-dynamically-added'] === true ? <DynamicallyAddedParameter {...props} key={props.schemaKey} /> : undefined
+        )}
       </div>
       <div className="msla-floating-action-menu-container">
         {!expanded ? renderMenuButton() : undefined}


### PR DESCRIPTION
Changes in this PR:
- Update serialization and deserialization of manual trigger parameters to match updated manifest (PR: https://msazure.visualstudio.com/One/_git/Flow-RP/pullrequest/8032179)
- Render parameters only if `x-ms-dynamically-added` is true -- this is set to true for all user-defined parameters (as opposed to static parameters from Flow-RP).