### PR TITLE
fix(openapi): Fix dynamic schema params being duplicated

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.mocks.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.mocks.ts
@@ -1,4 +1,4 @@
-import type { OperationManifest } from "@microsoft/utils-logic-apps";
+import type { OperationManifest } from '@microsoft/utils-logic-apps';
 
 export const mockGetMyOffice365ProfileOpenApiManifest: OperationManifest = {
   properties: {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.mocks.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.mocks.ts
@@ -1,0 +1,317 @@
+import type { OperationManifest } from "@microsoft/utils-logic-apps";
+
+export const mockGetMyOffice365ProfileOpenApiManifest: OperationManifest = {
+  properties: {
+    description:
+      'Retrieves the profile of the current user. Learn more about available fields to select: https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/user#properties',
+    summary: 'Get my profile (V2)',
+    iconUri: 'https://connectoricons-df.azureedge.net/releases/v1.0.1626/1.0.1626.3238/office365users/icon.png',
+    brandColor: '#eb3c00',
+    inputs: {
+      type: 'object',
+      properties: {
+        $select: {
+          type: 'string',
+          title: 'Select fields',
+          description: 'Comma separated list of fields to select. Example: surname, department, jobTitle',
+          'x-ms-visibility': 'advanced',
+          'x-ms-property-name-alias': '$select',
+        },
+      },
+      required: [],
+    },
+    inputsLocation: ['inputs', 'parameters'],
+  },
+};
+
+export const mockPostTeamsAdaptiveCardOpenApiManifest: OperationManifest = {
+  properties: {
+    description: 'This operation posts an adaptive card to a chat or a channel and waits for a response.',
+    summary: 'Post adaptive card and wait for a response',
+    iconUri: 'https://connectoricons-df.azureedge.net/u/v-sriyen/PreviewApril18/1.0.1632.3271/teams/icon.png',
+    brandColor: '#4B53BC',
+    externalDocs: {
+      url: 'https://docs.microsoft.com/connectors/teams/#post-adaptive-card-and-wait-for-a-response',
+    },
+    inputs: {
+      type: 'object',
+      properties: {
+        poster: {
+          type: 'string',
+          title: 'Post as',
+          description: 'Select an option',
+          default: 'Flow bot',
+          enum: ['Power Virtual Agents', 'Flow bot'],
+          minLength: 1,
+          'x-ms-enum-values': [
+            {
+              displayName: 'Power Virtual Agents (Preview)',
+              value: 'Power Virtual Agents',
+            },
+            {
+              displayName: 'Flow bot',
+              value: 'Flow bot',
+            },
+          ],
+          'x-ms-property-name-alias': 'poster',
+        },
+        location: {
+          type: 'string',
+          title: 'Post in',
+          'x-ms-dynamic-list': {
+            itemValuePath: 'id',
+            dynamicState: {
+              operationId: 'GetMessageLocations',
+              parameters: {
+                messageType: {
+                  value: 'ParentMessage',
+                },
+                poster: {
+                  parameterReference: 'poster',
+                  required: true,
+                },
+              },
+              itemsPath: 'value',
+              itemValuePath: 'id',
+              itemTitlePath: 'displayName',
+            },
+            parameters: {
+              poster: {
+                parameterReference: 'poster',
+                required: true,
+              },
+            },
+          },
+          description: 'Select an option',
+          minLength: 1,
+          'x-ms-property-name-alias': 'location',
+        },
+        body: {
+          type: 'object',
+          properties: {
+            body: {
+              type: 'object',
+              properties: {
+                recipient: {
+                  type: 'object',
+                  'x-ms-dynamic-properties': {
+                    dynamicState: {
+                      extension: {
+                        operationId: 'GetUnifiedActionSchema',
+                        parameters: {
+                          actionType: {
+                            value: 'GatherInput',
+                          },
+                          poster: {
+                            parameterReference: 'poster',
+                            required: true,
+                          },
+                          recipientType: {
+                            parameterReference: 'location',
+                            required: true,
+                          },
+                        },
+                        itemValuePath: 'schema',
+                      },
+                      isInput: true,
+                      schemaAlias: 'body/body/recipient',
+                    },
+                    parameters: {
+                      poster: {
+                        parameterReference: 'poster',
+                        required: true,
+                      },
+                      recipientType: {
+                        parameterReference: 'location',
+                        required: true,
+                      },
+                    },
+                  },
+                  'x-ms-property-name-alias': 'body/body/recipient',
+                },
+                messageBody: {
+                  type: 'string',
+                  title: 'Message',
+                  'x-ms-property-name-alias': 'body/body/messageBody',
+                },
+                updateMessage: {
+                  type: 'string',
+                  title: 'Update message',
+                  description: 'Message to show as an update in the original card following response',
+                  default: 'Thanks for your response!',
+                  'x-ms-property-name-alias': 'body/body/updateMessage',
+                },
+              },
+              required: ['messageBody', 'recipient'],
+              'x-ms-property-name-alias': 'body/body',
+            },
+          },
+          required: ['body'],
+          description: 'The flow continuation subscription request',
+          'x-ms-property-name-alias': 'body',
+        },
+      },
+      required: ['body', 'location', 'poster'],
+    },
+    inputsLocation: ['inputs', 'parameters'],
+  },
+};
+
+export const mockSendAnOfficeOutlookEmailOpenApiManifest: OperationManifest = {
+  properties: {
+    description: 'This operation sends an email message.',
+    inputs: {
+      type: 'object',
+      properties: {
+        emailMessage: {
+          type: 'object',
+          properties: {
+            To: {
+              type: 'string',
+              title: 'To',
+              'x-ms-dynamic-list': {
+                builtInOperation: 'AadGraph.GetUsers',
+                itemValuePath: 'mail',
+                dynamicState: {
+                  builtInOperation: 'AadGraph.GetUsers',
+                  parameters: {},
+                  itemValuePath: 'mail',
+                },
+                parameters: {},
+              },
+              format: 'email',
+              description: 'Specify email addresses separated by semicolons like someone@contoso.com',
+              'x-ms-property-name-alias': 'emailMessage/To',
+            },
+            Subject: {
+              type: 'string',
+              title: 'Subject',
+              description: 'Specify the subject of the mail',
+              'x-ms-property-name-alias': 'emailMessage/Subject',
+            },
+            Body: {
+              type: 'string',
+              title: 'Body',
+              format: 'html',
+              description: 'Specify the body of the mail',
+              'x-ms-property-name-alias': 'emailMessage/Body',
+            },
+            From: {
+              type: 'string',
+              title: 'From (Send as)',
+              format: 'email',
+              description:
+                'Email address to send mail from (requires "Send as" or "Send on behalf of" permission for that mailbox). For more info on granting permissions please refer https://docs.microsoft.com/office365/admin/manage/send-email-as-distribution-list',
+              'x-ms-visibility': 'advanced',
+              'x-ms-property-name-alias': 'emailMessage/From',
+            },
+            Cc: {
+              type: 'string',
+              title: 'CC',
+              'x-ms-dynamic-list': {
+                builtInOperation: 'AadGraph.GetUsers',
+                itemValuePath: 'mail',
+                dynamicState: {
+                  builtInOperation: 'AadGraph.GetUsers',
+                  parameters: {},
+                  itemValuePath: 'mail',
+                },
+                parameters: {},
+              },
+              format: 'email',
+              description: 'Specify email addresses separated by semicolons like someone@contoso.com',
+              'x-ms-visibility': 'advanced',
+              'x-ms-property-name-alias': 'emailMessage/Cc',
+            },
+            Bcc: {
+              type: 'string',
+              title: 'BCC',
+              'x-ms-dynamic-list': {
+                builtInOperation: 'AadGraph.GetUsers',
+                itemValuePath: 'mail',
+                dynamicState: {
+                  builtInOperation: 'AadGraph.GetUsers',
+                  parameters: {},
+                  itemValuePath: 'mail',
+                },
+                parameters: {},
+              },
+              format: 'email',
+              description: 'Specify email addresses separated by semicolons like someone@contoso.com',
+              'x-ms-visibility': 'advanced',
+              'x-ms-property-name-alias': 'emailMessage/Bcc',
+            },
+            Attachments: {
+              type: 'array',
+              title: 'Attachments',
+              items: {
+                type: 'object',
+                properties: {
+                  Name: {
+                    type: 'string',
+                    title: 'Name',
+                    description: 'Attachment name',
+                    'x-ms-property-name-alias': 'Name',
+                  },
+                  ContentBytes: {
+                    type: 'string',
+                    title: 'Content',
+                    format: 'byte',
+                    description: 'Attachment content',
+                    'x-ms-property-name-alias': 'ContentBytes',
+                  },
+                },
+                required: ['ContentBytes', 'Name'],
+                description: 'Attachment',
+              },
+              description: 'Attachments',
+              'x-ms-visibility': 'advanced',
+              'x-ms-property-name-alias': 'emailMessage/Attachments',
+            },
+            Sensitivity: {
+              type: 'string',
+              title: 'Sensitivity',
+              'x-ms-dynamic-list': {
+                itemValuePath: 'Id',
+                dynamicState: {
+                  operationId: 'GetSensitivityLabels',
+                  parameters: {},
+                  itemValuePath: 'Id',
+                  itemTitlePath: 'DisplayName',
+                },
+                parameters: {},
+              },
+              description: 'Sensitivity',
+              'x-ms-visibility': 'advanced',
+              'x-ms-property-name-alias': 'emailMessage/Sensitivity',
+            },
+            ReplyTo: {
+              type: 'string',
+              title: 'Reply To',
+              format: 'email',
+              description: 'The email addresses to use when replying',
+              'x-ms-visibility': 'advanced',
+              'x-ms-property-name-alias': 'emailMessage/ReplyTo',
+            },
+            Importance: {
+              type: 'string',
+              title: 'Importance',
+              description: 'Importance',
+              default: 'Normal',
+              enum: ['Low', 'Normal', 'High'],
+              'x-ms-visibility': 'advanced',
+              'x-ms-property-name-alias': 'emailMessage/Importance',
+            },
+          },
+          required: ['Body', 'Subject', 'To'],
+          description: 'Email.',
+          'x-ms-property-name-alias': 'emailMessage',
+        },
+      },
+      required: ['emailMessage'],
+    },
+    inputsLocation: ['inputs', 'parameters'],
+    iconUri: 'https://connectoricons-df.azureedge.net/releases/v1.0.1626/1.0.1626.3238/office365/icon.png',
+    brandColor: '#0078D4',
+  },
+};

--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.spec.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.spec.ts
@@ -1,167 +1,13 @@
 import { getInputParametersFromManifest } from '../initialize';
-import type { OperationManifest } from '@microsoft/utils-logic-apps';
+import {
+  mockGetMyOffice365ProfileOpenApiManifest,
+  mockPostTeamsAdaptiveCardOpenApiManifest,
+  mockSendAnOfficeOutlookEmailOpenApiManifest,
+} from './initialize.mocks';
 
 describe('bjsworkflow initialize', () => {
   describe('getInputParametersFromManifest', () => {
     test('works for an OpenAPI operation with input parameters and values', () => {
-      const manifest: OperationManifest = {
-        properties: {
-          description: 'This operation sends an email message.',
-          inputs: {
-            type: 'object',
-            properties: {
-              emailMessage: {
-                type: 'object',
-                properties: {
-                  To: {
-                    type: 'string',
-                    title: 'To',
-                    'x-ms-dynamic-list': {
-                      builtInOperation: 'AadGraph.GetUsers',
-                      itemValuePath: 'mail',
-                      dynamicState: {
-                        builtInOperation: 'AadGraph.GetUsers',
-                        parameters: {},
-                        itemValuePath: 'mail',
-                      },
-                      parameters: {},
-                    },
-                    format: 'email',
-                    description: 'Specify email addresses separated by semicolons like someone@contoso.com',
-                    'x-ms-property-name-alias': 'emailMessage/To',
-                  },
-                  Subject: {
-                    type: 'string',
-                    title: 'Subject',
-                    description: 'Specify the subject of the mail',
-                    'x-ms-property-name-alias': 'emailMessage/Subject',
-                  },
-                  Body: {
-                    type: 'string',
-                    title: 'Body',
-                    format: 'html',
-                    description: 'Specify the body of the mail',
-                    'x-ms-property-name-alias': 'emailMessage/Body',
-                  },
-                  From: {
-                    type: 'string',
-                    title: 'From (Send as)',
-                    format: 'email',
-                    description:
-                      'Email address to send mail from (requires "Send as" or "Send on behalf of" permission for that mailbox). For more info on granting permissions please refer https://docs.microsoft.com/office365/admin/manage/send-email-as-distribution-list',
-                    'x-ms-visibility': 'advanced',
-                    'x-ms-property-name-alias': 'emailMessage/From',
-                  },
-                  Cc: {
-                    type: 'string',
-                    title: 'CC',
-                    'x-ms-dynamic-list': {
-                      builtInOperation: 'AadGraph.GetUsers',
-                      itemValuePath: 'mail',
-                      dynamicState: {
-                        builtInOperation: 'AadGraph.GetUsers',
-                        parameters: {},
-                        itemValuePath: 'mail',
-                      },
-                      parameters: {},
-                    },
-                    format: 'email',
-                    description: 'Specify email addresses separated by semicolons like someone@contoso.com',
-                    'x-ms-visibility': 'advanced',
-                    'x-ms-property-name-alias': 'emailMessage/Cc',
-                  },
-                  Bcc: {
-                    type: 'string',
-                    title: 'BCC',
-                    'x-ms-dynamic-list': {
-                      builtInOperation: 'AadGraph.GetUsers',
-                      itemValuePath: 'mail',
-                      dynamicState: {
-                        builtInOperation: 'AadGraph.GetUsers',
-                        parameters: {},
-                        itemValuePath: 'mail',
-                      },
-                      parameters: {},
-                    },
-                    format: 'email',
-                    description: 'Specify email addresses separated by semicolons like someone@contoso.com',
-                    'x-ms-visibility': 'advanced',
-                    'x-ms-property-name-alias': 'emailMessage/Bcc',
-                  },
-                  Attachments: {
-                    type: 'array',
-                    title: 'Attachments',
-                    items: {
-                      type: 'object',
-                      properties: {
-                        Name: {
-                          type: 'string',
-                          title: 'Name',
-                          description: 'Attachment name',
-                          'x-ms-property-name-alias': 'Name',
-                        },
-                        ContentBytes: {
-                          type: 'string',
-                          title: 'Content',
-                          format: 'byte',
-                          description: 'Attachment content',
-                          'x-ms-property-name-alias': 'ContentBytes',
-                        },
-                      },
-                      required: ['ContentBytes', 'Name'],
-                      description: 'Attachment',
-                    },
-                    description: 'Attachments',
-                    'x-ms-visibility': 'advanced',
-                    'x-ms-property-name-alias': 'emailMessage/Attachments',
-                  },
-                  Sensitivity: {
-                    type: 'string',
-                    title: 'Sensitivity',
-                    'x-ms-dynamic-list': {
-                      itemValuePath: 'Id',
-                      dynamicState: {
-                        operationId: 'GetSensitivityLabels',
-                        parameters: {},
-                        itemValuePath: 'Id',
-                        itemTitlePath: 'DisplayName',
-                      },
-                      parameters: {},
-                    },
-                    description: 'Sensitivity',
-                    'x-ms-visibility': 'advanced',
-                    'x-ms-property-name-alias': 'emailMessage/Sensitivity',
-                  },
-                  ReplyTo: {
-                    type: 'string',
-                    title: 'Reply To',
-                    format: 'email',
-                    description: 'The email addresses to use when replying',
-                    'x-ms-visibility': 'advanced',
-                    'x-ms-property-name-alias': 'emailMessage/ReplyTo',
-                  },
-                  Importance: {
-                    type: 'string',
-                    title: 'Importance',
-                    description: 'Importance',
-                    default: 'Normal',
-                    enum: ['Low', 'Normal', 'High'],
-                    'x-ms-visibility': 'advanced',
-                    'x-ms-property-name-alias': 'emailMessage/Importance',
-                  },
-                },
-                required: ['Body', 'Subject', 'To'],
-                description: 'Email.',
-                'x-ms-property-name-alias': 'emailMessage',
-              },
-            },
-            required: ['emailMessage'],
-          },
-          inputsLocation: ['inputs', 'parameters'],
-          iconUri: 'https://connectoricons-df.azureedge.net/releases/v1.0.1626/1.0.1626.3238/office365/icon.png',
-          brandColor: '#0078D4',
-        },
-      };
       const stepDefinition = {
         runAfter: {},
         type: 'OpenApiConnection',
@@ -184,7 +30,12 @@ describe('bjsworkflow initialize', () => {
         },
       };
 
-      const inputParameters = getInputParametersFromManifest('Send_an_email', manifest, undefined /* customSwagger */, stepDefinition);
+      const inputParameters = getInputParametersFromManifest(
+        'Send_an_email',
+        mockSendAnOfficeOutlookEmailOpenApiManifest,
+        undefined /* customSwagger */,
+        stepDefinition
+      );
 
       expect(inputParameters.inputs.parameterGroups.default.parameters.length).toBe(10);
       expect(inputParameters.inputs.parameterGroups.default.parameters[0].value[0].value).toBe('johndoe@example.com');
@@ -192,31 +43,47 @@ describe('bjsworkflow initialize', () => {
       expect(inputParameters.inputs.parameterGroups.default.parameters[2].value[0].value).toBe('test1');
       expect(inputParameters.inputs.parameterGroups.default.parameters[9].value[0].value).toBe('Normal');
     });
-
-    test('works for an OpenAPI operation with input parameters but no values', () => {
-      const manifest: OperationManifest = {
-        properties: {
-          description:
-            'Retrieves the profile of the current user. Learn more about available fields to select: https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/user#properties',
-          summary: 'Get my profile (V2)',
-          iconUri: 'https://connectoricons-df.azureedge.net/releases/v1.0.1626/1.0.1626.3238/office365users/icon.png',
-          brandColor: '#eb3c00',
-          inputs: {
-            type: 'object',
-            properties: {
-              $select: {
-                type: 'string',
-                title: 'Select fields',
-                description: 'Comma separated list of fields to select. Example: surname, department, jobTitle',
-                'x-ms-visibility': 'advanced',
-                'x-ms-property-name-alias': '$select',
-              },
-            },
-            required: [],
+    test('works for an OpenAPI operation with input parameters that have a dynamic schema', () => {
+      const stepDefinition = {
+        runAfter: {
+          Get_items: ['Succeeded'],
+        },
+        metadata: {
+          operationMetadataId: 'f7bc459b-4bea-4135-b65d-dd4f4136441e',
+        },
+        type: 'OpenApiConnectionWebhook',
+        inputs: {
+          host: {
+            apiId: '/providers/Microsoft.PowerApps/apis/shared_teams',
+            operationId: 'PostCardAndWaitForResponse',
+            connection: 'shared_teams',
           },
-          inputsLocation: ['inputs', 'parameters'],
+          parameters: {
+            poster: 'Flow bot',
+            location: 'Chat with Flow bot',
+            'body/body/messageBody': 'hi hello ',
+            'body/body/updateMessage': 'Thanks for your response!',
+            'body/body/recipient/to': 'johndoe@example.com;',
+          },
+          authentication: "@parameters('$authentication')",
         },
       };
+
+      const inputParameters = getInputParametersFromManifest(
+        'Post_an_adaptive_card',
+        mockPostTeamsAdaptiveCardOpenApiManifest,
+        undefined /* customSwagger */,
+        stepDefinition
+      );
+
+      expect(inputParameters.inputs.parameterGroups.default.parameters.length).toBe(4); // Dynamic schema param (recipient/to) should not be in the array.
+      expect(inputParameters.inputs.parameterGroups.default.parameters[0].value[0].value).toBe('Flow bot');
+      expect(inputParameters.inputs.parameterGroups.default.parameters[1].value[0].value).toBe('Chat with Flow bot');
+      expect(inputParameters.inputs.parameterGroups.default.parameters[2].value[0].value).toBe('hi hello ');
+      expect(inputParameters.inputs.parameterGroups.default.parameters[3].value[0].value).toBe('Thanks for your response!');
+    });
+
+    test('works for an OpenAPI operation with input parameters but no values', () => {
       const stepDefinition = {
         runAfter: {},
         type: 'OpenApiConnection',
@@ -233,7 +100,12 @@ describe('bjsworkflow initialize', () => {
         },
       };
 
-      const inputParameters = getInputParametersFromManifest('Get_my_profile', manifest, undefined /* customSwagger */, stepDefinition);
+      const inputParameters = getInputParametersFromManifest(
+        'Get_my_profile',
+        mockGetMyOffice365ProfileOpenApiManifest,
+        undefined /* customSwagger */,
+        stepDefinition
+      );
 
       expect(inputParameters.inputs.parameterGroups.default.parameters.length).toBe(1);
       expect(inputParameters.inputs.parameterGroups.default.parameters[0].value[0].value).toBe('');

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1064,7 +1064,11 @@ export function updateParameterWithValues(
           const valueExpandable =
             isObject(clonedParameterValue) || (Array.isArray(clonedParameterValue) && clonedParameterValue.length === 1);
           if (valueExpandable) {
+            const dynamicSchemaKeyPrefixes: string[] = [];
             for (const descendantInputParameter of descendantInputParameters) {
+              if (descendantInputParameter.dynamicSchema) {
+                dynamicSchemaKeyPrefixes.push(`${descendantInputParameter.alias}/`);
+              }
               const extraSegments = getExtraSegments(descendantInputParameter.key, parameterKey);
               if (descendantInputParameter.alias) {
                 reduceRedundantSegments(extraSegments);
@@ -1102,6 +1106,9 @@ export function updateParameterWithValues(
             // for the rest properties, create corresponding invisible parameter to preserve the value when serialize
             if (createInvisibleParameter) {
               for (const restPropertyName of Object.keys(clonedParameterValue)) {
+                if (dynamicSchemaKeyPrefixes.some((prefix) => restPropertyName.startsWith(prefix))) {
+                  continue;
+                }
                 const propertyValue = clonedParameterValue[restPropertyName];
                 if (propertyValue !== undefined) {
                   const childKeySegments = [...keySegments, { value: restPropertyName, type: SegmentType.Property }];

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1066,12 +1066,12 @@ export function updateParameterWithValues(
           if (valueExpandable) {
             const dynamicSchemaKeyPrefixes: string[] = [];
             for (const descendantInputParameter of descendantInputParameters) {
-              if (descendantInputParameter.dynamicSchema) {
-                dynamicSchemaKeyPrefixes.push(`${descendantInputParameter.alias}/`);
-              }
               const extraSegments = getExtraSegments(descendantInputParameter.key, parameterKey);
               if (descendantInputParameter.alias) {
                 reduceRedundantSegments(extraSegments);
+                if (descendantInputParameter.dynamicSchema) {
+                  dynamicSchemaKeyPrefixes.push(`${descendantInputParameter.alias}/`);
+                }
               }
               const descendantValue = getPropertyValueWithSpecifiedPathSegments(clonedParameterValue, extraSegments);
               let alternativeParameterKeyExtraSegment: Segment[] | null = null;


### PR DESCRIPTION
In #1721, we had prevented OpenAPI parameters from executing the code path which populated **all parameters** that had values in the step definition, even if they were dynamic. However, in #2184, this code path was reactivated.

Now, parameters with a dynamic schema that have an existing value are populated twice: once using the value, which has a complete reference key (e.g., `body/body/recipient/to`), and once from the manifest, which has a dynamic schema reference key (e.g., `body/body/recipient`). This results in two objects being shown in the parameter list.

![image](https://user-images.githubusercontent.com/1350074/236331270-1d85eb5b-473b-459d-b26a-88b040283d18.png)

This fix addresses the issue so that if a parameter has a dynamic schema, we do not statically populate it in the parameters list.

![image](https://user-images.githubusercontent.com/1350074/236331228-4588e752-25d1-4ec5-bdb0-c7224f33ef84.png)