### PR TITLE
fix(designer): Custom Code Workspace fix empty lib folder

### DIFF
--- a/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
+++ b/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
@@ -76,7 +76,7 @@ export async function validateAndInstallBinaries(context: IActionContext) {
         await runWithDurationTelemetry(context, 'azureLogicAppsStandard.validateDotNetIsLatest', async () => {
           progress.report({ increment: 20, message: `.NET SDK` });
           await timeout(validateDotNetIsLatest, dependencyTimeout, dependenciesVersions?.dotnet);
-          await setDotNetCommand();
+          await setDotNetCommand(context);
         });
         ext.outputChannel.appendLog(
           localize(

--- a/apps/vs-code-designer/src/app/utils/dotnet/dotnet.ts
+++ b/apps/vs-code-designer/src/app/utils/dotnet/dotnet.ts
@@ -14,8 +14,9 @@ import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { executeCommand } from '../funcCoreTools/cpUtils';
 import { runWithDurationTelemetry } from '../telemetry';
-import { getGlobalSetting, updateGlobalSetting } from '../vsCodeConfig/settings';
-import { findFiles } from '../workspace';
+import { tryGetFunctionProjectRoot } from '../verifyIsProject';
+import { getGlobalSetting, updateGlobalSetting, updateWorkspaceSetting } from '../vsCodeConfig/settings';
+import { findFiles, getWorkspaceFolder } from '../workspace';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import type { IWorkerRuntime } from '@microsoft/vscode-extension';
@@ -220,7 +221,7 @@ export function getDotNetCommand(): string {
   return command;
 }
 
-export async function setDotNetCommand(): Promise<void> {
+export async function setDotNetCommand(context: IActionContext): Promise<void> {
   const binariesLocation = getGlobalSetting<string>(autoRuntimeDependenciesPathSettingKey);
   const dotNetBinariesPath = path.join(binariesLocation, dotnetDependencyName);
   const binariesExist = fs.existsSync(dotNetBinariesPath);
@@ -235,31 +236,36 @@ export async function setDotNetCommand(): Promise<void> {
     fs.chmodSync(dotNetBinariesPath, 0o777);
 
     try {
-      const terminalConfig = vscode.workspace.getConfiguration();
-      const pathEnv = {
-        PATH: newPath,
-      };
+      if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+        const workspaceFolder = await getWorkspaceFolder(context);
+        const projectPath = await tryGetFunctionProjectRoot(context, workspaceFolder);
 
-      // Required for dotnet cli in VSCode Terminal
-      switch (process.platform) {
-        case Platform.windows: {
-          terminalConfig.update('terminal.integrated.env.windows', pathEnv, vscode.ConfigurationTarget.Workspace);
-          break;
-        }
+        if (projectPath) {
+          const pathEnv = {
+            PATH: newPath,
+          };
 
-        case Platform.linux: {
-          terminalConfig.update('terminal.integrated.env.linux', pathEnv, vscode.ConfigurationTarget.Workspace);
-          break;
-        }
+          // Required for dotnet cli in VSCode Terminal
+          switch (process.platform) {
+            case Platform.windows: {
+              await updateWorkspaceSetting('integrated.env.windows', pathEnv, projectPath, 'terminal');
+              break;
+            }
 
-        case Platform.mac: {
-          terminalConfig.update('terminal.integrated.env.osx', pathEnv, vscode.ConfigurationTarget.Workspace);
-          break;
+            case Platform.linux: {
+              await updateWorkspaceSetting('integrated.env.linux', pathEnv, projectPath, 'terminal');
+              break;
+            }
+
+            case Platform.mac: {
+              await updateWorkspaceSetting('integrated.env.osx', pathEnv, projectPath, 'terminal');
+              break;
+            }
+          }
+          // Required for CoreClr
+          await updateWorkspaceSetting('dotNetCliPaths', [dotNetBinariesPath], projectPath, 'omnisharp');
         }
       }
-
-      // Required for CoreClr
-      terminalConfig.update('omnisharp.dotNetCliPaths', [dotNetBinariesPath], vscode.ConfigurationTarget.Workspace);
     } catch (error) {
       console.log(error);
     }


### PR DESCRIPTION
Bug ticket: https://dev.azure.com/msazure/One/_workitems/edit/25869315
Create a custom code project.
Build the project (open integrated terminal / run dotnet build
Open logic app on designer - logic app finds the dlls and runs accordingly.
Close VS Code
Reopen VS Code with the custom project
Confirm that lib/custom folder with its contents exists
Open logic app on designer - the lib folder will be emptied and the action fails because it can't find the custom code contract.
Recording: https://clipchamp.com/watch/QGl5FTzBYjL
/
* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
 https://dev.azure.com/msazure/One/_workitems/edit/25869315

