### PR TITLE
fix(designer): Nested loops actions update in monitoring view

### DIFF
--- a/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -106,7 +106,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
     if (parentRunIndex !== undefined && isMonitoringView) {
       refetch();
     }
-  }, [dispatch, parentRunIndex, isMonitoringView, refetch]);
+  }, [dispatch, parentRunIndex, isMonitoringView, refetch, repetitionName]);
 
   const dependencies = useTokenDependencies(id);
 

--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -92,7 +92,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
     if (parentRunIndex !== undefined && isMonitoringView) {
       refetch();
     }
-  }, [dispatch, parentRunIndex, isMonitoringView, refetch]);
+  }, [dispatch, parentRunIndex, isMonitoringView, refetch, repetitionName]);
 
   const [{ isDragging }, drag, dragPreview] = useDrag(
     () => ({

--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -65,7 +65,7 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
     if (normalizedType === constants.NODE.TYPE.FOREACH) {
       refetch();
     }
-  }, [runInstance?.id, refetch, scopeId, normalizedType, metadata?.runData]);
+  }, [runInstance?.id, refetch, scopeId, normalizedType]);
 
   if (!forEachItemsCount || isError || collapsed) {
     return null;

--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -105,8 +105,11 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
   const failedIterationProps =
     failedRepetitions.length > 0
       ? {
-          max: failedRepetitions[failedRepetitions.length - 1] + 1,
-          min: failedRepetitions[0] + 1,
+          max:
+            failedRepetitions[failedRepetitions.length - 1] + 1 <= forEachItemsCount
+              ? failedRepetitions[failedRepetitions.length - 1] + 1
+              : forEachItemsCount,
+          min: failedRepetitions[0] + 1 >= 1 ? failedRepetitions[0] + 1 : 1,
           onClickNext: onClickNextFailed,
           onClickPrevious: onClickPreviousFailed,
         }


### PR DESCRIPTION
* [X] The commit message follows our guidelines
* [X] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #3016 

- **What is the current behavior?** (You can also link to an open issue here)
Actions inside nested nested loops doesn't update when parent loop changes iteration
When an actions fails the failed iterator max and min wasn't limiting the nested loop, therefore user could iterate in repetitions that didn't exist

- **What is the new behavior (if this is a feature change)?**
Now when updating parent loop iteration it also updates children loops actions

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**:

For each loop

https://github.com/Azure/LogicAppsUX/assets/102700317/bac1088c-3c4a-4b63-8d93-036bf732a099

Do until loop



https://github.com/Azure/LogicAppsUX/assets/102700317/f5b6ac10-3de6-44c6-8751-d25193baf3e0

