### PR TITLE
chore: Added branch and release_type to release action

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -1,5 +1,5 @@
 name: Production Build
-
+run-name: Production Build - [${{ github.event.inputs.branch }}][${{ github.event.inputs.release_type || 'no_type_specified' }}]
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Added branch and release type to run name for easier locating of specific runs
 Ex. `Production Build - [hotfix/v2.15][patch]`

There isn't an easy way for us to get the specific version right now


// Do we have pr title tag that's not fix or feat?