### PR TITLE
feat(vscode): Add host version to http headers in extension httpClient

### DIFF
--- a/apps/vs-code-designer-react/src/app/app.tsx
+++ b/apps/vs-code-designer-react/src/app/app.tsx
@@ -34,6 +34,7 @@ export const App = () => {
     oauthRedirectUrl,
     isMonitoringView,
     runId,
+    hostVersion,
   } = vscodeState;
   const [standardApp, setStandardApp] = useState<StandardApp | undefined>(panelMetaData?.standardApp);
   const [runInstance, setRunInstance] = useState<LogicAppsV2.RunInstanceDefinition | null>(null);
@@ -79,7 +80,8 @@ export const App = () => {
       panelMetaData,
       fileSystemConnectionCreate,
       vscode,
-      oauthRedirectUrl
+      oauthRedirectUrl,
+      hostVersion
     );
   }, [baseUrl, apiVersion, apiHubServiceDetails, tenantId, isLocal, connectionData, panelMetaData, vscode, oauthRedirectUrl, dispatch]);
 

--- a/apps/vs-code-designer-react/src/app/servicesHelper.ts
+++ b/apps/vs-code-designer-react/src/app/servicesHelper.ts
@@ -34,7 +34,8 @@ export const getDesignerServices = (
   panelMetadata: IDesignerPanelMetadata | null,
   createFileSystemConnection: (connectionInfo: ConnectionCreationInfo, connectionName: string) => Promise<ConnectionCreationInfo>,
   vscode: WebviewApi<unknown>,
-  oauthRedirectUrl: string
+  oauthRedirectUrl: string,
+  hostVersion: string
 ): {
   connectionService: StandardConnectionService;
   connectorService: StandardConnectorService;
@@ -76,7 +77,7 @@ export const getDesignerServices = (
     });
   };
 
-  const httpClient = new HttpClient({ accessToken: authToken, baseUrl, apiHubBaseUrl: apiHubServiceDetails.baseUrl });
+  const httpClient = new HttpClient({ accessToken: authToken, baseUrl, apiHubBaseUrl: apiHubServiceDetails.baseUrl, hostVersion });
   const connectionService = new StandardConnectionService({
     baseUrl,
     apiVersion,

--- a/apps/vs-code-designer-react/src/state/DesignerSlice.ts
+++ b/apps/vs-code-designer-react/src/state/DesignerSlice.ts
@@ -18,6 +18,7 @@ export interface designerState {
   fileSystemConnections: Record<string, any>;
   iaMapArtifacts: ListDynamicValue[];
   oauthRedirectUrl: string;
+  hostVersion: string;
 }
 
 const initialState: designerState = {
@@ -44,6 +45,7 @@ const initialState: designerState = {
   fileSystemConnections: {},
   iaMapArtifacts: [],
   oauthRedirectUrl: '',
+  hostVersion: '',
 };
 
 export const designerSlice = createSlice({
@@ -62,6 +64,7 @@ export const designerSlice = createSlice({
         oauthRedirectUrl,
         isMonitoringView,
         runId,
+        hostVersion,
       } = action.payload;
 
       state.panelMetaData = panelMetadata;
@@ -75,6 +78,7 @@ export const designerSlice = createSlice({
       state.runId = runId;
       state.tenantId = apiHubServiceDetails?.tenantId;
       state.oauthRedirectUrl = oauthRedirectUrl;
+      state.hostVersion = hostVersion;
     },
     updateCallbackUrl: (state, action: PayloadAction<any>) => {
       const { callbackInfo } = action.payload;

--- a/apps/vs-code-designer/src/app/commands/workflows/exportLogicApp.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/exportLogicApp.ts
@@ -347,6 +347,7 @@ export async function exportLogicApp(): Promise<void> {
             accessToken,
             cloudHost,
             project: 'export',
+            hostVersion: ext.extensionVersion,
           },
         });
         interval = setInterval(async () => {

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
@@ -93,6 +93,7 @@ export class OpenDesignerForAzureResource extends OpenDesignerBase {
             isLocal: this.isLocal,
             isMonitoringView: this.isMonitoringView,
             workflowDetails: this.workflowDetails,
+            hostVersion: ext.extensionVersion,
           },
         });
         break;

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -176,6 +176,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
             isMonitoringView: this.isMonitoringView,
             workflowDetails: this.workflowDetails,
             oauthRedirectUrl: this.oauthRedirectUrl,
+            hostVersion: ext.extensionVersion,
           },
         });
         break;

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
@@ -117,6 +117,7 @@ export default class openMonitoringViewForAzureResource extends OpenMonitoringVi
             isLocal: this.isLocal,
             isMonitoringView: this.isMonitoringView,
             runId: this.runName,
+            hostVersion: ext.extensionVersion,
           },
         });
         break;

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
@@ -113,6 +113,7 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
             isLocal: this.isLocal,
             isMonitoringView: this.isMonitoringView,
             runId: this.runName,
+            hostVersion: ext.extensionVersion,
           },
         });
         break;

--- a/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
@@ -126,6 +126,7 @@ export async function openOverview(context: IAzureConnectorsContext, node: vscod
             accessToken: accessToken,
             workflowProperties: workflowProps,
             project: 'overview',
+            hostVersion: ext.extensionVersion,
           },
         });
         // Just shipping the access Token every 5 seconds is easier and more

--- a/apps/vs-code-designer/src/app/commands/workflows/reviewValidation.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/reviewValidation.ts
@@ -56,6 +56,7 @@ export async function reviewValidation(_context: IActionContext, node: vscode.Ur
               data: {
                 project: 'review',
                 reviewContent,
+                hostVersion: ext.extensionVersion,
               },
             });
             break;

--- a/apps/vs-code-designer/src/app/utils/extension.ts
+++ b/apps/vs-code-designer/src/app/utils/extension.ts
@@ -6,7 +6,7 @@ import { logicAppsStandardExtensionId } from '../../constants';
 import * as vscode from 'vscode';
 
 /**
- * Gets extension version from the pacakge.json version.
+ * Gets extension version from the package.json version.
  * @returns {string} Extension version.
  */
 export const getExtensionVersion = (): string => {

--- a/apps/vs-code-designer/src/app/utils/extension.ts
+++ b/apps/vs-code-designer/src/app/utils/extension.ts
@@ -1,18 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { logicAppsStandardExtensionId } from '../../constants';
 import * as vscode from 'vscode';
 
-// Get the extension's information
+/**
+ * Gets extension version from the pacakge.json version.
+ * @returns {string} Extension version.
+ */
 export const getExtensionVersion = (): string => {
-  const extension = vscode.extensions.getExtension('ms-azuretools.vscode-azurelogicapps');
+  const extension = vscode.extensions.getExtension(logicAppsStandardExtensionId);
 
   if (extension) {
-    // Access the package.json information
     const { packageJSON } = extension;
 
     if (packageJSON) {
-      // Retrieve the version
       const version = packageJSON.version;
-
-      // Do something with the version
       return version;
     }
   }

--- a/apps/vs-code-designer/src/app/utils/extension.ts
+++ b/apps/vs-code-designer/src/app/utils/extension.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+
+// Get the extension's information
+export const getExtensionVersion = (): string => {
+  const extension = vscode.extensions.getExtension('ms-azuretools.vscode-azurelogicapps');
+
+  if (extension) {
+    // Access the package.json information
+    const { packageJSON } = extension;
+
+    if (packageJSON) {
+      // Retrieve the version
+      const version = packageJSON.version;
+
+      // Do something with the version
+      return version;
+    }
+  }
+
+  return '';
+};

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -18,6 +18,8 @@ export const vscodeFolderName = '.vscode';
 export const workflowFileName = 'workflow.json';
 export const funcIgnoreFileName = '.funcignore';
 
+export const logicAppsStandardExtensionId = 'ms-azuretools.vscode-azurelogicapps';
+
 // Functions
 export const func = 'func';
 export const functionsExtensionId = 'ms-azuretools.vscode-azurefunctions';

--- a/apps/vs-code-designer/src/extensionVariables.ts
+++ b/apps/vs-code-designer/src/extensionVariables.ts
@@ -19,6 +19,7 @@ export namespace ext {
   export let workflowDesignChildProcess: cp.ChildProcess | undefined;
   export let outputChannel: IAzExtOutputChannel;
   export let workflowRuntimePort: number;
+  export let extensionVersion: string;
   export const prefix = 'azureLogicAppsStandard';
 
   // Tree item view

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -6,6 +6,7 @@ import { getResourceGroupsApi } from './app/resourcesExtension/getExtensionApi';
 import type { AzureAccountTreeItemWithProjects } from './app/tree/AzureAccountTreeItemWithProjects';
 import { stopDesignTimeApi } from './app/utils/codeless/startDesignTimeApi';
 import { UriHandler } from './app/utils/codeless/urihandler';
+import { getExtensionVersion } from './app/utils/extension';
 import { registerFuncHostTaskEvents } from './app/utils/funcCoreTools/funcHostTask';
 import { verifyVSCodeConfigOnActivate } from './app/utils/vsCodeConfig/verifyVSCodeConfigOnActivate';
 import { extensionCommand, logicAppFilter } from './constants';
@@ -42,6 +43,7 @@ export async function activate(context: vscode.ExtensionContext) {
     runPostWorkflowCreateStepsFromCache();
     validateFuncCoreToolsIsLatest();
 
+    ext.extensionVersion = getExtensionVersion();
     ext.rgApi = await getResourceGroupsApi();
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/apps/vs-code-react/src/app/overview/app.tsx
+++ b/apps/vs-code-react/src/app/overview/app.tsx
@@ -33,6 +33,7 @@ export interface AppProps {
   corsNotice?: string;
   accessToken?: string;
   onOpenRun(run: RunDisplayItem): void;
+  hostVersion?: string;
 }
 
 export const App: React.FC<AppProps> = (props) => {
@@ -51,9 +52,9 @@ export const App: React.FC<AppProps> = (props) => {
   );
 };
 
-const OverviewApp: React.FC<AppProps> = ({ workflowProperties, apiVersion, baseUrl, accessToken, onOpenRun, corsNotice }) => {
+const OverviewApp: React.FC<AppProps> = ({ workflowProperties, apiVersion, baseUrl, accessToken, onOpenRun, corsNotice, hostVersion }) => {
   const runService = useMemo(() => {
-    const httpClient = new HttpClient({ accessToken: accessToken, baseUrl, apiHubBaseUrl: '' });
+    const httpClient = new HttpClient({ accessToken: accessToken, baseUrl, apiHubBaseUrl: '', hostVersion });
 
     return new StandardRunService({
       baseUrl,

--- a/apps/vs-code-react/src/app/overview/index.tsx
+++ b/apps/vs-code-react/src/app/overview/index.tsx
@@ -23,6 +23,7 @@ export const OverviewApp: React.FC = () => {
       workflowProperties={vscodeState.workflowProperties}
       accessToken={vscodeState.accessToken}
       corsNotice={vscodeState.corsNotice}
+      hostVersion={vscodeState.hostVersion}
     ></App>
   ) : null;
 };

--- a/apps/vs-code-react/src/state/vscodeSlice.ts
+++ b/apps/vs-code-react/src/state/vscodeSlice.ts
@@ -13,6 +13,7 @@ export interface InitializePayload {
   workflowProperties: OverviewPropertiesProps;
   project: ProjectName;
   reviewContent?: IValidationData;
+  hostVersion?: string;
 }
 
 export enum Status {
@@ -34,6 +35,7 @@ export interface InitializedVscodeState {
   statuses?: string[];
   finalStatus?: Status;
   reviewContent?: IValidationData;
+  hostVersion?: string;
 }
 
 interface UninitializedVscodeState {
@@ -52,7 +54,8 @@ export const vscodeSlice = createSlice({
   initialState: initialState as VscodeState,
   reducers: {
     initialize: (state: VscodeState, action: PayloadAction<InitializePayload>) => {
-      const { apiVersion, baseUrl, corsNotice, accessToken, workflowProperties, project, reviewContent, cloudHost } = action.payload;
+      const { apiVersion, baseUrl, corsNotice, accessToken, workflowProperties, project, reviewContent, cloudHost, hostVersion } =
+        action.payload;
       state.initialized = true;
       const initializedState = state as InitializedVscodeState;
       initializedState.project = project;
@@ -81,6 +84,7 @@ export const vscodeSlice = createSlice({
         },
         selectedAdvanceOptions: [AdvancedOptionsTypes.generateInfrastructureTemplates],
       };
+      initializedState.hostVersion = hostVersion;
     },
     updateAccessToken: (state: VscodeState, action: PayloadAction<string | undefined>) => {
       state.accessToken = action.payload;

--- a/libs/vscode-extension/src/lib/services/httpClient.ts
+++ b/libs/vscode-extension/src/lib/services/httpClient.ts
@@ -7,6 +7,7 @@ export interface HttpOptions {
   baseUrl?: string;
   apiHubBaseUrl?: string;
   accessToken?: string;
+  hostVersion?: string;
 }
 
 export class HttpClient implements IHttpClient {
@@ -19,7 +20,7 @@ export class HttpClient implements IHttpClient {
     this._baseUrl = options.baseUrl;
     this._accessToken = options.accessToken;
     this._apihubBaseUrl = options.apiHubBaseUrl;
-    this._extraHeaders = getExtraHeaders();
+    this._extraHeaders = getExtraHeaders(options.hostVersion ?? '');
   }
 
   dispose(): void {}
@@ -142,9 +143,9 @@ export function isArmResourceId(resourceId: string): boolean {
   return resourceId ? resourceId.indexOf('/subscriptions/') !== -1 : false;
 }
 
-function getExtraHeaders(): Record<string, string> {
+function getExtraHeaders(hostVersion: string): Record<string, string> {
   return {
-    'x-ms-user-agent': `LogicAppsDesigner/(host vscode)`,
+    'x-ms-user-agent': `LogicAppsDesigner/(host vscode ${hostVersion})`,
   };
 }
 


### PR DESCRIPTION
#### Main Code Changes
- Add host version to getExtraHeaders function
- Add function to get the vscode extension version from the extension package.json
- Send extension version from vscode to designer and react projects
- Add host version to designer and react project slices

Closes #2258 

<img width="1161" alt="Screenshot 2023-05-31 at 9 46 45 AM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/9c97d35a-ed86-4d80-86ae-dc449a22daa0">
