### PR TITLE
Fixes amending source key with directAccess when brackets are in a string

### DIFF
--- a/libs/data-mapper/src/lib/utils/__test__/DataMapUtils.spec.ts
+++ b/libs/data-mapper/src/lib/utils/__test__/DataMapUtils.spec.ts
@@ -13,6 +13,7 @@ import {
   removeSequenceFunction,
   splitKeyIntoChildren,
   isValidToMakeMapDefinition,
+  amendSourceKeyForDirectAccessIfNeeded,
 } from '../DataMap.Utils';
 import { addSourceReactFlowPrefix } from '../ReactFlow.Util';
 import { convertSchemaToSchemaExtended, flattenSchemaIntoDictionary } from '../Schema.Utils';
@@ -946,6 +947,36 @@ describe('utils/DataMap', () => {
       expect(result[8]).toEqual('/ns0:PersonOrigin/LastName');
       expect(result[9]).toEqual(Separators.CloseParenthesis);
       expect(result[10]).toEqual(Separators.CloseParenthesis);
+    });
+  });
+
+  describe('amendSourceKeyForDirectAccessIfNeeded', () => {
+    it('returns unchanged source key for single quoted string expression with block quotes', () => {
+      const result = amendSourceKeyForDirectAccessIfNeeded("'[Y0001]-[M01]-[D01]'");
+      expect(result).toEqual(["'[Y0001]-[M01]-[D01]'", '']);
+    });
+
+    it('returns unchanged source key for double quoted string expression with block quotes', () => {
+      const result = amendSourceKeyForDirectAccessIfNeeded('"[Y0001]-[M01]-[D01]"');
+      expect(result).toEqual(['"[Y0001]-[M01]-[D01]"', '']);
+    });
+
+    it('returns unchanged source key for expression without direct access', () => {
+      const result = amendSourceKeyForDirectAccessIfNeeded('/root/Array/*/Property');
+      expect(result).toEqual(['/root/Array/*/Property', '']);
+    });
+
+    it('returns unchanged source key for expression with direct access embedded in a function', () => {
+      const result = amendSourceKeyForDirectAccessIfNeeded('concat(/root/Array/*[1]/Property, /root/Array/*[1]/Property)');
+      expect(result).toEqual(['concat(/root/Array/*[1]/Property, /root/Array/*[1]/Property)', '']);
+    });
+
+    it('amends source key for an expression with direct access', () => {
+      const result = amendSourceKeyForDirectAccessIfNeeded('/root/Array/*[/root/Array2/*[1]]/Property');
+      expect(result).toEqual([
+        'directAccess(/root/Array2/*[1], /root/Array/*, /root/Array/*/Property)',
+        'directAccess(/root/Array2/*[1], /root/Array/*, /root/Array/*/Property)',
+      ]);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.84.0",
+  "version": "2.85.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.84.0",
+      "version": "2.85.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes/features)
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
  When creating connections during deserialization of a map, function `directAccess` is amended to expressions that contain `[` and `]`. However, it currently does not incorporate the situation in which one or both of those brackets are located inside a quoted string.

  Also, a whole function expression is parsed first, followed by parsing each of its parameter expressions recursively. But amending an expression with function directAccess cannot be done for a function expression with multiple parameters, as in theory different parameters can contain `[` and `]`. As a result, it should only be performed on expressions other than string and function expressions.

  Fixes #3714

- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**:
