### PR TITLE
feat(vscode): Added wizard prompt to set logic app name by User 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
   "typescript.tsdk": "node_modules\\typescript\\lib",
   "cSpell.words": ["fluentui", "reactflow"],
-  "eslint.validate": ["json"]
+  "eslint.validate": ["json"],
+  "terminal.integrated.env.windows": {
+    "PATH": "C:\\Users\\samikarakra.REDMOND\\.azurelogicapps\\dependencies\\DotNetSDK;${env:PATH}"
+  },
+  "omnisharp.dotNetCliPaths": ["C:\\Users\\samikarakra.REDMOND\\.azurelogicapps\\dependencies\\DotNetSDK"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
   "typescript.tsdk": "node_modules\\typescript\\lib",
   "cSpell.words": ["fluentui", "reactflow"],
-  "eslint.validate": ["json"],
-  "terminal.integrated.env.windows": {
-    "PATH": "C:\\Users\\samikarakra.REDMOND\\.azurelogicapps\\dependencies\\DotNetSDK;${env:PATH}"
-  },
-  "omnisharp.dotNetCliPaths": ["C:\\Users\\samikarakra.REDMOND\\.azurelogicapps\\dependencies\\DotNetSDK"]
+  "eslint.validate": ["json"]
 }

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/NewCodeProjectTypeStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/NewCodeProjectTypeStep.ts
@@ -86,7 +86,12 @@ export class NewCodeProjectTypeStep extends AzureWizardPromptStep<IProjectWizard
     await fs.ensureDir(workspacePath);
     context.customWorkspaceFolderPath = workspacePath;
 
-    const logicAppFolderPath = path.join(workspacePath, 'LogicApp');
+    let logicAppFolderName = 'LogicApp';
+    if (!isCustomCodeLogicApp && context.isCustomCodeLogicApp !== null && context.logicAppName) {
+      logicAppFolderName = context.logicAppName;
+    }
+
+    const logicAppFolderPath = path.join(workspacePath, logicAppFolderName);
     await fs.ensureDir(logicAppFolderPath);
     context.logicAppFolderPath = logicAppFolderPath;
 
@@ -98,7 +103,6 @@ export class NewCodeProjectTypeStep extends AzureWizardPromptStep<IProjectWizard
     }
     await this.createWorkspaceFile(context);
   }
-
   /**
    * Setup directories and configs for custom code logic app
    * @param context - Project wizard context
@@ -165,13 +169,21 @@ export class NewCodeProjectTypeStep extends AzureWizardPromptStep<IProjectWizard
    * @param context - Project wizard context
    */
   private async createWorkspaceFile(context: IProjectWizardContext): Promise<void> {
-    const workspaceData = {
-      folders: [{ name: 'LogicApp', path: './LogicApp' }],
-    };
+    // Start with an empty folders array
+    const workspaceFolders = [];
 
+    // Add Functions folder first if it's a custom code code Logic App
     if (context.isCustomCodeLogicApp) {
-      workspaceData.folders.unshift({ name: 'Functions', path: './Function' });
+      workspaceFolders.push({ name: 'Functions', path: './Function' });
     }
+
+    // Use context.logicAppName for the folder name; default to 'LogicApp' if not available
+    const logicAppName = context.logicAppName || 'LogicApp';
+    workspaceFolders.push({ name: logicAppName, path: `./${logicAppName}` });
+
+    const workspaceData = {
+      folders: workspaceFolders,
+    };
 
     const workspaceFilePath = path.join(context.customWorkspaceFolderPath, `${context.workspaceName}.code-workspace`);
     context.customWorkspaceFolderPath = workspaceFilePath;

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/ProjectCodeCreateStepBase.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/ProjectCodeCreateStepBase.ts
@@ -49,8 +49,8 @@ export abstract class ProjectCodeCreateStepBase extends AzureWizardExecuteStep<I
     await this.executeCore(context, progress);
 
     // Initialize a git repository if one is not already present
-    if ((await isGitInstalled(context.workspaceCustomFilePath)) && !(await isInsideRepo(context.workspaceCustomFilePath))) {
-      await gitInit(context.workspaceCustomFilePath);
+    if ((await isGitInstalled(context.customWorkspaceFolderPath)) && !(await isInsideRepo(context.customWorkspaceFolderPath))) {
+      await gitInit(context.customWorkspaceFolderPath);
     }
 
     // Log telemetry for the step

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetLogicAppNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetLogicAppNameStep.ts
@@ -1,0 +1,27 @@
+import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
+import type { IProjectWizardContext } from '@microsoft/vscode-extension';
+import * as vscode from 'vscode';
+
+export class SetLogicAppName extends AzureWizardPromptStep<IProjectWizardContext> {
+  public async prompt(context: IProjectWizardContext): Promise<void> {
+    const logicAppName = await vscode.window.showInputBox({
+      prompt: 'Enter a name for your Logic App project',
+      validateInput: (value: string): string | undefined => {
+        if (!value || value.length === 0) {
+          return 'Project name cannot be empty';
+        }
+        return undefined;
+      },
+    });
+
+    if (logicAppName) {
+      context.logicAppName = logicAppName;
+    } else {
+      throw new Error('Logic App project name is required.');
+    }
+  }
+
+  public shouldPrompt(context: IProjectWizardContext): boolean {
+    return !context.isCustomCodeLogicApp && context.isCustomCodeLogicApp !== null;
+  }
+}

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetLogicAppNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetLogicAppNameStep.ts
@@ -1,14 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../../../extensionVariables';
+import { localize } from '../../../../localize';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension';
-import * as vscode from 'vscode';
 
 export class SetLogicAppName extends AzureWizardPromptStep<IProjectWizardContext> {
   public async prompt(context: IProjectWizardContext): Promise<void> {
-    const logicAppName = await vscode.window.showInputBox({
-      prompt: 'Enter a name for your Logic App project',
+    const logicAppName = await context.ui.showInputBox({
+      placeHolder: localize('logicAppNamePlaceHolder', 'Logic App name'),
+      prompt: localize('logicAppNamePrompt', 'Enter a name for your Logic App project'),
       validateInput: (value: string): string | undefined => {
         if (!value || value.length === 0) {
-          return 'Project name cannot be empty';
+          return localize('projectNameEmpty', 'Project name cannot be empty');
         }
         return undefined;
       },
@@ -16,8 +22,10 @@ export class SetLogicAppName extends AzureWizardPromptStep<IProjectWizardContext
 
     if (logicAppName) {
       context.logicAppName = logicAppName;
+      ext.outputChannel.appendLog(localize('logicAppNameSet', `Logic App project name set to ${logicAppName}`));
     } else {
-      throw new Error('Logic App project name is required.');
+      ext.outputChannel.appendLog(localize('logicAppNameRequired', 'Error: Logic App project name is required.'));
+      throw new Error(localize('logicAppNameError', 'Logic App project name is required.'));
     }
   }
 

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/ScriptProjectCreateStep.ts
@@ -80,7 +80,7 @@ bin
 obj
 appsettings.json
 local.settings.json
-__blobstorage__
+.debug
 __queuestorage__
 __azurite_db*__.json`)
       );

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/ScriptProjectCreateStep.ts
@@ -80,9 +80,15 @@ bin
 obj
 appsettings.json
 local.settings.json
+__blobstorage__
 .debug
 __queuestorage__
-__azurite_db*__.json`)
+__azurite_db*__.json
+
+# Added folders and file patterns
+workflow-designtime/
+.vscode/
+*.code-workspace`)
       );
     }
 

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createNewCodeProject.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createNewCodeProject.ts
@@ -17,6 +17,7 @@ import { OpenBehaviorStep } from '../createNewProject/OpenBehaviorStep';
 import { FolderListStep } from '../createNewProject/createProjectSteps/FolderListStep';
 import { NewCodeProjectTypeStep } from './CodeProjectBase/NewCodeProjectTypeStep';
 import { OpenFolderStepCodeProject } from './CodeProjectBase/OpenFolderStepCodeProject';
+import { SetLogicAppName } from './CodeProjectBase/SetLogicAppNameStep';
 import { setWorkspaceName } from './CodeProjectBase/SetWorkspaceName';
 import { SetLogicAppType } from './CodeProjectBase/setLogicAppType';
 import { isString } from '@microsoft/utils-logic-apps';
@@ -79,6 +80,7 @@ export async function createNewCodeProjectInternal(context: IActionContext, opti
       new FolderListStep(),
       new setWorkspaceName(),
       new SetLogicAppType(),
+      new SetLogicAppName(),
       new NewCodeProjectTypeStep(options.templateId, options.functionSettings),
       new OpenBehaviorStep(),
     ],

--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ProjectCreateStepBase.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ProjectCreateStepBase.ts
@@ -8,6 +8,7 @@ import { AzureWizardExecuteStep, callWithTelemetryAndErrorHandling } from '@micr
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension';
 import * as fse from 'fs-extra';
+import * as path from 'path';
 import type { Progress } from 'vscode';
 
 export abstract class ProjectCreateStepBase extends AzureWizardExecuteStep<IProjectWizardContext> {
@@ -32,7 +33,13 @@ export abstract class ProjectCreateStepBase extends AzureWizardExecuteStep<IProj
     await this.executeCore(context, progress);
 
     if ((await isGitInstalled(context.workspacePath)) && !(await isInsideRepo(context.workspacePath))) {
-      await gitInit(context.workspacePath);
+      //Init git repo inside mutli root workspace custom logic app project
+      if (!context.isCustomCodeLogicApp && context.isCustomCodeLogicApp !== null) {
+        const parentDirectory = path.dirname(context.workspacePath);
+        await gitInit(parentDirectory);
+      } else {
+        await gitInit(context.workspacePath);
+      }
     }
 
     // OpenFolderStep sometimes restarts the extension host. Adding a second event here to see if we're losing any telemetry

--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
@@ -73,6 +73,7 @@ obj
 appsettings.json
 local.settings.json
 __blobstorage__
+.debug
 __queuestorage__
 __azurite_db*__.json`)
       );

--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
@@ -62,7 +62,13 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
       await writeFormattedJson(localSettingsJsonPath, localSettingsJson);
     }
 
-    const gitignorePath: string = path.join(context.projectPath, gitignoreFileName);
+    // Determine the base directory for the .gitignore file.
+    // If 'isCustomCodeLogicApp' is explicitly false (neither true nor null),
+    // use the parent directory of 'workspacePath'. Otherwise, use 'projectPath'.
+    const baseDirectory =
+      !context.isCustomCodeLogicApp && context.isCustomCodeLogicApp !== null ? path.dirname(context.workspacePath) : context.projectPath;
+    const gitignorePath = path.join(baseDirectory, gitignoreFileName);
+
     if (await confirmOverwriteFile(context, gitignorePath)) {
       await fse.writeFile(
         gitignorePath,
@@ -74,6 +80,7 @@ appsettings.json
 local.settings.json
 __blobstorage__
 .debug
+.gitignore
 __queuestorage__
 __azurite_db*__.json
 

--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
@@ -75,7 +75,12 @@ local.settings.json
 __blobstorage__
 .debug
 __queuestorage__
-__azurite_db*__.json`)
+__azurite_db*__.json
+
+# Added folders and file patterns
+workflow-designtime/
+.vscode/
+*.code-workspace`)
       );
     }
 

--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
@@ -80,7 +80,6 @@ appsettings.json
 local.settings.json
 __blobstorage__
 .debug
-.gitignore
 __queuestorage__
 __azurite_db*__.json
 

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -229,6 +229,7 @@ async function callStandardResourcesApi(
     }
 
     const apiUrl = `http://localhost:${ext.workflowDesignTimePort}${managementApiPrefix}/generateDeploymentArtifacts`;
+    ext.outputChannel.appendLog(localize('apiUrl', `Calling API URL: ${apiUrl}`));
 
     // Construct the request body based on the parameters
     const deploymentArtifactsInput = {
@@ -250,7 +251,7 @@ async function callStandardResourcesApi(
         'Content-Type': 'application/json',
         Accept: 'application/zip',
       },
-      encoding: 'binary', // <-- Ensure response is treated as binary data
+      encoding: 'binary',
     };
 
     ext.outputChannel.appendLog(
@@ -264,7 +265,12 @@ async function callStandardResourcesApi(
     ext.outputChannel.appendLog(localize('apiCallSuccessful', 'API call successful, processing response...'));
     return Buffer.from(response, 'binary');
   } catch (error) {
-    ext.outputChannel.appendLog(localize('failedStandardResourcesApiCall', 'Failed to call Standard Resources API.'));
+    ext.outputChannel.appendLog(
+      localize('failedStandardResourcesApiCall', `Failed to call Standard Resources API. Error: ${error.message || error}`)
+    );
+    if (error.stack) {
+      ext.outputChannel.appendLog(localize('errorStack', `Error Stack: ${error.stack}`));
+    }
     await handleError(error, localize('errorStandardResourcesApi', 'Error calling Standard Resources API'));
   }
 }
@@ -348,9 +354,7 @@ async function gatherAndValidateInputs(scriptContext: IAzureScriptWizard, folder
   try {
     ext.outputChannel.appendLog(localize('fetchLocalSettingsAttempt', 'Attempting to fetch local settings...'));
     localSettings = await getLocalSettings(scriptContext, folder);
-    ext.outputChannel.appendLog(
-      localize('fetchLocalSettingsSuccess', `Successfully fetched local settings: ${JSON.stringify(localSettings)}`)
-    );
+    ext.outputChannel.appendLog(localize('fetchLocalSettingsSuccess', `Successfully fetched local settings from ${localSettings}`));
   } catch (error) {
     ext.outputChannel.appendLog(localize('fetchLocalSettingsError', `Error fetching local settings: ${error}`));
     await handleError(error, localize('handleErrorFetchLocalSettings', 'Error fetching local settings'));

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/iacGestureHelperFunctions.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/iacGestureHelperFunctions.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../../extensionVariables';
 import * as vscode from 'vscode';
 
 export class FileManagement {
@@ -11,17 +12,24 @@ export class FileManagement {
    */
   public static addFolderToWorkspace(folderPath: string): void {
     try {
+      ext.outputChannel.appendLog(`Adding folder to workspace: ${folderPath}`);
+
       const uri = vscode.Uri.file(folderPath);
       const existingFolders = vscode.workspace.workspaceFolders || [];
-
-      // Check if the folder is already in the workspace
       const isAlreadyInWorkspace = existingFolders.some((folder) => folder.uri.fsPath === folderPath);
 
-      // Add the folder to the workspace if it's not already there
       if (!isAlreadyInWorkspace) {
-        vscode.workspace.updateWorkspaceFolders(0, null, { uri });
+        const result = vscode.workspace.updateWorkspaceFolders(0, null, { uri });
+        if (result) {
+          ext.outputChannel.appendLog(`Folder added successfully: ${folderPath}`);
+        } else {
+          ext.outputChannel.appendLog(`Failed to add folder to workspace (updateWorkspaceFolders returned false): ${folderPath}`);
+        }
+      } else {
+        ext.outputChannel.appendLog(`Folder is already in the workspace: ${folderPath}`);
       }
     } catch (error) {
+      ext.outputChannel.appendLog(`Error in addFolderToWorkspace: ${error}`);
       vscode.window.showErrorMessage('Failed to add folder to workspace: ' + error.message);
     }
   }
@@ -30,25 +38,28 @@ export class FileManagement {
    * Converts a directory to a valid multi root workspace.
    * @param targetDirectory - The directory to be converted.
    */
+
   public static convertToValidWorkspace(targetDirectory: string): void {
     try {
+      ext.outputChannel.appendLog(`Converting directory to valid workspace: ${targetDirectory}`);
       const workspaceFolders = vscode.workspace.workspaceFolders;
       const folderPaths = workspaceFolders?.map((folder) => folder.uri.fsPath) || [];
 
-      // Check if the target directory is already a workspace folder
       if (folderPaths.includes(targetDirectory)) {
+        ext.outputChannel.appendLog(`Directory is already a workspace folder: ${targetDirectory}`);
         return;
       }
 
-      // Add the target directory as the root workspace folder
       folderPaths.unshift(targetDirectory);
-
-      // Update the workspace folders with the new configuration
       const added = vscode.workspace.updateWorkspaceFolders(0, null, ...folderPaths.map((path) => ({ uri: vscode.Uri.file(path) })));
+
       if (!added) {
         throw new Error(workspaceFolders ? 'Failed to add folder to workspace' : 'Failed to create workspace');
+      } else {
+        ext.outputChannel.appendLog(`Workspace folders updated successfully with new directory: ${targetDirectory}`);
       }
     } catch (error) {
+      ext.outputChannel.appendLog(`Error in convertToValidWorkspace: ${error}`);
       vscode.window.showErrorMessage('Failed to convert to valid workspace: ' + error.message);
     }
   }

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/iacGestureHelperFunctions.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/iacGestureHelperFunctions.ts
@@ -1,7 +1,12 @@
-// Update the import path as needed
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import * as vscode from 'vscode';
+
+import { ext } from '../../../extensionVariables';
 
 export class FileManagement {
   /**

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/iacGestureHelperFunctions.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/iacGestureHelperFunctions.ts
@@ -1,8 +1,6 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Update the import path as needed
 import { ext } from '../../../extensionVariables';
+import { localize } from '../../../localize';
 import * as vscode from 'vscode';
 
 export class FileManagement {
@@ -12,7 +10,7 @@ export class FileManagement {
    */
   public static addFolderToWorkspace(folderPath: string): void {
     try {
-      ext.outputChannel.appendLog(`Adding folder to workspace: ${folderPath}`);
+      ext.outputChannel.appendLog(localize('addingFolderToWorkspace', `Adding folder to workspace: ${folderPath}`));
 
       const uri = vscode.Uri.file(folderPath);
       const existingFolders = vscode.workspace.workspaceFolders || [];
@@ -21,16 +19,18 @@ export class FileManagement {
       if (!isAlreadyInWorkspace) {
         const result = vscode.workspace.updateWorkspaceFolders(0, null, { uri });
         if (result) {
-          ext.outputChannel.appendLog(`Folder added successfully: ${folderPath}`);
+          ext.outputChannel.appendLog(localize('folderAddedSuccessfully', `Folder added successfully: ${folderPath}`));
         } else {
-          ext.outputChannel.appendLog(`Failed to add folder to workspace (updateWorkspaceFolders returned false): ${folderPath}`);
+          ext.outputChannel.appendLog(
+            localize('failedToAddFolder', `Failed to add folder to workspace (updateWorkspaceFolders returned false): ${folderPath}`)
+          );
         }
       } else {
-        ext.outputChannel.appendLog(`Folder is already in the workspace: ${folderPath}`);
+        ext.outputChannel.appendLog(localize('folderAlreadyInWorkspace', `Folder is already in the workspace: ${folderPath}`));
       }
     } catch (error) {
-      ext.outputChannel.appendLog(`Error in addFolderToWorkspace: ${error}`);
-      vscode.window.showErrorMessage('Failed to add folder to workspace: ' + error.message);
+      ext.outputChannel.appendLog(localize('errorAddingFolder', `Error in addFolderToWorkspace: ${error}`));
+      vscode.window.showErrorMessage(localize('errorMessageAddingFolder', 'Failed to add folder to workspace: ') + error.message);
     }
   }
 
@@ -38,15 +38,19 @@ export class FileManagement {
    * Converts a directory to a valid multi root workspace.
    * @param targetDirectory - The directory to be converted.
    */
-
   public static convertToValidWorkspace(targetDirectory: string): void {
     try {
-      ext.outputChannel.appendLog(`Converting directory to valid workspace: ${targetDirectory}`);
+      ext.outputChannel.appendLog(
+        localize('convertingDirectoryToWorkspace', `Converting directory to valid workspace: ${targetDirectory}`)
+      );
+
       const workspaceFolders = vscode.workspace.workspaceFolders;
       const folderPaths = workspaceFolders?.map((folder) => folder.uri.fsPath) || [];
 
       if (folderPaths.includes(targetDirectory)) {
-        ext.outputChannel.appendLog(`Directory is already a workspace folder: ${targetDirectory}`);
+        ext.outputChannel.appendLog(
+          localize('directoryAlreadyWorkspaceFolder', `Directory is already a workspace folder: ${targetDirectory}`)
+        );
         return;
       }
 
@@ -54,13 +58,21 @@ export class FileManagement {
       const added = vscode.workspace.updateWorkspaceFolders(0, null, ...folderPaths.map((path) => ({ uri: vscode.Uri.file(path) })));
 
       if (!added) {
-        throw new Error(workspaceFolders ? 'Failed to add folder to workspace' : 'Failed to create workspace');
+        throw new Error(
+          workspaceFolders
+            ? localize('failedToAddFolderToWorkspace', 'Failed to add folder to workspace')
+            : localize('failedToCreateWorkspace', 'Failed to create workspace')
+        );
       } else {
-        ext.outputChannel.appendLog(`Workspace folders updated successfully with new directory: ${targetDirectory}`);
+        ext.outputChannel.appendLog(
+          localize('workspaceFoldersUpdated', `Workspace folders updated successfully with new directory: ${targetDirectory}`)
+        );
       }
     } catch (error) {
-      ext.outputChannel.appendLog(`Error in convertToValidWorkspace: ${error}`);
-      vscode.window.showErrorMessage('Failed to convert to valid workspace: ' + error.message);
+      ext.outputChannel.appendLog(localize('errorConvertingToWorkspace', `Error in convertToValidWorkspace: ${error}`));
+      vscode.window.showErrorMessage(
+        localize('errorMessageConvertingToWorkspace', 'Failed to convert to valid workspace: ') + error.message
+      );
     }
   }
 }

--- a/apps/vs-code-designer/src/app/utils/taskUtils.ts
+++ b/apps/vs-code-designer/src/app/utils/taskUtils.ts
@@ -116,9 +116,22 @@ export function showPreviewWarning(commandIdentifier: string): void {
  * @param messagePrefix - A string prefix that will be prepended to the error message.
  * @throws {Error} - Throws a new Error with a localized message including the prefix and error details.
  */
-export async function handleError(error: any, messagePrefix: string) {
-  const errorString = JSON.stringify(error, Object.getOwnPropertyNames(error));
-  const localizedMessage = localize('handleError.errorMessage', messagePrefix, errorString);
-  vscode.window.showErrorMessage(localizedMessage);
-  throw new Error(localize('handleError.error', messagePrefix, errorString));
+export async function handleError(error: Error, messagePrefix: string): Promise<void> {
+  let errorDetails: string = error.message || 'Unknown Error';
+
+  if (error.stack) {
+    errorDetails += `\nStack Trace: ${error.stack}`;
+  }
+
+  // Serializing other potential properties on the error object
+  const additionalErrorInfo: string = JSON.stringify(error, Object.getOwnPropertyNames(error));
+  if (additionalErrorInfo && additionalErrorInfo !== '{}') {
+    errorDetails += `\nAdditional Info: ${additionalErrorInfo}`;
+  }
+
+  const fullErrorMessage = `${messagePrefix}: ${errorDetails}`;
+  vscode.window.showErrorMessage(fullErrorMessage);
+
+  // Throwing a new error with the composed message for consistency and clarity
+  throw new Error(localize('handleError.error', fullErrorMessage));
 }

--- a/libs/vscode-extension/src/lib/models/project.ts
+++ b/libs/vscode-extension/src/lib/models/project.ts
@@ -65,6 +65,7 @@ export interface IProjectWizardContext extends IActionContext {
   openApiSpecificationFile?: Uri[];
   targetFramework?: string | string[];
   isCustomCodeLogicApp?: boolean;
+  logicAppName?: string;
 }
 
 export enum OpenBehavior {


### PR DESCRIPTION
### PR Description
---

#### What kind of change does this PR introduce?
This PR introduces both a bug fix and a feature update. It improves the handling and naming of Logic App project folders and integrates a more dynamic structure for managing workspace folders and initializing git repositories in custom Logic App projects.

---

#### What is the current behavior?
Currently, the naming convention for Logic App projects and the structure of the workspace folders are static, defaulting to "LogicApp". Additionally, the git repository initialization doesn't check if the workspace folder is already part of a git repository, leading to potential redundant initializations.

---

#### What is the new behavior (if this is a feature change)?
- **Dynamic Folder Naming**: The Logic App project folders are now named based on the user input (`context.logicAppName`). If no name is provided, it defaults to "LogicApp", if it is a custom code workspace. If it is a deafult logic app project, we throw an error. 
- **Workspace Folder Update**: In custom code Logic App projects, a 'Functions' folder is added to the workspace for better organization.
- **Git Initialization Check**: The git repository initialization process now includes checks to prevent redundant repository initializations within existing git repositories.

---

#### Does this PR introduce a breaking change?
No breaking changes are introduced. Users will find the new dynamic naming feature and folder structure more flexible, but it won't require any changes in their existing applications.

---

### Updates Summary:

- Enhanced **folder naming** and **structure** in Logic App projects based on user-defined names.
- Added **'Functions' folder** for better organization in custom code Logic App projects.
- Implemented checks for **git repository initialization** to avoid redundancy.
- Ensured the **wizard prompt step** in the Azure Wizard is more intuitive and error-proof, mandating a project name for Logic Apps.
- **Updated `.gitignore`** for better management of Azure-specific and development-specific files and folders.

---

_This PR targets some key improvements in how Logic App projects are set up and managed, focusing on flexibility, organization, and reducing the chances of redundant operations, specifically in source control management. 

[work Item 25644784](https://msazure.visualstudio.com/One/_workitems/edit/25644784)
