### PR TITLE
fix(designer): Fixed connections with non-optional gateway parameters

### DIFF
--- a/libs/designer-ui/src/lib/createConnection/index.tsx
+++ b/libs/designer-ui/src/lib/createConnection/index.tsx
@@ -34,7 +34,7 @@ import {
   usesLegacyManagedIdentity,
 } from '@microsoft/utils-logic-apps';
 import type { FormEvent } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 export interface CreateConnectionProps {
@@ -123,13 +123,13 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
   );
   const isMultiAuth = useMemo(() => (connectionParameterSets?.values?.length ?? 0) > 1, [connectionParameterSets?.values]);
 
-  const isOnlyGatewayCapable = useCallback(
-    (capabilities: string[] = []) =>
-      (capabilities?.includes(Capabilities[Capabilities.gateway]) && !capabilities?.includes(Capabilities[Capabilities.cloud])) ?? false,
-    []
+  const hasOnlyOnPremGateway = useMemo(
+    () =>
+      (connectorCapabilities?.includes(Capabilities[Capabilities.gateway]) &&
+        !connectorCapabilities?.includes(Capabilities[Capabilities.cloud])) ??
+      false,
+    [connectorCapabilities]
   );
-
-  const hasOnlyOnPremGateway = useMemo(() => isOnlyGatewayCapable(connectorCapabilities), [connectorCapabilities, isOnlyGatewayCapable]);
 
   const [enabledCapabilities, setEnabledCapabilities] = useState<Capabilities[]>([]);
   const toggleCapability = useCallback(
@@ -142,6 +142,10 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
     },
     [enabledCapabilities]
   );
+
+  useEffect(() => {
+    if (hasOnlyOnPremGateway && !enabledCapabilities.includes(Capabilities.gateway)) toggleCapability(Capabilities.gateway);
+  }, [enabledCapabilities, hasOnlyOnPremGateway, toggleCapability]);
 
   const supportsServicePrincipalConnection = useMemo(
     () => connectorContainsAllServicePrinicipalConnectionParameters(singleAuthParams),
@@ -220,6 +224,7 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
     (capability: Capabilities) => parametersByCapability?.[Capabilities[capability]] ?? {},
     [parametersByCapability]
   );
+
   const capabilityEnabledParameters = useMemo(() => {
     let output: Record<string, ConnectionParameterSetParameter | ConnectionParameter> = parametersByCapability['general'];
     Object.entries(parametersByCapability).forEach(([capabilityText, parameters]) => {
@@ -234,8 +239,8 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
 
   // Don't show name for simple connections
   const showNameInput = useMemo(
-    () => isMultiAuth || Object.keys(parametersByCapability['general'] ?? {}).length > 0 || legacyManagedIdentitySelected,
-    [isMultiAuth, parametersByCapability, legacyManagedIdentitySelected]
+    () => isMultiAuth || Object.keys(capabilityEnabledParameters ?? {}).length > 0 || legacyManagedIdentitySelected,
+    [isMultiAuth, capabilityEnabledParameters, legacyManagedIdentitySelected]
   );
 
   const hasOAuth = useMemo(
@@ -490,6 +495,24 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
           </div>
         )}
 
+        {/* OptionalGateway Checkbox */}
+        {!hasOnlyOnPremGateway && Object.entries(getParametersByCapability(Capabilities.gateway)).length > 0 && (
+          <div className="param-row center" style={{ margin: '8px 0px' }}>
+            <Checkbox
+              label={intl.formatMessage({
+                defaultMessage: 'Connect via on-premises data gateway',
+                description: 'Checkbox label for using an on-premises gateway',
+              })}
+              checked={enabledCapabilities.includes(Capabilities.gateway)}
+              onChange={() => toggleCapability(Capabilities.gateway)}
+              disabled={isLoading}
+            />
+            <TooltipHost content={gatewayTooltipText}>
+              <Icon iconName="Info" style={{ marginLeft: '4px', transform: 'translate(0px, 2px)' }} />
+            </TooltipHost>
+          </div>
+        )}
+
         {/* Name */}
         {showNameInput && (
           <div className="param-row">
@@ -562,44 +585,25 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
             )
           )}
 
-        {!hasOnlyOnPremGateway && Object.keys(getParametersByCapability(Capabilities.gateway)).length > 0 && (
-          <>
-            {/* OptionalGateway Checkbox */}
-            <div className="param-row center" style={{ margin: '8px 0px' }}>
-              <Checkbox
-                label={intl.formatMessage({
-                  defaultMessage: 'Connect via on-premises data gateway',
-                  description: 'Checkbox label for using an on-premises gateway',
-                })}
-                checked={enabledCapabilities.includes(Capabilities.gateway)}
-                onChange={() => toggleCapability(Capabilities.gateway)}
-                disabled={isLoading}
+        {/* Gateway-Specific Parameters */}
+        {showConfigParameters &&
+          enabledCapabilities.includes(Capabilities.gateway) &&
+          Object.entries(getParametersByCapability(Capabilities.gateway))?.map(
+            ([key, parameter]: [string, ConnectionParameterSetParameter | ConnectionParameter]) => (
+              <UniversalConnectionParameter
+                key={key}
+                parameterKey={key}
+                parameter={parameter}
+                value={parameterValues[key]}
+                setValue={(val: any) => setParameterValues({ ...parameterValues, [key]: val })}
+                isLoading={isLoading}
+                selectedSubscriptionId={selectedSubscriptionId}
+                selectSubscriptionCallback={selectSubscriptionCallback}
+                availableGateways={availableGateways}
+                availableSubscriptions={availableSubscriptions}
               />
-              <TooltipHost content={gatewayTooltipText}>
-                <Icon iconName="Info" style={{ marginLeft: '4px', transform: 'translate(0px, 2px)' }} />
-              </TooltipHost>
-            </div>
-            {/* Gateway-Specific Parameters */}
-            {showConfigParameters &&
-              enabledCapabilities.includes(Capabilities.gateway) &&
-              Object.entries(getParametersByCapability(Capabilities.gateway))?.map(
-                ([key, parameter]: [string, ConnectionParameterSetParameter | ConnectionParameter]) => (
-                  <UniversalConnectionParameter
-                    key={key}
-                    parameterKey={key}
-                    parameter={parameter}
-                    value={parameterValues[key]}
-                    setValue={(val: any) => setParameterValues({ ...parameterValues, [key]: val })}
-                    isLoading={isLoading}
-                    selectedSubscriptionId={selectedSubscriptionId}
-                    selectSubscriptionCallback={selectSubscriptionCallback}
-                    availableGateways={availableGateways}
-                    availableSubscriptions={availableSubscriptions}
-                  />
-                )
-              )}
-          </>
-        )}
+            )
+          )}
 
         {/* Resource Selector UI */}
         {resourceSelectedProps && <AzureResourcePicker {...resourceSelectedProps} />}


### PR DESCRIPTION
## Main Changes
Parameters with the `gateway` capability were only shown if they were optional before, on some connectors they are required and these were being filtered out.  They are now shown.

![image](https://github.com/Azure/LogicAppsUX/assets/25409734/2612ff26-143e-442a-8e69-0c3d79c10d32)

Cherry picked from : https://github.com/Azure/LogicAppsUX/pull/2519