### PR TITLE
fix(Data Mapper): User able to paste path directly into "Select existing"

### DIFF
--- a/libs/data-mapper/src/lib/components/fileDropdown/fileDropdown.tsx
+++ b/libs/data-mapper/src/lib/components/fileDropdown/fileDropdown.tsx
@@ -86,6 +86,7 @@ export const FileDropdown: React.FC<FileDropdownProps> = (props: FileDropdownPro
         appearance="outline"
         value={typedInput}
         disabled={props.disabled === true}
+        onPaste={(e) => e.preventDefault()}
       >
         {formattedOptions}
       </Combobox>


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
Users have inconsistent behavior of at times being able to paste local path to add schema panel. If this works, reloading map will crash since the schema cannot be found in Artifacts/Schema folder.
- **What is the new behavior (if this is a feature change)?**
Users will not be able to paste anything to the ComboBox to prevent local path pasting.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
- **Please Include Screenshots or Videos of the intended change**:
n/a

AB#25434352