### PR TITLE
fix(vscode): Invalid connection message when switching blades/tabs in vscode

### DIFF
--- a/apps/vs-code-designer-react/src/app/DesignerCommandBar/index.tsx
+++ b/apps/vs-code-designer-react/src/app/DesignerCommandBar/index.tsx
@@ -10,6 +10,7 @@ import {
 } from '@microsoft/logic-apps-designer';
 import type { RootState } from '@microsoft/logic-apps-designer';
 import { RUN_AFTER_COLORS } from '@microsoft/utils-logic-apps';
+import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { ExtensionCommand } from '@microsoft/vscode-extension';
 import { createSelector } from '@reduxjs/toolkit';
 import { useContext, useMemo } from 'react';
@@ -22,9 +23,16 @@ export interface DesignerCommandBarProps {
   isDisabled: boolean;
   onRefresh(): void;
   isDarkMode: boolean;
+  updateStandardApp(definition: LogicAppsV2.WorkflowDefinition): void;
 }
 
-export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({ isRefreshing, isDisabled, onRefresh, isDarkMode }) => {
+export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({
+  isRefreshing,
+  isDisabled,
+  onRefresh,
+  isDarkMode,
+  updateStandardApp,
+}) => {
   const intl = useIntl();
   const vscode = useContext(VSCodeContext);
   const dispatch = useDispatch();
@@ -42,6 +50,7 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({ isRefres
       skipValidation: false,
       ignoreNonCriticalErrors: true,
     });
+    updateStandardApp(definition);
     await vscode.postMessage({
       command: ExtensionCommand.save,
       definition,

--- a/apps/vs-code-designer-react/src/app/app.tsx
+++ b/apps/vs-code-designer-react/src/app/app.tsx
@@ -135,6 +135,10 @@ export const App = () => {
     onError: onRunInstanceError,
   });
 
+  const updateStandardApp = (definition: LogicAppsV2.WorkflowDefinition) => {
+    setStandardApp({ ...standardApp, definition: definition } as StandardApp);
+  };
+
   useEffect(() => {
     refetch();
   }, [isMonitoringView, runId, services, refetch]);
@@ -158,8 +162,11 @@ export const App = () => {
         isRefreshing={isRefetching}
         onRefresh={refetch}
         isDarkMode={theme === Theme.Dark}
+        updateStandardApp={updateStandardApp}
       />
     );
+
+  console.log('charlie: VSCode Designer', standardApp?.definition);
 
   const designerApp = standardApp ? (
     <BJSWorkflowProvider

--- a/apps/vs-code-designer-react/src/app/app.tsx
+++ b/apps/vs-code-designer-react/src/app/app.tsx
@@ -166,8 +166,6 @@ export const App = () => {
       />
     );
 
-  console.log('charlie: VSCode Designer', standardApp?.definition);
-
   const designerApp = standardApp ? (
     <BJSWorkflowProvider
       workflow={{


### PR DESCRIPTION
* [X] The commit message follows our guidelines
* [X] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Fixes #2294 

- **What is the current behavior?** (You can also link to an open issue here)
- Issue its happening when updating workflow to another action and then switch to another vscode tab. 

- **What is the new behavior (if this is a feature change)?**
- It also saves the new definition schema in the react project context, not only in the workflow.json

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

- **Please Include Screenshots or Videos of the intended change**:
#### Before
https://github.com/Azure/LogicAppsUX/assets/102700317/a27731d7-c56f-4cb9-bac7-be405cba083f


#### After
https://github.com/Azure/LogicAppsUX/assets/102700317/0428bac8-8037-4d96-a96b-f21c4b393f36

