### PR TITLE
fix(Designer): OAuth - Passed redirect url value from oauth setting in connection parameters

### DIFF
--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/createConnectionTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/createConnectionTab.tsx
@@ -138,6 +138,19 @@ const CreateConnectionTab = () => {
           outputParameterValues = { ...outputParameterValues, ...assistedParams };
         }
 
+        // If oauth, find the oauth parameter and assign the redirect url
+        if (isOAuthConnection && selectedParameterSet) {
+          const oAuthParameter = Object.entries(selectedParameterSet?.parameters).find(
+            ([_, parameter]) => !!parameter?.oAuthSettings?.redirectUrl
+          );
+          if (oAuthParameter) {
+            const oAuthParameterKey = oAuthParameter?.[0];
+            const oAuthParameterObj = oAuthParameter?.[1];
+            const redirectUrl = oAuthParameterObj?.oAuthSettings?.redirectUrl;
+            outputParameterValues[oAuthParameterKey] = redirectUrl;
+          }
+        }
+
         const connectionParameterSetValues: ConnectionParameterSetValues = {
           name: selectedParameterSet?.name ?? '',
           values: Object.keys(outputParameterValues).reduce((acc: any, key) => {


### PR DESCRIPTION
## Main Changes

We had an oAuth connection setting that wasn't being sent in the initial pre-auth connection request, which was needed for a small number of connectors using oAuth, the setting has been added in this PR.

AB#25013483