### PR TITLE
fix(Designer): Fixed issue with case-insensitive dependency parameters

### DIFF
--- a/libs/designer-ui/src/lib/createConnection/index.tsx
+++ b/libs/designer-ui/src/lib/createConnection/index.tsx
@@ -187,9 +187,7 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
       if (legacyManagedIdentitySelected) return false; // TODO: Riley - Only show the managed identity parameters (which is none for now)
       if (constraints?.hidden === 'true' || constraints?.hideInUI === 'true') return false;
       const dependentParam = constraints?.dependentParameter;
-      if (dependentParam?.parameter) {
-        if (getPropertyValue(parameterValues, dependentParam.parameter) !== dependentParam.value) return false;
-      }
+      if (dependentParam?.parameter && getPropertyValue(parameterValues, dependentParam.parameter) !== dependentParam.value) return false;
       if (parameter.type === ConnectionParameterTypes[ConnectionParameterTypes.oauthSetting]) return false;
       if (parameter.type === ConnectionParameterTypes[ConnectionParameterTypes.managedIdentity]) return false;
       return true;

--- a/libs/designer-ui/src/lib/createConnection/index.tsx
+++ b/libs/designer-ui/src/lib/createConnection/index.tsx
@@ -30,7 +30,7 @@ import {
   ConnectionParameterTypes,
   SERVICE_PRINCIPLE_CONSTANTS,
   connectorContainsAllServicePrinicipalConnectionParameters,
-  getCaseInsensitiveProperty,
+  getPropertyValue,
   isServicePrinicipalConnectionParameter,
   usesLegacyManagedIdentity,
 } from '@microsoft/utils-logic-apps';
@@ -187,8 +187,9 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
       if (legacyManagedIdentitySelected) return false; // TODO: Riley - Only show the managed identity parameters (which is none for now)
       if (constraints?.hidden === 'true' || constraints?.hideInUI === 'true') return false;
       const dependentParam = constraints?.dependentParameter;
-      const currentDependencyValue = getCaseInsensitiveProperty(parameterValues, dependentParam?.parameter);
-      if (dependentParam && currentDependencyValue !== dependentParam.value) return false;
+      if (dependentParam?.parameter) {
+        if (getPropertyValue(parameterValues, dependentParam.parameter) !== dependentParam.value) return false;
+      }
       if (parameter.type === ConnectionParameterTypes[ConnectionParameterTypes.oauthSetting]) return false;
       if (parameter.type === ConnectionParameterTypes[ConnectionParameterTypes.managedIdentity]) return false;
       return true;

--- a/libs/designer-ui/src/lib/createConnection/index.tsx
+++ b/libs/designer-ui/src/lib/createConnection/index.tsx
@@ -30,6 +30,7 @@ import {
   ConnectionParameterTypes,
   SERVICE_PRINCIPLE_CONSTANTS,
   connectorContainsAllServicePrinicipalConnectionParameters,
+  getCaseInsensitiveProperty,
   isServicePrinicipalConnectionParameter,
   usesLegacyManagedIdentity,
 } from '@microsoft/utils-logic-apps';
@@ -185,8 +186,9 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
         return isServicePrinicipalConnectionParameter(key) && isServicePrincipalParameterVisible(key, parameter);
       if (legacyManagedIdentitySelected) return false; // TODO: Riley - Only show the managed identity parameters (which is none for now)
       if (constraints?.hidden === 'true' || constraints?.hideInUI === 'true') return false;
-      const dependencyParam = constraints?.dependentParameter;
-      if (dependencyParam && parameterValues[dependencyParam.parameter] !== dependencyParam.value) return false;
+      const dependentParam = constraints?.dependentParameter;
+      const currentDependencyValue = getCaseInsensitiveProperty(parameterValues, dependentParam?.parameter);
+      if (dependentParam && currentDependencyValue !== dependentParam.value) return false;
       if (parameter.type === ConnectionParameterTypes[ConnectionParameterTypes.oauthSetting]) return false;
       if (parameter.type === ConnectionParameterTypes[ConnectionParameterTypes.managedIdentity]) return false;
       return true;

--- a/libs/utils/src/lib/helpers/functions.ts
+++ b/libs/utils/src/lib/helpers/functions.ts
@@ -937,3 +937,19 @@ export function findAncestorElement(
 export function hasInvalidChars(str: string, invalidChars: string[]): boolean {
   return invalidChars.some((invalidChar) => includes(str, invalidChar));
 }
+
+/**
+ * Returns the property value from an object, using a case-insensitive search on the property key.
+ * @arg {Record<string, any>} object - The object.
+ * @arg {string} propertyKey - The property key.
+ */
+export function getCaseInsensitiveProperty(object: Record<string, any>, propertyKey?: string): any {
+  if (!propertyKey) return undefined;
+  for (const key of Object.keys(object)) {
+    if (equals(key, propertyKey, true)) {
+      return object[key];
+    }
+  }
+
+  return undefined;
+}

--- a/libs/utils/src/lib/helpers/functions.ts
+++ b/libs/utils/src/lib/helpers/functions.ts
@@ -937,19 +937,3 @@ export function findAncestorElement(
 export function hasInvalidChars(str: string, invalidChars: string[]): boolean {
   return invalidChars.some((invalidChar) => includes(str, invalidChar));
 }
-
-/**
- * Returns the property value from an object, using a case-insensitive search on the property key.
- * @arg {Record<string, any>} object - The object.
- * @arg {string} propertyKey - The property key.
- */
-export function getCaseInsensitiveProperty(object: Record<string, any>, propertyKey?: string): any {
-  if (!propertyKey) return undefined;
-  for (const key of Object.keys(object)) {
-    if (equals(key, propertyKey, true)) {
-      return object[key];
-    }
-  }
-
-  return undefined;
-}


### PR DESCRIPTION
## Main Changes
- On the SAP connector there were connection parameters with constraints for the auth type parameter as a dependent parameter, but there was a key casing mismatch between the two
  - Ex: `AuthenticationType` on the dependency definition vs `authenticationType` on the actual parameter key
  - The in-app SAP connector was the only connector I've been able to see this issue on
- I just switched our dependency logic to be case-insensitive when checking for the dependent parameter
  - Made this a helper function in our utils package for future use

Fixes https://github.com/Azure/LogicAppsUX/issues/2633