### PR TITLE
fix(designer): Add a new connection host enum type for hybrid trigger

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -517,6 +517,10 @@ interface OpenApiConnectionInfo {
   host: LogicAppsV2.OpenApiConnectionHost;
 }
 
+interface HybridTriggerConnectionInfo {
+  host: LogicAppsV2.HybridTriggerConnectionHost;
+}
+
 interface ServiceProviderConnectionConfigInfo {
   serviceProviderConfiguration: {
     connectionName: string;
@@ -529,7 +533,13 @@ const serializeHost = (
   nodeId: string,
   manifest: OperationManifest,
   rootState: RootState
-): FunctionConnectionInfo | ApiManagementConnectionInfo | OpenApiConnectionInfo | ServiceProviderConnectionConfigInfo | undefined => {
+):
+  | FunctionConnectionInfo
+  | ApiManagementConnectionInfo
+  | OpenApiConnectionInfo
+  | ServiceProviderConnectionConfigInfo
+  | HybridTriggerConnectionInfo
+  | undefined => {
   if (!manifest.properties.connectionReference) {
     return undefined;
   }
@@ -566,6 +576,14 @@ const serializeHost = (
           connectionName: referenceKey,
           operationId,
           serviceProviderId: connectorId,
+        },
+      };
+    case ConnectionReferenceKeyFormat.HybridTrigger:
+      return {
+        host: {
+          connection: {
+            name: "@parameters('$connections')[" + referenceKey + "]['connectionId']",
+          },
         },
       };
     default:

--- a/libs/utils/src/lib/models/logicAppsV2.ts
+++ b/libs/utils/src/lib/models/logicAppsV2.ts
@@ -112,6 +112,14 @@ export interface OpenApiConnectionHost {
   connection: ApiConnectionHostConnection;
 }
 
+export interface HybridTriggerConnectionHost {
+  connection: HybridTriggerConnectionHostType;
+}
+
+export interface HybridTriggerConnectionHostType {
+  name: ApiConnectionHostConnection;
+}
+
 export interface ApiConnectionHostType {
   api: ApiConnectionHostApi;
   connection: ApiConnectionHostConnection;

--- a/libs/utils/src/lib/models/operationmanifest.ts
+++ b/libs/utils/src/lib/models/operationmanifest.ts
@@ -57,6 +57,7 @@ export enum ConnectionReferenceKeyFormat {
   Function = 'function',
   OpenApi = 'openapi',
   ServiceProvider = 'serviceprovider',
+  HybridTrigger = 'hybridtrigger',
 }
 
 export interface ActionSetting {


### PR DESCRIPTION
Adding new connection host type for hybrid triggers:
Connection host for hybrid triggers in existing v1:
![image](https://user-images.githubusercontent.com/91710207/235571883-12f13b33-cc77-4bae-a03d-d1c8bcd6111e.png)
