### PR TITLE
fix(copilot): Making 'Preview' white in dark mode

### DIFF
--- a/libs/chatbot/src/lib/ui/styles.less
+++ b/libs/chatbot/src/lib/ui/styles.less
@@ -164,9 +164,4 @@
       background-color: #141313;
     }
   }
-  .msla-chatbot-header-title-container {
-    .msla-chatbot-header-subtitle {
-      color: #a9a9a9;
-    }
-  }
 }


### PR DESCRIPTION
Removing code that was making preview gray in dark mode so that it now shows up as white to have good contrast.

Before:
<img width="217" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/103c92d3-a122-48e8-b544-94819203ef61">

After:
<img width="220" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/e8fc1f54-4ab4-4b3f-9fc7-ba2dd2b4367f">
