### PR TITLE
fix(designer): Fixed connections passing empty non-required parameters

### DIFF
--- a/libs/designer/src/lib/ui/panel/panelTabs/createConnectionTab.tsx
+++ b/libs/designer/src/lib/ui/panel/panelTabs/createConnectionTab.tsx
@@ -119,7 +119,7 @@ const CreateConnectionTab = () => {
 
       if (selectedParameterSet) {
         const requiredParameters = Object.entries(selectedParameterSet?.parameters)?.filter(
-          ([, parameter]) => parameter?.uiDefinition.constraints?.required
+          ([, parameter]) => parameter?.uiDefinition.constraints?.required === 'true'
         );
         requiredParameters?.forEach(([key, parameter]) => {
           if (!outputParameterValues?.[key]) {
@@ -146,6 +146,7 @@ const CreateConnectionTab = () => {
             return acc;
           }, {}),
         };
+
         const connectionInfo: ConnectionCreationInfo = {
           displayName,
           connectionParametersSet: selectedParameterSet ? connectionParameterSetValues : undefined,


### PR DESCRIPTION
Our parameter "required" check for multi-auth connections was evaluating true on "false" strings, so we were getting undefined passed to the backend which was causing our connection creation errors

Cherry-pick of: https://github.com/Azure/LogicAppsUX/pull/2435