### PR TITLE
fix(Designer): Fixed issue with some alternate swagger-based dynamic parameter formatting

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -61,6 +61,7 @@ import {
   ParameterLocations,
   SchemaProcessor,
   WildIndexSegment,
+  replaceSubsegmentSeparator,
 } from '@microsoft/parsers-logic-apps';
 import type { Connection, Connector, OpenAPIV2, OperationInfo, OperationManifest } from '@microsoft/utils-logic-apps';
 import {
@@ -635,6 +636,22 @@ function getSwaggerBasedInputParameters(
     operationPath,
     basePath as string
   );
+
+  // We are recieving some swagger parameters in the following format, ex:
+  //     body.$.body/content/appId
+  // We need to remove the extra `body` and convert the '/' to '.', ex:
+  //     body.$.content.appId
+  for (const inputParameter of dynamicInputParameters) {
+    if (isOpenApiParameter(inputParameter)) {
+      const { key: _key, in: _in } = inputParameter;
+      const key = replaceSubsegmentSeparator(_key)?.replace(`${_in}.$.${_in}.`, '') ?? '';
+      const name = key.split('.').pop() ?? '';
+
+      inputParameter.key = `${_in}.$.${key}`;
+      inputParameter.name = name;
+      inputParameter.title = name;
+    }
+  }
 
   if (isNested) {
     const parameter = first((inputParameter) => inputParameter.key === key, dynamicInputParameters);

--- a/libs/parsers/src/lib/common/helpers/keysutility.ts
+++ b/libs/parsers/src/lib/common/helpers/keysutility.ts
@@ -96,6 +96,10 @@ export function expandAndEncodePropertySegment(segment: string): string {
   return expandedSegments.join(_separator);
 }
 
+export function replaceSubsegmentSeparator(key: string): string {
+  return key.replace(new RegExp(`\\${_subSegmentSeparator}`, 'g'), _separator);
+}
+
 export function isAncestorKey(key: string, testAncestorKey: string | undefined): boolean {
   const segments = parseEx(key);
   if (testAncestorKey !== undefined) {


### PR DESCRIPTION
## Main Changes

Some connectors like `Dataverse` have an alternate swagger dynamic parameter formatting.
Normally the parameter keys follow this format:
> body.$.other.parameterName

But the mentioned alternate formatting instead is as follows:
> body.$.body/other/parameterName

I've added an extra step in the parameter parsing to convert the parameter key + other data as needed so that it de/serializes the swagger dynamic parameters correctly.

Fixes: https://github.com/Azure/LogicAppsUX/issues/2920