### PR TITLE
fix(designer): Load connection when not present in resource group

### DIFF
--- a/libs/designer-ui/src/lib/createConnection/index.tsx
+++ b/libs/designer-ui/src/lib/createConnection/index.tsx
@@ -249,8 +249,8 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
 
   // Don't show name for simple connections
   const showNameInput = useMemo(
-    () => isMultiAuth || Object.keys(capabilityEnabledParameters ?? {}).length > 0 || legacyManagedIdentitySelected,
-    [isMultiAuth, capabilityEnabledParameters, legacyManagedIdentitySelected]
+    () => !(isUsingOAuth && !isMultiAuth) && (isMultiAuth || Object.keys(capabilityEnabledParameters ?? {}).length > 0 || legacyManagedIdentitySelected),
+    [isUsingOAuth, isMultiAuth, capabilityEnabledParameters, legacyManagedIdentitySelected]
   );
 
   const [connectionDisplayName, setConnectionDisplayName] = useState<string>('');
@@ -291,7 +291,7 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
     const identitySelected = legacyManagedIdentitySelected ? selectedManagedIdentity : undefined;
 
     return createConnectionCallback?.(
-      showNameInput ? connectionDisplayName : '',
+      showNameInput ? connectionDisplayName : undefined,
       connectionParameterSets?.values[selectedParamSetIndex],
       visibleParameterValues,
       isUsingOAuth,

--- a/libs/designer-ui/src/lib/selectConnection/index.tsx
+++ b/libs/designer-ui/src/lib/selectConnection/index.tsx
@@ -77,11 +77,13 @@ export const SelectConnection = (props: SelectConnectionProps): JSX.Element => {
   // Assign connection on initial load
   useEffect(() => {
     if (currentConnectionId) {
-      setSelect((currentSelect) => {
-        const index = connections.findIndex((conn) => areIdLeavesEqual(conn.id, currentConnectionId));
-        currentSelect.setIndexSelected(index, true, false);
-        return currentSelect;
-      });
+      const index = connections.findIndex((conn) => areIdLeavesEqual(conn.id, currentConnectionId));
+      if (index >= 0) {
+        setSelect((currentSelect) => {
+          currentSelect.setIndexSelected(index, true, false);
+          return currentSelect;
+        });
+      }
     }
   }, [connections, currentConnectionId]);
 

--- a/libs/designer/src/lib/core/utils/connectors/connections.ts
+++ b/libs/designer/src/lib/core/utils/connectors/connections.ts
@@ -49,7 +49,7 @@ export async function isConnectionReferenceValid(
     return false;
   }
 
-  const connection = await getConnection(reference.connection.id, connectorId);
+  const connection = await getConnection(reference.connection.id, connectorId, /* fetchResourceIfNeeded */true);
   return !!connection && !connection.properties?.statuses?.some((status) => equals(status.status, 'error'));
 }
 


### PR DESCRIPTION
fixes #2488 

The issue was user was using different resource group in their connection id that may have been created for connectors in different region. So while listing connections under that connector this valid connectionId would not be retrieved and user would see Invalid Connection issue.
We are now also trying to do a get on a connectionid, when it is not found on the list.

Two other minor fixes -
1. Do not show connection name on OAuth single auth connections
2. When connection was not found on the list while opening select connections it would automatically update to first connection, updating users action without their action.