### PR TITLE
fix(Designer): Search requests now only rely on nextlinks, not the value length

### DIFF
--- a/libs/services/designer-client-services/src/lib/base/search.ts
+++ b/libs/services/designer-client-services/src/lib/base/search.ts
@@ -87,7 +87,7 @@ export abstract class BaseSearchService implements ISearchService {
 
     try {
       const { nextLink, value = [] } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri, queryParameters });
-      return { value, hasMore: !!nextLink || value.length !== 0 };
+      return { value, hasMore: !!nextLink };
     } catch (error) {
       return { value: [], hasMore: false };
     }
@@ -100,7 +100,7 @@ export abstract class BaseSearchService implements ISearchService {
       try {
         const { nextLink, value: newValue } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri, queryParameters });
         value.push(...newValue);
-        if (nextLink && newValue.length !== 0) return await requestPage(nextLink, value);
+        if (nextLink) return await requestPage(nextLink, value);
         return value;
       } catch (error) {
         return value;


### PR DESCRIPTION
## Main Changes
Fixes https://github.com/Azure/LogicAppsUX/issues/2768
We initially checked for empty value properties because with how we were requesting custom connectors and operations, backend was returning infinite nextlinks, I've tested for this behavior again and this is no longer an issue we need to adjust for. 