### PR TITLE
fix(vscode): Update logic app list in tree view after creating logic app in azure

### DIFF
--- a/apps/vs-code-designer/src/app/tree/subscriptionTree/SubscriptionTreeItem.ts
+++ b/apps/vs-code-designer/src/app/tree/subscriptionTree/SubscriptionTreeItem.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { LogicAppResolver } from '../../../LogicAppResolver';
 import { projectLanguageSetting, workflowappRuntime } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
@@ -216,6 +217,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
     }
 
     const resolved = new LogicAppResourceTree(subscription.subscription, nonNullProp(wizardContext, 'site'));
+    await LogicAppResolver.getSubscriptionSites(context, subscription.subscription);
     await ext.rgApi.appResourceTree.refresh(context);
     return new SlotTreeItem(subscription, resolved);
   }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines
* [X] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #3459 

- **What is the current behavior?** (You can also link to an open issue here)
Resource tree doesn't update 

<img width="1195" alt="Screenshot 2023-10-17 at 11 50 09 AM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/c8df66ae-11d1-470e-aec5-fce86bdff257">
