### PR TITLE
feat(designer): Add support for recommendation view to work without depending on prefetched data

### DIFF
--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -51,7 +51,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
 
   const { data: allOperations, isLoading: isLoadingOperations } = useAllOperations();
   const [selectedOperation, setSelectedOperation] = useState<DiscoveryOperation<DiscoveryResultTypes> | undefined>(undefined);
-  const [isWaitingOperationsGroup, setIsWaitingOperationGroup] = useState<boolean>(false);
+  const [isLoadingOperationsGroup, setIsLoadingOperationGroup] = useState<boolean>(false);
 
   const selectedOperationGroupId = useSelectedSearchOperationGroupId();
   const { data: allConnectors } = useAllConnectors();
@@ -72,12 +72,15 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
           })
         );
 
-    searchResultPromise.then((filteredOps) => {
-      setAllOperationsForGroup(filteredOps);
-      setIsWaitingOperationGroup(false);
-    });
+    setIsLoadingOperationGroup(true);
+    searchResultPromise
+      .then((filteredOps) => {
+        setAllOperationsForGroup(filteredOps);
+      })
+      .finally(() => {
+        setIsLoadingOperationGroup(false);
+      });
     setSelectionState(SELECTION_STATES.DETAILS);
-    setIsWaitingOperationGroup(true);
   }, [selectedOperationGroupId, allOperations, filters]);
 
   const navigateBack = useCallback(() => {
@@ -176,7 +179,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
               groupOperations={allOperationsForGroup}
               filters={filters}
               onOperationClick={onOperationClick}
-              isLoading={isLoadingOperations || isWaitingOperationsGroup}
+              isLoading={isLoadingOperations || isLoadingOperationsGroup}
               displayRuntimeInfo={displayRuntimeInfo}
             />
           ) : null,

--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -51,7 +51,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
 
   const { data: allOperations, isLoading: isLoadingOperations } = useAllOperations();
   const [selectedOperation, setSelectedOperation] = useState<DiscoveryOperation<DiscoveryResultTypes> | undefined>(undefined);
-  const [isLoadingOperationsGroup, setIsLoadingOperationGroup] = useState<boolean>(false);
+  const [isLoadingOperationGroup, setIsLoadingOperationGroup] = useState<boolean>(false);
 
   const selectedOperationGroupId = useSelectedSearchOperationGroupId();
   const { data: allConnectors } = useAllConnectors();
@@ -179,7 +179,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
               groupOperations={allOperationsForGroup}
               filters={filters}
               onOperationClick={onOperationClick}
-              isLoading={isLoadingOperations || isLoadingOperationsGroup}
+              isLoading={isLoadingOperations || isLoadingOperationGroup}
               displayRuntimeInfo={displayRuntimeInfo}
             />
           ) : null,

--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -51,6 +51,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
 
   const { data: allOperations, isLoading: isLoadingOperations } = useAllOperations();
   const [selectedOperation, setSelectedOperation] = useState<DiscoveryOperation<DiscoveryResultTypes> | undefined>(undefined);
+  const [isWaitingOperationsGroup, setIsWaitingOperationGroup] = useState<boolean>(false);
 
   const selectedOperationGroupId = useSelectedSearchOperationGroupId();
   const { data: allConnectors } = useAllConnectors();
@@ -73,9 +74,11 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
 
     searchResultPromise.then((filteredOps) => {
       setAllOperationsForGroup(filteredOps);
-      setSelectionState(SELECTION_STATES.DETAILS);
+      setIsWaitingOperationGroup(false);
     });
-  }, [selectedOperationGroupId, allOperations]);
+    setSelectionState(SELECTION_STATES.DETAILS);
+    setIsWaitingOperationGroup(true);
+  }, [selectedOperationGroupId, allOperations, filters]);
 
   const navigateBack = useCallback(() => {
     dispatch(selectOperationGroupId(''));
@@ -173,7 +176,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
               groupOperations={allOperationsForGroup}
               filters={filters}
               onOperationClick={onOperationClick}
-              isLoading={isLoadingOperations}
+              isLoading={isLoadingOperations || isWaitingOperationsGroup}
               displayRuntimeInfo={displayRuntimeInfo}
             />
           ) : null,

--- a/libs/services/designer-client-services/src/lib/search.ts
+++ b/libs/services/designer-client-services/src/lib/search.ts
@@ -28,6 +28,8 @@ export interface ISearchService {
   searchOperations?(searchTerm: string, actionType?: string, runtimeFilter?: string): Promise<DiscoveryOperation<DiscoveryResultTypes>[]>;
   getRuntimeCategories?(): OperationRuntimeCategory[];
   filterConnector?(connector: Connector, runtimeFilter: string): boolean;
+  getOperationById?(operationId: string): Promise<DiscoveryOperation<DiscoveryResultTypes> | undefined>;
+  getOperationsByConnector?(connectorId: string, actionType?: string): Promise<DiscoveryOperation<DiscoveryResultTypes>[]>;
 }
 
 let service: ISearchService;


### PR DESCRIPTION
Introduce new methods in the search service to help the recommendation view work without relying on prefetched data. this includes:

* `getOperationById` to help retrieve the operation by id upon click.
* `getOperationsByConnector` to help retrieve the list of operations for a specific connector, when the connector header is clicked on from the browse or search views.

The change has been smoke tested for Power Automate integration without returning any operation in the prefetch call, and completely relying on the new method callbacks.

- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**:


AB#25597550