### PR TITLE
fix(Designer): Fixed issue with some MI ServiceProvider connections failing  

### DIFF
--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -52,8 +52,13 @@ export const useConnectorByNodeId = (nodeId: string): Connector | undefined => {
   const storeConnectorId = useSelector((state: RootState) => state.operations.operationInfo[nodeId]?.connectorId);
   const operationInfo = useOperationInfo(nodeId);
 
-  const useManifest = OperationManifestService().isSupported(operationInfo?.type ?? '', operationInfo?.kind ?? '');
-  const connectorFromService = useConnector(storeConnectorId, !useManifest)?.data;
+  // Connectors we get inside of operation manifests are missing some data currently.
+  // The below logic is to get the connector from the service unless it is a manifest-based + non-service provider operation
+  // The operations we are preventing the service call for are expected to fail
+  const isManifestSupported = OperationManifestService().isSupported(operationInfo?.type ?? '', operationInfo?.kind ?? '');
+  const isServiceProvider = isServiceProviderOperation(operationInfo?.type);
+  const useManifestConnector = isManifestSupported && !isServiceProvider;
+  const connectorFromService = useConnector(storeConnectorId, !useManifestConnector)?.data;
   return connectorFromService ?? connectorFromManifest;
 };
 


### PR DESCRIPTION
## Main Changes
We currently have an issue where some ServiceProvider connectors are failing during connection creation when using ManagedIdentity.
This is due to us prioritizing the connector we get from operation manifests on manifest based operations, however the connector we get from the manifest is missing some data.  This led to the connection issue by the connector missing some of the connection parameters needed for Managed Identity connection creation.

This PR fixes the issue best we can on the front-end, making manifest based operations use the service call connector instead when it is a service provider operation.