### PR TITLE
fix(designer-ui): Prevent text formatting in non-HTML inputs

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -25,6 +25,7 @@ import { LexicalComposer } from '@lexical/react/LexicalComposer';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import { HistoryPlugin as History } from '@lexical/react/LexicalHistoryPlugin';
+import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -163,6 +164,8 @@ export const BaseEditor = ({
   };
 
   const id = useId('msla-described-by-message');
+  const TextPlugin = toolbar ? RichTextPlugin : PlainTextPlugin;
+
   return (
     <div style={{ width: '100%' }}>
       <LexicalComposer initialConfig={initialConfig}>
@@ -174,7 +177,7 @@ export const BaseEditor = ({
           title={placeholder}
         >
           {toolbar ? <Toolbar readonly={readonly} /> : null}
-          <RichTextPlugin
+          <TextPlugin
             contentEditable={
               <ContentEditable className={css('editor-input', readonly && 'readonly')} ariaLabelledBy={labelId} ariaDescribedBy={id} />
             }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Text can be bolded, italicized, etc. in non-HTML editors using keyboard shortcuts. (See #3700.)

- **What is the new behavior (if this is a feature change)?**

Plaintext editor is used when toolbar is not shown, preventing use of rich text. Fixes #3700.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

It's very difficult to show, but I tried my best using keystrokes in the GIF below.

![format-non-html-fix](https://github.com/Azure/LogicAppsUX/assets/1350074/70b73cad-04ef-4320-9c9a-108d729fe39f)