### PR TITLE
fix(designer): Do not throw error on unknown parameters during validation by default

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -3470,14 +3470,18 @@ export function isParameterRequired(parameterInfo: ParameterInfo): boolean {
   return parameterInfo && parameterInfo.required && !(parameterInfo.info.parentProperty && parameterInfo.info.parentProperty.optional);
 }
 
-export function validateParameter(parameter: ParameterInfo, parameterValue: ValueSegment[]): string[] {
+export function validateParameter(
+  parameter: ParameterInfo,
+  parameterValue: ValueSegment[],
+  shouldValidateUnknownParameterAsError = false
+): string[] {
   const parameterType = getInferredParameterType(parameterValue, parameter.type);
   const parameterValueString = parameterValueToStringWithoutCasting(parameterValue, /* forValidation */ true);
   const isJsonObject = parameterType === constants.SWAGGER.TYPE.OBJECT;
 
   return isJsonObject
     ? validateJSONParameter(parameter, parameterValue)
-    : validateStaticParameterInfo(parameter, parameterValueString, true);
+    : validateStaticParameterInfo(parameter, parameterValueString, shouldValidateUnknownParameterAsError);
 }
 
 // Riley - This is a very specific case where the either of the limit properties can be filled, but they cannot both be empty


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Validate parameter always throws error for existence of unknown parameters.

- **What is the new behavior (if this is a feature change)?**
If the host is calling validate parameter on save then they can pass in the fag to the function to throw error for unknown parameters, by default it wont be throwing if called from designer code.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, any host method calling "validateParameter" exported function should pass in the argument which specifies if host needs to block users from creating unknown parameters in any action. BY default for LA that is not a error scenario.

- **Please Include Screenshots or Videos of the intended change**:
