### PR TITLE
fix(designer): TestConnection errors now show properly in panel

### DIFF
--- a/libs/services/designer-client-services/src/lib/standard/connection.ts
+++ b/libs/services/designer-client-services/src/lib/standard/connection.ts
@@ -511,7 +511,7 @@ export class StandardConnectionService extends BaseConnectionService {
 
       return response;
     } catch (e: any) {
-      return Promise.reject(JSON.parse(e?.responseText));
+      return Promise.reject(e);
     }
   }
 }


### PR DESCRIPTION
TestConnection error were not showing properly, saying 'undefined is not valid JSON', we now just pass the error object up