### PR TITLE
fix(Designer): Fixed filtering of cloud capability parameters

### DIFF
--- a/libs/designer-ui/src/lib/createConnection/index.tsx
+++ b/libs/designer-ui/src/lib/createConnection/index.tsx
@@ -122,7 +122,7 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
     () => connectionParameterSets?.values[selectedParamSetIndex].parameters ?? {},
     [connectionParameterSets, selectedParamSetIndex]
   );
-  const isMultiAuth = useMemo(() => (connectionParameterSets?.values?.length ?? 0) > 1, [connectionParameterSets?.values]);
+  const isMultiAuth = useMemo(() => (connectionParameterSets?.values?.length ?? 0) > 0, [connectionParameterSets?.values]);
 
   const hasOnlyOnPremGateway = useMemo(
     () =>
@@ -132,7 +132,7 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
     [connectorCapabilities]
   );
 
-  const [enabledCapabilities, setEnabledCapabilities] = useState<Capabilities[]>([]);
+  const [enabledCapabilities, setEnabledCapabilities] = useState<Capabilities[]>([Capabilities.general, Capabilities.cloud]);
   const toggleCapability = useCallback(
     (capability: Capabilities) => {
       if (enabledCapabilities.includes(capability)) {
@@ -571,27 +571,7 @@ export const CreateConnection = (props: CreateConnectionProps): JSX.Element => {
 
         {/* Connector Parameters */}
         {showConfigParameters &&
-          Object.entries(parametersByCapability['general'] ?? {})?.map(
-            ([key, parameter]: [string, ConnectionParameterSetParameter | ConnectionParameter]) => (
-              <UniversalConnectionParameter
-                key={key}
-                parameterKey={key}
-                parameter={parameter}
-                value={parameterValues[key]}
-                setValue={(val: any) => setParameterValues({ ...parameterValues, [key]: val })}
-                isLoading={isLoading}
-                selectedSubscriptionId={selectedSubscriptionId}
-                selectSubscriptionCallback={selectSubscriptionCallback}
-                availableGateways={availableGateways}
-                availableSubscriptions={availableSubscriptions}
-              />
-            )
-          )}
-
-        {/* Gateway-Specific Parameters */}
-        {showConfigParameters &&
-          enabledCapabilities.includes(Capabilities.gateway) &&
-          Object.entries(getParametersByCapability(Capabilities.gateway))?.map(
+          Object.entries(capabilityEnabledParameters)?.map(
             ([key, parameter]: [string, ConnectionParameterSetParameter | ConnectionParameter]) => (
               <UniversalConnectionParameter
                 key={key}

--- a/libs/utils/src/lib/models/connector.ts
+++ b/libs/utils/src/lib/models/connector.ts
@@ -8,6 +8,7 @@ export enum Capabilities {
   gateway,
   cloud,
   vnetgateway,
+  general,
 }
 
 export enum ConnectionParameterTypes {


### PR DESCRIPTION
## Main Changes
- The MySQL connector now shows all connection parameters
  - We were requiring at least 2 different auth types to show multi-auth, this connector only had 1
- Reworked a bit of the capability filtering to always include cloud capability parameters

I've tested these changes on a variety of connectors with different capabilities to ensure it won't cause regressions

Fixes https://github.com/Azure/LogicAppsUX/issues/2782