### PR TITLE
fix(Designer): Add connectionReferenceKeyFormat for hybrid triggers for deserialization

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -408,6 +408,9 @@ function getConnectionReferenceKeyForManifest(referenceFormat: string, operation
 
     case ConnectionReferenceKeyFormat.OpenApi:
       return getOpenApiConnectionReferenceKey((operationDefinition as LogicAppsV2.OpenApiOperationAction).inputs);
+
+    case ConnectionReferenceKeyFormat.HybridTrigger:
+      return getHybridTriggerConnectionReferenceKey((operationDefinition as LogicAppsV2.HybridTriggerOperationAction).inputs);
     default:
       throw Error('No known connection reference key type');
   }
@@ -439,4 +442,20 @@ export function getLegacyConnectionReferenceKey(operationDefinition: any): strin
     }
   }
   return referenceKey;
+}
+
+function getHybridTriggerConnectionReferenceKey(operationDefinition: LogicAppsV2.HybridTriggerConnectionInfo): string {
+  let connectionName: string;
+  if (typeof operationDefinition.host.connection.name === 'string') {
+    const hostName =  operationDefinition.host.connection.name;
+    // hostName of the format: `@parameters('$connections')['${referenceKey}']['connectionId']`
+    const startDelimiter = "['";
+    const endDelimiter = "']";
+    const startIndex = hostName.indexOf(startDelimiter) + startDelimiter.length;
+    const endIndex = hostName.indexOf(endDelimiter, startIndex);
+    connectionName = hostName.substring(startIndex, endIndex);
+  } else {
+    connectionName = operationDefinition.host.connection.name.referenceName;
+  }
+  return connectionName;
 }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -445,14 +445,11 @@ export function getLegacyConnectionReferenceKey(operationDefinition: any): strin
 }
 
 function getHybridTriggerConnectionReferenceKey(operationDefinition: LogicAppsV2.HybridTriggerConnectionInfo): string {
-  let connectionName: string;
   const hostName =  operationDefinition.host.connection.name;
   // hostName of the format: `@parameters('$connections')['${referenceKey}']['connectionId']`
   const startDelimiter = "['";
   const endDelimiter = "']";
   const startIndex = hostName.indexOf(startDelimiter) + startDelimiter.length;
   const endIndex = hostName.indexOf(endDelimiter, startIndex);
-  connectionName = hostName.substring(startIndex, endIndex);
-
-  return connectionName;
+  return hostName.substring(startIndex, endIndex);
 }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -410,7 +410,7 @@ function getConnectionReferenceKeyForManifest(referenceFormat: string, operation
       return getOpenApiConnectionReferenceKey((operationDefinition as LogicAppsV2.OpenApiOperationAction).inputs);
 
     case ConnectionReferenceKeyFormat.HybridTrigger:
-      return getHybridTriggerConnectionReferenceKey((operationDefinition as LogicAppsV2.HybridTriggerOperationAction).inputs);
+      return getHybridTriggerConnectionReferenceKey((operationDefinition as LogicAppsV2.HybridTriggerOperation).inputs);
     default:
       throw Error('No known connection reference key type');
   }
@@ -446,16 +446,13 @@ export function getLegacyConnectionReferenceKey(operationDefinition: any): strin
 
 function getHybridTriggerConnectionReferenceKey(operationDefinition: LogicAppsV2.HybridTriggerConnectionInfo): string {
   let connectionName: string;
-  if (typeof operationDefinition.host.connection.name === 'string') {
-    const hostName =  operationDefinition.host.connection.name;
-    // hostName of the format: `@parameters('$connections')['${referenceKey}']['connectionId']`
-    const startDelimiter = "['";
-    const endDelimiter = "']";
-    const startIndex = hostName.indexOf(startDelimiter) + startDelimiter.length;
-    const endIndex = hostName.indexOf(endDelimiter, startIndex);
-    connectionName = hostName.substring(startIndex, endIndex);
-  } else {
-    connectionName = operationDefinition.host.connection.name.referenceName;
-  }
+  const hostName =  operationDefinition.host.connection.name;
+  // hostName of the format: `@parameters('$connections')['${referenceKey}']['connectionId']`
+  const startDelimiter = "['";
+  const endDelimiter = "']";
+  const startIndex = hostName.indexOf(startDelimiter) + startDelimiter.length;
+  const endIndex = hostName.indexOf(endDelimiter, startIndex);
+  connectionName = hostName.substring(startIndex, endIndex);
+
   return connectionName;
 }

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -120,7 +120,7 @@ export const getUpdatedManifestForSplitOn = (manifest: OperationManifest, splitO
       throw new AssertionException(AssertionErrorCode.INVALID_SPLITON, invalidSplitOn);
     }
 
-    const isAliasPathParsingEnabled = (manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.OpenApi || manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.HybridTrigger) ? true : false;
+    const isAliasPathParsingEnabled = manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.OpenApi || manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.HybridTrigger;
     const parsedValue = ExpressionParser.parseTemplateExpression(splitOn, isAliasPathParsingEnabled);
     const properties: string[] = [];
     let manifestSection = updatedManifest.properties.outputs;

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -120,7 +120,7 @@ export const getUpdatedManifestForSplitOn = (manifest: OperationManifest, splitO
       throw new AssertionException(AssertionErrorCode.INVALID_SPLITON, invalidSplitOn);
     }
 
-    const isAliasPathParsingEnabled = manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.OpenApi;
+    const isAliasPathParsingEnabled = (manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.OpenApi || manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.HybridTrigger) ? true : false;
     const parsedValue = ExpressionParser.parseTemplateExpression(splitOn, isAliasPathParsingEnabled);
     const properties: string[] = [];
     let manifestSection = updatedManifest.properties.outputs;

--- a/libs/utils/src/lib/models/logicAppsV2.ts
+++ b/libs/utils/src/lib/models/logicAppsV2.ts
@@ -100,6 +100,14 @@ export interface OpenApiOperationInputs extends RetryableActionInputs {
   parameters?: any;
 }
 
+export interface HybridTriggerOperationAction extends Trigger {
+  inputs: HybridTriggerConnectionInfo;
+}
+
+export interface HybridTriggerConnectionInfo {
+  host: HybridTriggerConnectionHost;
+}
+
 export type OpenApiConnectionNotificationTrigger = OpenApiConnectionWebhookTrigger;
 
 export type ApiConnectionHeaders = string | Record<string, string>;

--- a/libs/utils/src/lib/models/logicAppsV2.ts
+++ b/libs/utils/src/lib/models/logicAppsV2.ts
@@ -100,12 +100,15 @@ export interface OpenApiOperationInputs extends RetryableActionInputs {
   parameters?: any;
 }
 
-export interface HybridTriggerOperationAction extends Trigger {
+export interface HybridTriggerOperation extends Trigger {
   inputs: HybridTriggerConnectionInfo;
 }
 
 export interface HybridTriggerConnectionInfo {
   host: HybridTriggerConnectionHost;
+  schema?: any;
+  operationId: string;
+  parameters: any;
 }
 
 export type OpenApiConnectionNotificationTrigger = OpenApiConnectionWebhookTrigger;
@@ -125,7 +128,7 @@ export interface HybridTriggerConnectionHost {
 }
 
 export interface HybridTriggerConnectionHostType {
-  name: ApiConnectionHostConnection;
+  name: string;
 }
 
 export interface ApiConnectionHostType {


### PR DESCRIPTION
1. For deserialization of workflow, adding the HybridTrigger case to extract the connectionReferenceKey
2. For adding the SplitOn value, adding the hybridTrigger connectionReferenceKey type to get the AliasPathParsing
