### PR TITLE
fix(Designer): Fixed an edge-node overlap bug

### DIFF
--- a/libs/designer/src/lib/core/graphlayout/elklayout.ts
+++ b/libs/designer/src/lib/core/graphlayout/elklayout.ts
@@ -14,7 +14,6 @@ export const layerSpacing = {
   default: '64',
   readOnly: '48',
   onlyEdge: '16',
-  edgeNode: '180',
 };
 
 const defaultLayoutOptions: Record<string, string> = {
@@ -28,7 +27,7 @@ const defaultLayoutOptions: Record<string, string> = {
   'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
   'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
   // Spacing values
-  'elk.spacing.edgeNode': layerSpacing.edgeNode,
+  'elk.spacing.edgeNode': '180',
   'elk.layered.spacing.edgeNodeBetweenLayers': layerSpacing.default,
   'elk.layered.spacing.nodeNodeBetweenLayers': layerSpacing.default,
   'elk.padding': '[top=0,left=16,bottom=16,right=16]',

--- a/libs/designer/src/lib/core/graphlayout/elklayout.ts
+++ b/libs/designer/src/lib/core/graphlayout/elklayout.ts
@@ -14,6 +14,7 @@ export const layerSpacing = {
   default: '64',
   readOnly: '48',
   onlyEdge: '16',
+  edgeNode: '180',
 };
 
 const defaultLayoutOptions: Record<string, string> = {
@@ -26,8 +27,8 @@ const defaultLayoutOptions: Record<string, string> = {
   'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
   'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
   'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
-  'elk.layered.spacing.edgeEdgeBetweenLayers': '0',
-  'elk.layered.spacing.edgeNodeBetweenLayers': layerSpacing.default,
+  // Spacing values
+  'elk.spacing.edgeNode': layerSpacing.edgeNode,
   'elk.layered.spacing.nodeNodeBetweenLayers': layerSpacing.default,
   'elk.padding': '[top=0,left=16,bottom=16,right=16]',
   // This option allows the first layer children of a graph to be laid out in order of appearance in manifest. This is useful for subgraph ordering, like in Switch nodes.

--- a/libs/designer/src/lib/core/graphlayout/elklayout.ts
+++ b/libs/designer/src/lib/core/graphlayout/elklayout.ts
@@ -29,6 +29,7 @@ const defaultLayoutOptions: Record<string, string> = {
   'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
   // Spacing values
   'elk.spacing.edgeNode': layerSpacing.edgeNode,
+  'elk.layered.spacing.edgeNodeBetweenLayers': layerSpacing.default,
   'elk.layered.spacing.nodeNodeBetweenLayers': layerSpacing.default,
   'elk.padding': '[top=0,left=16,bottom=16,right=16]',
   // This option allows the first layer children of a graph to be laid out in order of appearance in manifest. This is useful for subgraph ordering, like in Switch nodes.


### PR DESCRIPTION
## Main Changes

Added spacing property between nodes and edges so they don't overlap.
Mostly applies to situations where a node and it's children share the same parent node

![image](https://github.com/Azure/LogicAppsUX/assets/25409734/f5f6a782-c0d4-4c40-9cde-8a539b0827e3)
![image](https://github.com/Azure/LogicAppsUX/assets/25409734/46f0a14b-c05f-498f-ba11-468a6a49d6f9)


Fixes https://github.com/Azure/LogicAppsUX/issues/3347