### PR TITLE
fix(designer): Load monaco from npm instead of cdn

### DIFF
--- a/libs/designer-ui/src/lib/editor/monaco/index.tsx
+++ b/libs/designer-ui/src/lib/editor/monaco/index.tsx
@@ -3,6 +3,7 @@ import { registerWorkflowLanguageProviders } from '../../workflow/languageservic
 import { useTheme } from '@fluentui/react';
 import Editor, { loader } from '@monaco-editor/react';
 import type { IScrollEvent, editor } from 'monaco-editor';
+import * as monaco from 'monaco-editor';
 import type { MutableRefObject } from 'react';
 import { useState, useEffect, forwardRef, useRef } from 'react';
 
@@ -114,6 +115,7 @@ export const MonacoEditor = forwardRef<editor.IStandaloneCodeEditor, MonacoProps
     const currentRef = useRef<editor.IStandaloneCodeEditor>();
 
     const initTemplateLanguage = async () => {
+      loader.config({ monaco });
       const { languages, editor } = await loader.init();
       if (!languages.getLanguages().some((lang: any) => lang.id === Constants.LANGUAGE_NAMES.WORKFLOW)) {
         registerWorkflowLanguageProviders(languages, editor);


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix
- **What is the current behavior?** (You can also link to an open issue here)
monaco is loaded from cdn. So if you don't have internet access or cdn is blocked, monaco errors and does not load
https://github.com/Azure/LogicAppsUX/issues/2788
- **What is the new behavior (if this is a feature change)?**
monaco is initialized from npm package
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
- **Please Include Screenshots or Videos of the intended change**:
before: 
![before](https://github.com/Azure/LogicAppsUX/assets/95886809/04ff5c21-5606-43d2-aee2-900e3ac0ffd3)

after: 
![after](https://github.com/Azure/LogicAppsUX/assets/95886809/070b5d51-115d-4a1f-ae9a-0f6bc23fe2ed)
