### PR TITLE
fix(openapi): Make parameters optional in OpenAPI builder

### DIFF
--- a/libs/designer/src/lib/core/utils/openapi/__test__/inputsbuilder.test.ts
+++ b/libs/designer/src/lib/core/utils/openapi/__test__/inputsbuilder.test.ts
@@ -1,0 +1,69 @@
+import type { OpenApiConnectionSerializedInputs } from '../inputsbuilder';
+import { OpenApiOperationInputsBuilder } from '../inputsbuilder';
+
+describe('OpenApiOperationInputsBuilder', () => {
+  describe('loadStaticInputValuesFromDefinition', () => {
+    test('handles undefined definition', () => {
+      const builder = new OpenApiOperationInputsBuilder();
+
+      const inputParameters = [{ key: 'inputs.$.to', name: 'to', type: 'string' }];
+      const result = builder.loadStaticInputValuesFromDefinition(undefined, inputParameters);
+
+      expect(result).toEqual(inputParameters);
+    });
+
+    test('handles undefined parameters', () => {
+      const builder = new OpenApiOperationInputsBuilder();
+
+      const inputParameters = [{ key: 'inputs.$.to', name: 'to', type: 'string' }];
+      const result = builder.loadStaticInputValuesFromDefinition(
+        { authentication: '@parameters("$authentication")', host: {} } as OpenApiConnectionSerializedInputs,
+        inputParameters
+      );
+
+      expect(result).toEqual(inputParameters);
+    });
+
+    test('handles parameters using name', () => {
+      const builder = new OpenApiOperationInputsBuilder();
+
+      const inputParameters = [{ key: 'inputs.$.to', name: 'to', type: 'string' }];
+      const result = builder.loadStaticInputValuesFromDefinition(
+        {
+          authentication: '@parameters("$authentication")',
+          host: {},
+          parameters: { toAliased: '1', to: '2' },
+        } as OpenApiConnectionSerializedInputs,
+        inputParameters
+      );
+
+      expect(result).toEqual([
+        {
+          ...inputParameters[0],
+          value: '2',
+        },
+      ]);
+    });
+
+    test('handles parameters using alias', () => {
+      const builder = new OpenApiOperationInputsBuilder();
+
+      const inputParameters = [{ alias: 'toAliased', key: 'inputs.$.to', name: 'to', type: 'string' }];
+      const result = builder.loadStaticInputValuesFromDefinition(
+        {
+          authentication: '@parameters("$authentication")',
+          host: {},
+          parameters: { toAliased: '1', to: '2' },
+        } as OpenApiConnectionSerializedInputs,
+        inputParameters
+      );
+
+      expect(result).toEqual([
+        {
+          ...inputParameters[0],
+          value: '1',
+        },
+      ]);
+    });
+  });
+});

--- a/libs/designer/src/lib/core/utils/openapi/inputsbuilder.ts
+++ b/libs/designer/src/lib/core/utils/openapi/inputsbuilder.ts
@@ -1,7 +1,7 @@
 import type { InputParameter } from '@microsoft/parsers-logic-apps';
 
 export interface OpenApiConnectionSerializedInputs {
-  parameters: Record<string, unknown>;
+  parameters?: Record<string, unknown>;
 }
 
 export class OpenApiOperationInputsBuilder {
@@ -16,7 +16,7 @@ export class OpenApiOperationInputsBuilder {
     inputsInDefinition: OpenApiConnectionSerializedInputs | undefined,
     inputParameters: InputParameter[]
   ): InputParameter[] {
-    if (!inputsInDefinition) {
+    if (!inputsInDefinition?.parameters) {
       return inputParameters;
     }
 


### PR DESCRIPTION
Code added in [`openapi/inputsbuilder.ts`](https://github.com/Azure/LogicAppsUX/pull/1721/files#diff-75eeb5274c2d267589ddfb8d49e94407030df7fa8594036767f45a82f5c46694) in #1721 was based on the v1 designer which handles parameters differently. In v1, parameters are always truthy (`{}` is passed if no parameters are set). However, v3 designer does not do this, resulting in an uncaught error when `inputsInDefinition.parameters` is falsy:

![image](https://user-images.githubusercontent.com/1350074/235269971-0cd5f390-2744-4819-97fc-13cdb0eb9117.png)

This PR makes `parameters` nullable and adds a check in `_loadKnownParametersFromDefinition` to verify that they are set.