### PR TITLE
fix(Data Mapper): not showing initial source Schema with connections

### DIFF
--- a/libs/data-mapper/src/lib/core/state/DataMapSlice.ts
+++ b/libs/data-mapper/src/lib/core/state/DataMapSlice.ts
@@ -31,7 +31,12 @@ import {
   addParentConnectionForRepeatingElementsNested,
   getParentId,
 } from '../../utils/DataMap.Utils';
-import { functionsForLocation, getFunctionLocationsForAllFunctions, isFunctionData } from '../../utils/Function.Utils';
+import {
+  functionsForLocation,
+  getConnectedSourceSchema,
+  getFunctionLocationsForAllFunctions,
+  isFunctionData,
+} from '../../utils/Function.Utils';
 import { LogCategory, LogService } from '../../utils/Logging.Utils';
 import type { ReactFlowIdParts } from '../../utils/ReactFlow.Util';
 import {
@@ -187,6 +192,7 @@ export const dataMapSlice = createSlice({
       const flattenedTargetSchema = flattenSchemaIntoDictionary(targetSchema, SchemaType.Target);
       const targetSchemaSortArray = flattenSchemaIntoSortArray(targetSchema.schemaTreeRoot);
       const functionNodes: FunctionDictionary = getFunctionLocationsForAllFunctions(dataMapConnections, flattenedTargetSchema);
+      const connectedFlattenedSourceSchema = getConnectedSourceSchema(dataMapConnections, flattenedSourceSchema);
 
       const newState: DataMapOperationState = {
         ...currentState,
@@ -198,7 +204,7 @@ export const dataMapSlice = createSlice({
         functionNodes,
         targetSchemaOrdering: targetSchemaSortArray,
         dataMapConnections: dataMapConnections ?? {},
-        currentSourceSchemaNodes: [],
+        currentSourceSchemaNodes: Object.values(connectedFlattenedSourceSchema),
         currentTargetSchemaNode: targetSchema.schemaTreeRoot,
         loadedMapMetadata: metadata,
       };

--- a/libs/data-mapper/src/lib/utils/Function.Utils.ts
+++ b/libs/data-mapper/src/lib/utils/Function.Utils.ts
@@ -160,6 +160,22 @@ export const getFunctionLocationsForAllFunctions = (
   }
   return functionNodes;
 };
+
+export const getConnectedSourceSchema = (
+  dataMapConnections: ConnectionDictionary,
+  flattenedSourceSchema: SchemaNodeDictionary
+): SchemaNodeDictionary => {
+  const connectedSourceSchema: SchemaNodeDictionary = {};
+
+  for (const connectionKey in dataMapConnections) {
+    if (flattenedSourceSchema?.[connectionKey]) {
+      connectedSourceSchema[connectionKey] = flattenedSourceSchema?.[connectionKey];
+    }
+  }
+
+  return connectedSourceSchema;
+};
+
 export const functionDropDownItemText = (key: string, node: FunctionData, connections: ConnectionDictionary) => {
   let fnInputValues: string[] = [];
   const connection = connections[key];


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
The source schema nodes do not load on the initial render even if it has connections. Because the source schema nodes that have connections do not appear, it confuses the user into thinking the map has not saved properly. Once the user selects the source nodes to appear again, it shows connections.
https://github.com/Azure/LogicAppsUX/issues/3283
- **What is the new behavior (if this is a feature change)?**
On the initial render, map renders the source nodes with connections. It leaves out the source nodes without connections.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
- **Please Include Screenshots or Videos of the intended change**:

[Before the fix: initial render of map]
<img width="974" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/144840522/0c0d4c06-1642-4c0a-a2ce-ce29099b50dd">

[After the fix: initial render of map]
<img width="969" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/144840522/847b5c02-5cd2-4825-80de-50b1d67afa9b">
