### PR TITLE
chore(ci): Removal of apps/vs-code-data-mapper in prod pipeline

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -69,13 +69,6 @@ jobs:
       - name: 'Local Version Bump'
         run: ${{ env.BUMP_COMMAND }} --skip.commit --skip.tag
 
-      - name: 'Set DM VSIX aiKey in package.json'
-        run: echo "`jq '.aiKey="${{ env.AI_KEY }}"' apps/vs-code-data-mapper/src/package.json`" > apps/vs-code-data-mapper/src/package.json
-
-      - run: npx nx build vs-code-data-mapper
-      - run: npx nx build vs-code-data-mapper-react
-      - run: npm run vscode:data-mapper:pack
-
       - name: 'Set Designer Extension VSIX aiKey in package.json'
         run: echo "`jq '.aiKey="${{ env.AI_KEY }}"' apps/vs-code-designer/src/package.json`" > apps/vs-code-designer/src/package.json
 
@@ -92,12 +85,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: |
-            dist/apps/vs-code-data-mapper/*.vsix
             dist/apps/vs-code-designer/*.vsix
 
       - uses: ncipollo/release-action@v1
         with:
-          artifacts: 'LICENSE.md,dist/apps/vs-code-data-mapper/*.vsix,dist/apps/vs-code-designer/*.vsix'
+          artifacts: 'LICENSE.md,dist/apps/vs-code-designer/*.vsix'
           generateReleaseNotes: true
           tag: '${{ steps.previoustag.outputs.tag }}'
           token: ${{ secrets.AUTOMATION_PAT }}

--- a/.versionrc
+++ b/.versionrc
@@ -27,10 +27,6 @@
       "type": "json"
     },
     {
-      "filename": "apps/vs-code-data-mapper/src/package.json",
-      "type": "json"
-    },
-    {
       "filename": "libs/data-mapper/package.json",
       "type": "json"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Logic Apps Designer
+### [2.80.1](https://github.com/Azure/LogicAppsUX/compare/v2.80.0...v2.80.1) (2023-11-02)
+
 ## [2.80.0](https://github.com/Azure/LogicAppsUX/compare/v2.79.0...v2.80.0) (2023-11-02)
 
 

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-azurelogicapps",
   "displayName": "Azure Logic Apps (Standard)",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "aiKey": "setInGitHubBuild",
   "repository": "https://github.com/Azure/LogicAppsUX",
   "main": "main.js",

--- a/libs/chatbot/package.json
+++ b/libs/chatbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/logic-apps-chatbot",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "scripts": {
     "yalcpush": "yalc push ../../dist/libs/chatbot"
   },

--- a/libs/data-mapper/package.json
+++ b/libs/data-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/logic-apps-data-mapper",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "scripts": {
     "yalcpush": "yalc push ../../dist/libs/data-mapper"
   }

--- a/libs/designer-ui/package.json
+++ b/libs/designer-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/designer-ui",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "scripts": {
     "yalcpush": "yalc push ../../dist/libs/designer-ui"
   },

--- a/libs/designer/package.json
+++ b/libs/designer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/logic-apps-designer",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "scripts": {
     "yalcpush": "yalc push ../../dist/libs/designer"
   },

--- a/libs/parsers/package.json
+++ b/libs/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/parsers-logic-apps",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "scripts": {
     "yalcpush": "yalc push ../../dist/libs/parsers"
   }

--- a/libs/services/designer-client-services/package.json
+++ b/libs/services/designer-client-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/designer-client-services-logic-apps",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "scripts": {
     "yalcpush": "yalc push ../../../dist/libs/services/designer-client-services"
   }

--- a/libs/services/intl/package.json
+++ b/libs/services/intl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/intl-logic-apps",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "scripts": {
     "yalcpush": "yalc push ../../../dist/libs/services/intl"
   }

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/utils-logic-apps",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "scripts": {
     "yalcpush": "yalc push ../../dist/libs/utils"
   }

--- a/libs/vscode-extension/package.json
+++ b/libs/vscode-extension/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@microsoft/vscode-extension-logic-apps",
-  "version": "2.80.0"
+  "version": "2.80.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "license": "MIT",
   "scripts": {
     "start": "nx serve",


### PR DESCRIPTION
Seems like there was a moving of Data mapper into Vscode Designer, and our prod pipeline was referencing unused vs-code-data-mapper code. This should fix our prod build