### PR TITLE
fix(designer): StandardRunService to properly include access token in headers

### DIFF
--- a/apps/vs-code-react/src/app/overview/app.tsx
+++ b/apps/vs-code-react/src/app/overview/app.tsx
@@ -59,7 +59,7 @@ const OverviewApp: React.FC<AppProps> = ({ workflowProperties, apiVersion, baseU
     return new StandardRunService({
       baseUrl,
       apiVersion,
-      accessToken,
+      getAccessToken: () => Promise.resolve(accessToken),
       workflowName: workflowProperties.name,
       httpClient,
     });


### PR DESCRIPTION
- **What is the current behavior?** (You can also link to an open issue here)

The `accessToken` option for StandardRunService didn't work because the "Headers" object (evaluates to empty object) from the fetch API is not compatible with the IHttpClient interface (expecting a Record<string, string>.

Using a constant is also problematic if the accessToken were to expire.

- **What is the new behavior (if this is a feature change)?**

Instead changing the option to accept a function to fetch the access token.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes changing accessToken option from string to fn is breaking

