### PR TITLE
fix(vscode): Add logic app icon path for light theme

### DIFF
--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -310,7 +310,10 @@
     "submenus": [
       {
         "id": "azureLogicAppsStandard.submenus.workspaceActions",
-        "icon": "assets/logicapp.png",
+        "icon": {
+          "light": "assets/logicapp.png",
+          "dark": "assets/logicapp.png"
+        },
         "label": "Azure Logic Apps"
       }
     ],


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines
* [X] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- Add path for the icon when is in light theme
<img width="713" alt="Screenshot 2023-07-10 at 1 32 04 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/39ae0c3e-40e1-418d-b2bc-0cc8195e154d">
