### PR TITLE
fix(Power Automate): Correctly set data-automation-ids on DOM elements

### DIFF
--- a/libs/designer-ui/src/lib/arrayeditor/index.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/index.tsx
@@ -62,6 +62,7 @@ export const ArrayEditor: React.FC<ArrayEditorProps> = ({
   labelProps,
   itemSchema,
   placeholder,
+  dataAutomationId,
   getTokenPicker,
   onChange,
   castParameter,
@@ -125,7 +126,7 @@ export const ArrayEditor: React.FC<ArrayEditorProps> = ({
   };
 
   return (
-    <div className="msla-array-editor-container">
+    <div className="msla-array-editor-container" data-automation-id={dataAutomationId}>
       {collapsed ? (
         <CollapsedArray
           labelProps={labelProps}

--- a/libs/designer-ui/src/lib/combobox/index.tsx
+++ b/libs/designer-ui/src/lib/combobox/index.tsx
@@ -240,6 +240,7 @@ export const Combobox = ({
             getTokenPicker={baseEditorProps.getTokenPicker}
             placeholder={baseEditorProps.placeholder}
             tokenPickerButtonEditorProps={{ showOnLeft: true }}
+            dataAutomationId={baseEditorProps.dataAutomationId}
           >
             <Change setValue={setValue} />
           </BaseEditor>

--- a/libs/designer-ui/src/lib/dictionary/index.tsx
+++ b/libs/designer-ui/src/lib/dictionary/index.tsx
@@ -65,7 +65,7 @@ export const DictionaryEditor: React.FC<DictionaryEditorProps> = ({
   };
 
   return (
-    <div className="msla-dictionary-editor-container">
+    <div className="msla-dictionary-editor-container" data-automation-id={baseEditorProps.dataAutomationId}>
       {collapsed && !(dictionaryType === DictionaryType.TABLE) ? (
         <CollapsedDictionary
           isValid={isValid}

--- a/libs/designer-ui/src/lib/dropdown/index.tsx
+++ b/libs/designer-ui/src/lib/dropdown/index.tsx
@@ -21,6 +21,7 @@ interface DropdownEditorProps {
   height?: number;
   fontSize?: number;
   label?: string;
+  dataAutomationId?: string;
   onChange?: ChangeHandler;
 }
 
@@ -41,6 +42,7 @@ export const DropdownEditor = ({
   height,
   fontSize,
   label,
+  dataAutomationId,
   onChange,
 }: DropdownEditorProps): JSX.Element => {
   const [selectedKey, setSelectedKey] = useState<string | undefined>(multiSelect ? undefined : getSelectedKey(options, initialValue));
@@ -93,7 +95,7 @@ export const DropdownEditor = ({
   };
 
   return (
-    <div className="msla-dropdown-editor-container">
+    <div className="msla-dropdown-editor-container" data-automation-id={dataAutomationId}>
       <Dropdown
         ariaLabel={label}
         styles={dropdownStyles}

--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -69,6 +69,7 @@ export interface BaseEditorProps {
   label?: string;
   valueType?: string;
   tokenPickerButtonEditorProps?: TokenPickerButtonEditorProps;
+  dataAutomationId?: string;
   onChange?: ChangeHandler;
   onBlur?: () => void;
   onFocus?: () => void;
@@ -97,6 +98,7 @@ export const BaseEditor = ({
   labelId,
   tokenPickerButtonEditorProps,
   valueType,
+  dataAutomationId,
   onFocus,
   onBlur,
   getTokenPicker,
@@ -181,7 +183,7 @@ export const BaseEditor = ({
   return (
     <TooltipHost content={placeholder} calloutProps={calloutProps} styles={{ root: { width: '100%' } }}>
       <LexicalComposer initialConfig={initialConfig}>
-        <div className={className ?? 'msla-editor-container'} id={editorId} ref={containerRef}>
+        <div className={className ?? 'msla-editor-container'} id={editorId} ref={containerRef} data-automation-id={dataAutomationId}>
           {toolbar ? <Toolbar readonly={readonly} /> : null}
           <RichTextPlugin
             contentEditable={

--- a/libs/designer-ui/src/lib/editor/monaco/index.tsx
+++ b/libs/designer-ui/src/lib/editor/monaco/index.tsx
@@ -249,7 +249,7 @@ export const MonacoEditor = forwardRef<editor.IStandaloneCodeEditor, MonacoProps
     };
 
     return (
-      <div className="msla-monaco-container" style={options.monacoContainerStyle}>
+      <div className="msla-monaco-container" style={options.monacoContainerStyle} data-automation-id={`monaco-editor-${label}`}>
         {canRender ? (
           <Editor
             keepCurrentModel={true}

--- a/libs/designer-ui/src/lib/editor/string/index.tsx
+++ b/libs/designer-ui/src/lib/editor/string/index.tsx
@@ -48,6 +48,7 @@ export const StringEditor = ({
       onBlur={handleBlur}
       onFocus={baseEditorProps.onFocus}
       labelId={labelId}
+      dataAutomationId={baseEditorProps.dataAutomationId}
     >
       {singleLine ? <SingleLine /> : null}
       <Change setValue={onValueChange} />

--- a/libs/designer-ui/src/lib/html/index.tsx
+++ b/libs/designer-ui/src/lib/html/index.tsx
@@ -4,7 +4,14 @@ import { BaseEditor } from '../editor/base';
 import { Change } from './plugins/toolbar/helper/Change';
 import { useState } from 'react';
 
-export const HTMLEditor = ({ placeholder, readonly, initialValue, getTokenPicker, onChange }: BaseEditorProps): JSX.Element => {
+export const HTMLEditor = ({
+  placeholder,
+  readonly,
+  initialValue,
+  dataAutomationId,
+  getTokenPicker,
+  onChange,
+}: BaseEditorProps): JSX.Element => {
   const [value, setValue] = useState<ValueSegment[]>(initialValue);
 
   const onValueChange = (newValue: ValueSegment[]): void => {
@@ -24,6 +31,7 @@ export const HTMLEditor = ({ placeholder, readonly, initialValue, getTokenPicker
       initialValue={initialValue}
       getTokenPicker={getTokenPicker}
       onBlur={handleBlur}
+      dataAutomationId={dataAutomationId}
     >
       <Change setValue={onValueChange} />
     </BaseEditor>

--- a/libs/designer-ui/src/lib/picker/filepickereditor.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickereditor.tsx
@@ -128,6 +128,7 @@ export const FilePickerEditor = ({
         getTokenPicker={baseEditorProps.getTokenPicker}
         placeholder={baseEditorProps.placeholder}
         tokenPickerButtonEditorProps={{ showOnLeft: true }}
+        dataAutomationId={baseEditorProps.dataAutomationId}
       >
         <EditorValueChange
           pickerDisplayValue={pickerDisplayValue}

--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -21,6 +21,7 @@ import { SchemaEditor } from '../../schemaeditor';
 import { TableEditor } from '../../table';
 import type { TokenGroup } from '../../tokenpicker/models/token';
 import { useId } from '../../useId';
+import { convertUIElementNameToAutomationId } from '../../utils';
 import type { SettingProps } from './settingtoggle';
 import { Label } from '@fluentui/react';
 
@@ -102,7 +103,7 @@ const TokenField = ({
           multiSelect={!!editorOptions?.multiSelect}
           serialization={editorOptions?.serialization}
           onChange={onValueChange}
-          data-automation-id={`msla-setting-token-editor-dropdowneditor-${label}`}
+          dataAutomationId={`msla-setting-token-editor-dropdowneditor-${convertUIElementNameToAutomationId(label)}`}
         />
       );
 
@@ -116,7 +117,6 @@ const TokenField = ({
           onChange={onValueChange}
           readonly={readOnly}
           placeholder={placeholder}
-          data-automation-id={`msla-setting-token-editor-codeeditor-${label}`}
         />
       );
 
@@ -135,20 +135,12 @@ const TokenField = ({
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
           onMenuOpen={onComboboxMenuOpen}
-          data-automation-id={`msla-setting-token-editor-combobox-${label}`}
+          dataAutomationId={`msla-setting-token-editor-combobox-${convertUIElementNameToAutomationId(label)}`}
         />
       );
 
     case 'schema':
-      return (
-        <SchemaEditor
-          label={label}
-          readonly={readOnly}
-          initialValue={value}
-          onChange={onValueChange}
-          data-automation-id={`msla-setting-token-editor-schemaeditor-${label}`}
-        />
-      );
+      return <SchemaEditor label={label} readonly={readOnly} initialValue={value} onChange={onValueChange} />;
 
     case 'dictionary':
       return (
@@ -161,7 +153,7 @@ const TokenField = ({
           valueType={editorOptions?.valueType}
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
-          data-automation-id={`msla-setting-token-editor-dictionaryeditor-${label}`}
+          dataAutomationId={`msla-setting-token-editor-dictionaryeditor-${convertUIElementNameToAutomationId(label)}`}
         />
       );
 
@@ -179,7 +171,7 @@ const TokenField = ({
           types={editorOptions?.columns?.types}
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
-          data-automation-id={`msla-setting-token-editor-tableditor-${label}`}
+          dataAutomationId={`msla-setting-token-editor-tableditor-${convertUIElementNameToAutomationId(label)}`}
         />
       );
 
@@ -188,7 +180,7 @@ const TokenField = ({
         <ArrayEditor
           labelId={labelId}
           arrayType={editorViewModel.arrayType}
-          labelProps={{ text: label ? `${label} Item` : 'Array Item' }}
+          labelProps={{ text: label ? `${convertUIElementNameToAutomationId(label)} Item` : 'Array Item' }}
           placeholder={placeholder}
           readonly={readOnly}
           initialValue={editorViewModel.uncastedValue}
@@ -196,7 +188,7 @@ const TokenField = ({
           itemSchema={editorViewModel.itemSchema}
           castParameter={onCastParameter}
           onChange={onValueChange}
-          data-automation-id={`msla-setting-token-editor-arrayeditor-${label}`}
+          dataAutomationId={`msla-setting-token-editor-arrayeditor-${convertUIElementNameToAutomationId(label)}`}
         />
       );
 
@@ -211,7 +203,6 @@ const TokenField = ({
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
           BasePlugins={{ tokens: showTokens }}
-          data-automation-id={`msla-setting-token-editor-authenticationeditor-${label}`}
         />
       );
 
@@ -223,7 +214,6 @@ const TokenField = ({
           isRowFormat={editorViewModel.isRowFormat}
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
-          data-automation-id={`msla-setting-token-editor-simplequerybuildereditor-${label}`}
         />
       ) : editorViewModel.isHybridEditor ? (
         <HybridQueryBuilderEditor
@@ -231,7 +221,6 @@ const TokenField = ({
           groupProps={JSON.parse(JSON.stringify(editorViewModel.items))}
           onChange={onValueChange}
           getTokenPicker={getTokenPicker}
-          data-automation-id={`msla-setting-token-editor-hybridquerybuildereditor-${label}`}
         />
       ) : (
         <QueryBuilderEditor
@@ -239,7 +228,6 @@ const TokenField = ({
           groupProps={JSON.parse(JSON.stringify(editorViewModel.items))}
           onChange={onValueChange}
           getTokenPicker={getTokenPicker}
-          data-automation-id={`msla-setting-token-editor-querybuildereditor-${label}`}
         />
       );
 
@@ -251,7 +239,6 @@ const TokenField = ({
           showPreview={editorOptions?.showPreview}
           initialValue={value}
           onChange={onValueChange}
-          data-automation-id={`msla-setting-token-editor-scheduleeditor-${label}`}
         />
       );
 
@@ -273,7 +260,7 @@ const TokenField = ({
           editorBlur={onValueChange}
           getTokenPicker={getTokenPicker}
           onChange={hideValidationErrors}
-          data-automation-id={`msla-setting-token-editor-filepickereditor-${label}`}
+          dataAutomationId={`msla-setting-token-editor-filepickereditor-${convertUIElementNameToAutomationId(label)}`}
         />
       );
     case 'html':
@@ -285,6 +272,7 @@ const TokenField = ({
           readonly={readOnly}
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
+          dataAutomationId={`msla-setting-token-editor-htmleditor-${convertUIElementNameToAutomationId(label)}`}
         />
       );
     case 'floatingactionmenu': {
@@ -294,7 +282,6 @@ const TokenField = ({
           useStaticInputs={editorOptions?.useStaticInputs}
           initialValue={value}
           onChange={onValueChange}
-          data-automation-id={`msla-setting-token-editor-floatingactionmenu-${label}`}
         />
       );
     }
@@ -311,7 +298,7 @@ const TokenField = ({
           editorBlur={onValueChange}
           getTokenPicker={getTokenPicker}
           onChange={hideValidationErrors}
-          data-automation-id={`msla-setting-token-editor-stringeditor-${label}`}
+          dataAutomationId={`msla-setting-token-editor-stringeditor-${convertUIElementNameToAutomationId(label)}`}
         />
       );
   }

--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -181,7 +181,7 @@ const TokenField = ({
         <ArrayEditor
           labelId={labelId}
           arrayType={editorViewModel.arrayType}
-          labelProps={{ text: label ? `${labelForAutomationId} Item` : 'Array Item' }}
+          labelProps={{ text: label ? `${label} Item` : 'Array Item' }}
           placeholder={placeholder}
           readonly={readOnly}
           initialValue={editorViewModel.uncastedValue}

--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -88,6 +88,7 @@ const TokenField = ({
   getTokenPicker,
 }: SettingTokenFieldProps & { labelId: string }) => {
   const dropdownOptions = editorOptions?.options?.value ?? editorOptions?.options ?? [];
+  const labelForAutomationId = convertUIElementNameToAutomationId(label);
 
   switch (editor?.toLowerCase()) {
     case 'copyable':
@@ -103,7 +104,7 @@ const TokenField = ({
           multiSelect={!!editorOptions?.multiSelect}
           serialization={editorOptions?.serialization}
           onChange={onValueChange}
-          dataAutomationId={`msla-setting-token-editor-dropdowneditor-${convertUIElementNameToAutomationId(label)}`}
+          dataAutomationId={`msla-setting-token-editor-dropdowneditor-${labelForAutomationId}`}
         />
       );
 
@@ -135,7 +136,7 @@ const TokenField = ({
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
           onMenuOpen={onComboboxMenuOpen}
-          dataAutomationId={`msla-setting-token-editor-combobox-${convertUIElementNameToAutomationId(label)}`}
+          dataAutomationId={`msla-setting-token-editor-combobox-${labelForAutomationId}`}
         />
       );
 
@@ -153,7 +154,7 @@ const TokenField = ({
           valueType={editorOptions?.valueType}
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
-          dataAutomationId={`msla-setting-token-editor-dictionaryeditor-${convertUIElementNameToAutomationId(label)}`}
+          dataAutomationId={`msla-setting-token-editor-dictionaryeditor-${labelForAutomationId}`}
         />
       );
 
@@ -171,7 +172,7 @@ const TokenField = ({
           types={editorOptions?.columns?.types}
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
-          dataAutomationId={`msla-setting-token-editor-tableditor-${convertUIElementNameToAutomationId(label)}`}
+          dataAutomationId={`msla-setting-token-editor-tableditor-${labelForAutomationId}`}
         />
       );
 
@@ -180,7 +181,7 @@ const TokenField = ({
         <ArrayEditor
           labelId={labelId}
           arrayType={editorViewModel.arrayType}
-          labelProps={{ text: label ? `${convertUIElementNameToAutomationId(label)} Item` : 'Array Item' }}
+          labelProps={{ text: label ? `${labelForAutomationId} Item` : 'Array Item' }}
           placeholder={placeholder}
           readonly={readOnly}
           initialValue={editorViewModel.uncastedValue}
@@ -188,7 +189,7 @@ const TokenField = ({
           itemSchema={editorViewModel.itemSchema}
           castParameter={onCastParameter}
           onChange={onValueChange}
-          dataAutomationId={`msla-setting-token-editor-arrayeditor-${convertUIElementNameToAutomationId(label)}`}
+          dataAutomationId={`msla-setting-token-editor-arrayeditor-${labelForAutomationId}`}
         />
       );
 
@@ -260,7 +261,7 @@ const TokenField = ({
           editorBlur={onValueChange}
           getTokenPicker={getTokenPicker}
           onChange={hideValidationErrors}
-          dataAutomationId={`msla-setting-token-editor-filepickereditor-${convertUIElementNameToAutomationId(label)}`}
+          dataAutomationId={`msla-setting-token-editor-filepickereditor-${labelForAutomationId}`}
         />
       );
     case 'html':
@@ -272,7 +273,7 @@ const TokenField = ({
           readonly={readOnly}
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
-          dataAutomationId={`msla-setting-token-editor-htmleditor-${convertUIElementNameToAutomationId(label)}`}
+          dataAutomationId={`msla-setting-token-editor-htmleditor-${labelForAutomationId}`}
         />
       );
     case 'floatingactionmenu': {
@@ -298,7 +299,7 @@ const TokenField = ({
           editorBlur={onValueChange}
           getTokenPicker={getTokenPicker}
           onChange={hideValidationErrors}
-          dataAutomationId={`msla-setting-token-editor-stringeditor-${convertUIElementNameToAutomationId(label)}`}
+          dataAutomationId={`msla-setting-token-editor-stringeditor-${labelForAutomationId}`}
         />
       );
   }

--- a/libs/designer-ui/src/lib/table/index.tsx
+++ b/libs/designer-ui/src/lib/table/index.tsx
@@ -50,6 +50,7 @@ export const TableEditor: React.FC<TableEditorProps> = ({
   readonly,
   labelId,
   placeholder,
+  dataAutomationId,
   getTokenPicker,
   onChange,
 }): JSX.Element => {
@@ -83,7 +84,7 @@ export const TableEditor: React.FC<TableEditorProps> = ({
     <div>
       <Dropdown styles={dropdownStyles} disabled={readonly} options={columnOptions} selectedKey={selectedKey} onChange={onOptionChange} />
       {selectedKey === ColumnMode.Custom ? (
-        <div className="msla-table-editor-container">
+        <div className="msla-table-editor-container" data-automation-id={dataAutomationId}>
           <DictionaryEditor
             labelId={labelId}
             keyTitle={titles?.[0]}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [Yes] The commit message follows our guidelines
- [N/A] Tests for the changes have been added (for bug fixes/features)
- [N/A] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix to update data-automation-ids to be used by playwright tests.

* **What is the current behavior?** (You can also link to an open issue here)

data-automation-ids are not available to be consumed by tests because they are passed as props to react components and not used anywhere else.

* **What is the new behavior (if this is a feature change)?**

data-automation-ids are now correctly set on DOM elements so they can be identified by playwright

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Please Include Screenshots or Videos of the intended change**:

AB#24260786