### PR TITLE
fix(desinger): Fixing deserialiation when operation cannot be loaded for triggers

### DIFF
--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -24,6 +24,7 @@ import {
 } from './parameters/helper';
 import { isTokenValueSegment } from './parameters/segment';
 import { TokenSegmentConvertor } from './parameters/tokensegment';
+import { getSplitOnValue } from './setting';
 import { foreachOperationInfo, OperationManifestService } from '@microsoft/designer-client-services-logic-apps';
 import type { OutputToken, Token } from '@microsoft/designer-ui';
 import { TokenType } from '@microsoft/designer-ui';
@@ -71,12 +72,11 @@ export const shouldAddForeach = async (
   const includeSelf = manifest ? shouldIncludeSelfForRepetitionReference(manifest, parameter?.parameterName) : false;
   const repetitionContext = await getRepetitionContext(
     nodeId,
-    getTriggerNodeId(state.workflow),
     state.operations.operationInfo,
     state.operations.inputParameters,
-    state.operations.settings,
     state.workflow.nodesMetadata,
     includeSelf,
+    getSplitOnValue(state.workflow, state.operations),
     state.workflow.idReplacements
   );
   const tokenOwnerNodeId = token.outputInfo.actionName ?? getTriggerNodeId(state.workflow);
@@ -129,12 +129,11 @@ export const addForeachToNode = createAsyncThunk(
 
     const repetitionInfo = await getRepetitionContext(
       foreachNodeId,
-      getTriggerNodeId(newState.workflow),
       newState.operations.operationInfo,
       { ...newState.operations.inputParameters, [foreachNodeId]: nodeInputs },
-      { ...newState.operations.settings, [foreachNodeId]: settings },
       newState.workflow.nodesMetadata,
       /* includeSelf */ false,
+      getSplitOnValue(newState.workflow, newState.operations),
       newState.workflow.idReplacements
     );
 
@@ -176,20 +175,14 @@ export const getRepetitionNodeIds = (
 
 export const getRepetitionContext = async (
   nodeId: string,
-  triggerNodeId: string,
   operationInfos: Record<string, NodeOperation>,
   allInputs: Record<string, NodeInputs>,
-  allSettings: Record<string, any>,
   nodesMetadata: NodesMetadata,
   includeSelf: boolean,
+  splitOn: string | undefined,
   idReplacements?: Record<string, string>
 ): Promise<RepetitionContext> => {
   const repetitionNodeIds = getRepetitionNodeIds(nodeId, nodesMetadata, operationInfos, includeSelf);
-  const splitOn =
-    triggerNodeId && allSettings[triggerNodeId].splitOn?.value?.enabled
-      ? (allSettings[triggerNodeId].splitOn?.value?.value as string)
-      : undefined;
-
   const repetitionReferences = (
     await Promise.all(
       repetitionNodeIds.map((repetitionNodeId) => getRepetitionReference(repetitionNodeId, operationInfos, allInputs, idReplacements))

--- a/libs/designer/src/lib/core/utils/setting.ts
+++ b/libs/designer/src/lib/core/utils/setting.ts
@@ -1,5 +1,9 @@
 import Constants from '../../common/constants';
 import type { Settings } from '../actions/bjsworkflow/settings';
+import type { OperationMetadataState } from '../state/operation/operationMetadataSlice';
+import type { WorkflowState } from '../state/workflow/workflowInterfaces';
+import { getTriggerNodeId } from './graph';
+import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 
 export function hasSecureOutputs(nodeType: string, allSettings: Settings | undefined): boolean {
   const { secureInputs, secureOutputs } = allSettings || {};
@@ -16,4 +20,14 @@ export function isSecureOutputsLinkedToInputs(nodeType?: string): boolean {
     default:
       return false;
   }
+}
+
+export function getSplitOnValue(workflowState: WorkflowState, operationState: OperationMetadataState): string | undefined {
+  const triggerNodeId = getTriggerNodeId(workflowState);
+  const settings = operationState.settings[triggerNodeId];
+  return settings
+    ? settings.splitOn?.value?.enabled
+      ? (settings.splitOn?.value?.value as string)
+      : undefined
+    : (workflowState.operations[triggerNodeId] as LogicAppsV2.Trigger)?.splitOn;
 }

--- a/libs/designer/src/lib/core/utils/tokens.ts
+++ b/libs/designer/src/lib/core/utils/tokens.ts
@@ -32,7 +32,7 @@ import {
   shouldIncludeSelfForRepetitionReference,
 } from './parameters/helper';
 import { createTokenValueSegment } from './parameters/segment';
-import { hasSecureOutputs } from './setting';
+import { getSplitOnValue, hasSecureOutputs } from './setting';
 import { getVariableTokens } from './variables';
 import { OperationManifestService } from '@microsoft/designer-client-services-logic-apps';
 import type { FunctionDefinition, OutputToken, Token, ValueSegment } from '@microsoft/designer-ui';
@@ -285,12 +285,11 @@ export const createValueSegmentFromToken = async (
       newRootState = newState as RootState;
       newRepetitionContext = await getRepetitionContext(
         nodeId,
-        getTriggerNodeId(newRootState.workflow),
         newRootState.operations.operationInfo,
         newRootState.operations.inputParameters,
-        newRootState.operations.settings,
         newRootState.workflow.nodesMetadata,
         /* includeSelf */ false,
+        getSplitOnValue(newRootState.workflow, newRootState.operations),
         newRootState.workflow.idReplacements
       );
     }


### PR DESCRIPTION
Workflow was crashing when certain operations cannot be loaded (unresolved apiids), this was causing repetition info load failure because we always expect trigger to be loaded fine.