### PR TITLE
fix(Data Mapper): Fix JSON loops to not be arrays

### DIFF
--- a/libs/data-mapper/src/lib/components/breadcrumb/EditorBreadcrumb.tsx
+++ b/libs/data-mapper/src/lib/components/breadcrumb/EditorBreadcrumb.tsx
@@ -101,7 +101,7 @@ export const EditorBreadcrumb = ({ isCodeViewOpen, setIsCodeViewOpen }: EditorBr
     let childItems: IContextualMenuItem[] = [];
     if (item && targetSchema) {
       const schemaKey = item.key;
-      const schemaNode = findNodeForKey(schemaKey, targetSchema.schemaTreeRoot);
+      const schemaNode = findNodeForKey(schemaKey, targetSchema.schemaTreeRoot, false);
       if (schemaNode) {
         childItems = schemaNode.children.map((childNode) => {
           return {
@@ -109,7 +109,7 @@ export const EditorBreadcrumb = ({ isCodeViewOpen, setIsCodeViewOpen }: EditorBr
             text: childNode.name,
             onClick: (_event, item) => {
               if (item) {
-                const newNode = findNodeForKey(item.key, schemaNode);
+                const newNode = findNodeForKey(item.key, schemaNode, false);
                 if (newNode) {
                   dispatch(setCurrentTargetSchemaNode(newNode));
                   return;
@@ -196,7 +196,7 @@ const convertToBreadcrumbItems = (
         text: pathItem.name,
         onClick: (_event, item) => {
           if (item) {
-            const newNode = findNodeForKey(item.key, schema.schemaTreeRoot);
+            const newNode = findNodeForKey(item.key, schema.schemaTreeRoot, false);
             if (newNode) {
               dispatch(setCurrentTargetSchemaNode(newNode));
               return;

--- a/libs/data-mapper/src/lib/mapDefinitions/MapDefinitionDeserializer.ts
+++ b/libs/data-mapper/src/lib/mapDefinitions/MapDefinitionDeserializer.ts
@@ -13,6 +13,7 @@ import {
   getSourceNode,
   getSourceValueFromLoop,
   getTargetValueWithoutLoops,
+  getTargetValueWithoutLoopsSchemaSpecific,
   qualifyLoopRelativeSourceKeys,
   splitKeyIntoChildren,
 } from '../utils/DataMap.Utils';
@@ -308,7 +309,7 @@ export class MapDefinitionDeserializer {
       // Handle loops in targetKey by back-tracking
       while (startIdxOfCurLoop > -1) {
         const srcLoopNodeKey = getSourceKeyOfLastLoop(loopKey.substring(0, startIdxOfPrevLoop));
-        const srcLoopNode = findNodeForKey(srcLoopNodeKey, this._sourceSchema.schemaTreeRoot);
+        const srcLoopNode = findNodeForKey(srcLoopNodeKey, this._sourceSchema.schemaTreeRoot, false); // XXX Pretty sure this is correct
 
         const idxOfIndexVariable = loopKey.substring(0, startIdxOfPrevLoop).indexOf('$', startIdxOfCurLoop + 1);
         let indexFnRfKey: string | undefined = undefined;
@@ -322,11 +323,11 @@ export class MapDefinitionDeserializer {
         if (!tgtLoopNodeKeyChunk.startsWith(mapNodeParams.for)) {
           // Gets tgtKey for current loop (which will be the single key chunk immediately following the loop path chunk)
           const startIdxOfNextPathChunk = loopKey.indexOf('/', endOfForIdx + 2);
-          tgtLoopNodeKey = getTargetValueWithoutLoops(
+          tgtLoopNodeKey = getTargetValueWithoutLoopsSchemaSpecific(
             startIdxOfNextPathChunk > -1 ? loopKey.substring(0, startIdxOfNextPathChunk) : loopKey,
-            targetArrayDepth
+            loopKey.indexOf('*') > -1
           );
-          tgtLoopNode = findNodeForKey(tgtLoopNodeKey, this._targetSchema.schemaTreeRoot);
+          tgtLoopNode = findNodeForKey(tgtLoopNodeKey, this._targetSchema.schemaTreeRoot, true); // XXX Confirm here
         }
 
         // Handle index variables

--- a/libs/data-mapper/src/lib/mapDefinitions/MapDefinitionDeserializer.ts
+++ b/libs/data-mapper/src/lib/mapDefinitions/MapDefinitionDeserializer.ts
@@ -309,7 +309,7 @@ export class MapDefinitionDeserializer {
       // Handle loops in targetKey by back-tracking
       while (startIdxOfCurLoop > -1) {
         const srcLoopNodeKey = getSourceKeyOfLastLoop(loopKey.substring(0, startIdxOfPrevLoop));
-        const srcLoopNode = findNodeForKey(srcLoopNodeKey, this._sourceSchema.schemaTreeRoot, false); // XXX Pretty sure this is correct
+        const srcLoopNode = findNodeForKey(srcLoopNodeKey, this._sourceSchema.schemaTreeRoot, false);
 
         const idxOfIndexVariable = loopKey.substring(0, startIdxOfPrevLoop).indexOf('$', startIdxOfCurLoop + 1);
         let indexFnRfKey: string | undefined = undefined;
@@ -327,7 +327,7 @@ export class MapDefinitionDeserializer {
             startIdxOfNextPathChunk > -1 ? loopKey.substring(0, startIdxOfNextPathChunk) : loopKey,
             loopKey.indexOf('*') > -1
           );
-          tgtLoopNode = findNodeForKey(tgtLoopNodeKey, this._targetSchema.schemaTreeRoot, true); // XXX Confirm here
+          tgtLoopNode = findNodeForKey(tgtLoopNodeKey, this._targetSchema.schemaTreeRoot, true);
         }
 
         // Handle index variables

--- a/libs/data-mapper/src/lib/mapDefinitions/MapDefinitionSerializer.ts
+++ b/libs/data-mapper/src/lib/mapDefinitions/MapDefinitionSerializer.ts
@@ -348,12 +348,16 @@ const addLoopingToNewPathItems = (
   });
 
   const selfNode = rootTargetConnection.self.node;
+  const isSchemaNode = isSchemaNodeExtended(selfNode);
 
   // Object within the loop
-  newPath.push({
-    key: pathItem.qName.startsWith('@') ? `$${pathItem.qName}` : pathItem.qName,
-    arrayIndex: isSchemaNodeExtended(selfNode) ? selfNode.arrayItemIndex : undefined,
-  });
+  // Skipping ArrayItem items for now, they will come into play with direct access arrays
+  if (isSchemaNode && !selfNode.nodeProperties.find((prop) => prop === SchemaNodeProperty.ArrayItem)) {
+    newPath.push({
+      key: pathItem.qName.startsWith('@') ? `$${pathItem.qName}` : pathItem.qName,
+      arrayIndex: isSchemaNodeExtended(selfNode) ? selfNode.arrayItemIndex : undefined,
+    });
+  }
 };
 
 const applyValueAtPath = (mapDefinition: MapDefinitionEntry, path: OutputPathItem[]) => {

--- a/libs/data-mapper/src/lib/mapDefinitions/__test__/MapDefinitionDeserializer.spec.ts
+++ b/libs/data-mapper/src/lib/mapDefinitions/__test__/MapDefinitionDeserializer.spec.ts
@@ -1379,11 +1379,9 @@ describe('mapDefinitions/MapDefinitionDeserializer', () => {
       it('creates a loop connection', () => {
         simpleMap['root'] = {
           ComplexArray1: {
-            '$for(/root/Nums/*)': [
-              {
-                F1: 'Num',
-              },
-            ],
+            '$for(/root/Nums/*)': {
+              F1: 'Num',
+            },
           },
         };
 
@@ -1766,11 +1764,9 @@ describe('mapDefinitions/MapDefinitionDeserializer', () => {
           TargetMadeUp: {
             ManySingleArray: {
               '$for(/root/SourceMadeUp/ManySingleArray/*)': {
-                '$for(*)': [
-                  {
-                    TargetMadeUp_NeedAProp: 'SourceMadeUp_NeedAProp',
-                  },
-                ],
+                '$for(*)': {
+                  TargetMadeUp_NeedAProp: 'SourceMadeUp_NeedAProp',
+                },
               },
             },
           },
@@ -1811,15 +1807,11 @@ describe('mapDefinitions/MapDefinitionDeserializer', () => {
         simpleMap['root'] = {
           TargetMadeUp: {
             ManyManyArray: {
-              '$for(/root/SourceMadeUp/ManyManyArray/*)': [
-                {
-                  '$for(*)': [
-                    {
-                      TargetMadeUp_NeedAProp: 'SourceMadeUp_NeedAProp',
-                    },
-                  ],
+              '$for(/root/SourceMadeUp/ManyManyArray/*)': {
+                '$for(*)': {
+                  TargetMadeUp_NeedAProp: 'SourceMadeUp_NeedAProp',
                 },
-              ],
+              },
             },
           },
         };
@@ -1829,31 +1821,28 @@ describe('mapDefinitions/MapDefinitionDeserializer', () => {
         const resultEntries = Object.entries(result);
         resultEntries.sort();
 
-        expect(resultEntries.length).toEqual(6);
+        expect(resultEntries.length).toEqual(5);
 
-        expect(resultEntries[1][0]).toEqual('source-/root/SourceMadeUp/ManyManyArray/*');
-        expect(resultEntries[1][1]).toBeTruthy();
-        expect(resultEntries[1][1].outputs[0].reactFlowKey).toEqual('target-/root/TargetMadeUp/ManyManyArray/*');
+        expect(resultEntries[0][0]).toEqual('source-/root/SourceMadeUp/ManyManyArray/*');
+        expect(resultEntries[0][1]).toBeTruthy();
+        expect(resultEntries[0][1].outputs[0].reactFlowKey).toEqual('target-/root/TargetMadeUp/ManyManyArray/*');
 
         expect(resultEntries[1][0]).toEqual('source-/root/SourceMadeUp/ManyManyArray/*/*');
         expect(resultEntries[1][1]).toBeTruthy();
-        expect(resultEntries[1][1].outputs[0].reactFlowKey).toEqual('target-/root/TargetMadeUp/ManyManyArray/*/*');
+        expect(resultEntries[1][1].outputs[0].reactFlowKey).toEqual('target-/root/TargetMadeUp/ManyManyArray/*');
 
-        expect(resultEntries[1][0]).toEqual('source-/root/SourceMadeUp/ManyManyArray/*/*/SourceMadeUp_NeedAProp');
-        expect(resultEntries[1][1]).toBeTruthy();
-        expect(resultEntries[1][1].outputs[0].reactFlowKey).toEqual('target-/root/TargetMadeUp/ManyManyArray/*/*/TargetMadeUp_NeedAProp');
+        expect(resultEntries[2][0]).toEqual('source-/root/SourceMadeUp/ManyManyArray/*/*/SourceMadeUp_NeedAProp');
+        expect(resultEntries[2][1]).toBeTruthy();
+        expect(resultEntries[2][1].outputs[0].reactFlowKey).toEqual('target-/root/TargetMadeUp/ManyManyArray/*/TargetMadeUp_NeedAProp');
 
-        expect(resultEntries[1][0]).toEqual('target-/root/TargetMadeUp/ManyManyArray/*');
-        expect(resultEntries[1][1]).toBeTruthy();
-        expect((resultEntries[1][1].inputs[0][0] as ConnectionUnit).reactFlowKey).toEqual('source-/root/SourceMadeUp/ManyManyArray/*');
+        expect(resultEntries[3][0]).toEqual('target-/root/TargetMadeUp/ManyManyArray/*');
+        expect(resultEntries[3][1]).toBeTruthy();
+        expect((resultEntries[3][1].inputs[0][0] as ConnectionUnit).reactFlowKey).toEqual('source-/root/SourceMadeUp/ManyManyArray/*/*');
+        expect((resultEntries[3][1].inputs[0][1] as ConnectionUnit).reactFlowKey).toEqual('source-/root/SourceMadeUp/ManyManyArray/*');
 
-        expect(resultEntries[1][0]).toEqual('target-/root/TargetMadeUp/ManyManyArray/*/*');
-        expect(resultEntries[1][1]).toBeTruthy();
-        expect((resultEntries[1][1].inputs[0][0] as ConnectionUnit).reactFlowKey).toEqual('source-/root/SourceMadeUp/ManyManyArray/*/*');
-
-        expect(resultEntries[1][0]).toEqual('target-/root/TargetMadeUp/ManyManyArray/*/*/TargetMadeUp_NeedAProp');
-        expect(resultEntries[1][1]).toBeTruthy();
-        expect((resultEntries[1][1].inputs[0][0] as ConnectionUnit).reactFlowKey).toEqual(
+        expect(resultEntries[4][0]).toEqual('target-/root/TargetMadeUp/ManyManyArray/*/TargetMadeUp_NeedAProp');
+        expect(resultEntries[4][1]).toBeTruthy();
+        expect((resultEntries[4][1].inputs[0][0] as ConnectionUnit).reactFlowKey).toEqual(
           'source-/root/SourceMadeUp/ManyManyArray/*/*/SourceMadeUp_NeedAProp'
         );
       });

--- a/libs/data-mapper/src/lib/mapDefinitions/__test__/MapDefinitionSerializer.spec.ts
+++ b/libs/data-mapper/src/lib/mapDefinitions/__test__/MapDefinitionSerializer.spec.ts
@@ -2601,11 +2601,11 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
 
         const forLoopObject = rootObject[targetLoopNode.qName] as MapDefinitionEntry;
         const actualForLoopObject = forLoopObject[`$for(${sourceArrayItemNode.key})`] as MapDefinitionEntry;
-        expect(actualForLoopObject.length).toEqual(1);
+        const actualForLoopObjectKeys = Object.keys(actualForLoopObject);
+        expect(actualForLoopObjectKeys.length).toEqual(2);
 
-        const arrayElement = actualForLoopObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode1.qName);
-        expect(arrayElement[targetArrayItemPropNode2.name]).toEqual(sourceArrayItemPropNode2.qName);
+        expect(actualForLoopObject[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode1.qName);
+        expect(actualForLoopObject[targetArrayItemPropNode2.name]).toEqual(sourceArrayItemPropNode2.qName);
       });
 
       it('Generates body with child objects loop', () => {
@@ -2690,10 +2690,10 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
 
         const forLoopObject = rootObject['ForLoop'] as MapDefinitionEntry;
         const actualForLoopObject = forLoopObject['$for(/root/generalData/address)'] as MapDefinitionEntry;
-        expect(actualForLoopObject.length).toEqual(1);
+        const actualForLoopObjectKeys = Object.keys(actualForLoopObject);
+        expect(actualForLoopObjectKeys.length).toEqual(1);
 
-        const arrayElement = actualForLoopObject[0] as MapDefinitionEntry;
-        const prop1Object = arrayElement[targetLoopChildObjectNode.name] as MapDefinitionEntry;
+        const prop1Object = actualForLoopObject[targetLoopChildObjectNode.name] as MapDefinitionEntry;
 
         const telNumberObject = prop1Object[targetLoopChildObjectPropNode1.name] as MapDefinitionEntry;
         expect(telNumberObject).toEqual(sourceLoopChildObjectPropNode1.qName);
@@ -2774,15 +2774,15 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
         const madeUpObject = rootObject['TargetMadeUp'] as MapDefinitionEntry;
         const complexArrayObject = madeUpObject[targetLoopNode.qName] as MapDefinitionEntry;
         const outerArrayObject = complexArrayObject[`$for(${sourceOuterArrayItemNode.key})`] as MapDefinitionEntry;
-        expect(outerArrayObject.length).toEqual(1);
+        const outerArrayObjectKeys = Object.keys(outerArrayObject);
+        expect(outerArrayObjectKeys.length).toEqual(1);
 
-        const outerArrayElement = outerArrayObject[0] as MapDefinitionEntry;
         const innerArray = `$for(${sourceInnerArrayItemNode.key.replace(`${sourceOuterArrayItemNode.key}/`, '')})`;
-        const innerArrayObject = outerArrayElement[innerArray] as MapDefinitionEntry;
-        expect(innerArrayObject.length).toEqual(1);
-        const innerArrayElement = innerArrayObject[0] as MapDefinitionEntry;
+        const innerArrayObject = outerArrayObject[innerArray] as MapDefinitionEntry;
+        const innerArrayObjectKeys = Object.keys(innerArrayObject);
+        expect(innerArrayObjectKeys.length).toEqual(1);
 
-        expect(innerArrayElement[targetInnerArrayItemPropNode.qName]).toEqual(sourceInnerArrayItemPropNode.name);
+        expect(innerArrayObject[targetInnerArrayItemPropNode.qName]).toEqual(sourceInnerArrayItemPropNode.name);
       });
 
       it('Generates body with many to one nested loops', () => {
@@ -2858,10 +2858,10 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
 
         const innerArray = `$for(${sourceInnerArrayItemNode.key.replace(`${sourceOuterArrayItemNode.key}/`, '')})`;
         const innerArrayObject = outerArrayObject[innerArray] as MapDefinitionEntry;
-        expect(innerArrayObject.length).toEqual(1);
-        const innerArrayElement = innerArrayObject[0] as MapDefinitionEntry;
+        const innerArrayObjectKeys = Object.keys(innerArrayObject);
+        expect(innerArrayObjectKeys.length).toEqual(1);
 
-        expect(innerArrayElement[targetArrayItemPropNode.qName]).toEqual(sourceInnerArrayItemPropNode.name);
+        expect(innerArrayObject[targetArrayItemPropNode.qName]).toEqual(sourceInnerArrayItemPropNode.name);
       });
 
       it('Generates body with function loop', () => {
@@ -2946,10 +2946,10 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
 
         const forLoopObject = rootObject[targetLoopNode.qName] as MapDefinitionEntry;
         const actualForLoopObject = forLoopObject[`$for(${sourceArrayItemNode.key})`] as MapDefinitionEntry;
-        expect(actualForLoopObject.length).toEqual(1);
+        const actualForLoopObjectKeys = Object.keys(actualForLoopObject);
+        expect(actualForLoopObjectKeys.length).toEqual(1);
 
-        const arrayElement = actualForLoopObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode.name]).toEqual('add(targetQuantity, rate)');
+        expect(actualForLoopObject[targetArrayItemPropNode.name]).toEqual('add(targetQuantity, rate)');
       });
 
       it('Generates body with index loop', () => {
@@ -3022,10 +3022,10 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
 
         const forLoopObject = rootObject[targetLoopNode.qName] as MapDefinitionEntry;
         const actualForLoopObject = forLoopObject[`$for(${sourceArrayItemNode.key}, $a)`] as MapDefinitionEntry;
-        expect(actualForLoopObject.length).toEqual(1);
+        const actualForLoopObjectKeys = Object.keys(actualForLoopObject);
+        expect(actualForLoopObjectKeys.length).toEqual(1);
 
-        const arrayElement = actualForLoopObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode.name]).toEqual(sourceArrayItemPropNode.qName);
+        expect(actualForLoopObject[targetArrayItemPropNode.name]).toEqual(sourceArrayItemPropNode.qName);
       });
 
       it('Generates body with index and passthrough loop', () => {
@@ -3109,11 +3109,11 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
 
         const forLoopObject = rootObject[targetLoopNode.qName] as MapDefinitionEntry;
         const actualForLoopObject = forLoopObject[`$for(${sourceArrayItemNode.key}, $a)`] as MapDefinitionEntry;
-        expect(actualForLoopObject.length).toEqual(1);
+        const actualForLoopObjectKeys = Object.keys(actualForLoopObject);
+        expect(actualForLoopObjectKeys.length).toEqual(2);
 
-        const arrayElement = actualForLoopObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode.qName);
-        expect(arrayElement[targetArrayItemPropNode2.name]).toEqual('$a');
+        expect(actualForLoopObject[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode.qName);
+        expect(actualForLoopObject[targetArrayItemPropNode2.name]).toEqual('$a');
       });
 
       it('Generates body with a sequence loop', () => {
@@ -3545,11 +3545,11 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
 
         const forLoopObject = rootObject[targetLoopNode.qName] as MapDefinitionEntry;
         const actualForLoopObject = forLoopObject[`$for(${sourceArrayItemNode.key}, $a)`] as MapDefinitionEntry;
-        expect(actualForLoopObject.length).toEqual(1);
+        const actualForLoopObjectKeys = Object.keys(actualForLoopObject);
+        expect(actualForLoopObjectKeys.length).toEqual(2);
 
-        const arrayElement = actualForLoopObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode.qName);
-        expect(arrayElement[targetArrayItemPropNode2.name]).toEqual('add(targetQuantity, $a)');
+        expect(actualForLoopObject[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode.qName);
+        expect(actualForLoopObject[targetArrayItemPropNode2.name]).toEqual('add(targetQuantity, $a)');
       });
 
       it('Generates body with many to one nested index loops', () => {
@@ -3657,11 +3657,11 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
 
         const innerArray = `$for(${sourceInnerArrayItemNode.key.replace(`${sourceOuterArrayItemNode.key}/`, '')}, $b)`;
         const innerArrayObject = outerArrayObject[innerArray] as MapDefinitionEntry;
-        expect(innerArrayObject.length).toEqual(1);
-        const innerArrayElement = innerArrayObject[0] as MapDefinitionEntry;
+        const innerArrayObjectKeys = Object.keys(innerArrayObject);
+        expect(innerArrayObjectKeys.length).toEqual(2);
 
-        expect(innerArrayElement[targetArrayItemPropNode1.qName]).toEqual('$b');
-        expect(innerArrayElement[targetArrayItemPropNode2.qName]).toEqual('$a');
+        expect(innerArrayObject[targetArrayItemPropNode1.qName]).toEqual('$b');
+        expect(innerArrayObject[targetArrayItemPropNode2.qName]).toEqual('$a');
       });
 
       it('Generates body with conditional looping', () => {
@@ -3765,10 +3765,10 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
         const complexArray1Object = rootObject[targetLoopNode.qName] as MapDefinitionEntry;
         const forLoopObject = complexArray1Object[`$for(${sourceArrayItemNode.key})`] as MapDefinitionEntry;
         const ifObject = forLoopObject['$if(is-greater-than(Num, 10))'] as MapDefinitionEntry;
-        expect(ifObject.length).toEqual(1);
+        const ifObjectKeys = Object.keys(ifObject);
+        expect(ifObjectKeys.length).toEqual(1);
 
-        const arrayElement = ifObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode.name]).toEqual(sourceArrayItemPropNode.qName);
+        expect(ifObject[targetArrayItemPropNode.name]).toEqual(sourceArrayItemPropNode.qName);
       });
 
       it('Generates body with an index and a conditional looping', () => {
@@ -3884,10 +3884,10 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
         const complexArray1Object = rootObject[targetLoopNode.qName] as MapDefinitionEntry;
         const forLoopObject = complexArray1Object[`$for(${sourceArrayItemNode.key}, $a)`] as MapDefinitionEntry;
         const ifObject = forLoopObject['$if(is-greater-than($a, 10))'] as MapDefinitionEntry;
-        expect(ifObject.length).toEqual(1);
+        const ifObjectKeys = Object.keys(ifObject);
+        expect(ifObjectKeys.length).toEqual(1);
 
-        const arrayElement = ifObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode.name]).toEqual(sourceArrayItemPropNode.qName);
+        expect(ifObject[targetArrayItemPropNode.name]).toEqual(sourceArrayItemPropNode.qName);
       });
 
       it('Generates body with custom value direct index access', () => {
@@ -4107,10 +4107,10 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
         const complexArray1Object = rootObject[targetLoopNode.qName] as MapDefinitionEntry;
         const forLoopObject = complexArray1Object[`$for(${sourceArrayItemNode.key}, $a)`] as MapDefinitionEntry;
         const ifObject = forLoopObject['$if(is-greater-than($a, 10))'] as MapDefinitionEntry;
-        expect(ifObject.length).toEqual(1);
+        const ifObjectKeys = Object.keys(ifObject);
+        expect(ifObjectKeys.length).toEqual(1);
 
-        const arrayElement = ifObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode.name]).toEqual('/root/Nums/*[$a]/Num');
+        expect(ifObject[targetArrayItemPropNode.name]).toEqual('/root/Nums/*[$a]/Num');
       });
 
       it('Generates body with an index loop and direct index access', () => {
@@ -4215,10 +4215,10 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
 
         const complexArray1Object = rootObject[targetLoopNode.qName] as MapDefinitionEntry;
         const forLoopObject = complexArray1Object[`$for(${sourceArrayItemNode.key}, $a)`] as MapDefinitionEntry;
-        expect(forLoopObject.length).toEqual(1);
+        const forLoopObjectKeys = Object.keys(forLoopObject);
+        expect(forLoopObjectKeys.length).toEqual(1);
 
-        const arrayElement = forLoopObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode.name]).toEqual('/root/Nums/*[$a]/Num');
+        expect(forLoopObject[targetArrayItemPropNode.name]).toEqual('/root/Nums/*[$a]/Num');
       });
     });
   });

--- a/libs/data-mapper/src/lib/mapDefinitions/__test__/MapDefinitionSerializer.spec.ts
+++ b/libs/data-mapper/src/lib/mapDefinitions/__test__/MapDefinitionSerializer.spec.ts
@@ -3197,10 +3197,10 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
         const actualForLoopObject = forLoopObject[
           `$for(sort(${sourceArrayItemNode.key}, ${sourceArrayItemPropNode.name}))`
         ] as MapDefinitionEntry;
-        expect(actualForLoopObject.length).toEqual(1);
+        const actualForLoopObjectKeys = Object.keys(actualForLoopObject);
+        expect(actualForLoopObjectKeys.length).toEqual(1);
 
-        const arrayElement = actualForLoopObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode.name]).toEqual(sourceArrayItemPropNode.qName);
+        expect(actualForLoopObject[targetArrayItemPropNode.name]).toEqual(sourceArrayItemPropNode.qName);
       });
 
       it('Generates body with a sequence and index loop', () => {
@@ -3306,11 +3306,11 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
         const actualForLoopObject = forLoopObject[
           `$for(sort(${sourceArrayItemNode.key}, ${sourceArrayItemPropNode.name}), $a)`
         ] as MapDefinitionEntry;
-        expect(actualForLoopObject.length).toEqual(1);
+        const actualForLoopObjectKeys = Object.keys(actualForLoopObject);
+        expect(actualForLoopObjectKeys.length).toEqual(2);
 
-        const arrayElement = actualForLoopObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode.qName);
-        expect(arrayElement[targetArrayItemPropNode2.name]).toEqual('$a');
+        expect(actualForLoopObject[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode.qName);
+        expect(actualForLoopObject[targetArrayItemPropNode2.name]).toEqual('$a');
       });
 
       it('Generates body with 2 sequences and index loop', () => {
@@ -3436,11 +3436,11 @@ describe('mapDefinitions/MapDefinitionSerializer', () => {
         const actualForLoopObject = forLoopObject[
           `$for(sort(sort(${sourceArrayItemNode.key}, ${sourceArrayItemPropNode.name}), ${sourceArrayItemPropNode.name}), $a)`
         ] as MapDefinitionEntry;
-        expect(actualForLoopObject.length).toEqual(1);
+        const actualForLoopObjectKeys = Object.keys(actualForLoopObject);
+        expect(actualForLoopObjectKeys.length).toEqual(2);
 
-        const arrayElement = actualForLoopObject[0] as MapDefinitionEntry;
-        expect(arrayElement[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode.qName);
-        expect(arrayElement[targetArrayItemPropNode2.name]).toEqual('$a');
+        expect(actualForLoopObject[targetArrayItemPropNode1.name]).toEqual(sourceArrayItemPropNode.qName);
+        expect(actualForLoopObject[targetArrayItemPropNode2.name]).toEqual('$a');
       });
 
       it('Generates body with function and index loop', () => {

--- a/libs/data-mapper/src/lib/utils/DataMap.Utils.ts
+++ b/libs/data-mapper/src/lib/utils/DataMap.Utils.ts
@@ -238,7 +238,7 @@ export const getSourceNode = (
     // We found a Function in source key -> let's find its data
     return findFunctionForFunctionName(sourceKey.substring(0, endOfFunctionIndex), functions);
   } else {
-    return findNodeForKey(sourceKey, sourceSchema.schemaTreeRoot, false); // XXX double check, pretty sure this is fine
+    return findNodeForKey(sourceKey, sourceSchema.schemaTreeRoot, false);
   }
 };
 
@@ -253,7 +253,7 @@ export const getDestinationNode = (targetKey: string, functions: FunctionData[],
 
   const destinationNode = isAGuid(destinationFunctionGuid)
     ? findFunctionForKey(destinationFunctionKey, functions)
-    : findNodeForKey(targetKey, schemaTreeRoot, false); // XXX
+    : findNodeForKey(targetKey, schemaTreeRoot, false);
 
   return destinationNode;
 };

--- a/libs/data-mapper/src/lib/utils/DataMap.Utils.ts
+++ b/libs/data-mapper/src/lib/utils/DataMap.Utils.ts
@@ -238,7 +238,7 @@ export const getSourceNode = (
     // We found a Function in source key -> let's find its data
     return findFunctionForFunctionName(sourceKey.substring(0, endOfFunctionIndex), functions);
   } else {
-    return findNodeForKey(sourceKey, sourceSchema.schemaTreeRoot);
+    return findNodeForKey(sourceKey, sourceSchema.schemaTreeRoot, false); // XXX double check, pretty sure this is fine
   }
 };
 
@@ -253,7 +253,7 @@ export const getDestinationNode = (targetKey: string, functions: FunctionData[],
 
   const destinationNode = isAGuid(destinationFunctionGuid)
     ? findFunctionForKey(destinationFunctionKey, functions)
-    : findNodeForKey(targetKey, schemaTreeRoot);
+    : findNodeForKey(targetKey, schemaTreeRoot, false); // XXX
 
   return destinationNode;
 };
@@ -429,8 +429,22 @@ export const getTargetValueWithoutLoops = (targetKey: string, targetArrayDepth: 
   const matchedLoops = targetKey.match(/\$for\(((?!\)).)+\)\//g) || [];
   // Start from the bottom and work up
   matchedLoops.reverse();
+
   matchedLoops.forEach((match, index) => {
     result = result.replace(match, index < targetArrayDepth ? '*/' : '');
+  });
+
+  return result;
+};
+
+export const getTargetValueWithoutLoopsSchemaSpecific = (targetKey: string, isJsonLoops: boolean): string => {
+  let result = targetKey;
+  const matchedLoops = targetKey.match(/\$for\(((?!\)).)+\)\//g) || [];
+  // Start from the bottom and work up
+  matchedLoops.reverse();
+
+  matchedLoops.forEach((match) => {
+    result = result.replace(match, isJsonLoops ? '*/' : '');
   });
 
   return result;

--- a/libs/data-mapper/src/lib/utils/Schema.Utils.ts
+++ b/libs/data-mapper/src/lib/utils/Schema.Utils.ts
@@ -106,7 +106,19 @@ export const flattenSchemaNode = (schemaNode: SchemaNodeExtended): SchemaNodeExt
 
 export const isLeafNode = (schemaNode: SchemaNodeExtended): boolean => schemaNode.children.length < 1;
 
-export const findNodeForKey = (nodeKey: string, schemaNode: SchemaNodeExtended): SchemaNodeExtended | undefined => {
+/**
+ * Finds a node for a key, searching within a given schema structure
+ *
+ * @param nodeKey The key to search for
+ * @param schemaNode The root node search to search within
+ * @param collapseLoopFallback Should the search attempt to collapse multiple loops into a single one
+ * in order to find a a potential many-one situation.
+ */
+export const findNodeForKey = (
+  nodeKey: string,
+  schemaNode: SchemaNodeExtended,
+  collapseLoopFallback: boolean
+): SchemaNodeExtended | undefined => {
   let tempKey = nodeKey;
   if (tempKey.includes(mapNodeParams.for)) {
     const layeredArrayItemForRegex = new RegExp(/\$for\([^)]*(?:\/\*){2,}\)/g);
@@ -122,7 +134,23 @@ export const findNodeForKey = (nodeKey: string, schemaNode: SchemaNodeExtended):
     }
   }
 
-  return searchChildrenNodeForKey(tempKey, schemaNode);
+  let result = searchChildrenNodeForKey(tempKey, schemaNode);
+
+  if (result || !collapseLoopFallback) {
+    return result;
+  }
+
+  let lastInstanceOfMultiLoop = tempKey.lastIndexOf('*/*');
+  while (lastInstanceOfMultiLoop > -1 && !result) {
+    const start = tempKey.substring(0, lastInstanceOfMultiLoop);
+    const end = tempKey.substring(lastInstanceOfMultiLoop + 2);
+    tempKey = start + end;
+
+    result = searchChildrenNodeForKey(tempKey, schemaNode);
+    lastInstanceOfMultiLoop = tempKey.lastIndexOf('*/*');
+  }
+
+  return result;
 };
 
 const searchChildrenNodeForKey = (key: string, schemaNode: SchemaNodeExtended): SchemaNodeExtended | undefined => {

--- a/libs/data-mapper/src/lib/utils/__test__/DataMapUtils.spec.ts
+++ b/libs/data-mapper/src/lib/utils/__test__/DataMapUtils.spec.ts
@@ -245,7 +245,8 @@ describe('utils/DataMap', () => {
     it('Single loop', () => {
       expect(
         getTargetValueWithoutLoops(
-          '/ns0:TargetSchemaRoot/Looping/ManyToOne/$for(/ns0:SourceSchemaRoot/Looping/ManyToOne/Simple, $a)/Simple/Direct'
+          '/ns0:TargetSchemaRoot/Looping/ManyToOne/$for(/ns0:SourceSchemaRoot/Looping/ManyToOne/Simple, $a)/Simple/Direct',
+          0
         )
       ).toBe('/ns0:TargetSchemaRoot/Looping/ManyToOne/Simple/Direct');
     });
@@ -253,7 +254,8 @@ describe('utils/DataMap', () => {
     it('Multiple loops', () => {
       expect(
         getTargetValueWithoutLoops(
-          '/ns0:TargetSchemaRoot/Looping/ManyToOne/$for(/ns0:SourceSchemaRoot/Looping/ManyToOne/Simple, $a)/RandomNode/$for(SourceSimpleChild)/$for(SourceSimpleChildChild, $c)/Simple/Direct'
+          '/ns0:TargetSchemaRoot/Looping/ManyToOne/$for(/ns0:SourceSchemaRoot/Looping/ManyToOne/Simple, $a)/RandomNode/$for(SourceSimpleChild)/$for(SourceSimpleChildChild, $c)/Simple/Direct',
+          0
         )
       ).toBe('/ns0:TargetSchemaRoot/Looping/ManyToOne/RandomNode/Simple/Direct');
     });


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines
* [X] Tests for the changes have been added (for bug fixes/features)
* [X] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix. Fixes #2592

- **What is the current behavior?** (You can also link to an open issue here)
Currently all JSON loops are also made into arrays

- **What is the new behavior (if this is a feature change)?**
JSON loops will be created as normal, not as arrays.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

- **Please Include Screenshots or Videos of the intended change**:
