### PR TITLE
fix(designer-ui): Ensure `convertEditorState` returns a non-empty value

### DIFF
--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/Change.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/Change.tsx
@@ -17,47 +17,48 @@ export const Change = ({ setValue }: ChangeProps) => {
     editorState.read(() => {
       getChildrenNodes($getRoot(), nodeMap);
     });
-    const newValue = convertEditorState(editor, nodeMap);
-    setValue(newValue);
+    convertEditorState(editor, nodeMap).then(setValue);
   };
   return <OnChangePlugin ignoreSelectionChange onChange={onChange} />;
 };
 
-const convertEditorState = (editor: LexicalEditor, nodeMap: Map<string, ValueSegment>): ValueSegment[] => {
-  const valueSegments: ValueSegment[] = [];
-  editor.update(() => {
-    const htmlEditorString = $generateHtmlFromNodes(editor);
-    // Create a temporary DOM element to parse the HTML string
-    const tempElement = document.createElement('div');
-    tempElement.innerHTML = htmlEditorString;
+const convertEditorState = (editor: LexicalEditor, nodeMap: Map<string, ValueSegment>): Promise<ValueSegment[]> => {
+  return new Promise((resolve) => {
+    const valueSegments: ValueSegment[] = [];
+    editor.update(() => {
+      const htmlEditorString = $generateHtmlFromNodes(editor);
+      // Create a temporary DOM element to parse the HTML string
+      const tempElement = document.createElement('div');
+      tempElement.innerHTML = htmlEditorString;
 
-    // Loop through all elements and remove unwanted attributes
-    const elements = tempElement.querySelectorAll('*');
-    for (let i = 0; i < elements.length; i++) {
-      const element = elements[i];
-      const attributes = Array.from(element.attributes);
-      for (let j = 0; j < attributes.length; j++) {
-        const attribute = attributes[j];
-        if (attribute.name !== 'id' && attribute.name !== 'style' && attribute.name !== 'href') {
-          element.removeAttribute(attribute.name);
+      // Loop through all elements and remove unwanted attributes
+      const elements = tempElement.querySelectorAll('*');
+      for (let i = 0; i < elements.length; i++) {
+        const element = elements[i];
+        const attributes = Array.from(element.attributes);
+        for (let j = 0; j < attributes.length; j++) {
+          const attribute = attributes[j];
+          if (attribute.name !== 'id' && attribute.name !== 'style' && attribute.name !== 'href') {
+            element.removeAttribute(attribute.name);
+          }
         }
       }
-    }
 
-    // Get the cleaned HTML string
-    const cleanedHtmlString = cleanHtmlString(tempElement.innerHTML);
+      // Get the cleaned HTML string
+      const cleanedHtmlString = cleanHtmlString(tempElement.innerHTML);
 
-    // Regular expression pattern to match <span id="..."></span>
-    const spanIdPattern = /<span id="(.*?)"><\/span>/g;
-    // Replace <span id="..."></span> with the captured "id" value if it is found in the viable ids map
-    const removeTokenTags = cleanedHtmlString.replace(spanIdPattern, (match, idValue) => {
-      if (nodeMap.get(idValue)) {
-        return idValue;
-      } else {
-        return match;
-      }
+      // Regular expression pattern to match <span id="..."></span>
+      const spanIdPattern = /<span id="(.*?)"><\/span>/g;
+      // Replace <span id="..."></span> with the captured "id" value if it is found in the viable ids map
+      const removeTokenTags = cleanedHtmlString.replace(spanIdPattern, (match, idValue) => {
+        if (nodeMap.get(idValue)) {
+          return idValue;
+        } else {
+          return match;
+        }
+      });
+      valueSegments.push(...convertStringToSegments(removeTokenTags, true, nodeMap));
+      resolve(valueSegments);
     });
-    valueSegments.push(...convertStringToSegments(removeTokenTags, true, nodeMap));
   });
-  return valueSegments;
 };


### PR DESCRIPTION
Note: I recommend viewing the changes without whitespace diff. ;)

- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

There is a race condition currently in `convertEditorState`, where because `editor.update()` is not synchronous, the `return` statement actually occurs before `editor.update()` completes, meaning that you will be given back an empty array. Though this is rare, it means that `<HTMLEditor>` can end up with `value == []` during its `onBlur` call, wiping out the field contents.

- **What is the new behavior (if this is a feature change)?**

This PR makes `convertEditorState` into a promise-based method, allowing it to either be awaited or chained with `.then` to set the value once `editor.update()` completes.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

Before (sorry, minified):

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/e5c2abff-26bd-41e0-9086-70e83e63266d)

After:

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/6b13a056-8d64-4b5e-acf9-f4d79e787f54)