### PR TITLE
fix(vscode): Add validation for workspace folder path as string

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createCodeless/createCodeless.ts
+++ b/apps/vs-code-designer/src/app/commands/createCodeless/createCodeless.ts
@@ -32,7 +32,7 @@ export async function createCodeless(
   workspacePath = isString(workspacePath) ? workspacePath : undefined;
   if (workspacePath === undefined) {
     workspaceFolder = await getWorkspaceFolder(context);
-    workspacePath = workspaceFolder.uri.fsPath;
+    workspacePath = isString(workspaceFolder) ? workspaceFolder : workspaceFolder.uri.fsPath;
   } else {
     workspaceFolder = getContainingWorkspace(workspacePath);
   }


### PR DESCRIPTION
This pull request to the `apps/vs-code-designer` app modifies the `createCodeless` function to allow `workspaceFolder` to be either a string or an object with a `uri` property, instead of just a string.

Main code change:

* <a href="diffhunk://#diff-2635cfa991b8fa950c0b76e46d2058c2c771d27a278847b77938d7f14ce5709cL35-R35">`apps/vs-code-designer/src/app/commands/createCodeless/createCodeless.ts`</a>: The `createCodeless` function now allows `workspaceFolder` to be either a string or an object with a `uri` property.