### PR TITLE
fix(designer): Add validation for isRoot placeholder trigger node

### DIFF
--- a/libs/designer/src/lib/common/constants.ts
+++ b/libs/designer/src/lib/common/constants.ts
@@ -324,6 +324,7 @@ export default {
       ELSE: 'else',
       SWITCH_CASE: 'switchcase',
       SWITCH_DEFAULT: 'switchdefault',
+      PLACEHOLDER_TRIGGER: 'builtin:newWorkflowTrigger',
       // Action and trigger types.
       API_CONNECTION_WEBHOOK: 'apiconnectionwebhook',
       API_CONNECTION: 'apiconnection',

--- a/libs/designer/src/lib/core/parsers/restructuringHelpers.ts
+++ b/libs/designer/src/lib/core/parsers/restructuringHelpers.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import constants from '../../common/constants';
 import { isWorkflowOperationNode } from '../actions/bjsworkflow/serializer';
 import type { NodesMetadata, WorkflowState } from '../state/workflow/workflowInterfaces';
 import type { WorkflowEdge, WorkflowNode } from './models/workflowNode';
@@ -126,7 +127,7 @@ export const applyIsRootNode = (state: WorkflowState, graph: WorkflowNode, metad
     }, graph.children?.filter((node) => isWorkflowOperationNode(node))?.map((node) => node.id) ?? []) ?? [];
 
   (graph.children ?? []).forEach((node) => {
-    const isRoot = rootNodeIds?.includes(node.id) ?? false;
+    const isRoot = node.id === constants.NODE.TYPE.PLACEHOLDER_TRIGGER ? true : rootNodeIds?.includes(node.id) ?? false;
     if (metadata[node.id]) metadata[node.id].isRoot = isRoot;
     if (isRoot) delete (state.operations[node.id] as LogicAppsV2.ActionDefinition)?.runAfter;
   });

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -1,3 +1,4 @@
+import constants from '../../../common/constants';
 import { updateNodeConnection } from '../../actions/bjsworkflow/connections';
 import { initializeGraphState } from '../../parsers/ParseReduxAction';
 import type { AddNodePayload } from '../../parsers/addNodeToWorkflow';
@@ -41,7 +42,6 @@ export const initialWorkflowState: WorkflowState = {
   isDirty: false,
 };
 
-const placeholderNodeId = 'builtin:newWorkflowTrigger';
 export const workflowSlice = createSlice({
   name: 'workflow',
   initialState: initialWorkflowState,
@@ -64,12 +64,12 @@ export const workflowSlice = createSlice({
       if (!graph) throw new Error('graph not set');
 
       if (action.payload.isTrigger) {
-        deleteWorkflowNode(placeholderNodeId, graph);
-        delete state.nodesMetadata[placeholderNodeId];
+        deleteWorkflowNode(constants.NODE.TYPE.PLACEHOLDER_TRIGGER, graph);
+        delete state.nodesMetadata[constants.NODE.TYPE.PLACEHOLDER_TRIGGER];
 
         if (graph.edges?.length) {
           graph.edges = graph.edges.map((edge) => {
-            if (equals(edge.source, placeholderNodeId)) {
+            if (equals(edge.source, constants.NODE.TYPE.PLACEHOLDER_TRIGGER)) {
               // eslint-disable-next-line no-param-reassign
               edge.source = action.payload.nodeId;
             }
@@ -135,7 +135,7 @@ export const workflowSlice = createSlice({
 
       if (isTrigger) {
         const placeholderNode = {
-          id: placeholderNodeId,
+          id: constants.NODE.TYPE.PLACEHOLDER_TRIGGER,
           width: 200,
           height: 44,
           type: WORKFLOW_NODE_TYPES.PLACEHOLDER_NODE,
@@ -145,9 +145,9 @@ export const workflowSlice = createSlice({
         deleteNodeFromWorkflow(action.payload, graph, state.nodesMetadata, state);
 
         graph.children = [...(graph?.children ?? []), placeholderNode];
-        state.nodesMetadata[placeholderNodeId] = { graphId, isRoot: true };
+        state.nodesMetadata[constants.NODE.TYPE.PLACEHOLDER_TRIGGER] = { graphId, isRoot: true };
         for (const childId of existingChildren) {
-          addNewEdge(state, placeholderNodeId, childId, graph, false);
+          addNewEdge(state, constants.NODE.TYPE.PLACEHOLDER_TRIGGER, childId, graph, false);
         }
       } else {
         deleteNodeFromWorkflow(action.payload, graph, state.nodesMetadata, state);


### PR DESCRIPTION
### Main Code Changes
- Add placeholder trigger id in constants
- Add exception for updating metadata `isRoot` property for placeholder trigger node

Fixes #2584 

### Issue
After deleting the trigger and adding an action, the metadata of the placeholder trigger was set to not be a root, therefore the next added action was having the
"runAfter": {
   "builtin:newWorkflowTrigger": ["SUCCEEDED"]
}

https://github.com/Azure/LogicAppsUX/assets/102700317/91e1cf48-bd06-4d12-8a50-bd0b1a3aff0f

### Implementation fix

https://github.com/Azure/LogicAppsUX/assets/102700317/cc97b458-0cde-4a35-ba64-b69eb0078578

