### PR TITLE
fix(Designer): Monitoring - StatusPill component `duration` in tooltip 

### DIFF
--- a/libs/designer-ui/src/lib/card/index.tsx
+++ b/libs/designer-ui/src/lib/card/index.tsx
@@ -9,6 +9,7 @@ import type { CommentBoxProps, MenuItemOption } from './types';
 import { getCardStyle } from './utils';
 import type { ISpinnerStyles, MessageBarType } from '@fluentui/react';
 import { Icon, Spinner, SpinnerSize, css } from '@fluentui/react';
+import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { useEffect, useMemo, useRef } from 'react';
 import type { ConnectDragPreview, ConnectDragSource } from 'react-dnd';
 
@@ -37,7 +38,7 @@ export interface CardProps {
   staticResultsEnabled?: boolean;
   title: string;
   onClick?(): void;
-  runData: { status?: string; duration?: string };
+  runData: LogicAppsV2.WorkflowRunAction | LogicAppsV2.WorkflowRunTrigger | undefined;
   setFocus?: boolean;
 }
 
@@ -75,7 +76,7 @@ export const Card: React.FC<CardProps> = ({
   staticResultsEnabled,
   title,
   onClick,
-  runData,
+  runData = {},
   setFocus,
 }) => {
   const handleClick: React.MouseEventHandler<HTMLElement> = (e) => {
@@ -133,7 +134,13 @@ export const Card: React.FC<CardProps> = ({
         onKeyUp={keyboardInteraction.keyUp}
       >
         {isMonitoringView ? (
-          <StatusPill id={`${title}-status`} status={runData.status ?? 'Waiting'} duration={runData.duration ?? '0s'} />
+          <StatusPill
+            id={`${title}-status`}
+            status={runData.status}
+            duration={runData.duration}
+            startTime={runData.startTime}
+            endTime={runData.endTime}
+          />
         ) : null}
         <div className={css('msla-selection-box', selected && 'selected')} />
         <div className="panel-card-main">

--- a/libs/designer-ui/src/lib/card/scopeCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/scopeCard/index.tsx
@@ -31,7 +31,7 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
   handleCollapse,
   selected,
   contextMenuOptions = [],
-  runData,
+  runData = {},
 }) => {
   const contextMenu = useCardContextMenu();
 
@@ -67,7 +67,13 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
           onKeyUp={keyboardInteraction.keyUp}
         >
           {isMonitoringView ? (
-            <StatusPill id={`${title}-status`} status={runData.status ?? 'Waiting'} duration={runData.duration ?? '0s'} />
+            <StatusPill
+              id={`${title}-status`}
+              status={runData.status}
+              duration={runData.duration}
+              startTime={runData.startTime}
+              endTime={runData.endTime}
+            />
           ) : null}
           <div className="msla-scope-card-content">
             <div className={css('msla-selection-box', 'white-outline', selected && 'selected')} />

--- a/libs/designer-ui/src/lib/monitoring/statuspill/__test__/statuspill.spec.tsx
+++ b/libs/designer-ui/src/lib/monitoring/statuspill/__test__/statuspill.spec.tsx
@@ -42,7 +42,7 @@ describe('lib/monitoring/statuspill', () => {
   });
 
   it('should render the duration as text and as an ARIA label', () => {
-    renderer.render(<StatusPill {...minimal} duration="1s" durationAnnounced="1 second" />);
+    renderer.render(<StatusPill {...minimal} duration="1s" startTime="4/28/2023, 12:06:28 AM" endTime="4/28/2023, 12:06:29 AM" />);
 
     const pill = renderer.getRenderOutput();
     expect(pill.props['aria-label']).toBe(`1 second. ${'Succeeded'}`);

--- a/libs/designer-ui/src/lib/monitoring/statuspill/index.tsx
+++ b/libs/designer-ui/src/lib/monitoring/statuspill/index.tsx
@@ -1,24 +1,35 @@
-import { getStatusString } from '../../utils';
+import { getDurationStringFromTimes, getStatusString } from '../../utils';
 import { StatusIcon } from './statusicon';
 import { css, TooltipHost } from '@fluentui/react';
 
 export interface StatusPillProps {
-  duration?: string;
-  durationAnnounced?: string;
-  hasRetries?: boolean;
   id?: string;
-  status: string;
+  duration?: string;
+  startTime?: string;
+  endTime?: string;
+  hasRetries?: boolean;
+  status?: string;
 }
 
-export const StatusPill: React.FC<StatusPillProps> = ({ duration, durationAnnounced, hasRetries = false, id, status }) => {
+export const StatusPill: React.FC<StatusPillProps> = ({
+  id,
+  duration = '0s',
+  startTime,
+  endTime,
+  hasRetries = false,
+  status = 'Waiting',
+}) => {
   const statusString = getStatusString(status, hasRetries);
-  const durationString = [durationAnnounced, statusString].join('. ');
-  const statusOnly = !duration || duration === '--';
-  const label = statusOnly ? statusString : durationString;
+  let tooltipLabel = statusString;
+  const statusOnly = !duration || duration === '--' || !startTime || !endTime;
+  if (!statusOnly) {
+    const fullDurationString = getDurationStringFromTimes(startTime, endTime, false);
+    tooltipLabel = [fullDurationString, statusString].join('. ');
+  }
 
   return (
-    <div id={id} aria-label={label} role="status" className={css('msla-pill', statusOnly && 'status-only')}>
-      <TooltipHost content={label}>
+    <div id={id} aria-label={tooltipLabel} role="status" className={css('msla-pill', statusOnly && 'status-only')}>
+      <TooltipHost content={tooltipLabel}>
         <div className="msla-pill--inner">
           {!statusOnly && <span aria-hidden={true}>{duration}</span>}
           <StatusIcon hasRetries={hasRetries} status={status} />

--- a/libs/designer-ui/src/lib/utils/utils.ts
+++ b/libs/designer-ui/src/lib/utils/utils.ts
@@ -115,6 +115,19 @@ export function getDurationString(milliseconds: number, abbreviated = true): str
 
 /**
  * Returns a string with a duration, possibly abbreviated, e.g., 15s or 15 second(s)
+ * @arg {string} startTime - The start time of the duration
+ * @arg {string} endTime - The end time of the duration
+ * @arg {boolean} [abbreviated=true] - True if the string should be abbreviated, e.g., "s" instead of "second(s)".
+ */
+export function getDurationStringFromTimes(startTime: string, endTime: string, abbreviated = true): string {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+  const duration = end.getTime() - start.getTime();
+  return getDurationString(duration, abbreviated);
+}
+
+/**
+ * Returns a string with a duration, possibly abbreviated, e.g., 15s or 15 second(s)
  * @arg {number} milliseconds - The number of milliseconds in the duration
  * @arg {boolean} [abbreviated=true] - True if the string should be abbreviated, e.g., "s" instead of "second(s)".
  * @return {string}

--- a/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -69,7 +69,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
   const nodesMetaData = useNodesMetadata();
   const repetitionName = getRepetitionName(parentRunIndex, id, nodesMetaData, operationsInfo);
 
-  const { status: statusRun, duration: durationRun, error: errorRun, code: codeRun, repetitionCount } = runData ?? {};
+  const { status: statusRun, error: errorRun, code: codeRun, repetitionCount } = runData ?? {};
 
   const getRunRepetition = () => {
     return RunService().getRepetition({ nodeId: id, runId: runInstance?.id }, repetitionName);
@@ -279,7 +279,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
           isDragging={isDragging}
           isLoading={isLoading}
           isMonitoringView={isMonitoringView}
-          runData={{ status: statusRun, duration: durationRun }}
+          runData={runData}
           readOnly={readOnly}
           onClick={nodeClick}
           selected={selected}

--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -66,7 +66,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
   const nodesMetaData = useNodesMetadata();
   const repetitionName = getRepetitionName(parentRunIndex, scopeId, nodesMetaData, operationsInfo);
 
-  const { status: statusRun, duration: durationRun, error: errorRun, code: codeRun, repetitionCount } = runData ?? {};
+  const { status: statusRun, error: errorRun, code: codeRun, repetitionCount } = runData ?? {};
 
   const getRunRepetition = () => {
     return RunService().getRepetition({ nodeId: scopeId, runId: runInstance?.id }, repetitionName);
@@ -274,7 +274,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
             onClick={nodeClick}
             selected={selected}
             contextMenuOptions={contextMenuOptions}
-            runData={{ status: statusRun, duration: durationRun }}
+            runData={runData}
           />
           {isMonitoringView && normalizedType === constants.NODE.TYPE.FOREACH ? (
             <LoopsPager metadata={metadata} scopeId={scopeId} collapsed={graphCollapsed} />


### PR DESCRIPTION
## Main Changes
Our `StatusPill` component was not correctly showing the full duration string in the tooltip.
This adds some extra logic to calculate the full duration string from run data.
Fixes https://github.com/Azure/LogicAppsUX/issues/2714

### Old
![image](https://github.com/Azure/LogicAppsUX/assets/25409734/aec3a136-c80e-49a2-acb6-16a215f8a4df)

### New
![image](https://github.com/Azure/LogicAppsUX/assets/25409734/bdca44b6-0917-45cb-b854-768e3e3db1c6)
