### PR TITLE
fix(Designer): Retry policy setting now de/serializing properly

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -122,19 +122,11 @@ export const getInputParametersFromManifest = (
     // avoid pushing a parameter for it as it is already being
     // handled in the settings store.
     // NOTE: this could be expanded to more settings that are treated as inputs.
-    if (
-      manifest.properties.settings &&
-      manifest.properties.settings.retryPolicy &&
-      operationData.inputs &&
-      operationData.inputs[PropertyName.RETRYPOLICY]
-    ) {
+    if (manifest.properties.settings?.retryPolicy && operationData.inputs?.[PropertyName.RETRYPOLICY]) {
       delete operationData.inputs.retryPolicy;
     }
 
-    if (
-      manifest.properties.connectionReference &&
-      manifest.properties.connectionReference.referenceKeyFormat === ConnectionReferenceKeyFormat.Function
-    ) {
+    if (manifest.properties.connectionReference?.referenceKeyFormat === ConnectionReferenceKeyFormat.Function) {
       delete operationData.inputs.function;
     }
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -120,6 +120,7 @@ import {
   SchemaProcessor,
   SegmentType,
   Visibility,
+  PropertyName,
 } from '@microsoft/parsers-logic-apps';
 import type { Exception, OpenAPIV2, OperationManifest, RecurrenceSetting } from '@microsoft/utils-logic-apps';
 import {
@@ -1829,6 +1830,16 @@ async function loadDynamicContentForInputsInNode(
             dispatch
           );
           const allInputParameters = getAllInputParameters(allInputs);
+
+          // In the case of retry policy, it is treated as an input
+          // avoid pushing a parameter for it as it is already being
+          // handled in the settings store.
+          // NOTE: this could be expanded to more settings that are treated as inputs.
+          const newOperationDefinition = clone(operationDefinition);
+          if (newOperationDefinition.inputs?.[PropertyName.RETRYPOLICY]) {
+            delete newOperationDefinition.inputs.retryPolicy;
+          }
+
           const allInputKeys = allInputParameters.map((param) => param.parameterKey);
           const schemaInputs = inputSchema
             ? await getDynamicInputsFromSchema(
@@ -1836,7 +1847,7 @@ async function loadDynamicContentForInputsInNode(
                 info.parameter as InputParameter,
                 operationInfo,
                 allInputKeys,
-                operationDefinition
+                newOperationDefinition
               )
             : [];
           const inputParameters = schemaInputs.map((input) => ({


### PR DESCRIPTION
## Main Changes
Operations with a retry policy setting were deserializing as normal inputs and not as settings.
Over in the initialization code we filter it out, but the dynamic data initialization did not.
Carrying that filtering over to the dynamic data init fixed the issue.

Fixes https://github.com/Azure/LogicAppsUX/issues/3133