### PR TITLE
fix(vscode): Resources image path in readme

### DIFF
--- a/apps/vs-code-designer/src/README.md
+++ b/apps/vs-code-designer/src/README.md
@@ -12,7 +12,7 @@ Now, your remote logic apps still appear in the Azure window, but in the Resourc
 
 Extension toolbar buttons have now migrated to the Workspace section.
 
-![Azure Logic Apps in Resources tab.](assets/logicAppResources.png)
+![Azure Logic Apps in Resources tab.](/apps/vs-code-designer/src/assets/logicAppResources.png)
 
 ## Known issues
 

--- a/apps/vs-code-react/src/app/overview/app.tsx
+++ b/apps/vs-code-react/src/app/overview/app.tsx
@@ -63,7 +63,7 @@ const OverviewApp: React.FC<AppProps> = ({ workflowProperties, apiVersion, baseU
       workflowName: workflowProperties.name,
       httpClient,
     });
-  }, [baseUrl, apiVersion, accessToken, workflowProperties.name]);
+  }, [baseUrl, apiVersion, accessToken, workflowProperties.name, hostVersion]);
 
   const loadRuns = ({ pageParam }: { pageParam?: string }) => {
     if (pageParam) {


### PR DESCRIPTION
### Main Code Changes
- Fix image path in extension readme
- Add missing useMemo dependency

#### Before
<img width="978" alt="Screenshot 2023-06-07 at 1 36 18 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/a26fd7a1-633f-421c-9da1-34b47f2a7ccf">


#### After

<img width="1293" alt="Screenshot 2023-06-07 at 1 42 14 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/73a09b92-0982-449f-84bf-db8476b35d1b">
