### PR TITLE
fix(designer): Don't throw for MISSING_DATA error in IntlProvider

### DIFF
--- a/libs/designer/src/lib/core/DesignerProvider.tsx
+++ b/libs/designer/src/lib/core/DesignerProvider.tsx
@@ -8,6 +8,7 @@ import { AzureThemeLight } from '@fluentui/azure-themes/lib/azure/AzureThemeLigh
 import { ThemeProvider } from '@fluentui/react';
 import { FluentProvider, webDarkTheme, webLightTheme } from '@fluentui/react-components';
 import type { OnErrorFn as OnIntlErrorFn } from '@formatjs/intl';
+import { LogEntryLevel, LoggerService } from '@microsoft/designer-client-services-logic-apps';
 import { IntlProvider } from '@microsoft/intl-logic-apps';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { Provider as ReduxProvider, useDispatch } from 'react-redux';
@@ -33,10 +34,12 @@ export const DesignerProvider = ({ locale = 'en', options, children }: DesignerP
   const webTheme = !isDarkMode ? webLightTheme : webDarkTheme;
   const themeName = useMemo(() => (!isDarkMode ? 'light' : 'dark'), [isDarkMode]);
   const onError = useCallback<OnIntlErrorFn>((err) => {
-    if (err.code === 'MISSING_TRANSLATION') {
-      return;
-    } else if (err.code === 'MISSING_DATA') {
-      console.log('IntlProvider MISSING_DATA error: ', err);
+    if (err.code === 'MISSING_TRANSLATION' || err.code === 'MISSING_DATA') {
+      LoggerService().log({
+        level: LogEntryLevel.Warning,
+        area: 'DesignerProvider',
+        message: err.message,
+      });
       return;
     }
     throw err;

--- a/libs/designer/src/lib/core/DesignerProvider.tsx
+++ b/libs/designer/src/lib/core/DesignerProvider.tsx
@@ -38,7 +38,7 @@ export const DesignerProvider = ({ locale = 'en', options, children }: DesignerP
       LoggerService().log({
         level: LogEntryLevel.Warning,
         area: 'DesignerProvider',
-        message: err.message,
+        message: `Error ${err.code} - ${err.message}`,
       });
       return;
     }

--- a/libs/designer/src/lib/core/DesignerProvider.tsx
+++ b/libs/designer/src/lib/core/DesignerProvider.tsx
@@ -35,6 +35,9 @@ export const DesignerProvider = ({ locale = 'en', options, children }: DesignerP
   const onError = useCallback<OnIntlErrorFn>((err) => {
     if (err.code === 'MISSING_TRANSLATION') {
       return;
+    } else if (err.code === 'MISSING_DATA') {
+      console.log('IntlProvider MISSING_DATA error: ', err);
+      return;
     }
     throw err;
   }, []);


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Prevents throwing  for MISSING_DATA error in IntlProvider. This makes it so if language/locale data is missing, we log the error and allow fallback to default language/locale, instead of failing to load the designer.

- **What is the current behavior?** (You can also link to an open issue here)
We throw the error which causes designer to not load. Screenshot below.

- **What is the new behavior (if this is a feature change)?**
We log MISSING_DATA error instead of throwing, as this does not look to be a fatal error.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

- **Please Include Screenshots or Videos of the intended change**:
Current bugged scenario looks like this:
![image](https://github.com/Azure/LogicAppsUX/assets/10837129/b35cb14b-d90b-476f-8b4c-e04a51769215)

After this fix, the designer gets loaded instead.

To fix the underlying issue of missing data, I've filed the following issue: https://github.com/Azure/LogicAppsUX/issues/3361