### PR TITLE
fix(designer): Fix combobox filtering to use display name instead of value

### DIFF
--- a/libs/designer-ui/src/lib/combobox/index.tsx
+++ b/libs/designer-ui/src/lib/combobox/index.tsx
@@ -114,7 +114,7 @@ export const Combobox = ({
         ? [loadingOption]
         : errorDetails
         ? [errorOption]
-        : options.filter((option) => new RegExp(searchValue.replace(/\\/g, '').toLowerCase()).test(option.value.toLowerCase()));
+        : options.filter((option) => new RegExp(searchValue.replace(/\\/g, '').toLowerCase()).test(option.displayName.toLowerCase()));
 
       if (newOptions.length === 0) {
         const noValuesLabel = intl.formatMessage({


### PR DESCRIPTION
Fix combobox filtering to use display name instead of value to have parity with v1 designer

AB#25265513