### PR TITLE
fix(Designer): Add missing quotes around reference key for hybrid triggers

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -644,7 +644,7 @@ const serializeHost = (
       return {
         host: {
           connection: {
-            name: "@parameters('$connections')[" + referenceKey + "]['connectionId']",
+            name: "@parameters('$connections')['" + referenceKey + "']['connectionId']",
           },
         },
       };

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -644,7 +644,7 @@ const serializeHost = (
       return {
         host: {
           connection: {
-            name: "@parameters('$connections')['" + referenceKey + "']['connectionId']",
+            name: `@parameters('$connections')['${referenceKey}']['connectionId']`,
           },
         },
       };

--- a/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
@@ -521,7 +521,10 @@ const getSplitOnValue = (
         // TODO (3727460) - Consume top level required fields when available here.
         const { alias, propertyName, required } = getSplitOnArrayAliasMetadata(manifest.properties.outputs, /* propertyRequired */ true);
         const propertyPath = alias || propertyName;
-        if (propertyPath) {
+        if (propertyPath && (manifest.properties.connectionReference?.referenceKeyFormat !== undefined && manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.HybridTrigger)) {
+          return `@${Constants.TRIGGER_BODY_OUTPUT}[${convertToStringLiteral(propertyPath)}]`;
+        }
+        else if (propertyPath) {
           return `@${Constants.TRIGGER_OUTPUTS_OUTPUT}${required ? '' : '?'}[${convertToStringLiteral(propertyPath)}]`;
         }
       }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
@@ -16,6 +16,7 @@ import type {
   UploadChunkMetadata,
 } from '@microsoft/utils-logic-apps';
 import {
+  ConnectionReferenceKeyFormat,
   equals,
   getObjectPropertyValue,
   getPropertyValue,

--- a/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
@@ -16,7 +16,6 @@ import type {
   UploadChunkMetadata,
 } from '@microsoft/utils-logic-apps';
 import {
-  ConnectionReferenceKeyFormat,
   equals,
   getObjectPropertyValue,
   getPropertyValue,
@@ -522,10 +521,7 @@ const getSplitOnValue = (
         // TODO (3727460) - Consume top level required fields when available here.
         const { alias, propertyName, required } = getSplitOnArrayAliasMetadata(manifest.properties.outputs, /* propertyRequired */ true);
         const propertyPath = alias || propertyName;
-        if (propertyPath && (manifest.properties.connectionReference?.referenceKeyFormat !== undefined && manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.HybridTrigger)) {
-          return `@${Constants.TRIGGER_BODY_OUTPUT}[${convertToStringLiteral(propertyPath)}]`;
-        }
-        else if (propertyPath) {
+        if (propertyPath) {
           return `@${Constants.TRIGGER_OUTPUTS_OUTPUT}${required ? '' : '?'}[${convertToStringLiteral(propertyPath)}]`;
         }
       }


### PR DESCRIPTION
**Fix 1:**
The connection reference format for hybrid trigger seems to be missing the quotes around the reference key:
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/9751f53a-e54c-488d-9b3c-2c3ad114644d)

**Fix2:**
Currently on the v3 designer, for a manifest based operation, we default the splitOn value to be added as `"@triggerOutputs()['<property_path>']",` defaulted here:

https://github.com/Azure/LogicAppsUX/blob/c2e7189c55629b61d0f2608cdf5a3d4c75af1f1c/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts#L525

 

But for hybridTriggers, it would need to be `"@triggerBody()['<property_path>']",`
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/b3f1e1ec-4212-4f82-a006-15ba5442f406)


AB#24273174