### PR TITLE
feat(designer): inputsLocationSwapMap manifest property to support non-objects

### DIFF
--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -297,7 +297,7 @@ export const TokenField = ({
         />
       );
     case 'floatingactionmenu': {
-      return editorOptions.menuKind === FloatingActionMenuKind.outputs ? (
+      return editorOptions?.menuKind === FloatingActionMenuKind.outputs ? (
         <FloatingActionMenuOutputs
           supportedTypes={editorOptions?.supportedTypes}
           initialValue={value}

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -571,8 +571,15 @@ const swapInputsLocationIfNeeded = (parametersValue: any, swapMap: LocationSwapM
   }
   let finalValue = clone(parametersValue);
   for (const { source, target } of swapMap) {
-    const value = { ...excludePathValueFromTarget(parametersValue, source, target), ...getObjectPropertyValue(parametersValue, source) };
+    const propertyValue = getObjectPropertyValue(parametersValue, source);
     deleteObjectProperty(finalValue, source);
+
+    if (typeof propertyValue !== 'object') {
+      finalValue = safeSetObjectPropertyValue(finalValue, target, propertyValue);
+      continue;
+    }
+
+    const value = { ...excludePathValueFromTarget(parametersValue, source, target), ...getObjectPropertyValue(parametersValue, source) };
     finalValue = !target.length ? { ...finalValue, ...value } : safeSetObjectPropertyValue(finalValue, target, value);
   }
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2419,7 +2419,16 @@ function swapInputsValueIfNeeded(inputsValue: any, manifest: OperationManifest) 
   let finalValue = clone(inputsValue);
   let propertiesToRetain: string[] = [];
   for (const { source, target } of swapMap) {
-    const value = clone(getObjectPropertyValue(finalValue, target));
+    const propertyValue = getObjectPropertyValue(finalValue, target);
+    deleteObjectProperty(finalValue, target);
+
+    // Don't want to use clone on a non-object
+    if (typeof propertyValue !== 'object') {
+      finalValue = safeSetObjectPropertyValue(finalValue, source, propertyValue);
+      continue;
+    }
+
+    const value = clone(propertyValue);
     if (!target.length) {
       propertiesToRetain = Object.keys(manifest.properties.inputs.properties);
       deleteObjectProperties(
@@ -2434,7 +2443,6 @@ function swapInputsValueIfNeeded(inputsValue: any, manifest: OperationManifest) 
       }
     }
 
-    deleteObjectProperty(finalValue, target);
     finalValue = !source.length ? { ...finalValue, ...value } : safeSetObjectPropertyValue(finalValue, source, value);
   }
   return finalValue;

--- a/libs/designer/src/lib/core/utils/validation.ts
+++ b/libs/designer/src/lib/core/utils/validation.ts
@@ -335,6 +335,7 @@ const validateFloatingActionMenuOutputsEditor = (editorViewModel: FloatingAction
         description: 'Invalid output names',
       })
     );
+    return;
   }
 
   const schemaKeysSet = new Set(schemaKeys);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

The `inputsLocationSwapMap` can currently be used to modify the location of input parameters, however it only works for objects.
This adds support for primitives.

- **What is the current behavior?** (You can also link to an open issue here)
![image](https://github.com/Azure/LogicAppsUX/assets/55114634/689fd1a4-5bf1-4e07-8de9-aa500e9f9e95)

- **What is the new behavior (if this is a feature change)?**
![image](https://github.com/Azure/LogicAppsUX/assets/55114634/e6bb0248-bbb5-46e3-80b0-646621c87914)

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No


### Other changes
Minor minor followups to  #3197