### PR TITLE
fix(Designer): Disabled operation schema validation when parsing incoming swaggers

### DIFF
--- a/libs/parsers/src/lib/swagger/parser.ts
+++ b/libs/parsers/src/lib/swagger/parser.ts
@@ -70,7 +70,14 @@ const ApiNotificationConstants = {
 
 export class SwaggerParser {
   static parse = async (swagger: OpenAPIV2.Document): Promise<OpenAPIV2.Document> => {
-    return APIParser.validate(swagger, { dereference: { circular: 'ignore' } });
+    return APIParser.validate(swagger, {
+      dereference: {
+        circular: 'ignore',
+      },
+      validate: {
+        schema: false,
+      },
+    });
   };
 
   constructor(public api: OpenAPIV2.Document) {}


### PR DESCRIPTION
## Main Changes
Added extra option on SwaggerParser to skip schema validation.
This was option was enabled in legacy designer and not carried over to new designer.
This was causing operations to fail on load that had invalid schemas, even if they still functioned fine (again this was the behavior in legacy designer). 

Fixes https://github.com/Azure/LogicAppsUX/issues/3055