### PR TITLE
fix(designer): Fix designer load for existing hybrid triggers

### DIFF
--- a/libs/designer-ui/src/lib/floatingactionmenu/floatingactionmenuinputs/helper.ts
+++ b/libs/designer-ui/src/lib/floatingactionmenu/floatingactionmenuinputs/helper.ts
@@ -65,7 +65,7 @@ export function deserialize(value: ValueSegment[], isRequestApiConnectionTrigger
 
   itemsProperties = rootObject;
   if (isRequestApiConnectionTrigger) {
-    itemsProperties = rootObject.properties ? rootObject.properties.rows.items : rootObject.rows.items;
+    itemsProperties = rootObject.properties?.rows?.items || rootObject.rows?.items || itemsProperties;
   }
 
   for (const [schemaKey, propertiesUnknown] of Object.entries(itemsProperties?.properties)) {


### PR DESCRIPTION
Fix designer load for existing hybrid triggers. The issue is that items in hybrid triggers would be serialized in the location: `inputs.schema.rows.items`, while for a flow that's saved from the v1 designer the items woudl be in `inputs.schema.items` directly.

To repro the issue: save a flow with a hybrid trigger on the v1 designer, open the same flow on the v3 designer, and click on the trigger, where you'll see an exception and everything disappearing.

AB#25323883