### PR TITLE
fix(designer): Preventing crash when switch cases have non-unique names

### DIFF
--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -13,6 +13,7 @@ import {
   equals,
   isNullOrEmpty,
   isNullOrUndefined,
+  getUniqueName,
 } from '@microsoft/utils-logic-apps';
 
 const hasMultipleTriggers = (definition: LogicAppsV2.WorkflowDefinition): boolean => {
@@ -36,6 +37,8 @@ export const Deserialize = (
   let triggerNode: WorkflowNode | null = null;
   let allActions: Operations = {};
   let nodesMetadata: NodesMetadata = {};
+  const allActionNames = getAllActionNames(definition.actions);
+
   if (definition.triggers && !isNullOrEmpty(definition.triggers)) {
     const [[tID, trigger]] = Object.entries(definition.triggers);
     triggerNode = createWorkflowNode(tID);
@@ -46,6 +49,7 @@ export const Deserialize = (
       ...(trigger?.metadata && { actionMetadata: trigger?.metadata }),
       ...addTriggerInstanceMetaData(runInstance),
     };
+    allActionNames.push(tID);
   }
 
   const children = [];
@@ -63,7 +67,7 @@ export const Deserialize = (
   }
 
   const [remainingChildren, edges, actions, actionNodesMetadata] = !isNullOrUndefined(definition.actions)
-    ? buildGraphFromActions(definition.actions, 'root', undefined /* parentNodeId */)
+    ? buildGraphFromActions(definition.actions, 'root', undefined /* parentNodeId */, allActionNames)
     : [[], [], {}];
   allActions = { ...allActions, ...actions };
   nodesMetadata = { ...nodesMetadata, ...actionNodesMetadata };
@@ -101,17 +105,40 @@ const isUntilAction = (action: LogicAppsV2.ActionDefinition) => action?.type?.to
 const buildGraphFromActions = (
   actions: Record<string, LogicAppsV2.ActionDefinition>,
   graphId: string,
-  parentNodeId: string | undefined
+  parentNodeId: string | undefined,
+  allActionNames: string[]
 ): [WorkflowNode[], WorkflowEdge[], Operations, NodesMetadata] => {
   const nodes: WorkflowNode[] = [];
   const edges: WorkflowEdge[] = [];
   let allActions: Operations = {};
   let nodesMetadata: NodesMetadata = {};
-  for (const [actionName, action] of Object.entries(actions)) {
+  for (const [actionName, _action] of Object.entries(actions)) {
+    // Making action extensible
+    const action = Object.assign({}, _action);
     const node = createWorkflowNode(
       actionName,
       isScopeAction(action) ? WORKFLOW_NODE_TYPES.GRAPH_NODE : WORKFLOW_NODE_TYPES.OPERATION_NODE
     );
+
+    if (isSwitchAction(action) && action?.cases) {
+      const caseKeys = Object.keys(action.cases);
+      for (const key of caseKeys) {
+        if (!allActionNames.includes(key)) {
+          allActionNames.push(key);
+          continue;
+        }
+        const caseAction: any = action.cases?.[key];
+        const { name: newCaseId } = getUniqueName(allActionNames, key);
+        allActionNames.push(newCaseId);
+        if (caseAction) {
+          action.cases = {
+            ...action.cases,
+            [newCaseId]: caseAction,
+          };
+          delete action.cases[key];
+        }
+      }
+    }
 
     allActions[actionName] = { ...action };
 
@@ -119,7 +146,7 @@ const buildGraphFromActions = (
     nodesMetadata[actionName] = { graphId, ...(parentNodeId ? { parentNodeId: parentNodeId } : {}) };
 
     if (isScopeAction(action)) {
-      const [scopeNodes, scopeEdges, scopeActions, scopeNodesMetadata] = processScopeActions(graphId, actionName, action);
+      const [scopeNodes, scopeEdges, scopeActions, scopeNodesMetadata] = processScopeActions(graphId, actionName, action, allActionNames);
       node.children = scopeNodes;
       node.edges = scopeEdges;
       allActions = { ...allActions, ...scopeActions };
@@ -150,7 +177,8 @@ const buildGraphFromActions = (
 const processScopeActions = (
   rootGraphId: string,
   actionName: string,
-  action: LogicAppsV2.ScopeAction
+  action: LogicAppsV2.ScopeAction,
+  allActionNames: string[]
 ): [WorkflowNode[], WorkflowEdge[], Operations, NodesMetadata] => {
   const nodes: WorkflowNode[] = [];
   const edges: WorkflowEdge[] = [];
@@ -164,7 +192,7 @@ const processScopeActions = (
 
   // For use on scope nodes with a single flow
   const applyActions = (graphId: string, actions?: LogicAppsV2.Actions) => {
-    const [graph, operations, metadata] = processNestedActions(graphId, graphId, actions);
+    const [graph, operations, metadata] = processNestedActions(graphId, graphId, actions, allActionNames);
 
     nodes.push(...(graph.children as []));
     edges.push(...(graph.edges as []));
@@ -199,7 +227,7 @@ const processScopeActions = (
     subgraphType: SubgraphType,
     subGraphLocation: string | undefined
   ) => {
-    const [graph, operations, metadata] = processNestedActions(subgraphId, graphId, actions, true);
+    const [graph, operations, metadata] = processNestedActions(subgraphId, graphId, actions, allActionNames, true);
     if (!graph?.edges) graph.edges = [];
 
     graph.subGraphLocation = subGraphLocation;
@@ -240,7 +268,7 @@ const processScopeActions = (
     scopeCardNode.id = scopeCardNode.id.replace('#scope', '#subgraph');
     scopeCardNode.type = WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE;
 
-    const [graph, operations, metadata] = processNestedActions(graphId, graphId, actions);
+    const [graph, operations, metadata] = processNestedActions(graphId, graphId, actions, allActionNames);
 
     nodes.push(...(graph?.children ?? []));
     edges.push(...(graph?.edges ?? []));
@@ -313,10 +341,11 @@ const processNestedActions = (
   graphId: string,
   parentNodeId: string | undefined,
   actions: LogicAppsV2.Actions | undefined,
+  allActionNames: string[],
   isSubgraph?: boolean
 ): [WorkflowNode, Operations, NodesMetadata] => {
   const [children, edges, scopeActions, scopeNodesMetadata] = !isNullOrUndefined(actions)
-    ? buildGraphFromActions(actions, graphId, parentNodeId)
+    ? buildGraphFromActions(actions, graphId, parentNodeId, allActionNames)
     : [[], [], {}, {}];
   return [
     {
@@ -388,4 +417,27 @@ const addActionsInstanceMetaData = (nodesMetadata: NodesMetadata, runInstance: L
   });
 
   return updatedNodesData;
+};
+
+const getAllActionNames = (actions: LogicAppsV2.Actions | undefined, names: string[] = []): string[] => {
+  if (isNullOrUndefined(actions)) return [];
+
+  for (const [actionName, action] of Object.entries(actions)) {
+    names.push(actionName);
+    if (isScopeAction(action)) {
+      if (action.actions) names.push(...getAllActionNames(action.actions));
+      if (isIfAction(action)) {
+        if (action.else?.actions) names.push(...getAllActionNames(action.else.actions));
+      }
+      if (isSwitchAction(action)) {
+        if (action.default?.actions) names.push(...getAllActionNames(action.default.actions));
+        if (action.cases) {
+          for (const caseAction of Object.values(action.cases)) {
+            if (caseAction.actions) names.push(...getAllActionNames(caseAction.actions));
+          }
+        }
+      }
+    }
+  }
+  return names;
 };


### PR DESCRIPTION
## Main Changes
Switch cases in legacy designer did not need to be unique before, importing one of these actions caused react flow to crash if it had a child with a duplicate name.
This change checks for duplicate names during deserialization and increments the switch case name if it detects a duplicate.
This _only_ occurs on switch cases, so there was no other work needed for tokens / run after / connection logic / etc.
On saving it will commit the unique name

![image](https://github.com/Azure/LogicAppsUX/assets/25409734/9b5153e2-b1d7-4602-b1e3-dbc2db621454)

Cherry-picked from https://github.com/Azure/LogicAppsUX/pull/2561