### PR TITLE
fix(Power Automate): Add static inputs option to floatingactionmenu editor

### DIFF
--- a/libs/designer-ui/src/lib/dynamicallyaddedparameter/helper.ts
+++ b/libs/designer-ui/src/lib/dynamicallyaddedparameter/helper.ts
@@ -190,12 +190,16 @@ export function serialize(props: DynamicallyAddedParameterProps[]): ValueSegment
   ];
 }
 
-export function getEmptySchemaValueSegmentForInitialization() {
-  const rootObject = {
+export function getEmptySchemaValueSegmentForInitialization(useStaticInputs: boolean) {
+  let rootObject: {type: string, properties: unknown, required: string[]} = {
     type: 'object',
     properties: {},
     required: [],
   };
+
+  if (useStaticInputs) {
+    rootObject = rootObjectWithStaticInputs;
+  }
 
   return [
     {
@@ -270,3 +274,84 @@ function convertDynamicallyAddedSchemaKeyToTitle(name: string, itemType: Dynamic
 
   return result;
 }
+
+const rootObjectWithStaticInputs = {
+  type: "object",
+  properties: {
+    "key-button-date": {
+      title: "Date",
+      type: "string",
+      "x-ms-dynamically-added": false
+    },
+    location: {
+      type: "object",
+      properties: {
+        fullAddress: {
+          title: "Full address",
+          type: "string",
+          "x-ms-dynamically-added": false
+        },
+        address: {
+          type: 'object',
+          properties: {
+            countryOrRegion: {
+              title: 'Country/Region',
+              type: 'string',
+              'x-ms-dynamically-added': false,
+            },
+            city: {
+              title: 'City',
+              type: 'string',
+              'x-ms-dynamically-added': false,
+            },
+            state: {
+              title: 'State',
+              type: 'string',
+              'x-ms-dynamically-added': false,
+            },
+            street: {
+              title: 'Street',
+              type: 'string',
+              'x-ms-dynamically-added': false,
+            },
+            postalCode: {
+              title: 'Postal code',
+              type: 'string',
+              'x-ms-dynamically-added': false,
+            },
+          },
+          required: [
+              "countryOrRegion",
+              "city",
+              "state",
+              "street",
+              "postalCode"
+          ]
+        },
+        coordinates: {
+          type: "object",
+          properties: {
+            latitude: {
+              title: 'Latitude',
+              type: 'number',
+              'x-ms-dynamically-added': false,
+            },
+            longitude: {
+              title: 'Longitude',
+              type: 'number',
+              'x-ms-dynamically-added': false,
+            },
+          },
+          required: [
+              "latitude",
+              "longitude"
+          ]
+        }
+      }
+    },
+  },
+  required: [
+    "key-button-date",
+    "location",
+  ],
+};

--- a/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
+++ b/libs/designer-ui/src/lib/floatingactionmenu/index.tsx
@@ -24,6 +24,7 @@ export interface FloatingActionMenuItem {
 
 export interface FloatingActionMenuProps {
   supportedTypes: Array<string>;
+  useStaticInputs: boolean |  undefined;
   initialValue: ValueSegment[];
   onChange?: ChangeHandler;
 }
@@ -40,7 +41,7 @@ export const FloatingActionMenu = (props: FloatingActionMenuProps): JSX.Element 
   if (props.initialValue.length > 0 && !props.initialValue[0].value) {
     const { onChange } = props;
     if (onChange) {
-      const value = getEmptySchemaValueSegmentForInitialization();
+      const value = getEmptySchemaValueSegmentForInitialization(!!props.useStaticInputs);
       onChange({ value });
     }
   }

--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -264,7 +264,14 @@ const TokenField = ({
     //     />
     //   );
     case 'floatingactionmenu': {
-      return <FloatingActionMenu supportedTypes={editorOptions?.supportedTypes} initialValue={value} onChange={onValueChange} />;
+      return (
+        <FloatingActionMenu
+          supportedTypes={editorOptions?.supportedTypes}
+          useStaticInputs={editorOptions?.useStaticInputs}
+          initialValue={value}
+          onChange={onValueChange}
+        />
+      );
     }
 
     default:


### PR DESCRIPTION
The change is isolated to PAuto-specific editor. Adding static inputs that were added ad-hoc and dynamically in V1 to be available for use in token picker.