### PR TITLE
fix(designer): Mark dependent parameters as valid for even output token references for dynamic call

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2252,10 +2252,7 @@ export function parameterHasValue(parameter: ParameterInfo): boolean {
 }
 
 export function parameterValidForDynamicCall(parameter: ParameterInfo): boolean {
-  const hasOutputTokenSegment = parameter.value.some(
-    (segment) => segment.type === ValueSegmentType.TOKEN && segment.token?.tokenType !== TokenType.PARAMETER
-  );
-  return parameter.required ? parameterHasValue(parameter) && !hasOutputTokenSegment : !hasOutputTokenSegment;
+  return !parameter.required || parameterHasValue(parameter);
 }
 
 export function getGroupAndParameterFromParameterKey(


### PR DESCRIPTION
fixes #2509 