### PR TITLE
fix(Data Mapper): Paste into test tool using right mouse click not working

### DIFF
--- a/libs/data-mapper/src/lib/components/testMapPanel/TestMapPanel.tsx
+++ b/libs/data-mapper/src/lib/components/testMapPanel/TestMapPanel.tsx
@@ -265,6 +265,7 @@ export const TestMapPanel = ({ mapDefinition, isOpen, onClose }: TestMapPanelPro
             value={testMapInput}
             onContentChanged={(e) => setTestMapInput(e.value ?? '')}
             className={styles.editorStyle}
+            contextMenu={true}
             {...commonCodeEditorProps}
           />
         </PivotItem>


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix
- **What is the current behavior?** (You can also link to an open issue here)
the test panel does not let users cut/copy/paste using the mouse right click context menu
- **What is the new behavior (if this is a feature change)?**
the test panel lets users cut/copy/paste using the mouse right click context menu
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
- **Please Include Screenshots or Videos of the intended change**:
- Before:
<img width="469" alt="277832046-4d4c369e-5e4a-4704-895c-1872cd9e57e0" src="https://github.com/Azure/LogicAppsUX/assets/144840522/783822d0-d017-4cea-b190-224f2f541206">

- After:
<img width="367" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/144840522/94e81272-5fd3-4a82-a113-427425257ce5">
