### PR TITLE
fix(designer): segment values are not showing properly

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
@@ -43,7 +43,7 @@ export const parseHtmlSegments = (value: ValueSegment[], tokensEnabled?: boolean
           data: segment,
           brandColor,
           icon: icon,
-          value: value ?? segmentValue,
+          value: segmentValue ?? value,
         });
         tokensEnabled && paragraph.append(token);
       } else {
@@ -108,7 +108,7 @@ export const parseSegments = (value: ValueSegment[], tokensEnabled?: boolean): R
           data: segment,
           brandColor,
           icon: icon,
-          value: value ?? segmentValue,
+          value: segmentValue ?? value,
         });
         tokensEnabled && paragraph.append(token);
       } else {


### PR DESCRIPTION
before:

<img width="491" alt="before" src="https://github.com/Azure/LogicAppsUX/assets/95886809/5fcd9fa1-db31-4403-8dc2-cdb49806e34f">


after:
<img width="490" alt="after" src="https://github.com/Azure/LogicAppsUX/assets/95886809/57b42b38-2929-4bd4-bc35-928ce3bcebf0">
