### PR TITLE
feat(vscode): Organize Azure workspace commands into submenu

### DIFF
--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -307,34 +307,42 @@
         "category": "Azure Logic Apps"
       }
     ],
+    "submenus": [
+      {
+        "id": "azureLogicAppsStandard.submenus.workspaceActions",
+        "icon": "assets/logicapp.png",
+        "label": "Azure Logic Apps"
+      }
+    ],
     "menus": {
-      "azureWorkspaceDeploy": [
+      "azureLogicAppsStandard.submenus.workspaceActions": [
+        {
+          "command": "azureLogicAppsStandard.createNewProject",
+          "group": "1_create@1"
+        },
+        {
+          "command": "azureLogicAppsStandard.createNewCodeProject",
+          "when": "isWindows",
+          "group": "1_create@2"
+        },
+        {
+          "command": "azureLogicAppsStandard.createCodeless",
+          "group": "1_create@3"
+        },
         {
           "command": "azureLogicAppsStandard.deploy",
-          "when": "view == azureWorkspace",
-          "group": "navigation@1"
+          "group": "2_deploy@1"
+        },
+        {
+          "command": "azureLogicAppsStandard.exportLogicApp",
+          "group": "3_export@1"
         }
       ],
       "view/title": [
         {
-          "command": "azureLogicAppsStandard.createNewProject",
-          "when": "view == azureWorkspace",
-          "group": "navigation@1"
-        },
-        {
-          "command": "azureLogicAppsStandard.createNewCodeProject",
-          "when": "view == azureWorkspace && isWindows",
-          "group": "navigation@1"
-        },
-        {
-          "command": "azureLogicAppsStandard.createCodeless",
+          "submenu": "azureLogicAppsStandard.submenus.workspaceActions",
           "when": "view == azureWorkspace",
           "group": "navigation@2"
-        },
-        {
-          "command": "azureLogicAppsStandard.exportLogicApp",
-          "when": "view == azureWorkspace",
-          "group": "navigation@4"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
Hello from the Azure extension team!

We are organizing the workspace `view/title` commands into submenus so that there is less clutter in the workspace menu. See https://github.com/microsoft/vscode-azureresourcegroups/blob/main/api/README.md#viewtitle-commands for more details. 

Here's what that looks like for Logic Apps:
<img width="292" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/12476526/4190676a-ea52-4661-b809-cdd3c68099e1">

We've done the same for all of our extensions. Here's what it looks like for Azure Functions:
![image](https://github.com/Azure/LogicAppsUX/assets/12476526/92cb03de-1402-472d-9c71-f3e9343f966f)

AB#24363706