### PR TITLE
fix(designer): ErrorHandling - Added case to flow run error handling for flowStatus Running

### DIFF
--- a/libs/designer/src/lib/common/utilities/error.ts
+++ b/libs/designer/src/lib/common/utilities/error.ts
@@ -21,7 +21,7 @@ export function getMonitoringError(
   statusRun: string | undefined,
   codeRun: string | undefined
 ): ErrorProps {
-  if (!codeRun || statusRun === constants.FLOW_STATUS.SUCCEEDED) {
+  if (!codeRun || statusRun === constants.FLOW_STATUS.SUCCEEDED || statusRun === constants.FLOW_STATUS.RUNNING) {
     return {
       errorLevel: undefined,
       errorMessage: undefined,


### PR DESCRIPTION
This change adds a case to the error handling for desktop flow runs. Currently clicking running a desktop flow returns an http request with status code 202 (Accepted) and the statusRun "Running". This results in a severe warning displayed in the messageBar with the text "Accepted". This change will handle the scenario in the same way a "Succeeded" response is handled -- consistent with how we handle this in v1.

Please see [Product Backlog Item 25046387](https://msazure.visualstudio.com/One/_workitems/edit/25046387): Accepted Message Displays with Warning UI in Test Run for Desktop Flows

AB#25072667