### PR TITLE
fix(designer): Adding error details in panel and card when operation cannot be deserialized

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -34,6 +34,7 @@ export type PanelContainerProps = {
   comment?: string;
   noNodeSelected: boolean;
   isError?: boolean;
+  errorMessage?: string;
   isLoading?: boolean;
   panelScope: PanelScope;
   pivotDisabled?: boolean;
@@ -62,6 +63,7 @@ export const PanelContainer = ({
   panelLocation,
   noNodeSelected,
   isError,
+  errorMessage,
   isLoading,
   panelScope,
   panelHeaderControlType,
@@ -172,7 +174,7 @@ export const PanelContainer = ({
               <Spinner size={SpinnerSize.large} />
             </div>
           ) : isError ? (
-            <MessageBar messageBarType={MessageBarType.error}>{panelErrorMessage}</MessageBar>
+            <MessageBar messageBarType={MessageBarType.error}>{errorMessage ?? panelErrorMessage}</MessageBar>
           ) : (
             <div className="msla-panel-page">
               <PanelPivot

--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../actions/bjsworkflow/connections';
 import type { OperationMetadataState } from '../../../state/operation/operationMetadataSlice';
 import type { RootState } from '../../../store';
-import type { StandardOperationManifestServiceOptions, IHttpClient } from '@microsoft/designer-client-services-logic-apps';
+import type { IHttpClient } from '@microsoft/designer-client-services-logic-apps';
 import {
   InitOperationManifestService,
   StandardOperationManifestService,
@@ -28,12 +28,20 @@ class MockHttpClient implements IHttpClient {
     const a: unknown = {};
     return a as ReturnType;
   }
+  put<ReturnType>() {
+    const a: unknown = {};
+    return a as ReturnType;
+  }
+  delete<ReturnType>() {
+    const a: unknown = {};
+    return a as ReturnType;
+  }
 }
 
 const nodeId = '1';
 const connectionName = 'name123';
 const mockHttp = new MockHttpClient();
-const serviceOptions: StandardOperationManifestServiceOptions = {
+const serviceOptions: any = {
   apiVersion: 'version',
   baseUrl: 'url',
   httpClient: mockHttp,

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -162,7 +162,7 @@ export const updateIdentityChangeInConection = createAsyncThunk(
   }
 );
 
-export async function getConnectionsMappingForNodes(operations: Operations, getState: () => RootState): Promise<Record<string, string>> {
+async function getConnectionsMappingForNodes(operations: Operations, getState: () => RootState): Promise<Record<string, string>> {
   let connectionsMapping: Record<string, string> = {};
   const operationManifestService = OperationManifestService();
 
@@ -179,7 +179,7 @@ export async function getConnectionsMappingForNodes(operations: Operations, getS
   return connectionsMapping;
 }
 
-export const getConnectionMappingForNode = (
+const getConnectionMappingForNode = (
   operation: LogicAppsV2.OperationDefinition,
   nodeId: string,
   operationManifestService: IOperationManifestService,

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -179,7 +179,7 @@ async function getConnectionsMappingForNodes(operations: Operations, getState: (
   return connectionsMapping;
 }
 
-const getConnectionMappingForNode = (
+export const getConnectionMappingForNode = (
   operation: LogicAppsV2.OperationDefinition,
   nodeId: string,
   operationManifestService: IOperationManifestService,

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -7,7 +7,7 @@ import type { ConnectorWithParsedSwagger } from '../../queries/connections';
 import { getConnectorWithSwagger } from '../../queries/connections';
 import { getOperationInfo, getOperationManifest } from '../../queries/operation';
 import type { DependencyInfo, NodeData, NodeInputs, NodeOperation, NodeOutputs } from '../../state/operation/operationMetadataSlice';
-import { initializeOperationInfo, initializeNodes } from '../../state/operation/operationMetadataSlice';
+import { ErrorLevel, updateErrorDetails, initializeOperationInfo, initializeNodes } from '../../state/operation/operationMetadataSlice';
 import { addResultSchema } from '../../state/staticresultschema/staticresultsSlice';
 import type { NodeTokens, VariableDeclaration } from '../../state/tokensSlice';
 import { initializeTokensAndVariables } from '../../state/tokensSlice';
@@ -228,14 +228,15 @@ export const initializeOperationDetailsForManifest = async (
 
     return;
   } catch (error) {
-    const errorMessage = `Unable to initialize operation details for operation - ${nodeId}. Error details - ${error}`;
+    const message = `Unable to initialize operation details for operation - ${nodeId}. Error details - ${error}`;
     LoggerService().log({
       level: LogEntryLevel.Error,
       area: 'operation deserializer',
-      message: errorMessage,
+      message,
       error: error instanceof Error ? error : undefined,
     });
 
+    dispatch(updateErrorDetails({ id: nodeId, errorInfo: { level: ErrorLevel.Critical, error, message } }));
     return;
   }
 };
@@ -481,33 +482,35 @@ export const updateDynamicDataInNodes = async (getState: () => RootState, dispat
   const rootState = getState();
   const {
     workflow: { nodesMetadata, operations },
-    operations: { inputParameters, settings, dependencies, operationInfo, actionMetadata },
+    operations: { inputParameters, settings, dependencies, operationInfo, actionMetadata, errors },
     tokens: { variables },
     connections,
   } = rootState;
   const allVariables = getAllVariables(variables);
   for (const [nodeId, operation] of Object.entries(operations)) {
-    const nodeDependencies = dependencies[nodeId];
-    const nodeInputs = inputParameters[nodeId];
-    const nodeMetadata = actionMetadata[nodeId];
-    const nodeSettings = settings[nodeId];
-    const isTrigger = isRootNodeInGraph(nodeId, 'root', nodesMetadata);
-    const nodeOperationInfo = operationInfo[nodeId];
-    const connectionReference = getConnectionReference(connections, nodeId);
+    if (errors[nodeId]?.level !== ErrorLevel.Critical) {
+      const nodeDependencies = dependencies[nodeId];
+      const nodeInputs = inputParameters[nodeId];
+      const nodeMetadata = actionMetadata[nodeId];
+      const nodeSettings = settings[nodeId];
+      const isTrigger = isRootNodeInGraph(nodeId, 'root', nodesMetadata);
+      const nodeOperationInfo = operationInfo[nodeId];
+      const connectionReference = getConnectionReference(connections, nodeId);
 
-    updateDynamicDataInNode(
-      nodeId,
-      isTrigger,
-      nodeOperationInfo,
-      connectionReference,
-      nodeDependencies,
-      nodeInputs,
-      nodeMetadata,
-      nodeSettings,
-      allVariables,
-      dispatch,
-      rootState,
-      operation
-    );
+      updateDynamicDataInNode(
+        nodeId,
+        isTrigger,
+        nodeOperationInfo,
+        connectionReference,
+        nodeDependencies,
+        nodeInputs,
+        nodeMetadata,
+        nodeSettings,
+        allVariables,
+        dispatch,
+        rootState,
+        operation
+      );
+    }
   }
 };

--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -98,7 +98,7 @@ export const useShowIdentitySelector = (nodeId: string): boolean => {
   return useSelector((state: RootState) => {
     const operationInfo = state.operations.operationInfo[nodeId];
     const connectionReference = getConnectionReference(state.connections, nodeId);
-    if (connectionReference && !isServiceProviderOperation(operationInfo.type) && !connectionQuery.isLoading) {
+    if (connectionReference && !isServiceProviderOperation(operationInfo?.type) && !connectionQuery.isLoading) {
       return isConnectionMultiAuthManagedIdentityType(connectionQuery.data, connector);
     }
 

--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -80,6 +80,18 @@ export interface OperationMetadata {
   brandColor: string;
 }
 
+export enum ErrorLevel {
+  Critical = 0,
+  Default = 1,
+}
+
+export interface ErrorInfo {
+  error: any;
+  level: ErrorLevel;
+  message: string;
+  code?: number;
+}
+
 export interface OperationMetadataState {
   operationInfo: Record<string, NodeOperation>;
   inputParameters: Record<string, NodeInputs>;
@@ -90,6 +102,7 @@ export interface OperationMetadataState {
   actionMetadata: Record<string, any>;
   staticResults: Record<string, NodeStaticResults>;
   repetitionInfos: Record<string, RepetitionContext>;
+  errors: Record<string, ErrorInfo>;
 }
 
 const initialState: OperationMetadataState = {
@@ -102,6 +115,7 @@ const initialState: OperationMetadataState = {
   actionMetadata: {},
   staticResults: {},
   repetitionInfos: {},
+  errors: {},
 };
 
 export interface AddNodeOperationPayload extends NodeOperation {
@@ -348,6 +362,14 @@ export const operationMetadataSlice = createSlice({
         ...repetition,
       };
     },
+    updateErrorDetails: (state, action: PayloadAction<{ id: string; errorInfo?: ErrorInfo; clear?: boolean }>) => {
+      const { id, errorInfo, clear } = action.payload;
+      if (errorInfo) {
+        state.errors[id] = errorInfo;
+      } else if (clear) {
+        delete state.errors[id];
+      }
+    },
     deinitializeOperationInfo: (state, action: PayloadAction<{ id: string }>) => {
       const { id } = action.payload;
       delete state.operationInfo[id];
@@ -386,6 +408,7 @@ export const {
   updateOutputs,
   updateActionMetadata,
   updateRepetitionContext,
+  updateErrorDetails,
   deinitializeOperationInfo,
   deinitializeNodes,
 } = operationMetadataSlice.actions;

--- a/libs/designer/src/lib/core/state/operation/operationSelector.ts
+++ b/libs/designer/src/lib/core/state/operation/operationSelector.ts
@@ -1,7 +1,7 @@
 import type { NodeStaticResults } from '../../actions/bjsworkflow/staticresults';
 import type { RootState } from '../../store';
 import { shouldUseParameterInGroup } from '../../utils/parameters/helper';
-import type { NodeInputs } from './operationMetadataSlice';
+import type { ErrorInfo, NodeInputs } from './operationMetadataSlice';
 import type { ParameterInfo } from '@microsoft/designer-ui';
 import { useSelector } from 'react-redux';
 
@@ -23,6 +23,12 @@ export const getOperationInputParameters = (rootState: RootState, nodeId: string
   }
 
   return allParameters;
+};
+
+export const useOperationErrorInfo = (nodeId: string): ErrorInfo | undefined => {
+  return useSelector((rootState: RootState) => {
+    return rootState.operations.errors[nodeId];
+  });
 };
 
 export const useOperationsInputParameters = (): Record<string, NodeInputs> => {

--- a/libs/designer/src/lib/core/utils/swagger/operation.ts
+++ b/libs/designer/src/lib/core/utils/swagger/operation.ts
@@ -13,7 +13,7 @@ import type {
 import { getOperationSettings } from '../../actions/bjsworkflow/settings';
 import { getConnectorWithSwagger } from '../../queries/connections';
 import type { DependencyInfo, NodeInputs, NodeOperation, OutputInfo } from '../../state/operation/operationMetadataSlice';
-import { DynamicLoadStatus, initializeOperationInfo } from '../../state/operation/operationMetadataSlice';
+import { ErrorLevel, updateErrorDetails, DynamicLoadStatus, initializeOperationInfo } from '../../state/operation/operationMetadataSlice';
 import { addResultSchema } from '../../state/staticresultschema/staticresultsSlice';
 import { getBrandColorFromConnector, getIconUriFromConnector } from '../card';
 import { toOutputInfo, updateOutputsForBatchingTrigger } from '../outputs';
@@ -106,14 +106,15 @@ export const initializeOperationDetailsForSwagger = async (
 
     throw new Error('Operation info could not be found for a swagger operation');
   } catch (error) {
-    const errorMessage = `Unable to initialize operation details for swagger based operation - ${nodeId}. Error details - ${error}`;
+    const message = `Unable to initialize operation details for swagger based operation - ${nodeId}. Error details - ${error}`;
     LoggerService().log({
       level: LogEntryLevel.Error,
       area: 'operation deserializer',
-      message: errorMessage,
+      message,
       error: error instanceof Error ? error : undefined,
     });
 
+    dispatch(updateErrorDetails({ id: nodeId, errorInfo: { level: ErrorLevel.Critical, error, message } }));
     return;
   }
 };

--- a/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -4,7 +4,13 @@ import type { AppDispatch } from '../../core';
 import { deleteOperation } from '../../core/actions/bjsworkflow/delete';
 import { moveOperation } from '../../core/actions/bjsworkflow/move';
 import { useMonitoringView, useReadOnly } from '../../core/state/designerOptions/designerOptionsSelectors';
-import { useParameterStaticResult, useParameterValidationErrors, useTokenDependencies } from '../../core/state/operation/operationSelector';
+import { ErrorLevel } from '../../core/state/operation/operationMetadataSlice';
+import {
+  useOperationErrorInfo,
+  useParameterStaticResult,
+  useParameterValidationErrors,
+  useTokenDependencies,
+} from '../../core/state/operation/operationSelector';
 import { useIsNodeSelected } from '../../core/state/panel/panelSelectors';
 import { changePanelNode, showDefaultTabs } from '../../core/state/panel/panelSlice';
 import {
@@ -53,7 +59,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
 
   const dispatch = useDispatch<AppDispatch>();
   const operationsInfo = useAllOperations();
-
+  const errorInfo = useOperationErrorInfo(id);
   const metadata = useNodeMetadata(id);
   const operationInfo = useOperationInfo(id);
   const isTrigger = useMemo(() => metadata?.graphId === 'root' && metadata?.isRoot, [metadata]);
@@ -211,23 +217,39 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
   });
 
   const { errorMessage, errorLevel } = useMemo(() => {
-    if (opQuery?.isError) return { errorMessage: opManifestErrorText, errorLevel: MessageBarType.error };
-    if (settingValidationErrors?.length > 0) return { errorMessage: settingValidationErrorText, errorLevel: MessageBarType.severeWarning };
-    if (parameterValidationErrors?.length > 0)
+    if (errorInfo) {
+      return {
+        errorMessage: errorInfo.message,
+        errorLevel: errorInfo.level === ErrorLevel.Critical ? MessageBarType.error : MessageBarType.severeWarning,
+      };
+    }
+
+    if (opQuery?.isError) {
+      return { errorMessage: opManifestErrorText, errorLevel: MessageBarType.error };
+    }
+
+    if (settingValidationErrors?.length > 0) {
+      return { errorMessage: settingValidationErrorText, errorLevel: MessageBarType.severeWarning };
+    }
+
+    if (parameterValidationErrors?.length > 0) {
       return { errorMessage: parameterValidationErrorText, errorLevel: MessageBarType.severeWarning };
+    }
 
     if (isMonitoringView) {
       return getMonitoringError(errorRun, statusRun, codeRun);
     }
+
     return { errorMessage: undefined, errorLevel: undefined };
   }, [
+    errorInfo,
     opQuery?.isError,
-    opManifestErrorText,
     settingValidationErrors?.length,
-    settingValidationErrorText,
     parameterValidationErrors?.length,
-    parameterValidationErrorText,
     isMonitoringView,
+    opManifestErrorText,
+    settingValidationErrorText,
+    parameterValidationErrorText,
     errorRun,
     statusRun,
     codeRun,

--- a/libs/designer/src/lib/ui/panel/panelTabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/parametersTab/index.tsx
@@ -52,8 +52,6 @@ export const ParametersTab = () => {
   const showIdentitySelector = useShowIdentitySelector(selectedNodeId);
 
   const replacedIds = useReplacedIds();
-  const tokenGroup = getOutputTokenSections(selectedNodeId, nodeType, tokenState, workflowParametersState, replacedIds);
-  const expressionGroup = getExpressionTokenSections();
 
   if (!operationInfo && !nodeMetadata?.subgraphType) {
     return (
@@ -62,6 +60,9 @@ export const ParametersTab = () => {
       </div>
     );
   }
+
+  const tokenGroup = getOutputTokenSections(selectedNodeId, nodeType, tokenState, workflowParametersState, replacedIds);
+  const expressionGroup = getExpressionTokenSections();
 
   return (
     <>

--- a/libs/designer/src/lib/ui/panel/panelroot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelroot.tsx
@@ -2,8 +2,8 @@ import constants from '../../common/constants';
 import type { AppDispatch, RootState } from '../../core';
 import { deleteOperation } from '../../core/actions/bjsworkflow/delete';
 import { useIsXrmConnectionReferenceMode, useMonitoringView, useReadOnly } from '../../core/state/designerOptions/designerOptionsSelectors';
-import { updateParameterValidation } from '../../core/state/operation/operationMetadataSlice';
-import { useParameterValidationErrors } from '../../core/state/operation/operationSelector';
+import { ErrorLevel, updateParameterValidation } from '../../core/state/operation/operationMetadataSlice';
+import { useOperationErrorInfo, useParameterValidationErrors } from '../../core/state/operation/operationSelector';
 import {
   useCurrentPanelModePanelMode,
   useIsPanelCollapsed,
@@ -274,6 +274,7 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
   const dismissPanel = () => dispatch(clearPanel());
 
   const opQuery = useOperationQuery(selectedNode);
+  const errorInfo = useOperationErrorInfo(selectedNode);
 
   const isLoading = useMemo(() => {
     if (nodeMetaData?.subgraphType) return false;
@@ -304,7 +305,8 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
       cardIcon={iconUri}
       comment={comment}
       noNodeSelected={!selectedNode}
-      isError={opQuery?.isError}
+      isError={errorInfo?.level === ErrorLevel.Critical || opQuery?.isError}
+      errorMessage={errorInfo?.message}
       isLoading={isLoading}
       panelScope={PanelScope.CardLevel}
       panelHeaderControlType={getPanelHeaderControlType() ? PanelHeaderControlType.DISMISS_BUTTON : PanelHeaderControlType.MENU}


### PR DESCRIPTION
This also fixes the code paths which should not be called when operation was not loaded correctly.
fixes #2033 