### PR TITLE
fix(vscode): Copy/Paste commands in vscode for Mac

### DIFF
--- a/libs/designer/src/lib/ui/panel/panelroot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelroot.tsx
@@ -316,6 +316,7 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
 
   const layerProps = {
     hostId: 'msla-layer-host',
+    eventBubblingEnabled: true,
   };
 
   const commonPanelProps: CommonPanelProps = {


### PR DESCRIPTION
### Main Code Changes
- Add `eventBubblingEnabled` in layerProps for Panel component

Closes #2326

Tested in
- vscode for Mac
- vscode for windows
- standalone app