### PR TITLE
fix(Designer): Select Connection panel now shows recently created connections

### DIFF
--- a/libs/designer/src/lib/core/queries/connections.ts
+++ b/libs/designer/src/lib/core/queries/connections.ts
@@ -77,6 +77,8 @@ export const useConnectionsForConnector = (connectorId: string) => {
   return useQuery([connectionKey, connectorId?.toLowerCase()], () => ConnectionService().getConnections(connectorId), {
     enabled: !!connectorId,
     refetchOnMount: true,
+    cacheTime: 0,
+    staleTime: 0,
   });
 };
 


### PR DESCRIPTION
## Main Changes
With the ReactQuery fixes recently, our queries were correctly no longer fetching on each render, and this was one of the places that actually needed the frequent refetch.
I've added cache/stale time props and now it refetches connections on opening the panel like intended.

Fixes: https://github.com/Azure/LogicAppsUX/issues/2884