### PR TITLE
fix(vscode): Create an OAuth connection to Key vault

### DIFF
--- a/apps/vs-code-designer-react/src/app/app.tsx
+++ b/apps/vs-code-designer-react/src/app/app.tsx
@@ -83,7 +83,19 @@ export const App = () => {
       oauthRedirectUrl,
       hostVersion
     );
-  }, [baseUrl, apiVersion, apiHubServiceDetails, tenantId, isLocal, connectionData, panelMetaData, vscode, oauthRedirectUrl, dispatch]);
+  }, [
+    baseUrl,
+    apiVersion,
+    apiHubServiceDetails,
+    tenantId,
+    isLocal,
+    connectionData,
+    panelMetaData,
+    vscode,
+    oauthRedirectUrl,
+    dispatch,
+    hostVersion,
+  ]);
 
   const connectionReferences: ConnectionReferences = useMemo(() => {
     return convertConnectionsDataToReferences(connectionData);

--- a/apps/vs-code-designer-react/src/app/servicesHelper.ts
+++ b/apps/vs-code-designer-react/src/app/servicesHelper.ts
@@ -19,6 +19,7 @@ import type {
   IHostService,
   IWorkflowService,
 } from '@microsoft/designer-client-services-logic-apps';
+import type { ManagedIdentity } from '@microsoft/utils-logic-apps';
 import { HTTP_METHODS, clone } from '@microsoft/utils-logic-apps';
 import type { ConnectionAndAppSetting, ConnectionsData, IDesignerPanelMetadata } from '@microsoft/vscode-extension';
 import { ExtensionCommand, HttpClient } from '@microsoft/vscode-extension';
@@ -231,6 +232,14 @@ export const getDesignerServices = (
         });
       }
     },
+    getAppIdentity: () => {
+      return {
+        principalId: '00000000-0000-0000-0000-000000000000',
+        tenantId: '00000000-0000-0000-0000-000000000000',
+        type: 'SystemAssigned',
+      } as ManagedIdentity;
+    },
+    isExplicitAuthRequiredForManagedIdentity: () => true,
   };
 
   const hostService: IHostService = {


### PR DESCRIPTION
### Main Code Changes
- Add getAppIdentity and isExplicitAuthRequiredForManagedIdentity callbacks in workflowService for vscode
- Add useMemo dependency

Closes #2655 


### Implementation
https://github.com/Azure/LogicAppsUX/assets/102700317/8d351be2-0147-49dc-84e2-fab8294c023f


