### PR TITLE
fix(designer): Fixed connections passing empty non-required parameters

### DIFF
--- a/libs/designer/src/lib/ui/panel/panelTabs/createConnectionTab.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/createConnectionTab.tsx
@@ -31,7 +31,6 @@ import type {
   Connector,
   ManagedIdentity,
 } from '@microsoft/utils-logic-apps';
-import { isTrue } from '@microsoft/utils-logic-apps';
 import { useCallback, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
@@ -119,8 +118,8 @@ const CreateConnectionTab = () => {
       let outputParameterValues = parameterValues;
 
       if (selectedParameterSet) {
-        const requiredParameters = Object.entries(selectedParameterSet?.parameters)?.filter(([, parameter]) =>
-          isTrue(parameter?.uiDefinition.constraints?.required)
+        const requiredParameters = Object.entries(selectedParameterSet?.parameters)?.filter(
+          ([, parameter]) => parameter?.uiDefinition.constraints?.required === 'true'
         );
         requiredParameters?.forEach(([key, parameter]) => {
           if (!outputParameterValues?.[key]) {

--- a/libs/designer/src/lib/ui/panel/panelTabs/createConnectionTab.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/createConnectionTab.tsx
@@ -119,7 +119,7 @@ const CreateConnectionTab = () => {
 
       if (selectedParameterSet) {
         const requiredParameters = Object.entries(selectedParameterSet?.parameters)?.filter(
-          ([, parameter]) => parameter?.uiDefinition.constraints?.required
+          ([, parameter]) => parameter?.uiDefinition.constraints?.required && parameter?.uiDefinition.constraints?.required !== 'false'
         );
         requiredParameters?.forEach(([key, parameter]) => {
           if (!outputParameterValues?.[key]) {
@@ -146,6 +146,7 @@ const CreateConnectionTab = () => {
             return acc;
           }, {}),
         };
+
         const connectionInfo: ConnectionCreationInfo = {
           displayName,
           connectionParametersSet: selectedParameterSet ? connectionParameterSetValues : undefined,

--- a/libs/designer/src/lib/ui/panel/panelTabs/createConnectionTab.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/createConnectionTab.tsx
@@ -31,6 +31,7 @@ import type {
   Connector,
   ManagedIdentity,
 } from '@microsoft/utils-logic-apps';
+import { isTrue } from '@microsoft/utils-logic-apps';
 import { useCallback, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
@@ -118,8 +119,8 @@ const CreateConnectionTab = () => {
       let outputParameterValues = parameterValues;
 
       if (selectedParameterSet) {
-        const requiredParameters = Object.entries(selectedParameterSet?.parameters)?.filter(
-          ([, parameter]) => parameter?.uiDefinition.constraints?.required && parameter?.uiDefinition.constraints?.required !== 'false'
+        const requiredParameters = Object.entries(selectedParameterSet?.parameters)?.filter(([, parameter]) =>
+          isTrue(parameter?.uiDefinition.constraints?.required)
         );
         requiredParameters?.forEach(([key, parameter]) => {
           if (!outputParameterValues?.[key]) {

--- a/libs/utils/src/lib/helpers/functions.ts
+++ b/libs/utils/src/lib/helpers/functions.ts
@@ -937,3 +937,12 @@ export function findAncestorElement(
 export function hasInvalidChars(str: string, invalidChars: string[]): boolean {
   return invalidChars.some((invalidChar) => includes(str, invalidChar));
 }
+
+/**
+ * Returns true if true or "true"
+ * @arg {any} value - A value to compare.
+ * @return {boolean} - True if true or "true"
+ */
+export function isTrue(value: any): boolean {
+  return value === true || value === 'true';
+}

--- a/libs/utils/src/lib/helpers/functions.ts
+++ b/libs/utils/src/lib/helpers/functions.ts
@@ -937,12 +937,3 @@ export function findAncestorElement(
 export function hasInvalidChars(str: string, invalidChars: string[]): boolean {
   return invalidChars.some((invalidChar) => includes(str, invalidChar));
 }
-
-/**
- * Returns true if true or "true"
- * @arg {any} value - A value to compare.
- * @return {boolean} - True if true or "true"
- */
-export function isTrue(value: any): boolean {
-  return value === true || value === 'true';
-}


### PR DESCRIPTION
Our parameter "required" check for multi-auth connections was evaluating true on "false" strings, so we were getting undefined passed to the backend which was causing our connection creation errors
I made us a utils method that ensures the value be a boolean `true` or a "true" string