### PR TITLE
feat(Designer): Recommendation panel now autofocuses to search bar

### DIFF
--- a/libs/designer-ui/src/lib/searchbox/index.tsx
+++ b/libs/designer-ui/src/lib/searchbox/index.tsx
@@ -17,6 +17,7 @@ export const DesignerSearchBox: React.FC<SearchBoxProps> = (props) => {
 
   return (
     <SearchBox
+      autoFocus
       ariaLabel={placeholder}
       placeholder={placeholder}
       className="msla-search-box"


### PR DESCRIPTION
## Main Change

Added autofocus to search bar in recommendation panel
Now when users click `add node` their focus will automatically be moved to the search bar
Also verified this is announced on screen readers as well

Fixes https://github.com/Azure/LogicAppsUX/issues/3371