### PR TITLE
fix(designer): Unfocusing an Editor ending in '/' would still show the typeahead menu

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -203,7 +203,7 @@ export const BaseEditor = ({
           {autoLink ? <AutoLink /> : null}
           {clearEditor ? <ClearEditor showButton={false} /> : null}
           {singleValueSegment ? <SingleValueSegment /> : null}
-          {tokens ? <TokenTypeAheadPlugin openTokenPicker={openTokenPicker} /> : null}
+          {tokens ? <TokenTypeAheadPlugin openTokenPicker={openTokenPicker} isEditorFocused={isEditorFocused} /> : null}
           <OnBlur command={handleBlur} />
           <OnFocus command={handleFocus} />
           <ReadOnly readonly={readonly} />

--- a/libs/designer-ui/src/lib/editor/base/plugins/TokenTypeahead.tsx
+++ b/libs/designer-ui/src/lib/editor/base/plugins/TokenTypeahead.tsx
@@ -1,6 +1,5 @@
 import { TokenPickerMode } from '../../../tokenpicker';
 import { useTokenTypeaheadTriggerMatch } from '../utils/tokenTypeaheadMatcher';
-import type { OpenTokenPickerProps } from './OpenTokenPicker';
 import { Icon, Text, css, useTheme } from '@fluentui/react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { LexicalTypeaheadMenuPlugin, TypeaheadOption } from '@lexical/react/LexicalTypeaheadMenuPlugin';
@@ -66,7 +65,12 @@ function TokenMenuItem({
   );
 }
 
-export const TokenTypeAheadPlugin = ({ openTokenPicker }: OpenTokenPickerProps) => {
+interface TokenTypeAheadPluginProps {
+  openTokenPicker: (tokenPickerMode: TokenPickerMode) => void;
+  isEditorFocused?: boolean;
+}
+
+export const TokenTypeAheadPlugin = ({ openTokenPicker, isEditorFocused }: TokenTypeAheadPluginProps) => {
   const [editor] = useLexicalComposerContext();
   const { isInverted } = useTheme();
   const checkForTriggerMatch = useTokenTypeaheadTriggerMatch('/', {
@@ -121,7 +125,7 @@ export const TokenTypeAheadPlugin = ({ openTokenPicker }: OpenTokenPickerProps) 
           return null;
         }
 
-        return anchorElementRef.current && options.length
+        return anchorElementRef.current && options.length && isEditorFocused
           ? ReactDOM.createPortal(
               <div className={css(isInverted ? 'msla-theme-dark' : null)} onMouseDown={(e) => e.preventDefault()}>
                 <div className="typeahead-popover">


### PR DESCRIPTION
fixed an issue when even when unfocusing an editor ending with '/' would still show the typeahead menu

before:

![a](https://github.com/Azure/LogicAppsUX/assets/95886809/832a446b-d6a3-4a82-ac82-f3ed687daa0c)


after: 

![b](https://github.com/Azure/LogicAppsUX/assets/95886809/36573543-1e7d-4e98-be8c-9fb098468d08)
