### PR TITLE
fix(designer): Using segment values instead of token values, which fails in the Condition Editors

### DIFF
--- a/__mocks__/workflows/Panel.json
+++ b/__mocks__/workflows/Panel.json
@@ -34,7 +34,7 @@
       "Parse_JSON": {
         "type": "ParseJson",
         "inputs": {
-          "content": "@triggerBody()?['string']",
+          "content": "@{triggerBody()?['string']}@{variables('ArrayVariable')}",
           "schema": {
             "type": "array",
             "items": {
@@ -66,6 +66,22 @@
         },
         "runAfter": {
           "Parse_JSON": ["SUCCEEDED"]
+        }
+      },
+      "HTTP": {
+        "type": "Http",
+        "inputs": {
+          "uri": "http://test.com",
+          "method": "GET",
+          "body": "@variables('ArrayVariable')"
+        },
+        "runAfter": {
+          "Filter_array": ["SUCCEEDED"]
+        },
+        "runtimeConfiguration": {
+          "contentTransfer": {
+            "transferMode": "Chunked"
+          }
         }
       }
     },

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
@@ -88,7 +88,7 @@ export function TokenPickerFooter({
   const insertOutputToken = async (outputToken: TokenGroupToken) => {
     const { brandColor, icon, title, description, value } = outputToken;
     const segment = await getValueSegmentFromToken(outputToken, false);
-    insertToken({ brandColor, description, title, icon, value, data: segment });
+    insertToken({ brandColor, description, title, icon, value, data: { ...segment, value: value ?? segment.value } });
   };
 
   const onUpdateOrAddClicked = () => {

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
@@ -88,7 +88,7 @@ export function TokenPickerFooter({
   const insertOutputToken = async (outputToken: TokenGroupToken) => {
     const { brandColor, icon, title, description, value } = outputToken;
     const segment = await getValueSegmentFromToken(outputToken, false);
-    insertToken({ brandColor, description, title, icon, value, data: { ...segment, value: value ?? segment.value } });
+    insertToken({ brandColor, description, title, icon, value, data: segment });
   };
 
   const onUpdateOrAddClicked = () => {

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -140,7 +140,7 @@ export const TokenPickerOptions = ({
         title,
         icon,
         value,
-        data: { ...segment, value: value ?? segment.value },
+        data: segment,
       });
       closeTokenPicker();
     }

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -86,8 +86,7 @@ export const TokenPickerOptions = ({
   };
 
   const handleTokenExpressionClicked = async (token: OutputToken) => {
-    const segment = await getValueSegmentFromToken(token, !tokenClickedCallback);
-    const expression = segment.value ?? token.value ?? '';
+    const expression = token.value ?? '';
     insertExpressionText(expression, 0);
   };
 
@@ -141,7 +140,7 @@ export const TokenPickerOptions = ({
         title,
         icon,
         value,
-        data: segment,
+        data: { ...segment, value: value ?? segment.value },
       });
       closeTokenPicker();
     }

--- a/libs/designer/src/lib/core/utils/parameters/__test__/segment.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/segment.spec.ts
@@ -50,9 +50,6 @@ describe('core/utils/parameters/segment', () => {
 
     it('should convert template expression to token segment successfully with uncasting.', () => {
       const convertor = new ValueSegmentConvertor({
-        repetitionContext: {
-          repetitionReferences: [],
-        },
         shouldUncast: true,
         rawModeEnabled: true,
       });
@@ -194,7 +191,7 @@ describe('core/utils/parameters/segment', () => {
       expectLiteralSegment(segments[8], ': ');
       expectLiteralSegment(segments[9], '"');
       expectOutputTokenSegment(segments[10], undefined, OutputSource.Body, 'foo', 'outputs.$.body.foo', undefined, true);
-      expectVariableTokenSegment(segments[11], 'v');
+      expectVariableTokenSegment(segments[11], 'v', "variables('v')");
       expectLiteralSegment(segments[12], '"');
       expectLiteralSegment(segments[13], ',\n  ');
       expectLiteralSegment(segments[14], '"expression"');
@@ -205,9 +202,6 @@ describe('core/utils/parameters/segment', () => {
 
     it('should convert FX token expression to token segment successfully.', () => {
       const convertor = new ValueSegmentConvertor({
-        repetitionContext: {
-          repetitionReferences: [],
-        },
         shouldUncast: false,
         rawModeEnabled: true,
       });
@@ -259,7 +253,7 @@ export function expectExpressionTokenSegment(segment: ValueSegment | undefined |
   expect(segment?.value).toEqual(value);
 }
 
-export function expectVariableTokenSegment(segment: ValueSegment | undefined | null, variableName: string, value?: string): void {
+export function expectVariableTokenSegment(segment: ValueSegment | undefined | null, variableName: string, value: string): void {
   expect(segment).toBeDefined();
   expect(segment).not.toBeNull();
   expect(segment?.type).toEqual(ValueSegmentType.TOKEN);
@@ -269,7 +263,7 @@ export function expectVariableTokenSegment(segment: ValueSegment | undefined | n
     key: variableName,
     name: variableName,
     title: variableName,
-    value: variableName,
+    value: value,
     description: variableName,
     brandColor: '#770bd6',
     icon: VariableIcon,

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -337,7 +337,14 @@ export function isOutputToken(token: Token): token is Token {
  * @arg {string} [value] - The value.
  * @return {Token}
  */
-export function createOutputToken(key: string, actionName: string | undefined, source: string, name: string, required: boolean): Token {
+export function createOutputToken(
+  key: string,
+  actionName: string | undefined,
+  source: string,
+  name: string,
+  required: boolean,
+  value: string
+): Token {
   const token: Token = {
     actionName,
     source,
@@ -346,7 +353,7 @@ export function createOutputToken(key: string, actionName: string | undefined, s
     required,
     tokenType: TokenType.OUTPUTS,
     title: name,
-    value: name,
+    value,
   };
 
   return token;
@@ -375,10 +382,10 @@ export function createExpressionToken(expression: Expression): Token {
  * @arg {string} variableName - The variable name.
  * @return {Token}
  */
-export function createVariableToken(variableName: string): Token {
+export function createVariableToken(variableName: string, expression: string): Token {
   return {
     description: variableName,
-    value: variableName,
+    value: expression,
     key: variableName,
     title: variableName,
     name: variableName,

--- a/libs/designer/src/lib/core/utils/parameters/tokensegment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/tokensegment.ts
@@ -27,16 +27,16 @@ export class TokenSegmentConvertor {
       const name = this._getTokenName(expression, source);
       const outputKey = this._getOutputKey(expression);
       const required = !!this._isTokenRequired(expression, source);
-
-      return createTokenValueSegment(createOutputToken(outputKey, step, source, name, required), value);
+      const outputToken = createOutputToken(outputKey, step, source, name, required, value);
+      return createTokenValueSegment(outputToken, value);
     } else if (this._isParameterToken(expression)) {
       const parameterName = (expression.arguments[0] as ExpressionLiteral).value;
 
       return createTokenValueSegment(createParameterToken(parameterName), value);
     } else if (TokenSegmentConvertor.isVariableToken(expression)) {
       const variableName = (expression.arguments[0] as ExpressionLiteral).value;
-
-      return createTokenValueSegment(createVariableToken(variableName), value);
+      const variableToken = createVariableToken(variableName, expression.expression);
+      return createTokenValueSegment(variableToken, value);
     } else if (TokenSegmentConvertor.isItemToken(expression)) {
       const source = this._getTokenSource(expression);
       const name = this._getTokenName(expression, source);

--- a/libs/designer/src/lib/core/utils/tokens.ts
+++ b/libs/designer/src/lib/core/utils/tokens.ts
@@ -296,10 +296,11 @@ export const createValueSegmentFromToken = async (
 ): Promise<ValueSegment> => {
   const tokenOwnerNodeId = token.outputInfo.actionName ?? getTriggerNodeId(rootState.workflow);
   const nodeType = rootState.operations.operationInfo[tokenOwnerNodeId].type;
-  const tokenValueSegment = convertTokenToValueSegment(token, nodeType);
+  const idReplacements = rootState.workflow.idReplacements;
+  const tokenValueSegment = convertTokenToValueSegment(token, nodeType, idReplacements);
 
   if (addLatestActionName && tokenValueSegment.token?.actionName) {
-    const newActionId = rootState.workflow.idReplacements[tokenValueSegment.token.actionName];
+    const newActionId = idReplacements[tokenValueSegment.token.actionName];
     if (newActionId && newActionId !== tokenValueSegment.token.actionName) {
       tokenValueSegment.token.actionName = newActionId;
     }
@@ -385,7 +386,7 @@ const getTokenValueSegmentTokenType = (token: OutputToken, nodeType: string): To
   return TokenType.OUTPUTS;
 };
 
-const convertTokenToValueSegment = (token: OutputToken, nodeType: string): ValueSegment => {
+const convertTokenToValueSegment = (token: OutputToken, nodeType: string, replacementIds: Record<string, string>): ValueSegment => {
   const tokenType = getTokenValueSegmentTokenType(token, nodeType);
   const { key, brandColor, icon, title, description, name, type, outputInfo } = token;
   const { actionName, required, format, source, isSecure, arrayDetails, schema } = outputInfo;
@@ -411,7 +412,7 @@ const convertTokenToValueSegment = (token: OutputToken, nodeType: string): Value
         }
       : undefined,
     schema,
-    value: getExpressionValueForOutputToken(token, nodeType),
+    value: rewriteValueId(token.outputInfo.actionName ?? '', getExpressionValueForOutputToken(token, nodeType) ?? '', replacementIds),
   };
 
   return createTokenValueSegment(segmentToken, segmentToken.value as string, format);


### PR DESCRIPTION
Fixes https://github.com/Azure/LogicAppsUX/issues/3624
Fixes https://github.com/Azure/LogicAppsUX/issues/3622
![http](https://github.com/Azure/LogicAppsUX/assets/95886809/fe7834ca-cf6c-4fb4-9067-160ea919e52a)

I'll summarize the issue cause going through the code can be confusing, basically, there were 2 places where we ended up doing patchwork

1. parseSegment.ts - this is where we would patch it by using the segment value instead of the token value (when they should be the same thing) - the reason for this was in segment.ts/tokensegment.ts for variables and output tokens instead of passing the expressions and values respectively to set the token value, we were using name/variable name. 
2. tokens.ts - now when actions are renamed, its reflected in the tokenpicker tokens (previously we were not renaming those actions, so they would keep their original names and not be created properly)
