### PR TITLE
fix(designer): Add empty schema when dynamic input fails and has value in definition

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2050,7 +2050,7 @@ async function tryGetInputDynamicSchema(
     );
     return schema;
   } catch (error: any) {
-    if (!dependencyInfo.parameter?.required) {
+    if (!dependencyInfo.parameter?.required && !(dependencyInfo.parameter as InputParameter).value) {
       throw error;
     }
 


### PR DESCRIPTION
Previously when dynamic inputs call fail, it will return empty schema only when it is a required parameter. But we should have an empty schema if definition has a value for that parameter else we will loose the inputs while serialization.
![image](https://github.com/Azure/LogicAppsUX/assets/48265693/c3fc02e1-98d3-41ec-80fe-69ae95367aaf)
