### PR TITLE
fix(Designer): Fixed type import build issue

### DIFF
--- a/libs/designer/src/lib/core/utils/tokens.ts
+++ b/libs/designer/src/lib/core/utils/tokens.ts
@@ -1,10 +1,10 @@
 import Constants from '../../common/constants';
 import type { ConnectionReferences } from '../../common/models/workflow';
+import type { NodeDataWithOperationMetadata } from '../actions/bjsworkflow/operationdeserializer';
 import {
   initializeOperationDetailsForManifest,
   initializeOutputTokensForOperations,
   initializeVariables,
-  type NodeDataWithOperationMetadata,
 } from '../actions/bjsworkflow/operationdeserializer';
 import type { Settings } from '../actions/bjsworkflow/settings';
 import { Deserialize } from '../parsers/BJSWorkflow/BJSDeserializer';


### PR DESCRIPTION
## Main Changes

One of our import statements had an internal `type` specification, this is fine in the Designer repo but will cause build errors on trying to build portal.
I've moved the type import out to it's own statement.

I looked for an eslint rule for this and I couldn't find one.  We have one import rule that potentially would have fixed this issue but it doesn't affect it when running `eslint --fix`.