### PR TITLE
fix(designer): When outputs are too large to show, monitoring view will show a download link to the file

### DIFF
--- a/libs/designer-ui/src/lib/monitoring/valuespanel/index.tsx
+++ b/libs/designer-ui/src/lib/monitoring/valuespanel/index.tsx
@@ -1,4 +1,5 @@
 import Constants from '../../constants';
+import { ValueDownload } from './valuedownload';
 import { ValueLink } from './valuelink';
 import { ValueList } from './valuelist';
 import type { BoundParameters } from '@microsoft/utils-logic-apps';
@@ -12,6 +13,8 @@ export interface ValuesPanelProps {
   linkText?: string;
   noValuesText: string;
   showLink?: boolean;
+  isDownload?: boolean;
+  link?: string;
   showMore: boolean;
   values: BoundParameters;
   onLinkClick?(): void;
@@ -29,6 +32,8 @@ export const ValuesPanel: React.FC<ValuesPanelProps> = ({
   values,
   onLinkClick,
   onMoreClick,
+  link,
+  isDownload,
 }) => {
   const borderStyle = {
     borderColor: hexToRgbA(brandColor, 0.7),
@@ -42,7 +47,11 @@ export const ValuesPanel: React.FC<ValuesPanelProps> = ({
         </div>
         {linkText ? <ValueLink linkText={linkText} visible={showLink} onLinkClick={onLinkClick} /> : null}
       </div>
-      <ValueList labelledBy={labelledBy} noValuesText={noValuesText} showMore={showMore} values={values} onMoreClick={onMoreClick} />
+      {isDownload && link ? (
+        <ValueDownload href={link} />
+      ) : (
+        <ValueList labelledBy={labelledBy} noValuesText={noValuesText} showMore={showMore} values={values} onMoreClick={onMoreClick} />
+      )}
     </section>
   );
 };

--- a/libs/designer-ui/src/lib/monitoring/valuespanel/valuedownload.tsx
+++ b/libs/designer-ui/src/lib/monitoring/valuespanel/valuedownload.tsx
@@ -1,0 +1,31 @@
+import { Link } from '@fluentui/react';
+import { useIntl } from 'react-intl';
+
+export interface ValueDownloadProps {
+  href: string;
+}
+
+export const ValueDownload: React.FC<ValueDownloadProps> = ({ href }) => {
+  const intl = useIntl();
+
+  const Resources = {
+    DOWNLOAD_PROMPT_MESSAGE: intl.formatMessage({
+      defaultMessage: 'Download (Alt/Option + click)',
+      description: 'Link text for the prompt to download large inputs or outputs',
+    }),
+  };
+
+  const handleClick: React.MouseEventHandler<HTMLElement> = (e) => {
+    e.preventDefault();
+  };
+
+  return (
+    <div className="msla-trace-values">
+      <div className="msla-trace-download-link">
+        <Link aria-label={Resources.DOWNLOAD_PROMPT_MESSAGE} download href={href} rel="noopener" target="_blank" onClick={handleClick}>
+          {Resources.DOWNLOAD_PROMPT_MESSAGE}
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/libs/designer-ui/src/lib/monitoring/valuespanel/valuedownload.tsx
+++ b/libs/designer-ui/src/lib/monitoring/valuespanel/valuedownload.tsx
@@ -16,7 +16,7 @@ export const ValueDownload: React.FC<ValueDownloadProps> = ({ href }) => {
   };
 
   const handleClick: React.MouseEventHandler<HTMLElement> = (e) => {
-    e.preventDefault();
+    e.stopPropagation();
   };
 
   return (

--- a/libs/designer/src/lib/ui/panel/panelTabs/monitoringTab/inputsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/monitoringTab/inputsPanel.tsx
@@ -62,7 +62,7 @@ export const InputsPanel: React.FC<InputsPanelProps> = ({ runMetaData, brandColo
         <ValuesPanel
           brandColor={brandColor}
           headerText={intlText.inputs}
-          linkText={intlText.showInputs}
+          linkText={isNullOrUndefined(values) ? '' : intlText.showInputs}
           showLink={!!uri}
           values={values}
           labelledBy={`inputs-${nodeId}`}
@@ -70,6 +70,8 @@ export const InputsPanel: React.FC<InputsPanelProps> = ({ runMetaData, brandColo
           showMore={showMore}
           onMoreClick={onMoreClick}
           onLinkClick={onSeeRawInputsClick}
+          isDownload={isNullOrUndefined(values)}
+          link={uri}
         />
       ) : null}
     </>

--- a/libs/designer/src/lib/ui/panel/panelTabs/monitoringTab/outputsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/monitoringTab/outputsPanel.tsx
@@ -62,7 +62,7 @@ export const OutputsPanel: React.FC<OutputsPanelProps> = ({ runMetaData, brandCo
         <ValuesPanel
           brandColor={brandColor}
           headerText={intlText.outputs}
-          linkText={intlText.showOutputs}
+          linkText={isNullOrUndefined(values) ? '' : intlText.showOutputs}
           showLink={!!uri}
           values={values}
           labelledBy={`outputs-${nodeId}`}
@@ -70,6 +70,8 @@ export const OutputsPanel: React.FC<OutputsPanelProps> = ({ runMetaData, brandCo
           showMore={showMore}
           onMoreClick={onMoreClick}
           onLinkClick={onSeeRawOutputsClick}
+          isDownload={isNullOrUndefined(values)}
+          link={uri}
         />
       ) : null}
     </>

--- a/libs/services/designer-client-services/src/lib/standard/run.ts
+++ b/libs/services/designer-client-services/src/lib/standard/run.ts
@@ -38,8 +38,8 @@ export class StandardRunService implements IRunService {
     const { uri, contentSize } = contentLink;
     const { httpClient } = this.options;
 
+    // 2^18
     if (contentSize > 262144) {
-      // 2^18
       return undefined;
     }
 

--- a/libs/services/designer-client-services/src/lib/standard/run.ts
+++ b/libs/services/designer-client-services/src/lib/standard/run.ts
@@ -35,8 +35,13 @@ export class StandardRunService implements IRunService {
   }
 
   async getContent(contentLink: ContentLink): Promise<any> {
-    const { uri } = contentLink;
+    const { uri, contentSize } = contentLink;
     const { httpClient } = this.options;
+
+    if (contentSize > 262144) {
+      // 2^18
+      return undefined;
+    }
 
     if (!uri) {
       throw new Error();


### PR DESCRIPTION
### Main Code Changes
- Update ValuesPanel component to show the download hyperlink
- Update run service to return undefined when the size of the file is bigger than the max size of content

Closes #2323 


### Implementation

<img width="1920" alt="Screenshot 2023-05-11 at 2 08 05 PM (2)" src="https://github.com/Azure/LogicAppsUX/assets/102700317/c6d75811-3d38-47ea-8aa6-aacc61f4d59c">

https://github.com/Azure/LogicAppsUX/assets/102700317/33f091a2-5910-4ccb-9dd5-6380be619da6

