### PR TITLE
fix(designer): Use skipValidation to skip throwing errors in serializeWorkflow

### DIFF
--- a/apps/vs-code-designer-react/src/app/DesignerCommandBar/index.tsx
+++ b/apps/vs-code-designer-react/src/app/DesignerCommandBar/index.tsx
@@ -38,7 +38,7 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({ isRefres
   const { isLoading: isSaving, mutate: saveWorkflowMutate } = useMutation(async () => {
     const designerState = DesignerStore.getState();
     const { definition, parameters, connectionReferences } = await serializeBJSWorkflow(designerState, {
-      skipValidation: true,
+      skipValidation: false,
       ignoreNonCriticalErrors: true,
     });
     await vscode.postMessage({

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -58,26 +58,29 @@ export interface SerializeOptions {
 }
 
 export const serializeWorkflow = async (rootState: RootState, options?: SerializeOptions): Promise<Workflow> => {
-  const operationsWithSettingsErrors = (Object.entries(rootState.settings.validationErrors) ?? []).filter(
-    ([_id, errorArr]) => errorArr.length > 0
-  );
-  if (operationsWithSettingsErrors.length > 0) {
-    throw new Error(
-      'Workflow has settings validation errors on the following operations: ' +
-        operationsWithSettingsErrors.map(([id, _errorArr]) => id).join(', ')
+  if (!options?.skipValidation) {
+    const operationsWithSettingsErrors = (Object.entries(rootState.settings.validationErrors) ?? []).filter(
+      ([_id, errorArr]) => errorArr.length > 0
     );
-  }
+    if (operationsWithSettingsErrors.length > 0) {
+      throw new Error(
+        'Workflow has settings validation errors on the following operations: ' +
+          operationsWithSettingsErrors.map(([id, _errorArr]) => id).join(', ')
+      );
+    }
 
-  const operationsWithParameterErrors = (Object.entries(rootState.operations.inputParameters) ?? []).filter(
-    ([_id, nodeInputs]: [id: string, i: NodeInputs]) =>
-      Object.values(nodeInputs.parameterGroups).some((parameterGroup: ParameterGroup) =>
-        parameterGroup.parameters.some((parameter: ParameterInfo) => (parameter?.validationErrors?.length ?? 0) > 0)
-      )
-  );
-  if (operationsWithParameterErrors.length > 0) {
-    throw new Error(
-      'Workflow has parameter validation errors on the following operations: ' + operationsWithParameterErrors.map(([id]) => id).join(', ')
+    const operationsWithParameterErrors = (Object.entries(rootState.operations.inputParameters) ?? []).filter(
+      ([_id, nodeInputs]: [id: string, i: NodeInputs]) =>
+        Object.values(nodeInputs.parameterGroups).some((parameterGroup: ParameterGroup) =>
+          parameterGroup.parameters.some((parameter: ParameterInfo) => (parameter?.validationErrors?.length ?? 0) > 0)
+        )
     );
+    if (operationsWithParameterErrors.length > 0) {
+      throw new Error(
+        'Workflow has parameter validation errors on the following operations: ' +
+          operationsWithParameterErrors.map(([id]) => id).join(', ')
+      );
+    }
   }
 
   const { connectionsMapping, connectionReferences: referencesObject } = rootState.connections;


### PR DESCRIPTION
Currently, skipValidation option is not used in serializer. We need a way to get the latest workflow from designer even when parameters might be empty (to undo to the previous state of workflow while user is editing). Not having skipValidation option throws an error and doesn't serialize the workflow when there are errors, eg. parameters are empty.