### PR TITLE
feat(vscode): Add APP_KIND and ProjectDirectoryPath values to settings file

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { gitignoreFileName, hostFileName, localSettingsFileName, workerRuntimeKey } from '../../../../constants';
+import { gitignoreFileName, hostFileName, localSettingsFileName, logicAppKind, workerRuntimeKey } from '../../../../constants';
 import { addDefaultBundle } from '../../../utils/bundleFeed';
 import { confirmOverwriteFile, writeFormattedJson } from '../../../utils/fs';
 import { getFunctionsWorkerRuntime } from '../../../utils/vsCodeConfig/settings';
@@ -48,6 +48,8 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
         IsEncrypted: false,
         Values: {
           AzureWebJobsStorage: '',
+          APP_KIND: logicAppKind,
+          ProjectDirectoryPath: path.join(context.projectPath),
         },
       };
 

--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -68,7 +68,7 @@ export async function startDesignTimeApi(projectPath: string): Promise<void> {
     );
 
     const designTimeDirectory: Uri | undefined = await getOrCreateDesignTimeDirectory(designTimeDirectoryName, projectPath);
-    settingsFileContent.Values[ProjectDirectoryPath] = path.join(designTimeDirectory.path);
+    settingsFileContent.Values[ProjectDirectoryPath] = path.join(designTimeDirectory.fsPath);
 
     if (designTimeDirectory) {
       await createJsonFile(designTimeDirectory, hostFileName, hostFileContent);

--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import {
+  ProjectDirectoryPath,
   defaultVersionRange,
   designerStartApi,
   extensionBundleId,
   hostFileName,
   localSettingsFileName,
+  logicAppKind,
   workflowDesignerLoadTimeout,
 } from '../../../constants';
 import { ext } from '../../../extensionVariables';
@@ -47,6 +49,7 @@ export async function startDesignTimeApi(projectPath: string): Promise<void> {
     Values: {
       AzureWebJobsSecretStorageType: 'Files',
       FUNCTIONS_WORKER_RUNTIME: os.platform() === 'win32' ? WorkerRuntime.DotnetIsolated : WorkerRuntime.Node,
+      APP_KIND: logicAppKind,
     },
   };
   if (!ext.workflowDesignTimePort) {
@@ -63,7 +66,10 @@ export async function startDesignTimeApi(projectPath: string): Promise<void> {
       localize('azureFunctions.designTimeApi', 'Starting workflow design time api. It might take a few seconds.'),
       'OK'
     );
+
     const designTimeDirectory: Uri | undefined = await getOrCreateDesignTimeDirectory(designTimeDirectoryName, projectPath);
+    settingsFileContent.Values[ProjectDirectoryPath] = path.join(designTimeDirectory.path);
+
     if (designTimeDirectory) {
       await createJsonFile(designTimeDirectory, hostFileName, hostFileContent);
       await createJsonFile(designTimeDirectory, localSettingsFileName, settingsFileContent);

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -22,6 +22,7 @@ export const funcIgnoreFileName = '.funcignore';
 export const func = 'func';
 export const functionsExtensionId = 'ms-azuretools.vscode-azurefunctions';
 export const workerRuntimeKey = 'FUNCTIONS_WORKER_RUNTIME';
+export const ProjectDirectoryPath = 'ProjectDirectoryPath';
 export const extensionVersionKey = 'FUNCTIONS_EXTENSION_VERSION';
 export const hostStartCommand = 'host start';
 export const hostStartTaskName = `${func}: ${hostStartCommand}`;


### PR DESCRIPTION
### Main Code Changes
- Add APP_KIND and ProjectDirectoryPath values to local.settings.json when creating a new project and when opening designer

### Implementation
-  Runtime local.settings.json
<img width="1920" alt="Screenshot 2023-05-19 at 3 06 36 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/3b5f5c94-fdb0-4d37-a6ca-d7c7b181d66f">

- Design time local.settings.json
<img width="1920" alt="Screenshot 2023-05-19 at 3 09 25 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/8575a87f-2c81-408b-893d-83e2249c006e">
