### PR TITLE
feat(designer): File system client configure password as App settings

### DIFF
--- a/libs/services/designer-client-services/src/lib/connection.ts
+++ b/libs/services/designer-client-services/src/lib/connection.ts
@@ -20,6 +20,7 @@ export interface ConnectionCreationInfo {
   alternativeParameterValues?: Record<string, any>;
   displayName?: string;
   parameterName?: string;
+  appSettings?: Record<string, string>;
 }
 
 export interface ConnectionParametersMetadata {

--- a/libs/services/designer-client-services/src/lib/standard/connection.ts
+++ b/libs/services/designer-client-services/src/lib/standard/connection.ts
@@ -627,7 +627,7 @@ function convertToServiceProviderConnectionsData(
       serviceProvider: { id: connectorId },
       displayName,
     },
-    settings: {},
+    settings: connectionInfo.appSettings ?? {},
     pathLocation: [serviceProviderLocation],
   };
   const rawConnection = createCopy(connectionsData.connectionData);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.52.0",
+  "version": "2.54.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.52.0",
+      "version": "2.54.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.54.0",
+  "version": "2.52.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.54.0",
+      "version": "2.52.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 

  This PR adds an improvment to the current file system connection client.

- **What is the current behavior?** (You can also link to an open issue here)
  When a new connection is added, the password for the app service configuration is written as palin text in the config

- **What is the new behavior (if this is a feature change)?**
   In this PR, we make the changes to reference the password as app settings in the configuration.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No this is not a breaking change. Existing connections will still continue to work. For new connections password will be configured in app settings.

### Screenshots

The connection creation experience still remains the same.
![Screenshot 2023-08-02 112734](https://github.com/Azure/LogicAppsUX/assets/16523769/9aa72d8f-723b-4a27-ab87-fba12cd063bb )

The app service config created during connection creation will have password refreneced as app settings now.

![Screenshot 2023-08-02 112427](https://github.com/Azure/LogicAppsUX/assets/16523769/8f038575-8591-4f86-afbe-e001afdf0e4c)

The app settings referenced will be added 

![Screenshot 2023-08-02 112008](https://github.com/Azure/LogicAppsUX/assets/16523769/80d77819-53ba-4025-901d-4d8d26ac6dad)
