### PR TITLE
fix(Copilot): Changing In-development to Preview

### DIFF
--- a/libs/chatbot/src/lib/ui/panelheader.tsx
+++ b/libs/chatbot/src/lib/ui/panelheader.tsx
@@ -15,8 +15,8 @@ export const CopilotPanelHeader = ({ collapsed, toggleCollapse }: CopilotPanelHe
     description: 'Chatbot header title',
   });
   const pillText = intl.formatMessage({
-    defaultMessage: 'In-Development',
-    description: 'Label in the chatbot header stating the chatbot feature is still in-development',
+    defaultMessage: 'Preview',
+    description: 'Label in the chatbot header stating the chatbot feature is a preview',
   });
 
   const collapseButtonTitle = intl.formatMessage({


### PR DESCRIPTION
Changed Copilot tag from saying In-Development to Preview

From:
<img width="271" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/3100fe89-ed7e-43bf-b3b9-2f3b1d741b06">

To:
<img width="269" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/f42daeca-546c-4904-b4c8-4784408b79c2">

