### PR TITLE
fix(designer): Support Expression editor multiline

### DIFF
--- a/libs/designer-ui/src/lib/expressioneditor/index.tsx
+++ b/libs/designer-ui/src/lib/expressioneditor/index.tsx
@@ -56,35 +56,8 @@ export function ExpressionEditor({
     }
   };
 
-  const handleChangeEvent = (e: editor.IModelContentChangedEvent): void => {
+  const handleChangeEvent = (): void => {
     setExpressionEditorError('');
-    const changedText = e.changes.length ? e.changes[0].text : '';
-    if (changedText === '\r\n' && editorRef?.current) {
-      const oldPosition = editorRef.current.getPosition();
-      const currentValue = editorRef.current.getValue();
-      const newValue = currentValue.replace(/\r\n/g, '');
-      editorRef.current.setValue(newValue);
-
-      if (oldPosition) {
-        const cursorPosition = oldPosition.column - 1;
-        setTimeout(() => setSelection(cursorPosition, cursorPosition));
-      }
-    }
-  };
-
-  const setSelection = (selectionStart: number, selectionEnd: number) => {
-    if (editorRef?.current) {
-      editorRef?.current.focus();
-
-      if (selectionStart !== undefined && selectionEnd !== undefined) {
-        editorRef?.current.setSelection({
-          startLineNumber: 1,
-          startColumn: selectionStart + 1,
-          endLineNumber: 1,
-          endColumn: selectionEnd + 1,
-        });
-      }
-    }
   };
 
   return (

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -103,19 +103,29 @@ export const TokenPickerOptions = ({
 
   const insertExpressionText = (text: string, caretOffset: number): void => {
     if (expressionEditorRef.current) {
+      // gets the original expression
       const oldExpression = expressionEditorRef.current.getValue();
-      const beforeSelection = oldExpression.substring(0, expression.selectionStart);
-      const afterSelection = oldExpression.substring(expression.selectionEnd);
-      const newExpression = `${beforeSelection}${text}${afterSelection}`;
+      // gets the line number of the current selection
+      const selectionLineNumber = expressionEditorRef.current.getPosition()?.lineNumber ?? 1;
+      // gets the line of the current selection and replaces the text with the new expression
+      const splitOldExpression = oldExpression.split('\r\n');
+      const oldExpressionLineNumber = splitOldExpression[selectionLineNumber - 1];
+      const beforeSelection = oldExpressionLineNumber.substring(0, expression.selectionStart);
+      const afterSelection = oldExpressionLineNumber.substring(expression.selectionEnd);
+      const newExpressionLineNumber = `${beforeSelection}${text}${afterSelection}`;
+      splitOldExpression[selectionLineNumber - 1] = newExpressionLineNumber;
+
+      // updates the split text and updates the new expression and selection
+      const newExpression = splitOldExpression.join('\r\n');
       const newSelection = newExpression.length - afterSelection.length + caretOffset;
       setExpression({ value: newExpression, selectionStart: newSelection, selectionEnd: newSelection });
 
       setTimeout(() => {
         expressionEditorRef.current?.setValue(newExpression);
         expressionEditorRef.current?.setSelection({
-          startLineNumber: 1,
+          startLineNumber: selectionLineNumber,
           startColumn: newSelection + 1,
-          endLineNumber: 1,
+          endLineNumber: selectionLineNumber,
           endColumn: newSelection + 1,
         });
         expressionEditorRef.current?.focus();


### PR DESCRIPTION
Our multiline editor didn't actually support multiline (Prevented users from going onto new lines unless text overflowed previous lines). This PR fixes that as well as fixing the token insertion offset/linenumber 
![multilineSupport](https://github.com/Azure/LogicAppsUX/assets/95886809/57646f3f-342e-4bd7-b2ac-e84ee61d6da8)

Fixes #3281