### PR TITLE
fix(Designer): Fixed issue with nested openapi swagger parameter format

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -282,17 +282,22 @@ export async function getDynamicInputsFromSchema(
     in: dynamicParameter.in,
   }));
 
-  // We are recieving some swagger parameters in the following format, ex:
-  //     body.$.body/content/appId
-  // We need to remove the extra `body` and convert the '/' to '.', ex:
+  // We are recieving some swagger parameters with keys in the following format, ex:
+  //     body.$.body/content.body/content/appId
+  // We need to reformat to the below string:
   //     body.$.content.appId
   for (const inputParameter of dynamicInputs) {
     if (isOpenApiParameter(inputParameter)) {
       const { key: _key, in: _in } = inputParameter;
-      const key = replaceSubsegmentSeparator(_key)?.replace(`${_in}.$.${_in}.`, '') ?? '';
-      const name = key.split('.').pop() ?? '';
+      // _key = body.$.body/content.body/content/appId
+      const path = replaceSubsegmentSeparator(_key.split('.').pop() ?? '');
+      // path = body.content.appId
+      const key = `${_in}.$.${path.replace(`${_in}.`, '')}`;
+      // key = body.$.content.appId
+      const name = path.split('.').pop() ?? '';
+      // name = appId
 
-      inputParameter.key = `${_in}.$.${key}`;
+      inputParameter.key = key;
       inputParameter.name = name;
       inputParameter.title = name;
     }


### PR DESCRIPTION
Our previous OpenAPI format parsing was not accounting for the intermediate folder structure, i.e.
> body.$.body/content.body/content/appId

So parameters were getting parsed incorrectly with their path as 
> content.body.content.appId

It now is properly parsed to become just
> content.appId