### PR TITLE
fix(designer): Showing only multi auth connection parameters when both legacy and multi auth is present

### DIFF
--- a/libs/designer-ui/src/lib/createConnection/index.tsx
+++ b/libs/designer-ui/src/lib/createConnection/index.tsx
@@ -158,8 +158,8 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
   );
 
   const showLegacyMultiAuth = useMemo(
-    () => supportsServicePrincipalConnection || supportsLegacyManagedIdentityConnection,
-    [supportsServicePrincipalConnection, supportsLegacyManagedIdentityConnection]
+    () => !isMultiAuth && (supportsServicePrincipalConnection || supportsLegacyManagedIdentityConnection),
+    [isMultiAuth, supportsServicePrincipalConnection, supportsLegacyManagedIdentityConnection]
   );
 
   const servicePrincipalSelected = useMemo(
@@ -237,12 +237,6 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
     return output ?? {};
   }, [enabledCapabilities, parametersByCapability]);
 
-  // Don't show name for simple connections
-  const showNameInput = useMemo(
-    () => isMultiAuth || Object.keys(capabilityEnabledParameters ?? {}).length > 0 || legacyManagedIdentitySelected,
-    [isMultiAuth, capabilityEnabledParameters, legacyManagedIdentitySelected]
-  );
-
   const hasOAuth = useMemo(
     () => checkOAuthCallback(isMultiAuth ? multiAuthParams : singleAuthParams) && !enabledCapabilities.includes(Capabilities.gateway),
     [checkOAuthCallback, enabledCapabilities, isMultiAuth, multiAuthParams, singleAuthParams]
@@ -251,6 +245,12 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
   const isUsingOAuth = useMemo(
     () => hasOAuth && !servicePrincipalSelected && !legacyManagedIdentitySelected,
     [hasOAuth, servicePrincipalSelected, legacyManagedIdentitySelected]
+  );
+
+  // Don't show name for simple connections
+  const showNameInput = useMemo(
+    () => isMultiAuth || Object.keys(capabilityEnabledParameters ?? {}).length > 0 || legacyManagedIdentitySelected,
+    [isMultiAuth, capabilityEnabledParameters, legacyManagedIdentitySelected]
   );
 
   const [connectionDisplayName, setConnectionDisplayName] = useState<string>('');


### PR DESCRIPTION
This fixes issue with key vault connection creations