### PR TITLE
fix(vscode): Update recommendations for logic apps project

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionConfigFile.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionConfigFile.ts
@@ -1,3 +1,4 @@
+import { dotnetExtensionId, functionsExtensionId } from '../../../../../constants';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension';
 import * as fs from 'fs-extra';
@@ -51,7 +52,7 @@ export class FunctionConfigFile extends AzureWizardPromptStep<IProjectWizardCont
   private async generateExtensionsJson(folderPath: string): Promise<void> {
     const filePath = path.join(folderPath, 'extensions.json');
     const content = {
-      recommendations: ['ms-azuretools.vscode-azurefunctions', 'ms-dotnettools.csharp'],
+      recommendations: [functionsExtensionId, dotnetExtensionId],
     };
     await fs.writeJson(filePath, content, { spaces: 2 });
   }

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/initLogicAppCodeProjectVScode/InitCodeProject.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/initLogicAppCodeProjectVScode/InitCodeProject.ts
@@ -14,7 +14,7 @@ import {
   launchFileName,
   extensionsFileName,
   extensionCommand,
-  functionsExtensionId,
+  logicAppsStandardExtensionId,
 } from '../../../../../../constants';
 import { ext } from '../../../../../../extensionVariables';
 import { localize } from '../../../../../../localize';
@@ -347,7 +347,7 @@ export abstract class InitCodeProject extends AzureWizardExecuteStep<IProjectWiz
   private async writeExtensionsJson(context: IActionContext, vscodePath: string, language: ProjectLanguage): Promise<void> {
     const extensionsJsonPath: string = path.join(vscodePath, extensionsFileName);
     await confirmEditJsonFile(context, extensionsJsonPath, (data: IExtensionsJson): Record<string, any> => {
-      const recommendations: string[] = [functionsExtensionId];
+      const recommendations: string[] = [logicAppsStandardExtensionId];
       if (this.getRecommendedExtensions) {
         recommendations.push(...this.getRecommendedExtensions(language));
       }

--- a/apps/vs-code-designer/src/app/commands/initProjectForVSCode/DotnetInitVSCodeStep.ts
+++ b/apps/vs-code-designer/src/app/commands/initProjectForVSCode/DotnetInitVSCodeStep.ts
@@ -2,7 +2,14 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { dotnetPublishTaskLabel, func, funcWatchProblemMatcher, hostStartCommand, show64BitWarningSetting } from '../../../constants';
+import {
+  dotnetExtensionId,
+  dotnetPublishTaskLabel,
+  func,
+  funcWatchProblemMatcher,
+  hostStartCommand,
+  show64BitWarningSetting,
+} from '../../../constants';
 import { localize } from '../../../localize';
 import { getProjFiles, getTargetFramework, getDotnetDebugSubpath, tryGetFuncVersion } from '../../utils/dotnet/dotnet';
 import type { ProjectFile } from '../../utils/dotnet/dotnet';
@@ -20,7 +27,7 @@ export class DotnetInitVSCodeStep extends InitVSCodeStepBase {
   private debugSubpath: string;
 
   protected getRecommendedExtensions(language: ProjectLanguage): string[] {
-    const recs: string[] = ['ms-dotnettools.csharp'];
+    const recs: string[] = [dotnetExtensionId];
     if (language === ProjectLanguage.FSharp) {
       recs.push('ionide.ionide-fsharp');
     }

--- a/apps/vs-code-designer/src/app/commands/initProjectForVSCode/InitVSCodeStepBase.ts
+++ b/apps/vs-code-designer/src/app/commands/initProjectForVSCode/InitVSCodeStepBase.ts
@@ -16,8 +16,8 @@ import {
   launchFileName,
   extensionsFileName,
   extensionCommand,
-  functionsExtensionId,
   vscodeFolderName,
+  logicAppsStandardExtensionId,
 } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
@@ -310,7 +310,7 @@ export abstract class InitVSCodeStepBase extends AzureWizardExecuteStep<IProject
   private async writeExtensionsJson(context: IActionContext, vscodePath: string, language: ProjectLanguage): Promise<void> {
     const extensionsJsonPath: string = path.join(vscodePath, extensionsFileName);
     await confirmEditJsonFile(context, extensionsJsonPath, (data: IExtensionsJson): Record<string, any> => {
-      const recommendations: string[] = [functionsExtensionId];
+      const recommendations: string[] = [logicAppsStandardExtensionId];
       if (this.getRecommendedExtensions) {
         recommendations.push(...this.getRecommendedExtensions(language));
       }

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -171,6 +171,7 @@ export enum DotnetVersion {
   net2 = 'netcoreapp2.1',
   net48 = 'net48',
 }
+export const dotnetExtensionId = 'ms-dotnettools.csharp';
 
 // Packages Manager
 export enum PackageManager {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines
* [X] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

### Main Code Changes
- Now we recommend our logic apps extension when users have a logic app projects in a vscode workspace and don't have the extension installed, instead of the functions extension

<img width="1920" alt="Screenshot 2023-10-19 at 11 19 44 AM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/768e46c3-5502-4ab3-8ffe-47f2c7cb3904">
