### PR TITLE
fix(Designer): Fixed error bubbling on managed connector request error

### DIFF
--- a/libs/designer/src/lib/core/utils/swagger/operation.ts
+++ b/libs/designer/src/lib/core/utils/swagger/operation.ts
@@ -106,7 +106,13 @@ export const initializeOperationDetailsForSwagger = async (
 
     throw new Error('Operation info could not be found for a swagger operation');
   } catch (error: any) {
-    const message = `Unable to initialize operation details for swagger based operation - ${nodeId}. Error details - ${error}`;
+    let errorString = '';
+    try {
+      errorString = error?.toString() ?? error;
+    } catch (_: any) {
+      errorString = 'Could not convert error to string';
+    }
+    const message = `Unable to initialize operation details for swagger based operation - ${nodeId}. Error details - ${errorString}`;
     LoggerService().log({
       level: LogEntryLevel.Error,
       area: 'operation deserializer',


### PR DESCRIPTION
## Main Changes

When requesting connectors by connection for managed connectors, we were not correctly passing errors back to the UI.
This has been fixed, and we now also stringify the error object so it won't appear as `[Object] object`

Fixes https://github.com/Azure/LogicAppsUX/issues/3328
