### PR TITLE
fix(Designer): Added extra icon and brand color fallbacks

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -114,7 +114,10 @@ const initializeOperationDetails = async (
     isConnectionRequired = isConnectionRequiredForOperation(manifest);
     connector = manifest.properties.connector as Connector;
 
-    const { iconUri, brandColor } = manifest.properties;
+    const { iconUri: operationIcon, brandColor: operationBrandColor } = manifest.properties;
+    const { iconUri: connectorIcon, brandColor: connectorBrandColor } = connector.properties;
+    const iconUri = operationIcon ?? connectorIcon;
+    const brandColor = operationBrandColor ?? connectorBrandColor;
     const { inputs: nodeInputs, dependencies: inputDependencies } = getInputParametersFromManifest(nodeId, manifest);
     const { outputs: nodeOutputs, dependencies: outputDependencies } = getOutputParametersFromManifest(manifest, isTrigger, nodeInputs);
     parsedManifest = new ManifestParser(manifest);


### PR DESCRIPTION
## Main Changes
Some of our built-in operations were missing icon uri's, this PR add the operation's connector icon as a fallback to catch this case.
(Azure operations are already using connector icons)