### PR TITLE
fix(designer): Token Picker Expression to use Extracted Value

### DIFF
--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -81,7 +81,6 @@ export function TokenPicker({
 
   useEffect(() => {
     if (expression.value && window.localStorage.getItem('msla-tokenpicker-expression') !== expression.value) {
-      console.log(expression.value);
       window.localStorage.setItem('msla-tokenpicker-expression', expression.value);
     }
   }, [expression.value]);

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -91,8 +91,9 @@ export const TokenPickerOptions = ({
     }
   };
 
-  const handleTokenExpressionClicked = (token: OutputToken) => {
-    const expression = token.value ?? '';
+  const handleTokenExpressionClicked = async (token: OutputToken) => {
+    const segment = await getValueSegmentFromToken(token, !tokenClickedCallback);
+    const expression = segment.value ?? token.value ?? '';
     insertExpressionText(expression, 0);
   };
 


### PR DESCRIPTION
use getValueSegmentFromToken to get expression value of dynamic content
-fixes https://github.com/Azure/LogicAppsUX/issues/3437