### PR TITLE
fix(designer): Disable action type dropdown when is trigger node

### DIFF
--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
@@ -1,11 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 /* eslint-disable react/jsx-no-literals */
 import { DesignerSearchBox } from '../../../searchbox';
-import { Checkbox, Icon, IconButton, Link, Text } from '@fluentui/react';
+import { Checkbox } from '@fluentui/react';
 import type { IDropdownOption } from '@fluentui/react/lib/Dropdown';
-import { Dropdown, DropdownMenuItemType } from '@fluentui/react/lib/Dropdown';
-import { useCallback } from 'react';
+import { Dropdown } from '@fluentui/react/lib/Dropdown';
 import { useIntl } from 'react-intl';
 
 interface OperationSearchHeaderProps {
@@ -49,7 +46,12 @@ export const OperationSearchHeader = (props: OperationSearchHeaderProps) => {
   ];
 
   const actionTypeFilters = isTriggerNode
-    ? []
+    ? [
+        {
+          key: 'actionType-triggers',
+          text: intl.formatMessage({ defaultMessage: 'Triggers', description: 'Filter by Triggers category of connectors' }),
+        },
+      ]
     : [
         {
           key: 'actionType-triggers',
@@ -103,6 +105,7 @@ export const OperationSearchHeader = (props: OperationSearchHeaderProps) => {
           onChange={onChange}
           multiSelect
           options={actionTypeFilters}
+          disabled={isTriggerNode}
         />
       </div>
       {searchTerm ? (

--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-literals */
 import { DesignerSearchBox } from '../../../searchbox';
 import { Checkbox } from '@fluentui/react';
 import type { IDropdownOption } from '@fluentui/react/lib/Dropdown';
@@ -110,7 +109,6 @@ export const OperationSearchHeader = (props: OperationSearchHeaderProps) => {
       </div>
       {searchTerm ? (
         <div className="msla-flex-row">
-          {/* <span className="msla-search-heading-text">{searchResultsText}</span> */}
           <Checkbox label={groupByConnectorLabelText} onChange={onGroupToggleChange} checked={isGrouped} />
         </div>
       ) : null}


### PR DESCRIPTION
### Main Code Changes
- Disable action type dropdown when is trigger node
- Show `Triggers` as placeholder for this scenario
- Remove unused lines of code

Closes #2101 


### Implementation
- Action type filter is disabled and with triggers option as placeholder
<img width="1462" alt="Screenshot 2023-04-28 at 10 31 43 AM" src="https://user-images.githubusercontent.com/102700317/235215541-76c9bcf7-d6fb-4b3a-9ac3-f43469967b24.png">


https://user-images.githubusercontent.com/102700317/235216055-67b06a97-2f2f-4bf5-85c7-9aadb27ca89b.mov


