### PR TITLE
fix(powerautomate): Fix results of getTreeDynamicValues call being cached unexpectedly in hotfix/v2.38 branch

### DIFF
--- a/libs/designer/src/lib/core/queries/connector.ts
+++ b/libs/designer/src/lib/core/queries/connector.ts
@@ -198,7 +198,8 @@ export const getDynamicTreeItems = async (
       operationId?.toLowerCase(),
       getParametersKey(parameters).toLowerCase(),
     ],
-    () => service.getTreeDynamicValues(connectionId, connectorId, operationId, parameterAlias, parameters, dynamicState)
+    () => service.getTreeDynamicValues(connectionId, connectorId, operationId, parameterAlias, parameters, dynamicState),
+    { cacheTime: 0, staleTime: 0 }
   );
 
   return values;


### PR DESCRIPTION
This PR fixes issue #2927 

- **Please check if the PR fulfills these requirements**

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix

- **What is the current behavior?** (You can also link to an open issue here)
User is unable to navigate past first level of folders in folder picker

- **What is the new behavior (if this is a feature change)?**
This fix restores the expected behavior of user being able to navigate folder picker and select a folder no matter how deeply nested it is.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

- **Please Include Screenshots or Videos of the intended change**:
After the fix, we are able to navigate to and selected a folder that's nested more than one level:
![image](https://github.com/Azure/LogicAppsUX/assets/10837129/5731b49e-9ce7-44db-bca3-ea6b2920fb20)
Example selected folder path: `/PAuto test/test folder/nested test folder`