### PR TITLE
fix(designer): Remove action type filtering for where the prefetched operations is empty

### DIFF
--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
@@ -11,6 +11,7 @@ interface OperationSearchHeaderProps {
   searchCallback: (s: string) => void;
   onGroupToggleChange: (ev?: React.FormEvent<HTMLElement | HTMLInputElement> | undefined, checked?: boolean | undefined) => void;
   displayRuntimeInfo: boolean;
+  displayActionType?: boolean;
   isGrouped?: boolean;
   searchTerm?: string;
   filters?: Record<string, string>;
@@ -45,6 +46,7 @@ export const OperationSearchHeader = (props: OperationSearchHeaderProps) => {
     setFilters,
     isTriggerNode,
     displayRuntimeInfo,
+    displayActionType,
   } = props;
 
   const intl = useIntl();
@@ -93,30 +95,34 @@ export const OperationSearchHeader = (props: OperationSearchHeaderProps) => {
   return (
     <div className="msla-sub-heading-container">
       <DesignerSearchBox searchCallback={searchCallback} searchTerm={searchTerm} />
-      <div style={{ display: 'grid', grid: 'auto-flow / 1fr 1fr', gridColumnGap: '8px' }}>
-        {displayRuntimeInfo && runtimeFilters.length > 0 ? (
-          <Dropdown
-            label={intl.formatMessage({ defaultMessage: 'Runtime', description: 'Filter by label' })}
-            placeholder={intl.formatMessage({ defaultMessage: 'Select a runtime', description: 'Select a runtime placeholder' })}
-            selectedKeys={Object.entries(props.filters ?? {}).map(([k, v]) => `${k}-${v}`)}
-            onChange={onChange}
-            multiSelect
-            options={runtimeFilters}
-          />
-        ) : null}
-        <Dropdown
-          label={intl.formatMessage({ defaultMessage: 'Action Type', description: 'Filter by label' })}
-          placeholder={intl.formatMessage({
-            defaultMessage: 'Select an action type',
-            description: 'Select an action type placeholder',
-          })}
-          selectedKeys={Object.entries(props.filters ?? {}).map(([k, v]) => `${k}-${v}`)}
-          onChange={onChange}
-          multiSelect
-          options={actionTypeFilters}
-          disabled={isTriggerNode}
-        />
-      </div>
+      {displayRuntimeInfo || displayActionType ? (
+        <div style={{ display: 'grid', grid: 'auto-flow / 1fr 1fr', gridColumnGap: '8px' }}>
+          {displayRuntimeInfo && runtimeFilters.length > 0 ? (
+            <Dropdown
+              label={intl.formatMessage({ defaultMessage: 'Runtime', description: 'Filter by label' })}
+              placeholder={intl.formatMessage({ defaultMessage: 'Select a runtime', description: 'Select a runtime placeholder' })}
+              selectedKeys={Object.entries(props.filters ?? {}).map(([k, v]) => `${k}-${v}`)}
+              onChange={onChange}
+              multiSelect
+              options={runtimeFilters}
+            />
+          ) : null}
+          {displayActionType ? (
+            <Dropdown
+              label={intl.formatMessage({ defaultMessage: 'Action Type', description: 'Filter by label' })}
+              placeholder={intl.formatMessage({
+                defaultMessage: 'Select an action type',
+                description: 'Select an action type placeholder',
+              })}
+              selectedKeys={Object.entries(props.filters ?? {}).map(([k, v]) => `${k}-${v}`)}
+              onChange={onChange}
+              multiSelect
+              options={actionTypeFilters}
+              disabled={isTriggerNode}
+            />
+          ) : null}
+        </div>
+      ) : null}
       {searchTerm ? (
         <div className="msla-flex-row">
           <Checkbox label={groupByConnectorLabelText} onChange={onGroupToggleChange} checked={isGrouped} />

--- a/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
@@ -36,7 +36,7 @@ export const BrowseView = ({
         if (!filterMethod(connector, filters['runtime'])) return false;
       }
 
-      if (filters['actionType']) {
+      if (filters['actionType'] && (allApiIdsWithActions.data.length > 0 || allApiIdsWithTriggers.data.length > 0)) {
         const capabilities = connector.properties?.capabilities ?? [];
         const ignoreCapabilities = capabilities.length === 0;
         const supportsActions =

--- a/libs/designer/src/lib/ui/panel/recommendation/operationGroupDetailView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/operationGroupDetailView.tsx
@@ -10,17 +10,19 @@ type OperationGroupDetailViewProps = {
   onOperationClick: (id: string, apiId?: string) => void;
   isLoading: boolean;
   displayRuntimeInfo: boolean;
+  respectActionsFilter: boolean;
 };
 
 export const OperationGroupDetailView = (props: OperationGroupDetailViewProps) => {
-  const { connector, groupOperations, filters, onOperationClick, isLoading, displayRuntimeInfo } = props;
+  const { connector, groupOperations, filters, onOperationClick, isLoading, displayRuntimeInfo, respectActionsFilter } = props;
 
   const filterItems = useCallback(
     (data: OperationActionData): boolean =>
-      !filters?.['actionType'] ||
-      (filters?.['actionType'] === 'actions' && !data.isTrigger) ||
-      (filters?.['actionType'] === 'triggers' && data.isTrigger),
-    [filters]
+      !filters?.['actionType'] || // if I don't have a filter
+      (filters?.['actionType'] === 'actions' && !data.isTrigger) || // or that the filter is actions, and the operation is not a trigger
+      (filters?.['actionType'] === 'triggers' && data.isTrigger) || // or that the filter is triggers, and the operation is a trigger
+      (filters?.['actionType'] === 'actions' && !respectActionsFilter), // or that the filter is action, and that I should not respect the actions filter
+    [filters, respectActionsFilter]
   );
 
   const operationGroupActions: OperationActionData[] = groupOperations

--- a/libs/designer/src/lib/ui/panel/recommendation/operationGroupDetailView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/operationGroupDetailView.tsx
@@ -10,19 +10,19 @@ type OperationGroupDetailViewProps = {
   onOperationClick: (id: string, apiId?: string) => void;
   isLoading: boolean;
   displayRuntimeInfo: boolean;
-  respectActionsFilter: boolean;
+  ignoreActionsFilter: boolean;
 };
 
 export const OperationGroupDetailView = (props: OperationGroupDetailViewProps) => {
-  const { connector, groupOperations, filters, onOperationClick, isLoading, displayRuntimeInfo, respectActionsFilter } = props;
+  const { connector, groupOperations, filters, onOperationClick, isLoading, displayRuntimeInfo, ignoreActionsFilter } = props;
 
   const filterItems = useCallback(
     (data: OperationActionData): boolean =>
       !filters?.['actionType'] || // if I don't have a filter
       (filters?.['actionType'] === 'actions' && !data.isTrigger) || // or that the filter is actions, and the operation is not a trigger
       (filters?.['actionType'] === 'triggers' && data.isTrigger) || // or that the filter is triggers, and the operation is a trigger
-      (filters?.['actionType'] === 'actions' && !respectActionsFilter), // or that the filter is action, and that I should not respect the actions filter
-    [filters, respectActionsFilter]
+      (filters?.['actionType'] === 'actions' && !ignoreActionsFilter), // or that the filter is action, and that I should not respect the actions filter
+    [filters, ignoreActionsFilter]
   );
 
   const operationGroupActions: OperationActionData[] = groupOperations

--- a/libs/designer/src/lib/ui/panel/recommendation/operationGroupDetailView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/operationGroupDetailView.tsx
@@ -21,7 +21,7 @@ export const OperationGroupDetailView = (props: OperationGroupDetailViewProps) =
       !filters?.['actionType'] || // if I don't have a filter
       (filters?.['actionType'] === 'actions' && !data.isTrigger) || // or that the filter is actions, and the operation is not a trigger
       (filters?.['actionType'] === 'triggers' && data.isTrigger) || // or that the filter is triggers, and the operation is a trigger
-      (filters?.['actionType'] === 'actions' && !ignoreActionsFilter), // or that the filter is action, and that I should not respect the actions filter
+      (filters?.['actionType'] === 'actions' && ignoreActionsFilter), // or that the filter is action, and that I should ignore the actions filter
     [filters, ignoreActionsFilter]
   );
 

--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -84,7 +84,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
         setIsLoadingOperationGroup(false);
       });
     setSelectionState(SELECTION_STATES.DETAILS);
-  }, [selectedOperationGroupId, allOperations, filters]);
+  }, [selectedOperationGroupId, allOperations, filters, hideActionTypeFilter]);
 
   const navigateBack = useCallback(() => {
     dispatch(selectOperationGroupId(''));

--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -185,7 +185,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
               onOperationClick={onOperationClick}
               isLoading={isLoadingOperations || isLoadingOperationGroup}
               displayRuntimeInfo={displayRuntimeInfo}
-              respectActionsFilter={!hideActionTypeFilter}
+              ignoreActionsFilter={hideActionTypeFilter}
             />
           ) : null,
           [SELECTION_STATES.SEARCH]: (

--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -57,6 +57,9 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
   const { data: allConnectors } = useAllConnectors();
   const selectedConnector = allConnectors?.find((c) => c.id === selectedOperationGroupId);
 
+  // hide actions type filter if we don't have any operations for the browse view
+  const hideActionTypeFilter = (!allOperations || allOperations.length === 0) && !searchTerm;
+
   // effect to set the current list of operations by group
   useEffect(() => {
     if (!selectedOperationGroupId) return;
@@ -64,7 +67,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
     const searchOperation = SearchService().getOperationsByConnector?.bind(SearchService());
 
     const searchResultPromise = searchOperation
-      ? searchOperation(selectedOperationGroupId, filters['actionType']?.toLowerCase())
+      ? searchOperation(selectedOperationGroupId, hideActionTypeFilter ? undefined : filters['actionType']?.toLowerCase())
       : Promise.resolve(
           (allOperations ?? []).filter((operation) => {
             const apiId = operation.properties.api.id;
@@ -86,6 +89,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
   const navigateBack = useCallback(() => {
     dispatch(selectOperationGroupId(''));
     dispatch(selectOperationId(''));
+    setAllOperationsForGroup([]);
     setSelectionState(SELECTION_STATES.SEARCH);
   }, [dispatch]);
 
@@ -181,6 +185,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
               onOperationClick={onOperationClick}
               isLoading={isLoadingOperations || isLoadingOperationGroup}
               displayRuntimeInfo={displayRuntimeInfo}
+              respectActionsFilter={!hideActionTypeFilter}
             />
           ) : null,
           [SELECTION_STATES.SEARCH]: (
@@ -194,6 +199,7 @@ export const RecommendationPanelContext = (props: RecommendationPanelContextProp
                 setFilters={setFilters}
                 isTriggerNode={isTrigger}
                 displayRuntimeInfo={displayRuntimeInfo}
+                displayActionType={!hideActionTypeFilter}
               />
               {searchTerm ? (
                 <SearchView


### PR DESCRIPTION
Remove action type filtering for where the prefetched operations is empty, given how browse would be empty otherwise. A subsequent change needed here is to have the connector details view not respect the 'actions' filter type in such case, given how there'd be no other way for users in the browse view to list triggers when trying to add actions.