### PR TITLE
feat(Designer): Browse View - Hiding connectors with no valid actions/triggers

### DIFF
--- a/libs/designer/src/lib/core/queries/browse.ts
+++ b/libs/designer/src/lib/core/queries/browse.ts
@@ -66,6 +66,54 @@ export const useAllOperations = () => {
   return useMemo(() => ({ data, isLoading }), [data, isLoading]);
 };
 
+// Query to return an array of fetched triggers
+export const useAllTriggers = () => {
+  const allOperations = useAllOperations();
+  return useMemo(
+    () => ({
+      ...allOperations,
+      data: allOperations.data.filter((operation) => !!operation.properties?.trigger),
+    }),
+    [allOperations]
+  );
+};
+
+// Query to return an array of api ids that have fetched triggers
+export const useAllApiIdsWithTriggers = () => {
+  const allTriggers = useAllTriggers();
+  return useMemo(
+    () => ({
+      ...allTriggers,
+      data: allTriggers.data.map((trigger) => trigger?.properties.api.id),
+    }),
+    [allTriggers]
+  );
+};
+
+// Query to return an array of fetched actions
+export const useAllActions = () => {
+  const allOperations = useAllOperations();
+  return useMemo(
+    () => ({
+      ...allOperations,
+      data: allOperations.data.filter((operation) => !operation.properties?.trigger),
+    }),
+    [allOperations]
+  );
+};
+
+// Query to return an array of api ids that have fetched actions
+export const useAllApiIdsWithActions = () => {
+  const allActions = useAllActions();
+  return useMemo(
+    () => ({
+      ...allActions,
+      data: allActions.data.map((action) => action?.properties.api.id),
+    }),
+    [allActions]
+  );
+};
+
 // Intended to be used in some root component, will handle the fetching
 export const usePreloadOperationsQuery = (): any => {
   const {


### PR DESCRIPTION
## Main Changes
Added filtering to hide connectors in browse view that have no valid actions / triggers based on the current filtering.
Previously this was done by capability but a large amount of connectors do not have any capabilities set, so now we are determining it by if we have fetched any operations that match the connector.
You should no longer click on a browse tile and see no actions/triggers.

Fixes https://github.com/Azure/LogicAppsUX/issues/2632