### PR TITLE
fix(designer):  Fix focus on comment box when comment is empty

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelheader/panelheadercomment.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheadercomment.tsx
@@ -5,7 +5,7 @@ import { Icon } from '@fluentui/react/lib/Icon';
 import type { ITextField, ITextFieldStyles } from '@fluentui/react/lib/TextField';
 import { TextField } from '@fluentui/react/lib/TextField';
 import { css } from '@fluentui/react/lib/Utilities';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 export interface PanelHeaderCommentProps {
@@ -32,7 +32,7 @@ export const PanelHeaderComment = ({
   const intl = useIntl();
 
   const [commentHasFocus, setCommentHasFocus] = useState(false);
-  const commentTextFieldRef = React.createRef<ITextField>();
+  const commentTextFieldRef = useRef<ITextField>(null);
 
   const commentLabel = intl.formatMessage({
     defaultMessage: 'Comment',


### PR DESCRIPTION
### Main Code Changes
- Changed `createRef` implementation to `useRef` to not be updated every render. 

### Reason for issue
- `createRef` was updating/creating a new ref object every time the component was rendering. 
Close #2161 

### Implementation 
- Focus on comment box when clickin in `Add a note`.
- Able to show tooltip when comment box is empty.
- Been able to navigate by keyboard to panel.

https://user-images.githubusercontent.com/102700317/235521326-956d1a25-a25c-4a50-86ba-dccec7fc1ce8.mov

- When changing to another node and going back to the node with a comment, comment box gets focused.

https://user-images.githubusercontent.com/102700317/235522260-9291fde8-5f89-43b6-bb61-8e4335d3cc7c.mov

- When collapse and expand panel, menu button gets focused and user is able to navigate to comment box.

https://user-images.githubusercontent.com/102700317/235522554-0d604a96-6818-4ba1-b5d8-9c136147cd8e.mov

