### PR TITLE
fix(designer): Render schedule editor only when recurrence values are literal segments

### DIFF
--- a/libs/designer/src/lib/common/constants.ts
+++ b/libs/designer/src/lib/common/constants.ts
@@ -185,6 +185,7 @@ export default {
     TABLE: 'table',
     VARIABLE_NAME: 'variablename',
     HTML: 'html',
+    RECURRENCE: 'recurrence',
   },
   EVENT_AUTH_COMPLETED: 'MSLA_AUTH_COMPLETED',
   ERROR_MESSAGES: {

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -421,6 +421,10 @@ export function getParameterEditorProps(
       displayValue = nodeMetadata?.[parameterValue[0].value];
     }
     editorViewModel = { displayValue, selectedItem: undefined };
+  } else if (editor === constants.EDITOR.RECURRENCE) {
+    if (parameterValue.some(isTokenValueSegment)) {
+      editor = undefined;
+    }
   }
 
   return { editor, editorOptions, editorViewModel, schema };


### PR DESCRIPTION
We will now load a normal editor if the recurrence contains any tokens, instead of showing the schedule editor.
![image](https://github.com/Azure/LogicAppsUX/assets/48265693/98be7bc9-9d4b-4a5e-a701-4879f424e047)

If user has to move to older view they will have to save this value with constants and reload designer. We are not creating a hybrid schedule editor as of now.

this fixes #2531 