### PR TITLE
fix(Designer): Ensure outputs merge only based on isRequestApiConnection FF

### DIFF
--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -360,11 +360,11 @@ export const getUpdatedManifestForSchemaDependency = (manifest: OperationManifes
           schemaValue = { ...currentSchemaValue, ...schemaToReplace };
           shouldMerge = true;
         } else {
-          schemaValue = currentSchemaValue;
-          shouldMerge = false;
+          continue;
         }
       } else {
-        continue;
+        schemaValue = { ...currentSchemaValue, ...schemaToReplace };
+        shouldMerge = false;
       }
       safeSetObjectPropertyValue(updatedManifest.properties.outputs, outputLocation, schemaValue, shouldMerge);
     }

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -349,9 +349,8 @@ export const getUpdatedManifestForSchemaDependency = (manifest: OperationManifes
 
       const currentSchemaValue = getObjectPropertyValue(updatedManifest.properties.outputs, outputLocation);
 
-      const inputSchema = updatedManifest.properties?.inputs?.properties?.schema;
       const isRequestApiConnectionTrigger =
-        'x-ms-editor-options' in inputSchema ? inputSchema['x-ms-editor-options'].isRequestApiConnectionTrigger : undefined;
+        !!updatedManifest.properties?.inputs?.properties?.schema?.['x-ms-editor-options']?.isRequestApiConnectionTrigger;
 
       let schemaValue: Schema;
       let shouldMerge: boolean;
@@ -365,8 +364,7 @@ export const getUpdatedManifestForSchemaDependency = (manifest: OperationManifes
           shouldMerge = false;
         }
       } else {
-        schemaValue = { ...currentSchemaValue, ...schemaToReplace };
-        shouldMerge = false;
+        continue;
       }
       safeSetObjectPropertyValue(updatedManifest.properties.outputs, outputLocation, schemaValue, shouldMerge);
     }

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -21,7 +21,14 @@ import { convertOutputsToTokens } from './tokens';
 import { OperationManifestService } from '@microsoft/designer-client-services-logic-apps';
 import { generateSchemaFromJsonString, ValueSegmentType } from '@microsoft/designer-ui';
 import { getIntl } from '@microsoft/intl-logic-apps';
-import type { Expression, ExpressionFunction, ExpressionLiteral, OutputParameter, OutputParameters } from '@microsoft/parsers-logic-apps';
+import type {
+  Expression,
+  ExpressionFunction,
+  ExpressionLiteral,
+  OutputParameter,
+  OutputParameters,
+  Schema,
+} from '@microsoft/parsers-logic-apps';
 import {
   create,
   OutputKeys,
@@ -342,17 +349,26 @@ export const getUpdatedManifestForSchemaDependency = (manifest: OperationManifes
 
       const currentSchemaValue = getObjectPropertyValue(updatedManifest.properties.outputs, outputLocation);
 
+      const inputSchema = updatedManifest.properties?.inputs?.properties?.schema;
+      const isRequestApiConnectionTrigger =
+        'x-ms-editor-options' in inputSchema ? inputSchema['x-ms-editor-options'].isRequestApiConnectionTrigger : undefined;
+
+      let schemaValue: Schema;
+      let shouldMerge: boolean;
       // if schema contains static object returned from RP, merge the current schema value and new schema value
-      if (schemaToReplace && 'rows' in schemaToReplace) {
-        if (!Object.keys(schemaToReplace.rows.items.properties) !== undefined && 'rows' in currentSchemaValue) {
-          safeSetObjectPropertyValue(
-            updatedManifest.properties.outputs,
-            outputLocation,
-            { ...currentSchemaValue, ...schemaToReplace },
-            true
-          );
+      if (isRequestApiConnectionTrigger && schemaToReplace && 'rows' in schemaToReplace) {
+        if ('rows' in currentSchemaValue) {
+          schemaValue = { ...currentSchemaValue, ...schemaToReplace };
+          shouldMerge = true;
+        } else {
+          schemaValue = currentSchemaValue;
+          shouldMerge = false;
         }
-      } else safeSetObjectPropertyValue(updatedManifest.properties.outputs, outputLocation, { ...currentSchemaValue, ...schemaToReplace });
+      } else {
+        schemaValue = { ...currentSchemaValue, ...schemaToReplace };
+        shouldMerge = false;
+      }
+      safeSetObjectPropertyValue(updatedManifest.properties.outputs, outputLocation, schemaValue, shouldMerge);
     }
   }
 


### PR DESCRIPTION
Enclosing outputs merge only if `isRequestHybridTrigger` flag is set.
Here are the sample outputs that were used to test the scenarios:

https://docs.google.com/document/d/1-gPlN3IxPn5OomHG-pQKx4ASaBbSwVhUIQCSt2fFwhM/edit?usp=sharing