### PR TITLE
fix(Designer): Fix spliton for hybrid triggers with headers schema in outputs

### DIFF
--- a/libs/parsers/src/lib/manifest/parser.ts
+++ b/libs/parsers/src/lib/manifest/parser.ts
@@ -25,7 +25,7 @@ export function getSplitOnArrayAliasMetadata(schema: SchemaObject, required: boo
   } else if (schema.type === SwaggerConstants.Types.Object) {
     const keys = Object.keys(schema.properties || {});
 
-    if (keys.length === 1) {
+    if (keys.length >= 1) {
       const firstKey = keys[0];
       const propertyRequired = required && (schema.required || []).indexOf(firstKey) !== -1;
       return getSplitOnArrayAliasMetadata(schema.properties?.[firstKey] as SchemaObject, propertyRequired, firstKey);


### PR DESCRIPTION
The hybrid trigger output in the manifest has two properties: body and headers. 
For setting the split-on we assume the outputs to have only 1 property which breaks setting spliton for hybrid triggers
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/37a9adf8-5cef-4b42-aa3a-843bae79de53)

Fixing this to ensure the spliton gets set even when there are more than one output properties and keeping the logic of looking for `firstKey` intact

**Without the fix,** the tokens get set with the wrong spliton and here is how the tokens get added:
![image](https://github.com/Azure/LogicAppsUX/assets/91710207/ef5e4bb6-f255-48f4-a80e-91a7a0faa952)
