### PR TITLE
fix(Designer): Fixed issue on the initialize variable action

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1835,8 +1835,8 @@ async function loadDynamicContentForInputsInNode(
           // avoid pushing a parameter for it as it is already being
           // handled in the settings store.
           // NOTE: this could be expanded to more settings that are treated as inputs.
-          const newOperationDefinition = clone(operationDefinition);
-          if (newOperationDefinition.inputs?.[PropertyName.RETRYPOLICY]) {
+          const newOperationDefinition = operationDefinition ? clone(operationDefinition) : operationDefinition;
+          if (newOperationDefinition?.inputs?.[PropertyName.RETRYPOLICY]) {
             delete newOperationDefinition.inputs.retryPolicy;
           }
 


### PR DESCRIPTION
## Main Changes

The `Initialize Variable` had a recent bug where it would not show the value field, and say there was an issue with dynamic data.
This was caused by a recent PR using our `clone()` function on a possibly undefined object.  This returns an empty object which caused issues (it was expecting it to still be null).  This PR fixes the issue.

Fixes https://github.com/Azure/LogicAppsUX/issues/3210

Will need to be hotfixed to live and staging