### PR TITLE
fix(designer): do not set Panel header horizontal padding when Panel is collapsed

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
@@ -226,7 +226,7 @@ export const PanelHeader = ({
       </div>
       {!noNodeOnCardLevel ? (
         <>
-          <div className={'msla-panel-card-header'} style={isRight ? {} : { paddingLeft: horizontalPadding }}>
+          <div className={'msla-panel-card-header'} style={isRight || isCollapsed ? {} : { paddingLeft: horizontalPadding }}>
             {iconComponent}
             {includeTitle ? (
               <div className="msla-panel-card-title-container" hidden={isCollapsed}>


### PR DESCRIPTION
Before:
![image](https://github.com/Azure/LogicAppsUX/assets/12244548/0cd300d5-5f51-409b-82cb-637338e01714)

Now:
![image](https://github.com/Azure/LogicAppsUX/assets/12244548/ac903d24-2bef-4b03-b322-54cfba9bd862)
