### PR TITLE
fix(Designer): Sort parameters alphabetically in `designer` instead of inside `designer-ui`. 

### DIFF
--- a/libs/designer-ui/src/lib/combobox/__test__/combobox.spec.tsx
+++ b/libs/designer-ui/src/lib/combobox/__test__/combobox.spec.tsx
@@ -65,7 +65,7 @@ describe('lib/combobox', () => {
     });
   });
 
-  it('ensures options are sorted alphabetically and special option is at the end', () => {
+  it('ensures options conform to the sort order of items passed in', () => {
     const { getByRole, getAllByRole } = render(<Combobox {...defaultProps} />);
     const combobox = getByRole('combobox');
 
@@ -79,9 +79,6 @@ describe('lib/combobox', () => {
     // Ensure the special option is at the end
     expect(optionTexts[optionTexts.length - 1]).toEqual('Enter custom value');
 
-    // Check the rest are sorted
-    const sortedTexts = [...optionTexts.slice(0, -1)].sort((a, b) => a.localeCompare(b));
-
-    expect(optionTexts.slice(0, -1)).toEqual(sortedTexts);
+    expect(optionTexts.slice(0, -1)).toEqual(defaultProps.options.map((option) => option.displayName));
   });
 });

--- a/libs/designer-ui/src/lib/combobox/index.tsx
+++ b/libs/designer-ui/src/lib/combobox/index.tsx
@@ -94,9 +94,6 @@ export const Combobox = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading]);
 
-  // Sort newOptions array alphabetically based on the `displayName` property.
-  options.sort((currentItem, nextItem) => currentItem.displayName.localeCompare(nextItem.displayName));
-
   const comboboxOptions = useMemo(() => {
     const loadingOption: ComboboxItem = {
       key: 'isloading',

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2063,6 +2063,9 @@ export async function loadDynamicValuesForParameter(
           workflowParameters
         );
 
+        // Sort Dynamic Values alphabetically ASC
+        dynamicValues.sort((currentItem, nextItem) => currentItem.displayName.localeCompare(nextItem.displayName));
+
         dispatch(
           updateNodeParameters({
             nodeId,


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adding back the default sort alphabetically(ASC) to dropdowns. I previously added this functionality, but according to [this comment](https://github.com/Azure/LogicAppsUX/pull/3499#discussion_r1367742809) learned that I implemented the logic in the wrong place. This PR is to improve on that previous change and fix my previous mistake.

- **What is the current behavior?** (You can also link to an open issue here)

https://github.com/Azure/LogicAppsUX/pull/3499

- **What is the new behavior (if this is a feature change)?**

Sort dropdown items alphabetically(ASC) by default.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

![image](https://github.com/Azure/LogicAppsUX/assets/3086302/1e33ae9f-cf1c-456e-b3ef-e11cf2f429b2)


AB#25650822