### PR TITLE
fix(designer): Clear preservedValue when removing dynamic schema parameter from UI

### DIFF
--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -333,7 +333,10 @@ export const operationMetadataSlice = createSlice({
       );
       if (index > -1) {
         state.inputParameters[nodeId].parameterGroups[groupId].parameters[index].conditionalVisibility = value;
-        if (value === false) state.inputParameters[nodeId].parameterGroups[groupId].parameters[index].value = [];
+        if (value === false) {
+          state.inputParameters[nodeId].parameterGroups[groupId].parameters[index].value = [];
+          state.inputParameters[nodeId].parameterGroups[groupId].parameters[index].preservedValue = undefined;
+        }
       }
     },
     updateParameterValidation: (


### PR DESCRIPTION
Fix for #2414 

This prevents the value from being serialized in the workflow definition after clicking the 'X' in the example below:
![image](https://github.com/Azure/LogicAppsUX/assets/55114634/9767b351-0396-49b3-833d-8b0d658b7714)
