### PR TITLE
fix(designer): Cleanup placeholder trigger when trigger is added

### DIFF
--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -10,7 +10,7 @@ import { isWorkflowNode } from '../../parsers/models/workflowNode';
 import type { MoveNodePayload } from '../../parsers/moveNodeInWorkflow';
 import { moveNodeInWorkflow } from '../../parsers/moveNodeInWorkflow';
 import { addNewEdge } from '../../parsers/restructuringHelpers';
-import { getImmediateSourceNodeIds, transformOperationTitle } from '../../utils/graph';
+import { createWorkflowNode, getImmediateSourceNodeIds, transformOperationTitle } from '../../utils/graph';
 import { resetWorkflowState } from '../global';
 import type { NodeOperation } from '../operation/operationMetadataSlice';
 import {
@@ -188,6 +188,10 @@ export const workflowSlice = createSlice({
 
         graph.children = [...(graph?.children ?? []), placeholderNode];
         state.nodesMetadata[constants.NODE.TYPE.PLACEHOLDER_TRIGGER] = { graphId, isRoot: true };
+        state.operations[constants.NODE.TYPE.PLACEHOLDER_TRIGGER] = createWorkflowNode(
+          constants.NODE.TYPE.PLACEHOLDER_TRIGGER,
+          WORKFLOW_NODE_TYPES.PLACEHOLDER_NODE
+        );
         for (const childId of existingChildren) {
           addNewEdge(state, constants.NODE.TYPE.PLACEHOLDER_TRIGGER, childId, graph, false);
         }

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -82,6 +82,7 @@ export const workflowSlice = createSlice({
       if (action.payload.isTrigger) {
         deleteWorkflowNode(constants.NODE.TYPE.PLACEHOLDER_TRIGGER, graph);
         delete state.nodesMetadata[constants.NODE.TYPE.PLACEHOLDER_TRIGGER];
+        delete state.operations[constants.NODE.TYPE.PLACEHOLDER_TRIGGER];
 
         if (graph.edges?.length) {
           graph.edges = graph.edges.map((edge) => {


### PR DESCRIPTION
Fix for #3462 

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
(When creating a new workflow) Clicking on settings tab for any action beyond the first will crash

- **What is the new behavior (if this is a feature change)?**
No crash, properly cleaning up store state (workflowSlice.operations) when trigger is added and removed

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

