### PR TITLE
feat(designer): Allow operations to specify unknown parameters to not be rendered or serialized

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -134,7 +134,9 @@ export const getInputParametersFromManifest = (
       ),
       '',
       primaryInputParametersInArray,
-      (!inputsLocation || !!inputsLocation.length) && !manifest.properties.inputsLocationSwapMap /* createInvisibleParameter */,
+      !operationData.metadata?.noUnknownParametersWithManifest &&
+        (!inputsLocation || !!inputsLocation.length) &&
+        !manifest.properties.inputsLocationSwapMap /* createInvisibleParameter */,
       false /* useDefault */
     );
   } else {

--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -511,7 +511,11 @@ function getManifestBasedInputParameters(
     knownKeys.add(clonedInputParameter.key);
   }
 
-  if (stepInputs !== undefined && !manifest.properties.inputsLocationSwapMap) {
+  if (
+    !operationDefinition.metadata?.noUnknownParametersWithManifest &&
+    stepInputs !== undefined &&
+    !manifest.properties.inputsLocationSwapMap
+  ) {
     // load unknown inputs not in the schema by key.
     const resultParameters = map(result, 'key');
     loadUnknownManifestBasedParameters(keyPrefix, '', stepInputs, resultParameters, new Set<string>(), knownKeys);

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1131,7 +1131,7 @@ export function updateParameterWithValues(
                     isUnknown: true,
                   };
 
-                  parameters.push(transformInputParameter(restInputParameter, propertyValue, /* invisible */ false));
+                  parameters.push(transformInputParameter(restInputParameter, propertyValue, /* invisible */ true));
                 }
               }
             }

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1131,7 +1131,7 @@ export function updateParameterWithValues(
                     isUnknown: true,
                   };
 
-                  parameters.push(transformInputParameter(restInputParameter, propertyValue, /* invisible */ true));
+                  parameters.push(transformInputParameter(restInputParameter, propertyValue, /* invisible */ false));
                 }
               }
             }


### PR DESCRIPTION
Unfortunately there are some scenarios where the workflowDefinition to be loaded can contain parameters that do not exist in the manifest (and should not exist).

We want to have a way for the workflowDefinition to indicate that we do not want to show these parameters or serialize them.

current behavior:
![image](https://github.com/Azure/LogicAppsUX/assets/55114634/3bafe0e2-2fe9-4ab5-8955-c9fd82a368cd)

