### PR TITLE
fix(designer): Fixed issue where some connection parameter dropdowns were passing name text as value

### DIFF
--- a/libs/designer-ui/src/lib/createConnection/universalConnectionParameter.tsx
+++ b/libs/designer-ui/src/lib/createConnection/universalConnectionParameter.tsx
@@ -58,20 +58,21 @@ export const UniversalConnectionParameter = (props: ConnectionParameterProps) =>
 
   // Dropdown Parameter
   else if ((constraints?.allowedValues?.length ?? 0) > 0) {
-    const selectedKey = constraints?.allowedValues?.findIndex((_value) => _value.text === value);
-    if (selectedKey === -1) setValue(constraints?.allowedValues?.[0].text);
+    const selectedKey = constraints?.allowedValues?.findIndex((_value) => _value.value === value);
+    if (selectedKey === -1) setValue(constraints?.allowedValues?.[0].value);
     inputComponent = (
       <Dropdown
         id={`connection-param-${parameterKey}`}
         className="connection-parameter-input"
         selectedKey={selectedKey}
-        onChange={(e: any, newVal?: IDropdownOption) => setValue(newVal?.text)}
+        onChange={(e: any, newVal?: IDropdownOption) => setValue(newVal?.data ?? newVal?.text)}
         disabled={isLoading}
         ariaLabel={description}
         placeholder={description}
         options={(constraints?.allowedValues ?? []).map((allowedValue: ConnectionParameterAllowedValue, index) => ({
           key: index,
-          text: allowedValue.text ?? '',
+          text: allowedValue?.text ?? allowedValue.value,
+          data: allowedValue.value,
         }))}
       />
     );

--- a/libs/services/designer-client-services/src/lib/base/connection.ts
+++ b/libs/services/designer-client-services/src/lib/base/connection.ts
@@ -202,14 +202,10 @@ export abstract class BaseConnectionService implements IConnectionService {
 
   protected async testConnection(connection: Connection): Promise<void> {
     let response: HttpResponse<any> | undefined = undefined;
-    try {
-      const testLinks = connection.properties?.testLinks;
-      if (!testLinks || testLinks.length === 0) return;
-      response = await this.requestTestConnection(connection);
-      if (response) this.handleTestConnectionResponse(response);
-    } catch (error: any) {
-      return Promise.reject(error);
-    }
+    const testLinks = connection.properties?.testLinks;
+    if (!testLinks || testLinks.length === 0) return;
+    response = await this.requestTestConnection(connection);
+    if (response) this.handleTestConnectionResponse(response);
   }
 
   protected async requestTestConnection(connection: Connection): Promise<HttpResponse<any> | undefined> {
@@ -228,7 +224,7 @@ export abstract class BaseConnectionService implements IConnectionService {
       else if (equals(method, HTTP_METHODS.DELETE)) response = await httpClient.delete<any>(requestOptions);
       return response;
     } catch (error: any) {
-      return Promise.reject(error);
+      return Promise.reject(error?.content ?? error);
     }
   }
 


### PR DESCRIPTION
## Main Changes
Some connections were being created with incorrect parameters because on dropdowns we were passing the `text` property of dropdown parameters instead of the `value` property.
This was brought up in an issue with the Salesforce OAuth connection creation but may have been impacting other connectors.
I also fixed the error catching messages on test connection.

Cherry picked from #2581