### PR TITLE
fix(designer): Properly catching invalid brand color values

### DIFF
--- a/libs/designer-ui/src/lib/monitoring/requestpanel/securedatasection.tsx
+++ b/libs/designer-ui/src/lib/monitoring/requestpanel/securedatasection.tsx
@@ -1,5 +1,5 @@
+import { getBrandColorRgbA } from '../../card/utils';
 import Constants from '../../constants';
-import { hexToRgbA } from '@microsoft/utils-logic-apps';
 import { useIntl } from 'react-intl';
 
 export interface SecureDataSectionProps {
@@ -7,7 +7,7 @@ export interface SecureDataSectionProps {
   headerText: string;
 }
 
-export const SecureDataSection: React.FC<SecureDataSectionProps> = ({ brandColor, headerText }) => {
+export const SecureDataSection: React.FC<SecureDataSectionProps> = ({ brandColor = Constants.DEFAULT_BRAND_COLOR, headerText }) => {
   const intl = useIntl();
 
   const Resources = {
@@ -18,7 +18,7 @@ export const SecureDataSection: React.FC<SecureDataSectionProps> = ({ brandColor
   };
 
   const borderStyle = {
-    borderColor: hexToRgbA(brandColor || Constants.DEFAULT_BRAND_COLOR, 0.7),
+    borderColor: getBrandColorRgbA(brandColor, 0.7),
   };
 
   return (

--- a/libs/designer-ui/src/lib/monitoring/valuespanel/index.tsx
+++ b/libs/designer-ui/src/lib/monitoring/valuespanel/index.tsx
@@ -1,9 +1,9 @@
+import { getBrandColorRgbA } from '../../card/utils';
 import Constants from '../../constants';
 import { ValueDownload } from './valuedownload';
 import { ValueLink } from './valuelink';
 import { ValueList } from './valuelist';
 import type { BoundParameters } from '@microsoft/utils-logic-apps';
-import { hexToRgbA } from '@microsoft/utils-logic-apps';
 import React from 'react';
 
 export interface ValuesPanelProps {
@@ -36,7 +36,7 @@ export const ValuesPanel: React.FC<ValuesPanelProps> = ({
   isDownload,
 }) => {
   const borderStyle = {
-    borderColor: hexToRgbA(brandColor, 0.7),
+    borderColor: getBrandColorRgbA(brandColor, 0.7),
   };
 
   return (


### PR DESCRIPTION
Our hex parsing function was getting called directly instead of going through our safe-execution wrapper in a few places, this has been fixed to use in all instances

From https://github.com/Azure/LogicAppsUX/pull/2456