### PR TITLE
fix(Data Mapper): Browse dialog only includes .XSD and All files

### DIFF
--- a/libs/data-mapper/src/lib/components/configPanel/AddOrUpdateSchemaView.tsx
+++ b/libs/data-mapper/src/lib/components/configPanel/AddOrUpdateSchemaView.tsx
@@ -10,7 +10,7 @@ import { useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
-const acceptedSchemaFileInputExtensions = '.xsd';
+const acceptedSchemaFileInputExtensions = '.xsd, .json';
 
 export enum UploadSchemaTypes {
   UploadNew = 'upload-new',


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
Adding new files only support .xsd or all files choices
https://github.com/Azure/LogicAppsUX/issues/3302
- **What is the new behavior (if this is a feature change)?**
By default, the file extension is "Custom files" which includes .xsd and .json.
(html input element does not support any renaming or separation of "Custom files" when adding >2 extension types for supported types)
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
- **Please Include Screenshots or Videos of the intended change**:
![38fb95ed-3e04-4065-880c-d5eab627dd36](https://github.com/Azure/LogicAppsUX/assets/144840522/4c11b409-0567-44af-8f2e-134bd2516026)
