### PR TITLE
fix(designer): Html Editor not showing proper tokens

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -206,7 +206,7 @@ export const BaseEditor = ({
             <TokenTypeAheadPlugin
               openTokenPicker={openTokenPicker}
               isEditorFocused={isEditorFocused}
-              hideExpression={tokenPickerButtonProps?.hideExpression}
+              hideTokenpickerOptions={tokenPickerButtonProps?.hideButtonOptions}
             />
           ) : null}
           <OnBlur command={handleBlur} />

--- a/libs/designer-ui/src/lib/editor/base/nodes/extendedTextNode.tsx
+++ b/libs/designer-ui/src/lib/editor/base/nodes/extendedTextNode.tsx
@@ -1,4 +1,4 @@
-import type { DOMConversion, DOMConversionMap, DOMConversionOutput, SerializedTextNode, TextFormatType } from 'lexical';
+import type { DOMConversion, DOMConversionMap, DOMConversionOutput, SerializedTextNode, Spread } from 'lexical';
 import { $isTextNode, TextNode } from 'lexical';
 
 // Since the TextNode is foundational to all Lexical packages, including the
@@ -7,6 +7,13 @@ import { $isTextNode, TextNode } from 'lexical';
 // deserialization of HTML/CSS styling properties to achieve full fidelity
 // between JSON <-> HTML. Since this is a very popular use case, below we are
 // proving a recipe to handle the most common use cases.
+
+export type SerializedExtendedTextNode = Spread<
+  {
+    type: 'extended-text';
+  },
+  SerializedTextNode
+>;
 
 export class ExtentedTextNode extends TextNode {
   static getType(): string {
@@ -52,8 +59,16 @@ export class ExtentedTextNode extends TextNode {
     return TextNode.importJSON(serializedNode);
   }
 
-  exportJSON(): SerializedTextNode {
-    return super.exportJSON();
+  exportJSON(): SerializedExtendedTextNode {
+    return {
+      text: this.__text,
+      format: this.__format,
+      detail: this.__detail,
+      style: this.__style,
+      type: 'extended-text',
+      mode: 'normal',
+      version: 1,
+    };
   }
 }
 
@@ -101,7 +116,7 @@ function patchStyleConversion(
   };
 }
 
-export function $createExtendedTextNode(text: string, styles?: string, format?: number | TextFormatType) {
+export function $createExtendedTextNode(text: string, styles?: string, format?: number) {
   const newNode = new ExtentedTextNode(text);
   newNode.setStyle(styles ?? '');
   newNode.setFormat(format ?? 0);

--- a/libs/designer-ui/src/lib/editor/base/plugins/TokenTypeahead.tsx
+++ b/libs/designer-ui/src/lib/editor/base/plugins/TokenTypeahead.tsx
@@ -1,5 +1,6 @@
 import { TokenPickerMode } from '../../../tokenpicker';
 import { useTokenTypeaheadTriggerMatch } from '../utils/tokenTypeaheadMatcher';
+import type { hideButtonOptions } from './tokenpickerbutton';
 import { Icon, Text, css, useTheme } from '@fluentui/react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { LexicalTypeaheadMenuPlugin, MenuOption } from '@lexical/react/LexicalTypeaheadMenuPlugin';
@@ -66,13 +67,14 @@ function TokenMenuItem({
 }
 
 interface TokenTypeAheadPluginProps {
-  openTokenPicker: (tokenPickerMode: TokenPickerMode) => void;
   isEditorFocused?: boolean;
-  hideExpression?: boolean;
+  hideTokenpickerOptions?: hideButtonOptions;
+  openTokenPicker: (tokenPickerMode: TokenPickerMode) => void;
 }
 
-export const TokenTypeAheadPlugin = ({ openTokenPicker, isEditorFocused, hideExpression = false }: TokenTypeAheadPluginProps) => {
+export const TokenTypeAheadPlugin = ({ isEditorFocused, hideTokenpickerOptions, openTokenPicker }: TokenTypeAheadPluginProps) => {
   const [editor] = useLexicalComposerContext();
+  const { hideDynamicContent, hideExpression } = hideTokenpickerOptions ?? {};
   const { isInverted } = useTheme();
   const checkForTriggerMatch = useTokenTypeaheadTriggerMatch('/', {
     minLength: 0,
@@ -106,19 +108,22 @@ export const TokenTypeAheadPlugin = ({ openTokenPicker, isEditorFocused, hideExp
     defaultMessage: 'Insert Dynamic Content',
     description: 'Label for button to open dynamic content picker',
   });
-  const options: TokenOption[] = [
-    new TokenOption(dynamicDataButtonText, 'dynamic', {
-      icon: () => <Icon iconName="LightningBolt" />,
-    }),
-  ];
+  const options: TokenOption[] = [];
+  // making the dynamic content button optional
+  !hideDynamicContent &&
+    options.push(
+      new TokenOption(dynamicDataButtonText, 'dynamic', {
+        icon: () => <Icon iconName="LightningBolt" />,
+      })
+    );
 
-  if (!hideExpression) {
+  // making the expression button optional
+  !hideExpression &&
     options.push(
       new TokenOption(expressionButtonText, 'expression', {
         icon: () => <Icon iconName="Variable" />,
       })
     );
-  }
 
   return (
     <LexicalTypeaheadMenuPlugin

--- a/libs/designer-ui/src/lib/editor/base/plugins/tokenpickerbutton/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/plugins/tokenpickerbutton/index.tsx
@@ -10,6 +10,8 @@ import { $getSelection } from 'lexical';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
+const singleTokenHeightReduction = 15;
+
 const dynamicContentIconProps: IIconProps = {
   iconName: 'LightningBolt',
 };
@@ -23,10 +25,17 @@ export enum TokenPickerButtonLocation {
   Right = 'right',
 }
 
+export interface hideButtonOptions {
+  hideDynamicContent?: boolean;
+  hideExpression?: boolean;
+}
+
 export interface TokenPickerButtonEditorProps {
   location?: TokenPickerButtonLocation;
-  insideEditor?: boolean;
-  hideExpression?: boolean;
+  hideButtonOptions?: hideButtonOptions;
+  verticalOffSet?: number;
+  horizontalOffSet?: number;
+  newlineVerticalOffset?: number;
 }
 
 interface TokenPickerButtonProps extends TokenPickerButtonEditorProps {
@@ -35,10 +44,13 @@ interface TokenPickerButtonProps extends TokenPickerButtonEditorProps {
 
 export const TokenPickerButton = ({
   location = TokenPickerButtonLocation.Left,
-  insideEditor,
+  hideButtonOptions,
+  verticalOffSet = 20,
+  horizontalOffSet = 38,
+  newlineVerticalOffset = 15,
   openTokenPicker,
-  hideExpression = false,
 }: TokenPickerButtonProps): JSX.Element => {
+  const { hideDynamicContent, hideExpression } = hideButtonOptions ?? {};
   const intl = useIntl();
   const [editor] = useLexicalComposerContext();
   const [anchorKey, setAnchorKey] = useState<NodeKey | null>(null);
@@ -68,29 +80,21 @@ export const TokenPickerButton = ({
       if (boxElem && rootElement && anchorElement) {
         const { right, left } = rootElement.getBoundingClientRect();
         const { top } = anchorElement.getBoundingClientRect();
-        const singleElementTop = hideExpression ? 15 : 0;
+        const additionalOffset = hideExpression || hideDynamicContent ? singleTokenHeightReduction : 0;
         if (anchorElement?.childNodes[0]?.nodeName === 'BR') {
-          // some of our editors have smaller heights, so we need to adjust the position of the tokenpicker button
-          if (rootElement.clientHeight === 24) {
-            boxElem.style.top = `${top - 16 + singleElementTop}px`;
-          } else {
-            boxElem.style.top = `${top - 15 + singleElementTop}px`;
-          }
+          boxElem.style.top = `${top - newlineVerticalOffset + additionalOffset}px`;
         } else {
-          boxElem.style.top = `${top - 20 + singleElementTop}px`;
+          boxElem.style.top = `${top - verticalOffSet + additionalOffset}px`;
         }
+
         if (location === TokenPickerButtonLocation.Right) {
           boxElem.style.left = `${right - 20}px`;
         } else {
-          if (insideEditor) {
-            boxElem.style.left = `${left - 33}px`;
-          } else {
-            boxElem.style.left = `${left - 38}px`;
-          }
+          boxElem.style.left = `${left - horizontalOffSet}px`;
         }
       }
     }
-  }, [anchorKey, editor, insideEditor, location, hideExpression]);
+  }, [anchorKey, editor, hideExpression, hideDynamicContent, location, newlineVerticalOffset, verticalOffSet, horizontalOffSet]);
 
   useEffect(() => {
     window.addEventListener('resize', updatePosition);
@@ -126,13 +130,15 @@ export const TokenPickerButton = ({
           style={{ boxShadow: Depths.depth4 }}
         >
           <TooltipHost content={dynamicContentButtonText}>
-            <IconButton
-              iconProps={dynamicContentIconProps}
-              styles={{ root: `top-root-button-style ${hideExpression ? 'top-root-button-style-single' : ''}` }}
-              className="msla-token-picker-entrypoint-button-dynamic-content"
-              data-automation-id="msla-token-picker-entrypoint-button-dynamic-content"
-              onClick={() => openTokenPicker(TokenPickerMode.TOKEN)}
-            />
+            {!hideDynamicContent ? (
+              <IconButton
+                iconProps={dynamicContentIconProps}
+                styles={{ root: `top-root-button-style ${hideExpression ? 'top-root-button-style-single' : ''}` }}
+                className="msla-token-picker-entrypoint-button-dynamic-content"
+                data-automation-id="msla-token-picker-entrypoint-button-dynamic-content"
+                onClick={() => openTokenPicker(TokenPickerMode.TOKEN)}
+              />
+            ) : null}
           </TooltipHost>
           {!hideExpression ? (
             <TooltipHost content={expressionButtonText}>

--- a/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
@@ -14,10 +14,11 @@ import type { HeadingNode } from '@lexical/rich-text';
 import { $isHeadingNode } from '@lexical/rich-text';
 import type { Expression } from '@microsoft/parsers-logic-apps';
 import { ExpressionParser } from '@microsoft/parsers-logic-apps';
-import type { LexicalNode, ParagraphNode, RootNode, TextFormatType } from 'lexical';
+import type { LexicalNode, ParagraphNode, RootNode } from 'lexical';
 import { $createParagraphNode, $isTextNode, $isLineBreakNode, $isParagraphNode, $createTextNode, $getRoot, createEditor } from 'lexical';
 
 export const parseHtmlSegments = (value: ValueSegment[], tokensEnabled?: boolean): RootNode => {
+  console.log(value);
   const editor = createEditor({ ...defaultInitialConfig, nodes: htmlNodes });
   const parser = new DOMParser();
   const root = $getRoot();
@@ -106,7 +107,7 @@ export const appendStringSegment = (
   paragraph: ParagraphNode | HeadingNode | ListNode | ListItemNode | LinkNode,
   value: string,
   childNodeStyles?: string,
-  childNodeFormat?: number | TextFormatType,
+  childNodeFormat?: number,
   nodeMap?: Map<string, ValueSegment>,
   tokensEnabled?: boolean
 ) => {
@@ -114,8 +115,9 @@ export const appendStringSegment = (
   let prevIndex = 0;
   while (currIndex < value.length) {
     if (value.substring(currIndex - 2, currIndex) === '$[') {
-      if (value.substring(prevIndex, currIndex - 2)) {
-        paragraph.append($createExtendedTextNode(value.substring(prevIndex, currIndex - 2), childNodeStyles, childNodeFormat));
+      const textSegment = value.substring(prevIndex, currIndex - 2);
+      if (textSegment) {
+        paragraph.append($createExtendedTextNode(textSegment, childNodeStyles, childNodeFormat));
       }
       const newIndex = value.indexOf(']$', currIndex) + 2;
       // token is found in the text
@@ -155,7 +157,10 @@ export const appendStringSegment = (
     }
     currIndex++;
   }
-  paragraph.append($createExtendedTextNode(value.substring(prevIndex, currIndex), childNodeStyles, childNodeFormat));
+  const textSegment = value.substring(prevIndex, currIndex);
+  if (textSegment) {
+    paragraph.append($createExtendedTextNode(textSegment, childNodeStyles, childNodeFormat));
+  }
 };
 
 export const parseSegments = (value: ValueSegment[], tokensEnabled?: boolean): RootNode => {
@@ -219,8 +224,11 @@ export const convertSegmentsToString = (input: ValueSegment[], nodeMap?: Map<str
     if (segment.type === ValueSegmentType.LITERAL) {
       text += segment.value;
     } else if (segment.token) {
-      const { title, value, brandColor } = segment.token;
-      const string = `$[${title},${value},${brandColor}]$`;
+      const segmentValue = segment.value;
+      // segment.token.value are not unique, so we'll need to use segment value instead
+      const { title, brandColor } = segment.token;
+      // get a unique identifier for the token
+      const string = `$[${title},${segmentValue},${brandColor}]$`;
       text += string;
       nodeMap?.set(string, segment);
     }

--- a/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
@@ -18,7 +18,6 @@ import type { LexicalNode, ParagraphNode, RootNode } from 'lexical';
 import { $createParagraphNode, $isTextNode, $isLineBreakNode, $isParagraphNode, $createTextNode, $getRoot, createEditor } from 'lexical';
 
 export const parseHtmlSegments = (value: ValueSegment[], tokensEnabled?: boolean): RootNode => {
-  console.log(value);
   const editor = createEditor({ ...defaultInitialConfig, nodes: htmlNodes });
   const parser = new DOMParser();
   const root = $getRoot();

--- a/libs/designer-ui/src/lib/html/index.tsx
+++ b/libs/designer-ui/src/lib/html/index.tsx
@@ -19,8 +19,12 @@ export const HTMLEditor = ({ initialValue, onChange, ...baseEditorProps }: BaseE
     <BaseEditor
       {...baseEditorProps}
       className="msla-html-editor"
-      BasePlugins={{ tokens: true, clearEditor: true, toolbar: true }}
       initialValue={initialValue}
+      BasePlugins={{ tokens: true, clearEditor: true, toolbar: true, ...baseEditorProps.BasePlugins }}
+      tokenPickerButtonProps={{
+        ...baseEditorProps.tokenPickerButtonProps,
+        newlineVerticalOffset: 20,
+      }}
       onBlur={handleBlur}
     >
       <Change setValue={onValueChange} />

--- a/libs/designer-ui/src/lib/querybuilder/Row.tsx
+++ b/libs/designer-ui/src/lib/querybuilder/Row.tsx
@@ -265,7 +265,11 @@ export const Row = ({
           clearEditorOnTokenInsertion={clearEditorOnTokenInsertion}
           onChange={handleKeyChange}
           editorBlur={handleKeySave}
-          tokenPickerButtonProps={{ location: TokenPickerButtonLocation.Left, insideEditor: !isSimpleQueryBuilder }}
+          tokenPickerButtonProps={{
+            location: TokenPickerButtonLocation.Left,
+            newlineVerticalOffset: 16,
+            horizontalOffSet: isSimpleQueryBuilder ? undefined /* uses default of 38*/ : 33,
+          }}
         />
         <RowDropdown disabled={readonly || key.length === 0} condition={operator} onChange={handleSelectedOption} key={operator} />
         <StringEditor
@@ -277,7 +281,7 @@ export const Row = ({
           getTokenPicker={getTokenPicker}
           editorBlur={handleValueSave}
           clearEditorOnTokenInsertion={clearEditorOnTokenInsertion}
-          tokenPickerButtonProps={{ location: TokenPickerButtonLocation.Left, insideEditor: true }}
+          tokenPickerButtonProps={{ location: TokenPickerButtonLocation.Left, newlineVerticalOffset: 16, horizontalOffSet: 33 }}
         />
       </div>
       {forceSingleCondition ? null : (

--- a/libs/designer-ui/src/lib/querybuilder/querybuilder.less
+++ b/libs/designer-ui/src/lib/querybuilder/querybuilder.less
@@ -31,13 +31,12 @@
       position: relative;
       .editor-input {
         outline: 1px solid @panel-mode-panel-border-color;
-        margin: 1px;
         resize: none;
         font-size: 12px;
         tab-size: 1;
         min-height: 24px;
-        line-height: 24px;
-        padding-inline-start: 5px;
+        line-height: 20px;
+        padding-inline-start: 6px;
         padding-inline-end: 15px;
         &.readonly {
           background-color: rgba(128, 128, 128, 0.1);
@@ -46,6 +45,7 @@
           outline: 2px solid @primary_focus_blue;
         }
         p {
+          padding-top: 2px;
           margin: 0;
         }
       }


### PR DESCRIPTION
Fixes -https://github.com/Azure/LogicAppsUX/issues/3497

Other HTML ui bugs fixed
- Text from HTML node (extendedTextNode) uncopyable
- Tokenpickerbutton not properly being offset in new lines of HTML editors
Other
- Adding a prop to also make it possible to only show the expression editor