### PR TITLE
fix(designer): pass the right parameters to respect node dimensions

### DIFF
--- a/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
+++ b/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
@@ -29,8 +29,8 @@ export const initializeGraphState = createAsyncThunk<
     const { definition, connectionReferences, parameters } = workflowDefinition;
     const deserializedWorkflow = BJSDeserialize(definition, runInstance);
     // For situations where there is an existing workflow, respect the node dimensions so that they are not reset
-    const previousGraphFlattened = flattenWorkflowNodes(deserializedWorkflow?.graph?.children || []);
-    updateChildrenDimensions(workflow?.graph?.children || [], previousGraphFlattened);
+    const previousGraphFlattened = flattenWorkflowNodes(workflow.graph?.children || []);
+    updateChildrenDimensions(deserializedWorkflow?.graph?.children || [], previousGraphFlattened);
 
     thunkAPI.dispatch(initializeConnectionReferences(connectionReferences ?? {}));
     thunkAPI.dispatch(initializeStaticResultProperties(deserializedWorkflow.staticResults ?? {}));


### PR DESCRIPTION
workflow.graph is the previous graph state
deserializedWorkflow.graph is the current graph state

Passing the right parameters to the functions.