### PR TITLE
fix(designer): Don't stop propagation on click of the token segment delete button

### DIFF
--- a/libs/designer-ui/src/lib/token/inputToken.tsx
+++ b/libs/designer-ui/src/lib/token/inputToken.tsx
@@ -64,10 +64,7 @@ export const InputToken: React.FC<InputTokenProps> = ({ value, brandColor, icon,
         title={tokenDelete}
         aria-label={tokenDelete}
         className="msla-button msla-token-delete"
-        onClick={(e) => {
-          e.stopPropagation();
-          handleTokenDeleteClicked();
-        }}
+        onClick={handleTokenDeleteClicked}
         onMouseDown={(e) => {
           e.preventDefault();
         }}


### PR DESCRIPTION
If we stop the propagation of the mouse click event when clicking the token delete button, this causes the click to stop at dispatching the node deletion without selecting the editor, which would made the node deletion to not actually take effect in the state of the editor until the editor is manually selected again. 

The code for stopping the propagation was to fix an old issue where the token expression would randomly show on the click of the delete button. The code has since been reworked with this is no longer needed. I tested the scenario in question, and it works without a problem.