### PR TITLE
fix(designer): Dynamic content was incorrectly cached for swagger based operations

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -320,15 +320,7 @@ export async function getFolderItems(
       connectionReference as ConnectionReference
     );
 
-    return getLegacyDynamicTreeItems(
-      connectionId,
-      connectorId,
-      operationId,
-      inputs,
-      definition.extension,
-      filePickerInfo,
-      managedIdentityRequestProperties
-    );
+    return getLegacyDynamicTreeItems(connectionId, connectorId, operationId, inputs, filePickerInfo, managedIdentityRequestProperties);
   }
 
   throw new UnsupportedException(`Dynamic extension '${definition.type}' is not implemented yet or not supported`);

--- a/libs/services/designer-client-services/src/lib/base/connector.ts
+++ b/libs/services/designer-client-services/src/lib/base/connector.ts
@@ -1,17 +1,11 @@
-import type { IConnectorService, ListDynamicValue, ManagedIdentityRequestProperties, TreeDynamicValue } from '../connector';
+import type { IConnectorService, ListDynamicValue, ManagedIdentityRequestProperties } from '../connector';
 import { getClientRequestIdFromHeaders, pathCombine } from '../helpers';
 import type { IHttpClient } from '../httpClient';
 import { getIntl } from '@microsoft/intl-logic-apps';
-import type { FilePickerInfo, LegacyDynamicSchemaExtension, LegacyDynamicValuesExtension } from '@microsoft/parsers-logic-apps';
-import { Types } from '@microsoft/parsers-logic-apps';
 import type { OpenAPIV2, OperationInfo } from '@microsoft/utils-logic-apps';
 import {
-  getPropertyValue,
   UnsupportedException,
-  getJSONValue,
-  getObjectPropertyValue,
   isArmResourceId,
-  isNullOrUndefined,
   ArgumentException,
   ConnectorServiceErrorCode,
   ConnectorServiceException,
@@ -58,44 +52,13 @@ export abstract class BaseConnectorService implements IConnectorService {
     }
   }
 
-  async getLegacyDynamicValues(
+  async getLegacyDynamicContent(
     connectionId: string,
     connectorId: string,
     parameters: Record<string, any>,
-    extension: LegacyDynamicValuesExtension,
-    parameterArrayType: string,
     managedIdentityProperties?: ManagedIdentityRequestProperties
-  ): Promise<ListDynamicValue[]> {
-    const response = await this._executeAzureDynamicApi(connectionId, connectorId, parameters, managedIdentityProperties);
-    const values = getObjectPropertyValue(response, extension['value-collection'] ? extension['value-collection'].split('/') : []);
-    if (values && values.length) {
-      return values.map((property: any) => {
-        let value: any, displayName: any;
-        let isSelectable = true;
-
-        if (parameterArrayType && parameterArrayType !== Types.Object) {
-          displayName = value = getJSONValue(property);
-        } else {
-          value = getObjectPropertyValue(property, extension['value-path'].split('/'));
-          displayName = extension['value-title'] ? getObjectPropertyValue(property, extension['value-title'].split('/')) : value;
-        }
-
-        const description = extension['value-description']
-          ? getObjectPropertyValue(property, extension['value-description'].split('/'))
-          : undefined;
-
-        if (extension['value-selectable']) {
-          const selectableValue = getObjectPropertyValue(property, extension['value-selectable'].split('/'));
-          if (!isNullOrUndefined(selectableValue)) {
-            isSelectable = selectableValue;
-          }
-        }
-
-        return { value, displayName, description, disabled: !isSelectable };
-      });
-    }
-
-    return response;
+  ): Promise<any> {
+    return this._executeAzureDynamicApi(connectionId, connectorId, parameters, managedIdentityProperties);
   }
 
   async getListDynamicValues(
@@ -132,28 +95,6 @@ export abstract class BaseConnectorService implements IConnectorService {
       content: { parameters: invokeParameters, configuration },
     });
     return this._getResponseFromDynamicApi(response, uri);
-  }
-
-  async getLegacyDynamicSchema(
-    connectionId: string,
-    connectorId: string,
-    parameters: Record<string, any>,
-    extension: LegacyDynamicSchemaExtension,
-    managedIdentityProperties?: ManagedIdentityRequestProperties
-  ): Promise<OpenAPIV2.SchemaObject | null> {
-    const response = await this._executeAzureDynamicApi(connectionId, connectorId, parameters, managedIdentityProperties);
-
-    if (!response) {
-      return null;
-    }
-
-    const schemaPath = extension['value-path'] ? extension['value-path'].split('/') : undefined;
-    return schemaPath
-      ? getObjectPropertyValue(
-          response,
-          schemaPath.length && equals(schemaPath[schemaPath.length - 1], 'properties') ? schemaPath.splice(-1, 1) : schemaPath
-        ) ?? null
-      : { properties: response, type: Types.Object };
   }
 
   async getDynamicSchema(
@@ -194,32 +135,6 @@ export abstract class BaseConnectorService implements IConnectorService {
       content: { parameters: invokeParameters, configuration },
     });
     return this._getResponseFromDynamicApi(response, uri);
-  }
-
-  async getLegacyDynamicTreeItems(
-    connectionId: string,
-    connectorId: string,
-    parameters: Record<string, any>,
-    extension: LegacyDynamicValuesExtension,
-    pickerInfo: FilePickerInfo,
-    managedIdentityProperties?: ManagedIdentityRequestProperties
-  ): Promise<TreeDynamicValue[]> {
-    const response = await this._executeAzureDynamicApi(connectionId, connectorId, parameters, managedIdentityProperties);
-    const { collectionPath, titlePath, folderPropertyPath, mediaPropertyPath } = pickerInfo;
-    const values = collectionPath ? getPropertyValue(response, collectionPath) : response;
-
-    if (values && values.length) {
-      return values.map((value: any) => {
-        return {
-          value,
-          displayName: getPropertyValue(value, titlePath as string),
-          isParent: !!getPropertyValue(value, folderPropertyPath as string),
-          mediaType: mediaPropertyPath ? getPropertyValue(value, mediaPropertyPath) : undefined,
-        };
-      });
-    }
-
-    return response;
   }
 
   protected _isClientSupportedOperation(connectorId: string, operationId: string): boolean {

--- a/libs/services/designer-client-services/src/lib/connector.ts
+++ b/libs/services/designer-client-services/src/lib/connector.ts
@@ -1,4 +1,3 @@
-import type { FilePickerInfo, LegacyDynamicSchemaExtension, LegacyDynamicValuesExtension } from '@microsoft/parsers-logic-apps';
 import type { OpenAPIV2 } from '@microsoft/utils-logic-apps';
 import { AssertionErrorCode, AssertionException } from '@microsoft/utils-logic-apps';
 
@@ -30,23 +29,19 @@ export interface ManagedIdentityRequestProperties {
 
 export interface IConnectorService {
   /**
-   * Gets the item dynamic values for azure operations backed by swagger.
+   * Gets the dynamic content for values/schema/tree items for azure operations backed by swagger.
    * @arg {string} connectionId - The connection id.
    * @arg {string} connectorId - The connector id.
    * @arg {Record<string, any>} parameters - The operation parameters. Keyed by parameter name.
-   * @arg {LegacyDynamicValuesExtension} extension - Dynamic value extension.
-   * @arg {string} parameterArrayType - Dynamic values parameter collection array type.
    * @arg {ManagedIdentityRequestProperties} managedIdentityProperties - Data to be sent in request payload for managed identity connections.
-   * @return {Promise<ListDynamicValue[]>}
+   * @return {Promise<any>}
    */
-  getLegacyDynamicValues(
+  getLegacyDynamicContent(
     connectionId: string,
     connectorId: string,
     parameters: Record<string, any>,
-    extension: LegacyDynamicValuesExtension,
-    parameterArrayType: string,
     managedIdentityProperties?: ManagedIdentityRequestProperties
-  ): Promise<ListDynamicValue[]>;
+  ): Promise<any>;
 
   /**
    * Gets the item dynamic values for manifest based operations.
@@ -69,23 +64,6 @@ export interface IConnectorService {
   ): Promise<ListDynamicValue[]>;
 
   /**
-   * Gets the dynamic schema for a parameter in azure operations backed by swagger.
-   * @arg {string} connectionId - The connection id.
-   * @arg {string} connectorId - The connector id.
-   * @arg {Record<string, any>} parameters - The operation parameters. Keyed by parameter name.
-   * @arg {LegacyDynamicSchemaExtension} extension - Dynamic schema extension.
-   * @arg {ManagedIdentityRequestProperties} managedIdentityProperties - Data to be sent in request payload for managed identity connections.
-   * @return {Promise<OpenAPIV2.SchemaObject | null>}
-   */
-  getLegacyDynamicSchema(
-    connectionId: string,
-    connectorId: string,
-    parameters: Record<string, any>,
-    extension: LegacyDynamicSchemaExtension,
-    managedIdentityProperties?: ManagedIdentityRequestProperties
-  ): Promise<OpenAPIV2.SchemaObject | null>;
-
-  /**
    * Gets the dynamic schema for a parameter in manifest based operations.
    * @arg {string | undefined} connectionId - The connection id.
    * @arg {string} connectorId - The connector id.
@@ -104,25 +82,6 @@ export interface IConnectorService {
     dynamicState: any,
     nodeMetadata: any
   ): Promise<OpenAPIV2.SchemaObject>;
-
-  /**
-   * Gets the tree dynamic values for azure operations backed by swagger.
-   * @arg {string} connectionId - The connection id.
-   * @arg {string} connectorId - The connector id.
-   * @arg {Record<string, any>} parameters - The operation parameters. Keyed by parameter name.
-   * @arg {LegacyDynamicValuesExtension} extension - Dynamic value extension.
-   * @arg {FilePickerInfo} pickerInfo - File picker info from swagger.
-   * @arg {ManagedIdentityRequestProperties} managedIdentityProperties - Data to be sent in request payload for managed identity connections.
-   * @return {Promise<TreeDynamicValue[]>}
-   */
-  getLegacyDynamicTreeItems(
-    connectionId: string,
-    connectorId: string,
-    parameters: Record<string, any>,
-    extension: LegacyDynamicValuesExtension,
-    pickerInfo: FilePickerInfo,
-    managedIdentityProperties?: ManagedIdentityRequestProperties
-  ): Promise<TreeDynamicValue[]>;
 }
 
 let service: IConnectorService;


### PR DESCRIPTION
Removing explicit legacy dynamic call methods from connector service and having one single method since it only calls connector with connection details and parameters.
All the filtering and repsonse manipulation code is moved in the caller since it was caching incorrect data for same response but different response selectors.