### PR TITLE
Changing In-Development to Preview

### DIFF
--- a/libs/chatbot/src/lib/ui/panelheader.tsx
+++ b/libs/chatbot/src/lib/ui/panelheader.tsx
@@ -15,8 +15,8 @@ export const CopilotPanelHeader = ({ collapsed, toggleCollapse }: CopilotPanelHe
     description: 'Chatbot header title',
   });
   const pillText = intl.formatMessage({
-    defaultMessage: 'In-Development',
-    description: 'Label in the chatbot header stating the chatbot feature is still in-development',
+    defaultMessage: 'Preview',
+    description: 'Label in the chatbot header stating the chatbot feature is a preview',
   });
 
   const collapseButtonTitle = intl.formatMessage({


### PR DESCRIPTION
Changed Copilot tag from saying In-Development to Preview

From:
<img width="271" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/637d6f07-8339-4830-b65b-e582b93e8015">

To:
<img width="271" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/7ec8bfba-e8be-4787-9377-d4bddac79e6a">
