### PR TITLE
fix(designer): FloatingActionMenuOutputs editor to lowercase serialized dynamically added property names (for consistency with V1)

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2249,7 +2249,7 @@ const getStringifiedValueFromFloatingActionMenuOutputsViewModel = (
     }
 
     if (config.title) {
-      const keyFromTitle = config.title.replace(' ', '_');
+      const keyFromTitle = config.title.toLowerCase().replace(' ', '_');
       schemaProperties[keyFromTitle] = config;
 
       const valueSegments = editorViewModel.outputValueSegmentsMap?.[key];


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Aligns behavior with V1 where the property names are lowercased

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking change, actions using this editor are not discoverable in production yet

- **Please Include Screenshots or Videos of the intended change**:
![image](https://github.com/Azure/LogicAppsUX/assets/55114634/0d0b213e-486d-49de-a466-2c6334dac7d8)
