### PR TITLE
fix(vscode): Fix nullish setting when getting user settings

### DIFF
--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
@@ -21,7 +21,7 @@ import type { WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
 export function getGlobalSetting<T>(key: string, prefix: string = ext.prefix): T | undefined {
   const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
   const result: { globalValue?: T; defaultValue?: T } | undefined = projectConfiguration.inspect<T>(key);
-  return result && (result.globalValue || result.defaultValue);
+  return result && (result.globalValue ?? result.defaultValue);
 }
 
 /**


### PR DESCRIPTION
This pull request to the `vs-code-designer` app improves the `getGlobalSetting` function in `settings.ts` by replacing the logical OR with the nullish coalescing operator to ensure that the default value is returned only when the global value is `null` or `undefined`.

Main code change:

* Replaced logical OR with nullish coalescing operator in `getGlobalSetting` function to ensure it returns default value only when global value is `null` or `undefined`.