### PR TITLE
feat(Designer): Added support for additional audiences on Managed Identity connections

### DIFF
--- a/libs/utils/src/lib/models/connector.ts
+++ b/libs/utils/src/lib/models/connector.ts
@@ -102,6 +102,7 @@ export interface OAuthSetting {
 
 export interface ManagedIdentitySetting {
   resourceUri: string;
+  additionalResourceUris?: string[];
 }
 
 export interface GatewaySetting {


### PR DESCRIPTION
## Main Changes
Added support for additional audiences on Managed Identity connections
This does not replace the existing `audiences` prop on MI connections, it just adds a separate `additionalAudiences` prop
This is currently only used on the Azure Monitor Logs connector, it was needed for MI to function properly in standard

![image](https://github.com/Azure/LogicAppsUX/assets/25409734/fa8b5e37-9ec3-4dbf-9157-908de95717de)
