### PR TITLE
fix(Designer): Invoker connection UI toggle doesn't retain after flow save

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -526,25 +526,14 @@ export const updateInvokerSettings = (
   dispatch: Dispatch,
   references?: ConnectionReferences
 ): void => {
-  if (isTrigger) {
-    return;
+  if (!isTrigger && tiggerNodeManifest?.properties?.settings?.invokerConnection) {
+    dispatch(updateNodeSettings({ id: nodeId, settings: { invokerConnection: { ...settings.invokerConnection, isSupported: true } } }));
   }
-
   if (references) {
     Object.keys(references).forEach((key) => {
       const impersonationSource = references[key].impersonation?.source;
       if (impersonationSource === ImpersonationSource.Invoker) {
-        // if impersonation is set, enable invoker settings
         dispatch(updateNodeSettings({ id: nodeId, settings: { invokerConnection: { isSupported: true, value: { enabled: true } } } }));
-      } else {
-        const nodeSettings = tiggerNodeManifest?.properties?.settings;
-        if (nodeSettings?.invokerConnection) {
-          const updatedInvokerConnection = {
-            ...settings.invokerConnection,
-            isSupported: true,
-          };
-          dispatch(updateNodeSettings({ id: nodeId, settings: { invokerConnection: updatedInvokerConnection } }));
-        }
       }
     });
   }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -1,5 +1,5 @@
 import Constants from '../../../common/constants';
-import type { WorkflowParameter } from '../../../common/models/workflow';
+import { ImpersonationSource, type ConnectionReferences, type WorkflowParameter } from '../../../common/models/workflow';
 import type { WorkflowNode } from '../../parsers/models/workflowNode';
 import { getConnectorWithSwagger, getSwaggerFromEndpoint } from '../../queries/connections';
 import { getOperationManifest } from '../../queries/operation';
@@ -523,9 +523,29 @@ export const updateInvokerSettings = (
   tiggerNodeManifest: OperationManifest | undefined,
   nodeId: string,
   settings: Settings,
-  dispatch: Dispatch
+  dispatch: Dispatch,
+  references?: ConnectionReferences
 ): void => {
-  if (!isTrigger && tiggerNodeManifest?.properties?.settings?.invokerConnection) {
-    dispatch(updateNodeSettings({ id: nodeId, settings: { invokerConnection: { ...settings.invokerConnection, isSupported: true } } }));
+  if (isTrigger) {
+    return;
+  }
+
+  if (references) {
+    Object.keys(references).forEach((key) => {
+      const impersonationSource = references[key].impersonation?.source;
+      if (impersonationSource === ImpersonationSource.Invoker) {
+        // if impersonation is set, enable invoker settings
+        dispatch(updateNodeSettings({ id: nodeId, settings: { invokerConnection: { isSupported: true, value: { enabled: true } } } }));
+      } else {
+        const nodeSettings = tiggerNodeManifest?.properties?.settings;
+        if (nodeSettings?.invokerConnection) {
+          const updatedInvokerConnection = {
+            ...settings.invokerConnection,
+            isSupported: true,
+          };
+          dispatch(updateNodeSettings({ id: nodeId, settings: { invokerConnection: updatedInvokerConnection } }));
+        }
+      }
+    });
   }
 };

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -141,7 +141,7 @@ export const initializeOperationMetadata = async (
     for (const nodeData of allNodeData) {
       const { id, settings } = nodeData;
       if (settings) {
-        updateInvokerSettings(id === triggerNodeId, triggerNodeManifest, id, settings, dispatch);
+        updateInvokerSettings(id === triggerNodeId, triggerNodeManifest, id, settings, dispatch, references);
       }
     }
   }


### PR DESCRIPTION
When the invoker connection toggle is on and then the flow is saved, the toggle turns back off.

**Existing issue:**
_**Before flow save;** User Invoker's Connection setting: **On**_
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/99637961-7fa1-487e-9039-eb671a69ae61)


_**After flow save:**_
Setting turns back off
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/582ae8a2-0488-487d-ad3c-d41dc65f606f)

InvokerSetting is determined by the `impersonation` object set in the connectionReferences:
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/70ce7336-890c-4a3d-b823-385212915658)

Current fix to read the `impersonation` object and determine if the setting needs to be turned on during flow save and deserialization 
