### PR TITLE
fix(designer): Update setVariable Boolean dropdown

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -156,7 +156,12 @@ export async function getDynamicSchema(
         case 'getVariable':
           // eslint-disable-next-line no-case-declarations
           const variable = variables.find((variable) => variable.name === operationParameters['name']);
-          schema = variable ? { type: getSwaggerTypeFromVariableType(variable.type?.toLowerCase()) } : {};
+          schema = variable
+            ? {
+                type: getSwaggerTypeFromVariableType(variable.type?.toLowerCase()),
+                enum: getSwaggerEnumFromVariableType(variable.type?.toLowerCase()),
+              }
+            : {};
           break;
         default:
           schema = await getDynamicSchemaProperties(


### PR DESCRIPTION
Small fix to make the setVariable use the same boolean dropdown as initialize variable

before
<img width="908" alt="beforeSet" src="https://github.com/Azure/LogicAppsUX/assets/95886809/668ba011-4705-4acb-bff6-f8f51214ad41">


after
<img width="939" alt="afterSet" src="https://github.com/Azure/LogicAppsUX/assets/95886809/02ed021b-187a-4efc-a52e-9e85a840d245">
