### PR TITLE
fix(Designer): Fixed trigger serialization check 

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -141,7 +141,7 @@ export const serializeWorkflow = async (rootState: RootState, options?: Serializ
       ...rootState.workflow.originalDefinition,
       actions: await getActions(rootState, options),
       ...(Object.keys(rootState?.staticResults?.properties).length > 0 ? { staticResults: rootState.staticResults.properties } : {}),
-      triggers: rootState.panel.addingTrigger ? {} : await getTrigger(rootState, options),
+      triggers: await getTrigger(rootState, options),
     },
     connectionReferences,
     parameters: getWorkflowParameters(rootState.workflowParameters.definitions),
@@ -179,6 +179,9 @@ const getActions = async (rootState: RootState, options?: SerializeOptions): Pro
 
 const getTrigger = async (rootState: RootState, options?: SerializeOptions): Promise<LogicAppsV2.Triggers> => {
   const rootNodeId = getTriggerNodeId(rootState.workflow);
+  if (rootNodeId === Constants.NODE.TYPE.PLACEHOLDER_TRIGGER) {
+    return {}; // Placeholder trigger was found, return empty object
+  }
   const idReplacements = rootState.workflow.idReplacements;
   return rootNodeId
     ? {

--- a/libs/designer/src/lib/core/state/panel/panelSlice.ts
+++ b/libs/designer/src/lib/core/state/panel/panelSlice.ts
@@ -28,12 +28,14 @@ export const panelSlice = createSlice({
     collapsePanel: (state) => {
       state.collapsed = true;
       state.selectedOperationGroupId = '';
+      state.addingTrigger = false;
     },
     clearPanel: (state) => {
       state.collapsed = true;
       state.currentState = undefined;
       state.selectedNode = '';
       state.selectedOperationGroupId = '';
+      state.addingTrigger = false;
     },
     changePanelNode: (state, action: PayloadAction<string>) => {
       if (!action) return;
@@ -41,6 +43,7 @@ export const panelSlice = createSlice({
       state.selectedNode = action.payload;
       state.currentState = undefined;
       state.selectedOperationGroupId = '';
+      state.addingTrigger = false;
     },
     expandDiscoveryPanel: (
       state,
@@ -64,6 +67,7 @@ export const panelSlice = createSlice({
       state.currentState = undefined;
       state.selectedOperationGroupId = '';
       state.selectedOperationId = action.payload;
+      state.addingTrigger = false;
     },
     switchToWorkflowParameters: (state) => {
       state.collapsed = false;
@@ -71,6 +75,7 @@ export const panelSlice = createSlice({
       state.selectedNode = '';
       state.selectedOperationGroupId = '';
       state.selectedOperationId = '';
+      state.addingTrigger = false;
     },
     switchToNodeSearchPanel: (state) => {
       state.collapsed = false;
@@ -78,6 +83,7 @@ export const panelSlice = createSlice({
       state.selectedNode = '';
       state.selectedOperationGroupId = '';
       state.selectedOperationId = '';
+      state.addingTrigger = false;
     },
     registerPanelTabs: (state, action: PayloadAction<Array<PanelTab>>) => {
       action.payload.forEach((tab) => {


### PR DESCRIPTION
## Main Changes
Our check for a missing trigger was depending on a redux flag for the panel that wouldn't catch all situations it needed.
I adjusted the serialization `getTrigger` method to return an empty object if it finds the placeholder trigger in state, this keeps the same behavior from before but covers the correct state scenarios.
I also fixed the `addingTrigger` state to better reflect state, but it doesn't have any logical effect at the moment after the previous change.

Fixes https://github.com/Azure/LogicAppsUX/issues/2730