### PR TITLE
feat(designer-ui): Add "See More" to all token picker sections

### DIFF
--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -62,14 +62,17 @@ export const TokenPickerOptions = ({
     });
   }, [index, searchQuery, section.tokens, setTokenLength]);
 
-  const buttonTextMore = intl.formatMessage({
-    defaultMessage: 'See More',
-    description: 'Click to view more token options',
-  });
+  const buttonTextMore = intl.formatMessage(
+    {
+      defaultMessage: 'See More ({count})',
+      description: 'Click to view more token options. {count} indicates the number of total tokens.',
+    },
+    { count: section.tokens.length }
+  );
 
   const buttonTextLess = intl.formatMessage({
     defaultMessage: 'See Less',
-    description: 'Click to view less token options',
+    description: 'Click to view less token options.',
   });
 
   const handleMoreLess = () => {

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -219,9 +219,6 @@ export const TokenPickerOptions = ({
                         {token.description}
                       </div>
                     </div>
-                    {/* {token.type && token.outputInfo?.type !== TokenType.FX ? (
-                      <div className="msla-token-picker-option-type">{token.type}</div>
-                    ) : null} */}
                   </div>
                 </button>
               );

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -24,6 +24,8 @@ interface TokenPickerOptionsProps extends TokenPickerBaseProps {
   setTokenLength: Dispatch<SetStateAction<number[]>>;
 }
 
+const maxTokensPerSection = 6;
+
 export const TokenPickerOptions = ({
   selectedKey,
   section,
@@ -166,6 +168,12 @@ export const TokenPickerOptions = ({
   const sectionHeaderColorRgb = lighten(sectionBrandColorRgb, 0.9);
   const sectionHeaderColorCss = `rgb(${sectionHeaderColorRgb.red}, ${sectionHeaderColorRgb.green}, ${sectionHeaderColorRgb.blue})`;
 
+  const maxRowsShown = selectedKey === TokenPickerMode.EXPRESSION ? section.tokens.length : maxTokensPerSection;
+  const showSeeMoreOrLessButton = !searchQuery && (
+    hasAdvanced(section.tokens) ||
+    section.tokens.length > maxRowsShown
+  );
+
   return (
     <>
       {(searchQuery && filteredTokens.length > 0) || !searchQuery ? (
@@ -180,42 +188,43 @@ export const TokenPickerOptions = ({
                 <Icon iconName="LockSolid" />
               </div>
             ) : null}
-            <span> {section.label}</span>
-            {searchQuery || !hasAdvanced(section.tokens) ? null : (
+            <span>{section.label}</span>
+            {!showSeeMoreOrLessButton ? null : (
               <button
                 className="msla-token-picker-section-header-button"
                 onClick={handleMoreLess}
                 data-automation-id={`msla-token-picker-section-header-button-${convertUIElementNameToAutomationId(section.label)}`}
               >
-                <span> {moreOptions ? buttonTextMore : buttonTextLess}</span>
+                <span>{moreOptions ? buttonTextMore : buttonTextLess}</span>
               </button>
             )}
           </div>
           <div className="msla-token-picker-section-options">
             {(!searchQuery ? section.tokens : filteredTokens).map((token, j) => {
-              if (!token.isAdvanced || !moreOptions || searchQuery) {
-                return (
-                  <button
-                    className="msla-token-picker-section-option"
-                    data-automation-id={`msla-token-picker-section-option-${j}`}
-                    key={`token-picker-option-${j}`}
-                    onClick={() => handleTokenClicked(token)}
-                  >
-                    <div className="msla-token-picker-section-option-text">
-                      <div className="msla-token-picker-option-inner">
-                        <div className="msla-token-picker-option-title">{token.title}</div>
-                        <div className="msla-token-picker-option-description" title={token.description}>
-                          {token.description}
-                        </div>
-                      </div>
-                      {/* {token.type && token.outputInfo?.type !== TokenType.FX ? (
-                        <div className="msla-token-picker-option-type">{token.type}</div>
-                      ) : null} */}
-                    </div>
-                  </button>
-                );
+              if ((token.isAdvanced || j >= maxRowsShown) && moreOptions && !searchQuery) {
+                return null;
               }
-              return null;
+
+              return (
+                <button
+                  className="msla-token-picker-section-option"
+                  data-automation-id={`msla-token-picker-section-option-${j}`}
+                  key={`token-picker-option-${j}`}
+                  onClick={() => handleTokenClicked(token)}
+                >
+                  <div className="msla-token-picker-section-option-text">
+                    <div className="msla-token-picker-option-inner">
+                      <div className="msla-token-picker-option-title">{token.title}</div>
+                      <div className="msla-token-picker-option-description" title={token.description}>
+                        {token.description}
+                      </div>
+                    </div>
+                    {/* {token.type && token.outputInfo?.type !== TokenType.FX ? (
+                      <div className="msla-token-picker-option-type">{token.type}</div>
+                    ) : null} */}
+                  </div>
+                </button>
+              );
             })}
           </div>
         </>


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

- **What is the current behavior?** (You can also link to an open issue here)

Sections of the token picker show all items no matter how many are in the section. Sections cannot be collapsed or expanded and there is no way to see how many items are in a section.

This PR is a follow-up to: #3675

This PR is also part of the following proposal: #3635

- **What is the new behavior (if this is a feature change)?**

All token picker sections with more than **six** items show "See More (X)" where "X" is the count of items in that section, allowing the section to be collapsed/expanded. Behavior is not changed for expressions tab since this is already based on basic/advanced expressions, except that the "(X)" is added to these headers as well.

Six was chosen for how that number of elements fits comfortably into the token picker. This number can be adjusted fairly easily.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/19d2f677-dfee-4fe6-be31-1959d6d8c4f4)

![token-picker-expandable](https://github.com/Azure/LogicAppsUX/assets/1350074/a7896a2c-3b89-462d-8f7c-2a1645dcbd9f)
