### PR TITLE
fix(vscode): Add validation of func command

### DIFF
--- a/apps/vs-code-designer/src/app/utils/funcCoreTools/funcVersion.ts
+++ b/apps/vs-code-designer/src/app/utils/funcCoreTools/funcVersion.ts
@@ -165,7 +165,11 @@ export async function setFunctionsCommand(): Promise<void> {
   if (binariesExist) {
     command = path.join(funcBinariesPath, ext.funcCliPath);
     fs.chmodSync(funcBinariesPath, 0o777);
-    fs.chmodSync(command, 0o777);
+
+    const funcExist = await fs.existsSync(command);
+    if (funcExist) {
+      fs.chmodSync(command, 0o777);
+    }
   }
 
   await updateGlobalSetting<string>(funcCoreToolsBinaryPathSettingKey, command);


### PR DESCRIPTION
This pull request to apps/vs-code-designer/src/app/utils/funcCoreTools improves the functionality of the codebase by adding a check to see if the function CLI exists before changing its permissions to 0o777 in `funcVersion.ts`.

Main change:

* <a href="diffhunk://#diff-436495b34a1c79b441856b49bb7d4d20c84e4dd38eb2d2f58aa9dae0e50c2f65R168-R173">`apps/vs-code-designer/src/app/utils/funcCoreTools/funcVersion.ts`</a>: Added a check to see if the function CLI exists before changing its permissions to 0o777.