### PR TITLE
feat(designer): Add utility for extracting UI from tokens ad hoc

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -148,7 +148,7 @@ export const initializeOperationMetadata = async (
   );
 };
 
-const initializeConnectorsForReferences = async (references: ConnectionReferences): Promise<ConnectorWithParsedSwagger[]> => {
+export const initializeConnectorsForReferences = async (references: ConnectionReferences): Promise<ConnectorWithParsedSwagger[]> => {
   const connectorIds = uniqueArray(Object.keys(references || {}).map((key) => references[key].api.id));
   const connectorPromises: Promise<ConnectorWithParsedSwagger | undefined>[] = [];
 
@@ -166,11 +166,14 @@ const initializeConnectorsForReferences = async (references: ConnectionReference
   return (await Promise.all(connectorPromises)).filter((result) => !!result) as ConnectorWithParsedSwagger[];
 };
 
+/**
+ * @param dispatch - Not required if only need to get the return data.
+ */
 export const initializeOperationDetailsForManifest = async (
   nodeId: string,
   _operation: LogicAppsV2.ActionDefinition | LogicAppsV2.TriggerDefinition,
   isTrigger: boolean,
-  dispatch: Dispatch
+  dispatch?: Dispatch
 ): Promise<NodeDataWithOperationMetadata[] | undefined> => {
   const operation = { ..._operation };
   try {
@@ -182,14 +185,14 @@ export const initializeOperationDetailsForManifest = async (
       const manifest = await getOperationManifest(operationInfo);
       const { iconUri, brandColor } = manifest.properties;
 
-      dispatch(initializeOperationInfo({ id: nodeId, ...nodeOperationInfo }));
+      dispatch?.(initializeOperationInfo({ id: nodeId, ...nodeOperationInfo }));
 
       const { connectorId, operationId } = nodeOperationInfo;
       const parsedManifest = new ManifestParser(manifest);
       const schema = staticResultService.getOperationResultSchema(connectorId, operationId, parsedManifest);
       schema.then((schema) => {
         if (schema) {
-          dispatch(addResultSchema({ id: `${connectorId}-${operationId}`, schema: schema }));
+          dispatch?.(addResultSchema({ id: `${connectorId}-${operationId}`, schema: schema }));
         }
       });
 
@@ -243,7 +246,7 @@ export const initializeOperationDetailsForManifest = async (
       error: error instanceof Error ? error : undefined,
     });
 
-    dispatch(updateErrorDetails({ id: nodeId, errorInfo: { level: ErrorLevel.Critical, error, message } }));
+    dispatch?.(updateErrorDetails({ id: nodeId, errorInfo: { level: ErrorLevel.Critical, error, message } }));
     return;
   }
 };
@@ -304,7 +307,7 @@ const processChildGraphAndItsInputs = (
   return nodesData;
 };
 
-const updateTokenMetadataInParameters = (
+export const updateTokenMetadataInParameters = (
   nodes: NodeDataWithOperationMetadata[],
   operations: Operations,
   workflowParameters: Record<string, WorkflowParameter>,
@@ -362,7 +365,7 @@ const updateTokenMetadataInParameters = (
   }
 };
 
-const initializeOutputTokensForOperations = (
+export const initializeOutputTokensForOperations = (
   allNodesData: NodeDataWithOperationMetadata[],
   operations: Operations,
   graph: WorkflowNode,
@@ -418,7 +421,7 @@ const initializeOutputTokensForOperations = (
   return result;
 };
 
-const initializeVariables = (
+export const initializeVariables = (
   operations: Operations,
   allNodesData: NodeDataWithOperationMetadata[]
 ): Record<string, VariableDeclaration[]> => {
@@ -443,7 +446,7 @@ const initializeVariables = (
   return declarations;
 };
 
-const initializeRepetitionInfos = async (
+export const initializeRepetitionInfos = async (
   triggerNodeId: string,
   allOperations: Operations,
   nodesData: NodeDataWithOperationMetadata[],

--- a/libs/designer/src/lib/core/utils/swagger/operation.ts
+++ b/libs/designer/src/lib/core/utils/swagger/operation.ts
@@ -49,12 +49,15 @@ interface OperationInputInfo {
   };
 }
 
+/**
+ * @param dispatch - Not required if only need to get the return data.
+ */
 export const initializeOperationDetailsForSwagger = async (
   nodeId: string,
   operation: LogicAppsV2.ActionDefinition | LogicAppsV2.TriggerDefinition,
   references: ConnectionReferences,
   isTrigger: boolean,
-  dispatch: Dispatch
+  dispatch?: Dispatch
 ): Promise<NodeDataWithOperationMetadata[] | undefined> => {
   try {
     const staticResultService = StaticResultService();
@@ -64,13 +67,13 @@ export const initializeOperationDetailsForSwagger = async (
       const { connectorId, operationId } = operationInfo;
 
       const nodeOperationInfo = { ...operationInfo, type: operation.type, kind: operation.kind };
-      dispatch(initializeOperationInfo({ id: nodeId, ...nodeOperationInfo }));
+      dispatch?.(initializeOperationInfo({ id: nodeId, ...nodeOperationInfo }));
       const { connector, parsedSwagger } = await getConnectorWithSwagger(operationInfo.connectorId);
 
       const schemaService = staticResultService.getOperationResultSchema(connectorId, operationId, parsedSwagger);
       schemaService.then((schema) => {
         if (schema) {
-          dispatch(addResultSchema({ id: `${connectorId}-${operationId}`, schema: schema }));
+          dispatch?.(addResultSchema({ id: `${connectorId}-${operationId}`, schema: schema }));
         }
       });
 
@@ -114,7 +117,7 @@ export const initializeOperationDetailsForSwagger = async (
       error: error instanceof Error ? error : undefined,
     });
 
-    dispatch(updateErrorDetails({ id: nodeId, errorInfo: { level: ErrorLevel.Critical, error, message } }));
+    dispatch?.(updateErrorDetails({ id: nodeId, errorInfo: { level: ErrorLevel.Critical, error, message } }));
     return;
   }
 };

--- a/libs/designer/src/lib/index.tsx
+++ b/libs/designer/src/lib/index.tsx
@@ -18,4 +18,6 @@ export * from './common/models/workflow';
 export { default as Constants } from './common/constants';
 export { serializeWorkflow as serializeBJSWorkflow } from './core/actions/bjsworkflow/serializer';
 export { updateCallbackUrl } from './core/actions/bjsworkflow/initialize';
+export { getTokensFromWorkflow } from './core/utils/tokens';
+export { parameterValueToString } from './core/utils/parameters/helper';
 export { ReactQueryProvider } from './core/ReactQueryProvider';


### PR DESCRIPTION
Takes in a workflow definition and basic services to return back Token UI data. 

Needed for our case, where we store only token value data on the backend, so have to build the token UI from that outside the context of the designer.