### PR TITLE
fix(Designer): Workflows without triggers now properly deserialize

### DIFF
--- a/libs/chatbot/src/lib/ui/chatbot.tsx
+++ b/libs/chatbot/src/lib/ui/chatbot.tsx
@@ -3,7 +3,6 @@ import { useBoolean } from '@fluentui/react-hooks';
 import type { ConversationItem } from '@microsoft/designer-ui';
 import { PanelLocation, ChatInput, ConversationItemType, ConversationMessage } from '@microsoft/designer-ui';
 import { useCallback, useEffect, useState } from 'react';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 interface ChatbotProps {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -94,6 +94,7 @@ export const initializeOperationMetadata = async (
   let triggerNodeId = '';
 
   for (const [operationId, operation] of Object.entries(operations)) {
+    if (operationId === Constants.NODE.TYPE.PLACEHOLDER_TRIGGER) continue;
     const isTrigger = isRootNodeInGraph(operationId, 'root', nodesMetadata);
 
     if (isTrigger) {
@@ -505,6 +506,7 @@ export const updateDynamicDataInNodes = async (getState: () => RootState, dispat
   } = rootState;
   const allVariables = getAllVariables(variables);
   for (const [nodeId, operation] of Object.entries(operations)) {
+    if (nodeId === Constants.NODE.TYPE.PLACEHOLDER_TRIGGER) continue;
     if (!errors[nodeId]?.[ErrorLevel.Critical]) {
       const nodeDependencies = dependencies[nodeId];
       const nodeInputs = inputParameters[nodeId];

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import constants from '../../../common/constants';
 import { UnsupportedException, UnsupportedExceptionCode } from '../../../common/exceptions/unsupported';
 import type { Operations, NodesMetadata } from '../../state/workflow/workflowInterfaces';
 import { createWorkflowNode, createWorkflowEdge } from '../../utils/graph';
@@ -49,6 +50,16 @@ export const Deserialize = (
       isRoot: true,
       ...(trigger?.metadata && { actionMetadata: trigger?.metadata }),
       ...addTriggerInstanceMetaData(runInstance),
+    };
+    allActionNames.push(tID);
+  } else {
+    // Workflow has no trigger, create a Placeholder trigger node
+    const tID = constants.NODE.TYPE.PLACEHOLDER_TRIGGER;
+    triggerNode = createWorkflowNode(tID, WORKFLOW_NODE_TYPES.PLACEHOLDER_NODE);
+    allActions[tID] = { ...triggerNode };
+    nodesMetadata[tID] = {
+      graphId: 'root',
+      isRoot: true,
     };
     allActionNames.push(tID);
   }

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -53,7 +53,7 @@ export const Deserialize = (
     };
     allActionNames.push(tID);
   } else {
-    // Workflow has no trigger, create a Placeholder trigger node
+    // Workflow has no trigger, create a placeholder trigger node to reference during initialization
     const tID = constants.NODE.TYPE.PLACEHOLDER_TRIGGER;
     triggerNode = createWorkflowNode(tID, WORKFLOW_NODE_TYPES.PLACEHOLDER_NODE);
     allActions[tID] = { ...triggerNode };


### PR DESCRIPTION
## Main Changes
- With our recent fix to serializing workflows without triggers, we were not handling the matching deserialization instance
  - Workflows would appear to just be blank with no option to add anything
- We now add the placeholder trigger node on deserialization if there is no trigger
  - Also added some catches so we don't over-initialize the placeholder node

Fixes https://github.com/Azure/LogicAppsUX/issues/2795

---
### One action with no triggers deserializes as this now:
![image](https://github.com/Azure/LogicAppsUX/assets/25409734/0ad38f8b-d596-46d5-bf12-fbd4894d01d3)
