### PR TITLE
fix(Copilot): Changing style of Preview tag

### DIFF
--- a/libs/chatbot/src/lib/ui/styles.less
+++ b/libs/chatbot/src/lib/ui/styles.less
@@ -27,6 +27,8 @@
 
 .msla-chatbot-header-icon {
   color: #2899f5;
+  transform: scale(1.5);
+  padding-left: 5px;
 }
 
 .msla-chatbot-header-title-container {
@@ -38,12 +40,14 @@
   }
 
   .msla-chatbot-header-subtitle {
-    margin-left: 14px;
+    margin-left: 15px;
+    padding-top: 4px;
     width: fit-content;
-    font-size: 14px;
+    font-size: 12px;
     font-weight: 400;
     border-radius: 20px;
     line-height: 15px;
+    color: #646464;
   }
 }
 


### PR DESCRIPTION
Changing the font size and color of "Preview" and making Logic Apps logo bigger

Before:
<img width="192" alt="preview-before" src="https://github.com/Azure/LogicAppsUX/assets/125534835/4f9ba6fe-97cc-4d07-84d5-873d2aa8fa29">


After:
<img width="179" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/404df5bd-de00-4733-b517-4ed61645a326">