### PR TITLE
fix(designer): Generate relative path parameters properties correctly

### DIFF
--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -294,6 +294,7 @@ export const getUpdatedManifestForSchemaDependency = (manifest: OperationManifes
               schemaToReplace = {
                 properties: parameters.reduce((properties: Record<string, any>, parameter: string) => {
                   return {
+                    ...properties,
                     [parameter]: {
                       type: Constants.SWAGGER.TYPE.STRING,
                       title: parameter,


### PR DESCRIPTION
Issue was the schema was incorrectly generated for relative path parameters to show other parameters in token picker.