### PR TITLE
fix(Designer): Fixed crash with manifest not having connector property 

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -13,7 +13,7 @@ import { initializeTokensAndVariables } from '../../state/tokensSlice';
 import type { WorkflowState } from '../../state/workflow/workflowInterfaces';
 import { addNode, setFocusNode } from '../../state/workflow/workflowSlice';
 import type { AppDispatch, RootState } from '../../store';
-import { getBrandColorFromConnector, getIconUriFromConnector } from '../../utils/card';
+import { getBrandColorFromConnector, getBrandColorFromManifest, getIconUriFromConnector, getIconUriFromManifest } from '../../utils/card';
 import { getTriggerNodeId, isRootNodeInGraph } from '../../utils/graph';
 import { getParameterFromName, updateDynamicDataInNode } from '../../utils/parameters/helper';
 import { createLiteralValueSegment } from '../../utils/parameters/segment';
@@ -98,7 +98,7 @@ const initializeOperationDetails = async (
   const isTrigger = isRootNodeInGraph(nodeId, 'root', state.workflow.nodesMetadata);
   const { type, kind, connectorId, operationId } = operationInfo;
   let isConnectionRequired = true;
-  let connector: Connector;
+  let connector: Connector | undefined;
   const operationManifestService = OperationManifestService();
   const staticResultService = StaticResultService();
 
@@ -112,12 +112,10 @@ const initializeOperationDetails = async (
   if (operationManifestService.isSupported(type, kind)) {
     manifest = await getOperationManifest(operationInfo);
     isConnectionRequired = isConnectionRequiredForOperation(manifest);
-    connector = manifest.properties.connector as Connector;
+    connector = manifest.properties?.connector;
 
-    const { iconUri: operationIcon, brandColor: operationBrandColor } = manifest.properties;
-    const { iconUri: connectorIcon, brandColor: connectorBrandColor } = connector.properties;
-    const iconUri = operationIcon ?? connectorIcon;
-    const brandColor = operationBrandColor ?? connectorBrandColor;
+    const iconUri = getIconUriFromManifest(manifest);
+    const brandColor = getBrandColorFromManifest(manifest);
     const { inputs: nodeInputs, dependencies: inputDependencies } = getInputParametersFromManifest(nodeId, manifest);
     const { outputs: nodeOutputs, dependencies: outputDependencies } = getOutputParametersFromManifest(manifest, isTrigger, nodeInputs);
     parsedManifest = new ManifestParser(manifest);
@@ -202,7 +200,7 @@ const initializeOperationDetails = async (
       dispatch,
       getState
     );
-  } else {
+  } else if (connector) {
     await trySetDefaultConnectionForNode(nodeId, connector, dispatch, isConnectionRequired);
   }
 

--- a/libs/designer/src/lib/core/utils/card.ts
+++ b/libs/designer/src/lib/core/utils/card.ts
@@ -1,22 +1,24 @@
 import type { Connector, OperationManifest } from '@microsoft/utils-logic-apps';
-import { fallbackConnectorUrl, getObjectPropertyValue } from '@microsoft/utils-logic-apps';
+import { fallbackConnectorUrl } from '@microsoft/utils-logic-apps';
 
 export function getBrandColorFromManifest(manifest: OperationManifest): string {
-  return getObjectPropertyValue(manifest, ['properties', 'brandColor']);
+  return manifest.properties?.brandColor ?? getBrandColorFromConnector(manifest.properties?.connector);
 }
 
 export function getIconUriFromManifest(manifest: OperationManifest): string {
-  return getObjectPropertyValue(manifest, ['properties', 'iconUri']);
+  return manifest.properties?.iconUri ?? getIconUriFromConnector(manifest.properties?.connector);
 }
 
-export function getBrandColorFromConnector(connector: Connector): string {
+export function getBrandColorFromConnector(connector: Connector | undefined): string {
+  if (!connector) return '#000000';
   const {
     properties: { brandColor, metadata },
   } = connector;
   return brandColor ?? metadata?.brandColor ?? '#000000';
 }
 
-export function getIconUriFromConnector(connector: Connector): string {
+export function getIconUriFromConnector(connector: Connector | undefined): string {
+  if (!connector) return '';
   const {
     properties: { iconUrl, iconUri, generalInformation },
   } = connector;


### PR DESCRIPTION
## Main changes
Recent changes to icon uri and brand color fallbacks assumed operation manifests had a connector property to read from.
Power Automate has operations without that property, this PR allows for this.