### PR TITLE
fix(meta): Fixed branch name in production build action

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -1,5 +1,5 @@
 name: Production Build
-run-name: Production Build - [${{ github.event.inputs.branch }}][${{ github.event.inputs.release_type || 'no_type_specified' }}]
+run-name: Production Build - [ ${{ github.ref_name || 'branch'  }} ] - ${{ github.event.inputs.release_type || 'no_type_specified' }}
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Main Changes

Fixes an issue where during the production deployment action, the branch name was not appearing in the run name

Should now appear as:
> Production Build - [ hotfix/v2.34 ] - patch