### PR TITLE
fix(designer): Add dynamic inputs for serialized workflow

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -152,6 +152,12 @@ export const serializeWorkflow = async (rootState: RootState, options?: Serializ
     connectionReferences,
     parameters,
   };
+
+  const workflowService = WorkflowService();
+  if (workflowService && workflowService.getDefinitionWithDynamicInputs) {
+    serializedWorkflow.definition = workflowService.getDefinitionWithDynamicInputs(serializedWorkflow.definition, rootState.operations.outputParameters)
+  }
+
   return serializedWorkflow;
 };
 

--- a/libs/services/designer-client-services/src/lib/workflow.ts
+++ b/libs/services/designer-client-services/src/lib/workflow.ts
@@ -1,9 +1,33 @@
-import type { ManagedIdentity } from '@microsoft/utils-logic-apps';
+import type { LogicAppsV2, ManagedIdentity, OpenAPIV2 } from '@microsoft/utils-logic-apps';
 import { AssertionErrorCode, AssertionException } from '@microsoft/utils-logic-apps';
 
 export interface CallbackInfo {
   method?: string;
   value: string;
+}
+
+export interface NodeOutputs {
+  outputs: Record<string, OutputInfo>;
+  originalOutputs?: Record<string, OutputInfo>;
+}
+
+export interface OutputInfo {
+  description?: string;
+  type: string;
+  format?: string;
+  isAdvanced: boolean;
+  isDynamic?: boolean;
+  isInsideArray?: boolean;
+  itemSchema?: OpenAPIV2.SchemaObject;
+  key: string;
+  name: string;
+  parentArray?: string;
+  required?: boolean;
+  schema?: OpenAPIV2.SchemaObject;
+  source?: string;
+  title: string;
+  value?: string;
+  alias?: string;
 }
 
 export interface IWorkflowService {
@@ -26,6 +50,11 @@ export interface IWorkflowService {
    * Gets definition schema version from current operation types.
    */
   getDefinitionSchema?(operationInfos: { type: string; kind?: string }[]): string;
+
+  /**
+   * Updates the serialized workflow with dynamic inputs from references.
+   */
+  getDefinitionWithDynamicInputs?(serializedWorkflow: LogicAppsV2.WorkflowDefinition, outputParameters: Record<string, NodeOutputs>): LogicAppsV2.WorkflowDefinition;
 }
 
 let service: IWorkflowService;


### PR DESCRIPTION
For Hybrid Triggers (HT), based on the referenced parameters from the actions, the trigger's input definition (schema property) needs to be updated to read these values during run time.

This discussion talks more on what is the issue: https://github.com/Azure/LogicAppsUX/discussions/2855

**Fix:** Added a **nullable hook** during flow serialization **as suggested** that sends the serialized definition to the host and accepts the modified definition with just the inputs of the HT being modified.

_Example scenario for the fix:_

Serialized workflow being sent to the host, the references from the actions would be used like below:
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/4ac147f6-e4b3-4cd2-bc05-56707ee10beb)


Return from the host: Only the schema properties from the trigger would be modified to use the dynamic inputs from the referenced parameters. 
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/b63c2715-4f65-479b-8b28-c4c9aed6d8f7)


Code-view of the trigger **before**:
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/b8e879ea-91fc-491d-a405-d116491c16ca)

Code-view **after flow-save with the updated dynamic inputs**:
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/379299f3-9868-4e42-be8a-00e49204f9ab)
