### PR TITLE
fix(designer): More user interactions now trigger dirty state

### DIFF
--- a/apps/designer-standalone/src/app/LocalDesigner/pseudoCommandBar.tsx
+++ b/apps/designer-standalone/src/app/LocalDesigner/pseudoCommandBar.tsx
@@ -2,8 +2,8 @@ import './pseudoCommandBar.less';
 import type { IModalStyles } from '@fluentui/react';
 import { ActionButton, Modal } from '@fluentui/react';
 import { MonacoEditor, EditorLanguage } from '@microsoft/designer-ui';
-import type { Workflow } from '@microsoft/logic-apps-designer';
-import { serializeWorkflow, switchToWorkflowParameters } from '@microsoft/logic-apps-designer';
+import type { Workflow, AppDispatch } from '@microsoft/logic-apps-designer';
+import { resetDesignerDirtyState, serializeWorkflow, switchToWorkflowParameters, useIsDesignerDirty } from '@microsoft/logic-apps-designer';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -15,7 +15,7 @@ const modalStyles: Partial<IModalStyles> = {
 
 export const PseudoCommandBar = () => {
   const state = useSelector((state: any) => state);
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
 
   const [showSerialization, setShowSeralization] = useState(false);
   const [serializedWorkflow, setSerializedWorkflow] = useState<Workflow>();
@@ -24,14 +24,33 @@ export const PseudoCommandBar = () => {
     setShowSeralization(true);
   };
 
+  const isDirty = useIsDesignerDirty();
+
   return (
     <div className="pseudo-command-bar">
-      <ActionButton iconProps={{ iconName: 'Code' }} text="Code View" onClick={serializeCallback} />
+      <ActionButton
+        iconProps={{ iconName: 'Save' }}
+        text="Save"
+        disabled={!isDirty}
+        onClick={() => {
+          alert("Congrats you saved the workflow! (Not really, you're in standalone)");
+          dispatch(resetDesignerDirtyState());
+        }}
+      />
+      <ActionButton
+        iconProps={{ iconName: 'Clear' }}
+        text="Discard"
+        disabled={!isDirty}
+        onClick={() => {
+          dispatch(resetDesignerDirtyState());
+        }}
+      />
       <ActionButton
         iconProps={{ iconName: 'Parameter' }}
         text="Workflow Parameters"
         onClick={() => dispatch(switchToWorkflowParameters())}
       />
+      <ActionButton iconProps={{ iconName: 'Code' }} text="Code View" onClick={serializeCallback} />
 
       {/* Code view modal */}
       <Modal

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -11,14 +11,14 @@ import { moveNodeInWorkflow } from '../../parsers/moveNodeInWorkflow';
 import { addNewEdge } from '../../parsers/restructuringHelpers';
 import { getImmediateSourceNodeIds } from '../../utils/graph';
 import { resetWorkflowState } from '../global';
-import { updateNodeParameters } from '../operation/operationMetadataSlice';
+import { updateNodeParameters, updateNodeSettings, updateStaticResults } from '../operation/operationMetadataSlice';
 import type { SpecTypes, WorkflowState } from './workflowInterfaces';
 import { getWorkflowNodeFromGraphState } from './workflowSelectors';
 import { LogEntryLevel, LoggerService } from '@microsoft/designer-client-services-logic-apps';
 import { getDurationStringPanelMode } from '@microsoft/designer-ui';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { equals, RUN_AFTER_STATUS, WORKFLOW_EDGE_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/utils-logic-apps';
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, isAnyOf } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { NodeChange, NodeDimensionChange } from 'reactflow';
 
@@ -339,10 +339,27 @@ export const workflowSlice = createSlice({
     builder.addCase(updateNodeParameters, (state, action) => {
       state.isDirty = state.isDirty || action.payload.isUserAction || false;
     });
-    builder.addCase(updateNodeConnection.fulfilled, (state) => {
-      state.isDirty = true;
-    });
     builder.addCase(resetWorkflowState, () => initialWorkflowState);
+    builder.addMatcher(
+      isAnyOf(
+        addNode,
+        moveNode,
+        deleteNode,
+        addSwitchCase,
+        deleteSwitchCase,
+        addSwitchCase,
+        addImplicitForeachNode,
+        setNodeDescription,
+        updateRunAfter,
+        replaceId,
+        updateNodeSettings,
+        updateNodeConnection.fulfilled,
+        updateStaticResults
+      ),
+      (state) => {
+        state.isDirty = true;
+      }
+    );
   },
 });
 

--- a/libs/designer/src/lib/ui/panel/panelroot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelroot.tsx
@@ -267,6 +267,10 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
     dispatch(replaceId({ originalId: selectedNode, newId }));
   };
 
+  const onCommentChange = (newDescription?: string) => {
+    dispatch(setNodeDescription({ nodeId: selectedNode, description: newDescription }));
+  };
+
   const handleDelete = (): void => {
     dispatch(deleteOperation({ nodeId: selectedNode, isTrigger: isTriggerNode }));
     // TODO: 12798935 Analytics (event logging)
@@ -334,9 +338,7 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
         togglePanel();
       }}
       trackEvent={handleTrackEvent}
-      onCommentChange={(value) => {
-        dispatch(setNodeDescription({ nodeId: selectedNode, description: value }));
-      }}
+      onCommentChange={onCommentChange}
       title={selectedNodeDisplayName}
       onTitleChange={onTitleChange}
     />


### PR DESCRIPTION
## Main Changes
More actions will now trigger dirty state, for allowing saving and discarding in Portal
- Updating settings
- Updating run after
- Updating action names
- Updating action comments
- Updating switch cases
- Updating static testing

Also added a pseudo save and discard button for testing dirty state in local standalone

Fixes #2248