### PR TITLE
fix(designer): Fix non-awaited dynamic data update call

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -491,6 +491,7 @@ export const updateDynamicDataInNodes = async (getState: () => RootState, dispat
     tokens: { variables },
     connections,
   } = rootState;
+  const dynamicDataUpdatePromises: Promise<void>[] = [];
   const allVariables = getAllVariables(variables);
   for (const [nodeId, operation] of Object.entries(operations)) {
     if (!errors[nodeId]?.[ErrorLevel.Critical]) {
@@ -502,22 +503,25 @@ export const updateDynamicDataInNodes = async (getState: () => RootState, dispat
       const nodeOperationInfo = operationInfo[nodeId];
       const connectionReference = getConnectionReference(connections, nodeId);
 
-      updateDynamicDataForValidConnection(
-        nodeId,
-        isTrigger,
-        nodeOperationInfo,
-        connectionReference,
-        nodeDependencies,
-        nodeInputs,
-        nodeMetadata,
-        nodeSettings,
-        allVariables,
-        dispatch,
-        rootState,
-        operation
+      dynamicDataUpdatePromises.push(
+        updateDynamicDataForValidConnection(
+          nodeId,
+          isTrigger,
+          nodeOperationInfo,
+          connectionReference,
+          nodeDependencies,
+          nodeInputs,
+          nodeMetadata,
+          nodeSettings,
+          allVariables,
+          dispatch,
+          rootState,
+          operation
+        )
       );
     }
   }
+  await Promise.all(dynamicDataUpdatePromises);
 };
 
 const updateDynamicDataForValidConnection = async (


### PR DESCRIPTION
A regression was introduced in #2254 where a call that used to be instant (i.e., synchronous) had an `async` function added to it but that call was not `await`-ed. This caused an issue where dynamic data could not be populated when other events fired, leading to it disappearing from the UI.

This PR adds the appropriate `await` to ensure all dynamic data updates are completed before completing the deserialization process.