### PR TITLE
feat(vscode): Azurite Start & Default Location

### DIFF
--- a/apps/vs-code-designer/src/app/azuriteExtension/executeOnAzuriteExt.ts
+++ b/apps/vs-code-designer/src/app/azuriteExtension/executeOnAzuriteExt.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { azuriteExtensionId } from '../../constants';
+import { localize } from '../../localize';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import { extensions } from 'vscode';
+import * as vscode from 'vscode';
+
+export async function executeOnAzurite(context: IActionContext, command: string, ...args: any[]): Promise<void> {
+  const azuriteExtension = extensions.getExtension(azuriteExtensionId);
+
+  if (azuriteExtension?.isActive) {
+    vscode.commands.executeCommand(command, {
+      ...args,
+    });
+  } else {
+    const message: string = localize('deactivatedAzuriteExt', 'Azurite extension is deactivated, make sure to activate it');
+    await context.ui.showWarningMessage(message);
+  }
+}

--- a/apps/vs-code-designer/src/app/utils/azurite/activateAzurite.ts
+++ b/apps/vs-code-designer/src/app/utils/azurite/activateAzurite.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { azuriteExtensionPrefix, azuriteLocationSetting, extensionCommand } from '../../../constants';
+import { localize } from '../../../localize';
+import { executeOnAzurite } from '../../azuriteExtension/executeOnAzuriteExt';
+import { getWorkspaceSetting, updateGlobalSetting, updateWorkspaceSetting } from '../vsCodeConfig/settings';
+import { getWorkspaceFolder } from '../workspace';
+import { DialogResponses, type IActionContext } from '@microsoft/vscode-azext-utils';
+import * as os from 'os';
+import * as path from 'path';
+import type { MessageItem } from 'vscode';
+
+/**
+ * Prompts user to set azurite.location and Start Azurite.
+ * If azurite extension location was not set:
+ * Overrides default Azurite location to new default location.
+ * User can specify location.
+ */
+export async function activateAzurite(context: IActionContext): Promise<void> {
+  const workspaceFolder = await getWorkspaceFolder(context);
+  const workspacePath = workspaceFolder.uri.fsPath;
+
+  const globalAzuriteLocationSetting: string = getWorkspaceSetting<string>(azuriteLocationSetting, workspacePath, azuriteExtensionPrefix);
+  context.telemetry.properties.globalAzuriteLocation = globalAzuriteLocationSetting;
+
+  const azuriteLoationSettingKey = 'azuriteLocationSetting';
+  const azuriteLocationExtSetting: string = getWorkspaceSetting<string>(azuriteLoationSettingKey);
+
+  const showAutoStartAzuriteWarningKey = 'showAutoStartAzuriteWarning';
+  const showAutoStartAzuriteWarning = !!getWorkspaceSetting<boolean>(showAutoStartAzuriteWarningKey);
+
+  const autoStartAzuriteKey = 'autoStartAzurite';
+  const autoStartAzurite = !!getWorkspaceSetting<boolean>(autoStartAzuriteKey);
+  context.telemetry.properties.autoStartAzurite = `${autoStartAzurite}`;
+
+  if (showAutoStartAzuriteWarning) {
+    const enableMessage: MessageItem = { title: localize('enableAutoStart', 'Enable AutoStart') };
+
+    const result = await context.ui.showWarningMessage(
+      localize('autoStartAzuriteTitle', 'Configure Azurite to autostart on project launch?'),
+      enableMessage,
+      DialogResponses.no,
+      DialogResponses.dontWarnAgain
+    );
+
+    if (result == DialogResponses.dontWarnAgain) {
+      await updateGlobalSetting(showAutoStartAzuriteWarningKey, false);
+    } else if (result == enableMessage) {
+      await updateGlobalSetting(showAutoStartAzuriteWarningKey, false);
+      await updateGlobalSetting(autoStartAzuriteKey, true);
+
+      // User has not configured workspace azurite.location.
+      if (!azuriteLocationExtSetting) {
+        const defaultAzuriteDir = path.join(os.homedir(), '.logicapps', 'azurite');
+        const azuriteDir = await context.ui.showInputBox({
+          placeHolder: localize('configureAzuriteLocation', 'Azurite Location'),
+          prompt: localize('configureWebhookEndpointPrompt', 'Configure Azurite Workspace location folder path'),
+          value: defaultAzuriteDir,
+        });
+
+        if (azuriteDir) {
+          await updateGlobalSetting(azuriteLoationSettingKey, azuriteDir);
+        } else {
+          await updateGlobalSetting(azuriteLoationSettingKey, defaultAzuriteDir);
+        }
+      }
+    }
+  }
+
+  if (getWorkspaceSetting<boolean>(autoStartAzuriteKey)) {
+    const azuriteWorkspaceSetting = getWorkspaceSetting<string>(azuriteLoationSettingKey);
+    await updateWorkspaceSetting(azuriteLocationSetting, azuriteWorkspaceSetting, workspacePath, azuriteExtensionPrefix);
+    await executeOnAzurite(context, extensionCommand.azureAzuriteStart);
+    context.telemetry.properties.azuriteStart = 'true';
+    context.telemetry.properties.azuriteLocation = azuriteWorkspaceSetting;
+  }
+}

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -20,6 +20,11 @@ export const funcIgnoreFileName = '.funcignore';
 
 export const logicAppsStandardExtensionId = 'ms-azuretools.vscode-azurelogicapps';
 
+// Azurite
+export const azuriteExtensionId = 'Azurite.azurite';
+export const azuriteExtensionPrefix = 'azurite';
+export const azuriteLocationSetting = 'location';
+
 // Functions
 export const func = 'func';
 export const functionsExtensionId = 'ms-azuretools.vscode-azurefunctions';
@@ -117,6 +122,7 @@ export enum extensionCommand {
   startRemoteDebug = 'azureLogicAppsStandard.startRemoteDebug',
   validateLogicAppProjects = 'azureLogicAppsStandard.validateFunctionProjects',
   reportIssue = 'azureLogicAppsStandard.reportIssue',
+  azureAzuriteStart = 'azurite.start',
 }
 
 // Context

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -4,6 +4,7 @@ import { validateFuncCoreToolsIsLatest } from './app/commands/funcCoreTools/vali
 import { registerCommands } from './app/commands/registerCommands';
 import { getResourceGroupsApi } from './app/resourcesExtension/getExtensionApi';
 import type { AzureAccountTreeItemWithProjects } from './app/tree/AzureAccountTreeItemWithProjects';
+import { activateAzurite } from './app/utils/azurite/activateAzurite';
 import { stopDesignTimeApi } from './app/utils/codeless/startDesignTimeApi';
 import { UriHandler } from './app/utils/codeless/urihandler';
 import { getExtensionVersion } from './app/utils/extension';
@@ -52,6 +53,8 @@ export async function activate(context: vscode.ExtensionContext) {
     callWithTelemetryAndErrorHandling(extensionCommand.validateLogicAppProjects, async (actionContext: IActionContext) => {
       await verifyVSCodeConfigOnActivate(actionContext, vscode.workspace.workspaceFolders);
     });
+
+    await activateAzurite(activateContext);
 
     registerEvent(
       extensionCommand.validateLogicAppProjects,

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -770,6 +770,20 @@
             "type": "boolean",
             "description": "Show a warning when an Azure Functions .NET project was detected that has mismatched target frameworks.",
             "default": true
+          },
+          "azureLogicAppsStandard.showAutoStartAzuriteWarning": {
+            "type": "boolean",
+            "description": "Show a warning asking if user's would like to configure Azurite auto start.",
+            "default": true
+          },
+          "azureLogicAppsStandard.autoStartAzurite": {
+            "type": "boolean",
+            "description": "Start Azurite when project starts.",
+            "default": false
+          },
+          "azureLogicAppsStandard.azuriteLocationSetting": {
+            "type": "string",
+            "description": "Default location for Azurite repository for Logic Apps Standard Workspaces"
           }
         }
       }


### PR DESCRIPTION
Starts Azurite via vscode extension command.
Prompts user to configure azurite.location setting if empty.
Will suggest default directory: **C:\Users\<User>\.logicapps\azurite**
User is redacted in telemetry.
The azurite location setting is saved to the Logic App Extension Global setting and then passed to the Azurite Extension scoped to Workspace only. This is so that it does not override Global.

Once enabled, this setting is configured for all Logic App Projects.

- **Please Include Screenshots or Videos of the intended change**:
On Logic App Project open. "Enable AutoStart" proceeds to set AutoStart setting to true and prompt for location setting.
<img width="352" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/12243528/db5a88b7-319a-4316-8b4e-756dcb5f8ca8">

Auto Start setting "checked"
User Input - Default location: C:\Users\<User>\.logicapps\azurite
If empty, it will be the default location:  C:\Users\<User>\.logicapps\azurite instead of the Azurite Default location (workspace directory)
<img width="1079" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/12243528/eb812d8b-9b05-44fa-913b-98ef88ae4b8a">

Global Logic App Azurite location setting 
<img width="531" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/12243528/73d7a166-6bc3-4835-9358-d366f2c2f370">

Global Azurite Location extension
<img width="406" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/12243528/1177288a-96c8-44b0-b8fd-a66b5d753b3f">

Workspace Azurite Location extension
<img width="511" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/12243528/6aa1cc0b-9df4-40cd-96f9-546d53ac84e4">

Auto start Azurite - 
<img width="356" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/12243528/e1b65b11-5a5a-426c-b93f-36272a1286aa">

