### PR TITLE
fix(Designer): Fixed HTML editor parameter value initialization

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
@@ -5,7 +5,6 @@ import { TokenType, ValueSegmentType } from '../../models/parameter';
 import { $createExtendedTextNode } from '../nodes/extendedTextNode';
 import { $createTokenNode } from '../nodes/tokenNode';
 import { defaultInitialConfig, htmlNodes } from './initialConfig';
-import { createHeadlessEditor } from '@lexical/headless';
 import { $generateNodesFromDOM } from '@lexical/html';
 import type { LinkNode } from '@lexical/link';
 import { $isLinkNode, $createLinkNode } from '@lexical/link';
@@ -16,10 +15,10 @@ import { $isHeadingNode } from '@lexical/rich-text';
 import type { Expression } from '@microsoft/parsers-logic-apps';
 import { ExpressionParser } from '@microsoft/parsers-logic-apps';
 import type { LexicalNode, ParagraphNode, RootNode, TextFormatType } from 'lexical';
-import { $createParagraphNode, $isTextNode, $isLineBreakNode, $isParagraphNode, $createTextNode, $getRoot } from 'lexical';
+import { $createParagraphNode, $isTextNode, $isLineBreakNode, $isParagraphNode, $createTextNode, $getRoot, createEditor } from 'lexical';
 
 export const parseHtmlSegments = (value: ValueSegment[], tokensEnabled?: boolean): RootNode => {
-  const editor = createHeadlessEditor({ ...defaultInitialConfig, nodes: htmlNodes });
+  const editor = createEditor({ ...defaultInitialConfig, nodes: htmlNodes });
   const parser = new DOMParser();
   const root = $getRoot();
   const rootChild = root.getFirstChild();


### PR DESCRIPTION
## Main Changes
Altered our parseHtmlSegments function for the HTML editor to use the normal lexical `createEditor` function instead of the headless version.
As far as I can tell this fixes the issue without any other negative side-effects.

Cherry-picked from https://github.com/Azure/LogicAppsUX/pull/2706
