### PR TITLE
fix(designer): Adding support for items token and updating repetition context for token addition

### DIFF
--- a/libs/designer-ui/src/lib/editor/models/parameter.ts
+++ b/libs/designer-ui/src/lib/editor/models/parameter.ts
@@ -87,6 +87,7 @@ export interface Token {
   key: string;
   name?: string;
   required?: boolean;
+  schema?: OpenAPIV2.SchemaObject;
   source?: string;
   title: string;
   tokenType: TokenType;

--- a/libs/designer-ui/src/lib/tokenpicker/models/token.ts
+++ b/libs/designer-ui/src/lib/tokenpicker/models/token.ts
@@ -21,6 +21,7 @@ export interface Token {
       itemSchema?: OpenAPIV2.SchemaObject;
       parentArray?: string;
     };
+    schema?: OpenAPIV2.SchemaObject;
     actionName?: string;
     functionName?: string; // For now, the only allowed values are 'variables' and 'parameters'.
     functionArguments?: string[]; //For now, the only allowed values are 'variables' and 'parameters'.

--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -2,6 +2,7 @@ import { getInputDependencies } from '../../actions/bjsworkflow/initialize';
 import type { Settings } from '../../actions/bjsworkflow/settings';
 import type { NodeStaticResults } from '../../actions/bjsworkflow/staticresults';
 import { StaticResultOption } from '../../actions/bjsworkflow/staticresults';
+import type { RepetitionContext } from '../../utils/parameters/helper';
 import { resetWorkflowState } from '../global';
 import type { ParameterInfo } from '@microsoft/designer-ui';
 import type { FilePickerInfo, InputParameter, OutputParameter, SwaggerParser } from '@microsoft/parsers-logic-apps';
@@ -29,6 +30,7 @@ export interface OutputInfo {
   name: string;
   parentArray?: string;
   required?: boolean;
+  schema?: OpenAPIV2.SchemaObject;
   source?: string;
   title: string;
   value?: string;
@@ -87,6 +89,7 @@ export interface OperationMetadataState {
   settings: Record<string, Settings>;
   actionMetadata: Record<string, any>;
   staticResults: Record<string, NodeStaticResults>;
+  repetitionInfos: Record<string, RepetitionContext>;
 }
 
 const initialState: OperationMetadataState = {
@@ -98,6 +101,7 @@ const initialState: OperationMetadataState = {
   operationMetadata: {},
   actionMetadata: {},
   staticResults: {},
+  repetitionInfos: {},
 };
 
 export interface AddNodeOperationPayload extends NodeOperation {
@@ -118,6 +122,7 @@ export interface NodeData {
   staticResult?: NodeStaticResults;
   settings?: Settings;
   actionMetadata?: Record<string, any>;
+  repetitionInfo?: RepetitionContext;
 }
 
 interface AddSettingsPayload {
@@ -166,7 +171,8 @@ export const operationMetadataSlice = createSlice({
       for (const nodeData of action.payload) {
         if (!nodeData) return;
 
-        const { id, nodeInputs, nodeOutputs, nodeDependencies, settings, operationMetadata, actionMetadata, staticResult } = nodeData;
+        const { id, nodeInputs, nodeOutputs, nodeDependencies, settings, operationMetadata, actionMetadata, staticResult, repetitionInfo } =
+          nodeData;
         state.inputParameters[id] = nodeInputs;
         state.outputParameters[id] = nodeOutputs;
         state.dependencies[id] = nodeDependencies;
@@ -175,11 +181,22 @@ export const operationMetadataSlice = createSlice({
         if (settings) {
           state.settings[id] = settings;
         }
+
         if (staticResult) {
           state.staticResults[id] = staticResult;
         }
-        if (actionMetadata) state.actionMetadata[id] = actionMetadata;
-        if (settings) state.settings[id] = settings;
+
+        if (actionMetadata) {
+          state.actionMetadata[id] = actionMetadata;
+        }
+
+        if (settings) {
+          state.settings[id] = settings;
+        }
+
+        if (repetitionInfo) {
+          state.repetitionInfos[id] = repetitionInfo;
+        }
       }
     },
     addDynamicInputs: (state, action: PayloadAction<AddDynamicInputsPayload>) => {
@@ -324,6 +341,13 @@ export const operationMetadataSlice = createSlice({
         ...actionMetadata,
       };
     },
+    updateRepetitionContext: (state, action: PayloadAction<{ id: string; repetition: RepetitionContext }>) => {
+      const { id, repetition } = action.payload;
+      state.repetitionInfos[id] = {
+        ...state.repetitionInfos[id],
+        ...repetition,
+      };
+    },
     deinitializeOperationInfo: (state, action: PayloadAction<{ id: string }>) => {
       const { id } = action.payload;
       delete state.operationInfo[id];
@@ -361,6 +385,7 @@ export const {
   removeParameterValidationError,
   updateOutputs,
   updateActionMetadata,
+  updateRepetitionContext,
   deinitializeOperationInfo,
   deinitializeNodes,
 } = operationMetadataSlice.actions;

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -50,6 +50,7 @@ export const toOutputInfo = (output: OutputParameter): OutputInfo => {
     itemSchema,
     parentArray,
     title,
+    schema,
     summary,
     description,
     source,
@@ -69,6 +70,7 @@ export const toOutputInfo = (output: OutputParameter): OutputInfo => {
     itemSchema,
     parentArray,
     title: title ?? summary ?? description ?? name,
+    schema,
     source,
     required,
     description,
@@ -273,7 +275,7 @@ export const getUpdatedManifestForSchemaDependency = (manifest: OperationManifes
           if (segment.type === ValueSegmentType.TOKEN) {
             // We only support getting schema from array tokens for now.
             if (segment.token?.type === Constants.SWAGGER.TYPE.ARRAY) {
-              schemaToReplace = segment.token.arrayDetails?.itemSchema ?? undefined;
+              schemaToReplace = segment.token.schema ?? undefined;
             }
           } else {
             // TODO - Add code to generate schema from value input

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -28,7 +28,7 @@ import type { WorkflowParameterDefinition } from '../../state/workflowparameters
 import type { RootState } from '../../store';
 import { initializeArrayViewModel } from '../editors/array';
 import { getAllParentsForNode, getFirstParentOfType, getTriggerNodeId } from '../graph';
-import { getParentArrayKey, isForeachActionNameForLoopsource } from '../loops';
+import { getParentArrayKey, isForeachActionNameForLoopsource, parseForeach } from '../loops';
 import { isOneOf } from '../openapi/schema';
 import { loadDynamicOutputsInNode } from '../outputs';
 import { hasSecureOutputs } from '../setting';
@@ -693,9 +693,7 @@ export function shouldIncludeSelfForRepetitionReference(manifest: OperationManif
 export function loadParameterValue(parameter: InputParameter): ValueSegment[] {
   const valueObject = parameter.isNotificationUrl ? `@${constants.HTTP_WEBHOOK_LIST_CALLBACK_URL_NAME}` : parameter.value;
 
-  let valueSegments = convertToValueSegments(valueObject, undefined /* repetitionContext */, !parameter.suppressCasting /* shouldUncast */);
-
-  // TODO - Need to set value display name correctly from metadata for file/folder picker.
+  let valueSegments = convertToValueSegments(valueObject, !parameter.suppressCasting /* shouldUncast */);
 
   valueSegments = compressSegments(valueSegments);
 
@@ -748,14 +746,9 @@ export function convertToTokenExpression(value: any): string {
   }
 }
 
-export function convertToValueSegments(
-  value: any,
-  repetitionContext: RepetitionContext | undefined,
-  shouldUncast: boolean
-): ValueSegment[] {
+export function convertToValueSegments(value: any, shouldUncast: boolean): ValueSegment[] {
   try {
     const convertor = new ValueSegmentConvertor({
-      repetitionContext,
       shouldUncast,
       rawModeEnabled: true,
     });
@@ -1757,7 +1750,7 @@ async function loadDynamicContentForInputsInNode(
           schema: input,
         })) as ParameterInfo[];
 
-        updateTokenMetadataInParameters(inputParameters, rootState);
+        updateTokenMetadataInParameters(nodeId, inputParameters, rootState);
 
         let swagger: SwaggerParser | undefined = undefined;
         if (!OperationManifestService().isSupported(operationInfo.type, operationInfo.kind)) {
@@ -2331,7 +2324,7 @@ function getClosestRepetitionReference(repetitionContext: RepetitionContext): Re
   return undefined;
 }
 
-export function updateTokenMetadataInParameters(parameters: ParameterInfo[], rootState: RootState): void {
+export function updateTokenMetadataInParameters(nodeId: string, parameters: ParameterInfo[], rootState: RootState): void {
   const {
     workflow: { operations, nodesMetadata },
     operations: { operationMetadata, outputParameters, settings },
@@ -2354,6 +2347,7 @@ export function updateTokenMetadataInParameters(parameters: ParameterInfo[], roo
     {}
   );
 
+  const repetitionContext = rootState.operations.repetitionInfos[nodeId];
   for (const parameter of parameters) {
     const segments = parameter.value;
 
@@ -2362,6 +2356,7 @@ export function updateTokenMetadataInParameters(parameters: ParameterInfo[], roo
         if (isTokenValueSegment(segment)) {
           return updateTokenMetadata(
             segment,
+            repetitionContext,
             actionNodes,
             triggerNodeId,
             nodesData,
@@ -2377,12 +2372,23 @@ export function updateTokenMetadataInParameters(parameters: ParameterInfo[], roo
     }
     const viewModel = parameter.editorViewModel;
     if (viewModel) {
-      flattenAndUpdateViewModel(viewModel, actionNodes, triggerNodeId, nodesData, operations, definitions, nodesMetadata, parameter.type);
+      flattenAndUpdateViewModel(
+        repetitionContext,
+        viewModel,
+        actionNodes,
+        triggerNodeId,
+        nodesData,
+        operations,
+        definitions,
+        nodesMetadata,
+        parameter.type
+      );
     }
   }
 }
 
 export const flattenAndUpdateViewModel = (
+  repetitionContext: RepetitionContext,
   items: any,
   actionNodes: Record<string, string>,
   triggerNodeId: string,
@@ -2399,6 +2405,7 @@ export const flattenAndUpdateViewModel = (
       if (!isTokenValueSegment(keyItem)) return keyItem;
       const valueSegmentToUpdate = updateTokenMetadata(
         keyItem,
+        repetitionContext,
         actionNodes,
         triggerNodeId,
         nodes,
@@ -2416,6 +2423,7 @@ export const flattenAndUpdateViewModel = (
   Object.entries(items).forEach(([itemKey, itemValue]) => {
     if (typeof itemValue === 'object') {
       replacedItems[itemKey] = flattenAndUpdateViewModel(
+        repetitionContext,
         itemValue,
         actionNodes,
         triggerNodeId,
@@ -2440,6 +2448,7 @@ export const flattenAndUpdateViewModel = (
 
 export function updateTokenMetadata(
   valueSegment: ValueSegment,
+  repetitionContext: RepetitionContext,
   actionNodes: Record<string, string>,
   triggerNodeId: string,
   nodes: Record<string, Partial<NodeDataWithOperationMetadata>>,
@@ -2474,14 +2483,24 @@ export function updateTokenMetadata(
       break;
   }
 
-  const { name, actionName, arrayDetails } = valueSegment.token as SegmentToken;
-  const tokenNodeId = actionName ? getPropertyValue(actionNodes, actionName) : triggerNodeId;
+  if (token.arrayDetails && repetitionContext) {
+    const repetitionReference = getRepetitionReference(repetitionContext, token.arrayDetails.loopSource);
+    const repetitionValue = repetitionReference?.repetitionValue;
+    const { step, path, fullPath } = parseForeach(repetitionValue, repetitionContext);
+    token.arrayDetails = {
+      ...token.arrayDetails,
+      parentArrayKey: fullPath,
+      parentArrayName: path,
+    };
+    token.actionName = step;
 
-  if (arrayDetails?.loopSource) {
-    // TODO - If the token comes from foreach with literal value, need to update tokenNodeId with foreach branding.
-    // Need to store repetition context in store to avoid re-calculation everytime.
+    if (!token.arrayDetails.loopSource && equals(repetitionReference?.actionType, constants.NODE.TYPE.FOREACH)) {
+      token.arrayDetails.loopSource = repetitionReference?.actionName;
+    }
   }
 
+  const { actionName, arrayDetails, name } = token;
+  const tokenNodeId = actionName ? getPropertyValue(actionNodes, actionName) : triggerNodeId;
   const { settings, nodeOutputs, operationMetadata } = nodes[tokenNodeId] ?? {};
   const tokenNodeOperation = operations[tokenNodeId];
   const nodeType = tokenNodeOperation?.type;
@@ -2533,7 +2552,9 @@ export function updateTokenMetadata(
     token.type = nodeOutputInfo.type;
     token.format = nodeOutputInfo.format;
     token.name = nodeOutputInfo.name;
+    token.schema = nodeOutputInfo.schema;
     token.description = nodeOutputInfo.description;
+    token.source = nodeOutputInfo.source;
     token.required = token.required !== undefined ? token.required : nodeOutputInfo.required;
 
     if (arrayDetails || outputInsideForeach) {
@@ -2602,7 +2623,7 @@ function getOutputByTokenInfo(
   const normalizedTokenName = decodePropertySegment(getNormalizedTokenName(name));
   for (const output of outputs) {
     const bothNotInArray = !arrayDetails && !output.isInsideArray;
-    const sameArray = equals(getNormalizedName(arrayDetails?.parentArrayName || ''), getNormalizedName(output.parentArray || ''));
+    const sameArray = isOutputInSameArray(tokenInfo, output);
     const sameName = decodePropertySegment(getNormalizedTokenName(output.name)) === normalizedTokenName;
     // Optional outputs end up getting ? added to their name. This should be stripped out on alias comparison.
     if (sameName && (sameArray || bothNotInArray)) {
@@ -2617,6 +2638,28 @@ function getOutputByTokenInfo(
   }
 
   return undefined;
+}
+
+function isOutputInSameArray(token: SegmentToken, output: OutputInfo): boolean {
+  const { source, arrayDetails } = token;
+  if (arrayDetails?.parentArrayName && output.parentArray && output.source !== source) {
+    const tokenArray =
+      source === OutputSource.Body && output.source === OutputSource.Outputs
+        ? arrayDetails.parentArrayName === OutputKeys.Body
+          ? 'body'
+          : `body.${arrayDetails.parentArrayName}`
+        : arrayDetails.parentArrayName;
+    const outputArray =
+      output.source === OutputSource.Body && source === OutputSource.Outputs
+        ? output.parentArray === OutputKeys.Body
+          ? 'body'
+          : `body.${output.parentArray}`
+        : output.parentArray;
+
+    return equals(getNormalizedName(tokenArray), getNormalizedName(outputArray));
+  } else {
+    return equals(getNormalizedName(arrayDetails?.parentArrayName || ''), getNormalizedName(output.parentArray || ''));
+  }
 }
 
 function getOutputsByType(allOutputs: OutputInfo[], type = constants.SWAGGER.TYPE.ANY): OutputInfo[] {

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -1,4 +1,3 @@
-import type { RepetitionContext } from './helper';
 import { VariableBrandColor, FxIcon, ParameterIcon, VariableIcon } from './helper';
 import { JsonSplitter } from './jsonsplitter';
 import { TokenSegmentConvertor } from './tokensegment';
@@ -20,11 +19,6 @@ import { format, guid, isNullOrUndefined, startsWith, UnsupportedException } fro
  * The options for value segment convertor.
  */
 export interface ValueSegmentConvertorOptions {
-  /**
-   * @member [RepetitionContext] repetitionContext - The repetition context.
-   */
-  repetitionContext?: RepetitionContext;
-
   /**
    * @member {boolean} shouldUncast - The value indicating whether uncasting should be done.
    */

--- a/libs/designer/src/lib/ui/panel/panelTabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/parametersTab/index.tsx
@@ -15,7 +15,6 @@ import { useNodeMetadata, useReplacedIds } from '../../../../core/state/workflow
 import type { AppDispatch, RootState } from '../../../../core/store';
 import { getConnectionReference } from '../../../../core/utils/connectors/connections';
 import { isRootNodeInGraph } from '../../../../core/utils/graph';
-import { addForeachToNode } from '../../../../core/utils/loops';
 import {
   loadDynamicTreeItemsForParameter,
   loadDynamicValuesForParameter,
@@ -237,18 +236,7 @@ const ParameterSection = ({
     token: OutputToken,
     addImplicitForeachIfNeeded: boolean
   ): Promise<ValueSegment> => {
-    const { segment, foreachDetails } = await createValueSegmentFromToken(
-      nodeId,
-      parameterId,
-      token,
-      addImplicitForeachIfNeeded,
-      rootState
-    );
-    if (foreachDetails) {
-      dispatch(addForeachToNode({ arrayName: foreachDetails.arrayValue, nodeId, token }));
-    }
-
-    return segment;
+    return createValueSegmentFromToken(nodeId, parameterId, token, addImplicitForeachIfNeeded, rootState, dispatch);
   };
 
   const getTokenPicker = (


### PR DESCRIPTION
Changes -
1. On every token addition, now we correctly identify the repetition context and loopsource on the token is updated correctly.
2. We calculate repetition context for all nodes during deserialization and store it. And on every token addition we update the repetition context for that node in the store.
3. Updates made in deserialization to correctly update token metadata for item and items token based on repetition context.