### PR TITLE
fix(vscode): Update permissions to binary func file

### DIFF
--- a/apps/vs-code-designer/src/app/utils/funcCoreTools/funcVersion.ts
+++ b/apps/vs-code-designer/src/app/utils/funcCoreTools/funcVersion.ts
@@ -165,6 +165,7 @@ export async function setFunctionsCommand(): Promise<void> {
   if (binariesExist) {
     command = path.join(funcBinariesPath, ext.funcCliPath);
     fs.chmodSync(funcBinariesPath, 0o777);
+    fs.chmodSync(command, 0o777);
   }
 
   await updateGlobalSetting<string>(funcCoreToolsBinaryPathSettingKey, command);


### PR DESCRIPTION
### Main Code Change
- Update permissions specifically to func core tools file executable