### PR TITLE
fix(designer): add parameter to specify whether the workflow graph should be recreated #2175

### DIFF
--- a/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
@@ -14,15 +14,16 @@ export interface BJSWorkflowProviderProps {
   workflow: Workflow;
   runInstance?: LogicAppsV2.RunInstanceDefinition | null;
   children?: React.ReactNode;
+  shouldRecreateWorkflowGraph?: boolean;
 }
 
-const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({ workflow, children, runInstance }) => {
+const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({ workflow, children, runInstance, shouldRecreateWorkflowGraph }) => {
   const dispatch = useDispatch<AppDispatch>();
   useEffect(() => {
     dispatch(initWorkflowSpec('BJS'));
     dispatch(initRunInstance(runInstance ?? null));
-    dispatch(initializeGraphState({ workflowDefinition: workflow, runInstance }));
-  }, [dispatch, workflow, runInstance]);
+    dispatch(initializeGraphState({ workflowDefinition: workflow, runInstance, shouldRecreateWorkflowGraph }));
+  }, [dispatch, workflow, runInstance, shouldRecreateWorkflowGraph]);
 
   return <>{children}</>;
 };

--- a/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
+++ b/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
@@ -13,7 +13,11 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 export const initializeGraphState = createAsyncThunk<
   DeserializedWorkflow,
-  { workflowDefinition: Workflow; runInstance: LogicAppsV2.RunInstanceDefinition | null | undefined },
+  {
+    workflowDefinition: Workflow;
+    runInstance: LogicAppsV2.RunInstanceDefinition | null | undefined;
+    shouldRecreateWorkflowGraph?: boolean;
+  },
   { state: RootState }
 >(
   'parser/deserialize',

--- a/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
+++ b/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
@@ -32,7 +32,7 @@ export const initializeGraphState = createAsyncThunk<
       getConnectionsQuery();
       const { definition, connectionReferences, parameters } = workflowDefinition;
       const deserializedWorkflow = BJSDeserialize(definition, runInstance);
-      if (shouldRecreateWorkflowGraph && workflow.graph) {
+      if (shouldRecreateWorkflowGraph === false && workflow.graph) {
         deserializedWorkflow.graph = workflow.graph;
       }
       thunkAPI.dispatch(initializeConnectionReferences(connectionReferences ?? {}));

--- a/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
+++ b/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
@@ -13,11 +13,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 export const initializeGraphState = createAsyncThunk<
   DeserializedWorkflow,
-  {
-    workflowDefinition: Workflow;
-    runInstance: LogicAppsV2.RunInstanceDefinition | null | undefined;
-    shouldRecreateWorkflowGraph?: boolean;
-  },
+  { workflowDefinition: Workflow; runInstance: LogicAppsV2.RunInstanceDefinition | null | undefined },
   { state: RootState }
 >(
   'parser/deserialize',
@@ -36,9 +32,7 @@ export const initializeGraphState = createAsyncThunk<
       getConnectionsQuery();
       const { definition, connectionReferences, parameters } = workflowDefinition;
       const deserializedWorkflow = BJSDeserialize(definition, runInstance);
-      // The host can specify whether the workflow graph should be recreated. This is used for scenarios where
-      // the flow is already loaded into the designer and recreating it will modify the existing node dimensions
-      if (shouldRecreateWorkflowGraph === false && workflow.graph) {
+      if (shouldRecreateWorkflowGraph && workflow.graph) {
         deserializedWorkflow.graph = workflow.graph;
       }
       thunkAPI.dispatch(initializeConnectionReferences(connectionReferences ?? {}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.12.0",
+  "version": "2.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.12.0",
+      "version": "2.14.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.14.0",
+  "version": "2.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.14.0",
+      "version": "2.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
The host can specify whether the workflow graph should be recreated. This is used for scenarios where the flow is already loaded into the designer and recreating it will modify the existing node dimensions.

Before the fix:
![image](https://user-images.githubusercontent.com/12244548/235025886-8d7b3327-3d08-4347-9c16-65ed4b9700a8.png)

After the fix:
![image](https://user-images.githubusercontent.com/12244548/235025645-1f4b5302-69bc-4d98-aefe-73c7e6b324f3.png)

Fixes https://github.com/Azure/LogicAppsUX/issues/2175