### PR TITLE
fix(Designer): Fixed creation of phantom "cases" node input object - cherrypick release 2.55

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -304,24 +304,6 @@ const processChildGraphAndItsInputs = (
             });
           }
         }
-
-        const { inputs: nodeInputs, dependencies: inputDependencies } = getInputParametersFromManifest(
-          subGraphKey,
-          subManifest,
-          /* presetParameterValues */ undefined,
-          /* customSwagger */ undefined,
-          subOperation
-        );
-        const nodeOutputs = { outputs: {} };
-        nodesData.push({
-          id: subGraphKey,
-          nodeInputs,
-          nodeOutputs,
-          nodeDependencies: { inputs: inputDependencies, outputs: {} },
-          operationInfo: { type: '', kind: '', connectorId: '', operationId: '' },
-          manifest: subManifest,
-          operationMetadata: { iconUri: '', brandColor: '' },
-        });
       }
     }
   }


### PR DESCRIPTION
## Main Changes
Previously we have always deserialized case nodes with an extra "cases" phantom operation using parameter data meant for the case operations.
Now we only deserialize to the case operation data like intended.

We will be hotfixing this into our current release as it is a regression.
This was found in our current release due to some extra pre-save validation we added.

Cherry pick of this PR https://github.com/Azure/LogicAppsUX/pull/3119
