### PR TITLE
fix(designer): Update 'about' tab to handle falsy property values

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -548,7 +548,13 @@ const serializeParametersFromSwagger = async (
 ): Promise<Record<string, any>> => {
   const { operationId, connectorId, type } = operationInfo;
   const { parsedSwagger } = await getConnectorWithSwagger(connectorId);
-  const { method, path } = parsedSwagger.getOperationByOperationId(operationId);
+
+  const operation = parsedSwagger.getOperationByOperationId(operationId);
+  if (!operation) {
+    throw new Error('APIM Operation not found');
+  }
+
+  const { method, path } = operation;
   const operationPath = removeConnectionPrefix(path);
   const operationMethod = equals(type, Constants.NODE.TYPE.API_CONNECTION_WEBHOOK) ? undefined : method;
   const parameterInputs = equals(type, Constants.NODE.TYPE.API_CONNECTION_NOTIFICATION)

--- a/libs/designer/src/lib/core/state/selectors/actionMetadataSelector.ts
+++ b/libs/designer/src/lib/core/state/selectors/actionMetadataSelector.ts
@@ -134,7 +134,10 @@ export const useOperationDescription = (operationInfo: NodeOperation) => {
   const { swagger } = connectorData ?? {};
   if (swagger) {
     const swaggerParsed = new SwaggerParser(swagger);
-    return { isLoading, result: swaggerParsed.getOperationByOperationId(operationInfo.operationId).description };
+    const swaggerResult = swaggerParsed.getOperationByOperationId(operationInfo.operationId)?.description;
+    if (swaggerResult) {
+      return { isLoading, result: swaggerResult };
+    }
   }
 
   return { result, isLoading };
@@ -148,8 +151,11 @@ export const useOperationDocumentation = (operationInfo: NodeOperation) => {
   const { result, isLoading } = useNodeAttribute(operationInfo, ['connector', 'properties', 'externalDocs'], ['externalDocs']);
   const { swagger } = connectorData ?? {};
   if (swagger) {
-    const swaggerparsed = new SwaggerParser(swagger);
-    return { isLoading, result: swaggerparsed.getOperationByOperationId(operationInfo.operationId).externalDocs };
+    const swaggerParsed = new SwaggerParser(swagger);
+    const swaggerResult = swaggerParsed.getOperationByOperationId(operationInfo.operationId)?.externalDocs;
+    if (swaggerResult) {
+      return { isLoading, result: swaggerResult };
+    }
   }
   return { result, isLoading };
 };

--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -391,7 +391,12 @@ function getParameterValuesForLegacyDynamicOperation(
   idReplacements: Record<string, string>,
   workflowParameters: Record<string, WorkflowParameterDefinition>
 ): Record<string, any> {
-  const { method, path } = swagger.getOperationByOperationId(operationId as string);
+  const operation = swagger.getOperationByOperationId(operationId);
+  if (!operation) {
+    throw new Error('APIM Operation not found');
+  }
+
+  const { method, path } = operation;
   const operationInputs = map(
     toParameterInfoMap(
       unmap(swagger.getInputParameters(operationId as string, { excludeInternalParameters: false, excludeInternalOperations: false }).byId)
@@ -613,7 +618,12 @@ function getSwaggerBasedInputParameters(
   operationInfo: NodeOperation,
   operationDefinition: any
 ): InputParameter[] {
-  const operationPath = removeConnectionPrefix(swagger.getOperationByOperationId(operationInfo.operationId).path);
+  const operation = swagger.getOperationByOperationId(operationInfo.operationId);
+  if (!operation) {
+    throw new Error('APIM Operation not found');
+  }
+
+  const operationPath = removeConnectionPrefix(operation.path);
   const basePath = swagger.api.basePath;
   const { key, isNested } = dynamicParameter;
   const parameterKey =

--- a/libs/designer/src/lib/core/utils/swagger/operation.ts
+++ b/libs/designer/src/lib/core/utils/swagger/operation.ts
@@ -173,7 +173,7 @@ export const getInputParametersFromSwagger = (
 
         inputParametersByKey = map(loadedInputParameters, 'key');
       } else {
-        const operationPath = removeConnectionPrefix(operation.path);
+        const operationPath = removeConnectionPrefix(operation?.path || '');
         const basePath = swagger.api.basePath;
         const loadedInputParameters = loadInputValuesFromDefinition(
           stepDefinition.inputs,

--- a/libs/parsers/src/lib/swagger/parser.ts
+++ b/libs/parsers/src/lib/swagger/parser.ts
@@ -288,7 +288,7 @@ export class SwaggerParser {
     return map(operations, 'operationId');
   }
 
-  getOperationByOperationId(operationId: string): Operation {
+  getOperationByOperationId(operationId: string): Operation | undefined {
     const operations = this.getOperations({ unsorted: true, excludeInternalOperations: false });
     return getPropertyValue(operations, operationId);
   }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] ~~Docs have been added / updated (for bug fixes / features)~~ (N/A)

- **What kind of change does this PR introduce?** Bug fix

- **What is the current behavior?** If a swagger is provided but does not contain the expected operation ID, the entire designer crashes with the error: `Cannot read properties of undefined (reading 'description')`

- **What is the new behavior (if this is a feature change)?** In the above scenario where the swagger does not contain the expected operation ID, we fall back to the description & docs link provided before the swagger is parsed.

- **Does this PR introduce a breaking change?** No.

- **Please Include Screenshots or Videos of the intended change**:

    - Before (upon clicking "About" tab for affected connector):

    ![image](https://github.com/Azure/LogicAppsUX/assets/1350074/c5adac9c-9fa4-4ab5-ba71-4e2adc5a5988)

    - After (sanitized due to feature in progress):

    ![image](https://github.com/Azure/LogicAppsUX/assets/1350074/a18aac7a-ac34-4f3b-a956-d9a68cdc9930)

AB#25043399