### PR TITLE
fix(designer): Fix expression for dynamic trigger output tokens

### DIFF
--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -416,7 +416,13 @@ export const loadDynamicOutputsInNode = async (
         dispatch(
           addDynamicTokens({
             nodeId,
-            tokens: convertOutputsToTokens(nodeId, operationInfo.type, dynamicOutputs, { iconUri, brandColor }, settings),
+            tokens: convertOutputsToTokens(
+              isTrigger ? undefined : nodeId,
+              operationInfo.type,
+              dynamicOutputs,
+              { iconUri, brandColor },
+              settings
+            ),
           })
         );
       }


### PR DESCRIPTION
Dynamic tokens for trigger outputs have actionName in the outputInfo:
![image](https://user-images.githubusercontent.com/8736762/235577523-ea73889f-ad27-4075-99f3-70d96e939e89.png)

This causes the trigger outputs to get converted into @body('trigger_name') format which is invalid:
![image](https://user-images.githubusercontent.com/8736762/235577595-9213e46c-1a6a-4859-9411-453913a93243.png)

This PR fixes the issue by not setting actionName if the operation is a trigger. This makes the dynamic token show up as @triggerBody() instead:
![image](https://user-images.githubusercontent.com/8736762/235578756-6468426c-b8af-478f-a07a-36c530a38797.png)
