### PR TITLE
fix(designer): Alert error messages for required editor fields

### DIFF
--- a/libs/designer/src/lib/ui/settings/settingsection.tsx
+++ b/libs/designer/src/lib/ui/settings/settingsection.tsx
@@ -330,7 +330,11 @@ const Setting = ({ id, settings, isReadOnly }: { id?: string; settings: Settings
       <div key={i} style={{ display: 'flex', gap: '4px' }}>
         <div className={getClassName()} style={{ flex: '1 1 auto' }}>
           {renderSetting()}
-          {errorMessage && !hideErrorMessage[i] && <div className="msla-input-parameter-error">{errorMessage}</div>}
+          {errorMessage && !hideErrorMessage[i] && (
+            <span className="msla-input-parameter-error" role="alert">
+              {errorMessage}
+            </span>
+          )}
         </div>
         <RemoveConditionalParameter />
       </div>


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Error messages under editors show up, but the parameter-error element is not focusable, so the error message is not visible to keyboard users.

- **What is the new behavior (if this is a feature change)?**
Error message is alerted when the element is rendered -- for reference, `msla-input-parameter-error` render happens 1) when the user initially leaves a required editor field blank, and 2) when the parameters panel is opened.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

- **Please Include Screenshots or Videos of the intended change**:
![image](https://github.com/Azure/LogicAppsUX/assets/10837129/d3b75807-e056-4cb0-90fb-4fedfad7959d)
