### PR TITLE
fix(Data Mapper): Reenabled Generate On Clean State

### DIFF
--- a/libs/data-mapper/src/lib/components/commandBar/EditorCommandBar.tsx
+++ b/libs/data-mapper/src/lib/components/commandBar/EditorCommandBar.tsx
@@ -174,7 +174,7 @@ export const EditorCommandBar = (props: EditorCommandBarProps) => {
         <ToolbarButton
           aria-label={Resources.GENERATE}
           icon={<ArrowExportLtr20Regular />}
-          disabled={!bothSchemasDefined || !isStateDirty}
+          disabled={!bothSchemasDefined}
           onClick={onGenerateClick}
         >
           {Resources.GENERATE}


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix
- **What is the current behavior?** (You can also link to an open issue here)
generate is disabled when save is disabled
- **What is the new behavior (if this is a feature change)?**
generate xslt button is always enabled after the schemas are defined
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
- **Please Include Screenshots or Videos of the intended change**:
<img width="1460" alt="image (1)" src="https://github.com/Azure/LogicAppsUX/assets/144840522/cb59bb68-48bc-48f6-8d68-96c3a1dffe72">
<img width="1431" alt="image (2)" src="https://github.com/Azure/LogicAppsUX/assets/144840522/72beee1c-f980-40b9-94b3-9faff2f260a5">


