### PR TITLE
fix(Designer): Terminate now shows `Code` and `Message` inputs on custom statuses

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -845,9 +845,12 @@ export function shouldUseParameterInGroup(parameter: ParameterInfo, allParameter
     }, []);
 
     return dependentParameters.every((dependentParameter) => {
-      const { actualValue, values } = dependentParameter;
+      const { actualValue, values, excludeValues } = dependentParameter;
       const isArray = Array.isArray(actualValue);
-      return values.some((value) => (isArray ? actualValue.includes(value) : actualValue === value));
+      const includesValue = (value: any) => (isArray ? actualValue.includes(value) : actualValue === value);
+      if (values) return values.some(includesValue);
+      if (excludeValues) return !excludeValues.some(includesValue);
+      return false; // Should always have one or the other
     });
   }
 

--- a/libs/parsers/src/lib/models/operation.ts
+++ b/libs/parsers/src/lib/models/operation.ts
@@ -217,7 +217,8 @@ export interface ParameterSerializationOptions {
 
 export interface DependentParameterInfo {
   name: string;
-  values: any[];
+  values?: any[];
+  excludeValues?: any[];
 }
 export interface InputDependencies {
   type: string;

--- a/libs/services/designer-client-services/src/lib/base/manifests/terminate.ts
+++ b/libs/services/designer-client-services/src/lib/base/manifests/terminate.ts
@@ -43,7 +43,7 @@ export default {
               title: 'Code',
               'x-ms-input-dependencies': {
                 type: 'visibility',
-                parameters: [{ name: 'runStatus', values: ['Failed'] }],
+                parameters: [{ name: 'runStatus', excludeValues: ['Succeeded', 'Cancelled'] }],
               },
             },
             message: {
@@ -53,7 +53,7 @@ export default {
               title: 'Message',
               'x-ms-input-dependencies': {
                 type: 'visibility',
-                parameters: [{ name: 'runStatus', values: ['Failed'] }],
+                parameters: [{ name: 'runStatus', excludeValues: ['Succeeded', 'Cancelled'] }],
               },
             },
           },


### PR DESCRIPTION
## Main Changes
- Manifests can now specify values to exclude for parameter dependency
- Terminate now shows `Code` and `Message` parameters on custom values

Fixes https://github.com/Azure/LogicAppsUX/issues/2906