### PR TITLE
chore: conditionally show dropdown designerTypes in bugreport

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,7 +42,7 @@ body:
       required: true
 
   - type: dropdown
-    id: deisgnerType
+    id: designerType
     attributes:
       label: Are you using Preview Designer or GA Designer
       options:
@@ -50,6 +50,20 @@ body:
         - Generally Available
     validations:
       required: true
+    conditions:
+      sku: 'Consumption (Portal)'
+
+  - type: dropdown
+    id: designerType2
+    attributes:
+      label: Are you using GA Designer or Fallback Designer
+      options:
+        - GA Designer
+        - Fallback Designer
+    validations:
+      required: true
+    conditions:
+      sku: 'Standard (VSCode)'
 
   - type: dropdown
     id: tsgchecked


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Now that standard is GA, its a little confusing to differentiate between GA designer and preview designer

- **What is the current behavior?** (You can also link to an open issue here)

We ask users to pick between GA designer and preview designer when our "preview designer" is our GA designer

- **What is the new behavior (if this is a feature change)?**

Now specify its "Fallback Designer" vs "GA designer"

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**:
