### PR TITLE
fix(designer): swapInputsLocation replacing whole input instead of only replacing source item

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -55,6 +55,7 @@ import {
   replaceTemplatePlaceholders,
   unmap,
   filterRecord,
+  excludePathValueFromTarget,
 } from '@microsoft/utils-logic-apps';
 import merge from 'lodash.merge';
 
@@ -568,10 +569,9 @@ const swapInputsLocationIfNeeded = (parametersValue: any, swapMap: LocationSwapM
   if (!swapMap?.length) {
     return parametersValue;
   }
-
   let finalValue = clone(parametersValue);
   for (const { source, target } of swapMap) {
-    const value = getObjectPropertyValue(parametersValue, source);
+    const value = { ...excludePathValueFromTarget(parametersValue, source, target), ...getObjectPropertyValue(parametersValue, source) };
     deleteObjectProperty(finalValue, source);
     finalValue = !target.length ? { ...finalValue, ...value } : safeSetObjectPropertyValue(finalValue, target, value);
   }

--- a/libs/utils/src/lib/helpers/functions.ts
+++ b/libs/utils/src/lib/helpers/functions.ts
@@ -397,6 +397,37 @@ export function deleteObjectProperties(object: Record<string, unknown>, properti
 }
 
 /**
+ * Removes an object's source property and then returns the target property of the removed object.
+ * sample
+ *      object: {
+ *          prop1: {
+ *              prop2: 'val',
+ *              prop3: 'val2'
+ *          }
+ *          prop4: {
+ *              prop5: 'val3',
+ *              prop6: 'val4'
+ *          }
+ *      }
+ *      source: ['prop1', 'prop2']
+ *      target: ['prop1']
+ *      result :
+ *          prop1: {
+ *              prop3: 'val2'
+ *          }
+ * @arg {Object} object - The object for search.
+ * @arg {string[]} source - The ordered array of property to remove.
+ * @arg {string[]} target - The ordered array of property to get object from.
+ * @return {any} - The value of the property, if found.
+ */
+export function excludePathValueFromTarget(object: Record<string, any>, source: string[], target: string[]): any {
+  const copiedObject = clone(object);
+  deleteObjectProperty(copiedObject, source);
+  const result = getObjectPropertyValue(copiedObject, target);
+  return result;
+}
+
+/**
  * Returns true if an object has a property whose name is case-insensitive.
  * @arg {Object} object - An object to search.
  * @arg {string} property - The property to search for.


### PR DESCRIPTION
The value we were swapping back into our target doesn't include the rest of the parameters so it ended up overwriting information

Fixes: https://github.com/Azure/LogicAppsUX/issues/3153