### PR TITLE
fix(Designer): Standalone - Errors command bar button now behaves as it does in portal

### DIFF
--- a/apps/designer-standalone/src/app/LocalDesigner/pseudoCommandBar.tsx
+++ b/apps/designer-standalone/src/app/LocalDesigner/pseudoCommandBar.tsx
@@ -2,15 +2,19 @@ import './pseudoCommandBar.less';
 import type { IModalStyles } from '@fluentui/react';
 import { ActionButton, Modal } from '@fluentui/react';
 import { MonacoEditor, EditorLanguage } from '@microsoft/designer-ui';
-import type { Workflow, AppDispatch } from '@microsoft/logic-apps-designer';
+import type { Workflow, AppDispatch, RootState } from '@microsoft/logic-apps-designer';
 import {
   useIsDesignerDirty,
   resetDesignerDirtyState,
   serializeWorkflow,
   switchToWorkflowParameters,
   switchToErrorsPanel,
+  useAllConnectionErrors,
+  useAllSettingsValidationErrors,
+  useWorkflowParameterValidationErrors,
 } from '@microsoft/logic-apps-designer';
-import { useState } from 'react';
+import { RUN_AFTER_COLORS } from '@microsoft/utils-logic-apps';
+import { useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 const modalStyles: Partial<IModalStyles> = {
@@ -29,6 +33,30 @@ export const PseudoCommandBar = () => {
     serializeWorkflow(state).then((serialized) => setSerializedWorkflow(serialized));
     setShowSeralization(true);
   };
+
+  const isDarkMode = useSelector((state: RootState) => state.designerOptions.isDarkMode);
+
+  const allInputErrors = useSelector((state: RootState) => {
+    return (Object.entries(state.operations.inputParameters) ?? []).filter(([_id, nodeInputs]) =>
+      Object.values(nodeInputs.parameterGroups).some((parameterGroup) =>
+        parameterGroup.parameters.some((parameter) => (parameter?.validationErrors?.length ?? 0) > 0)
+      )
+    );
+  });
+  const haveInputErrors = allInputErrors.length > 0;
+
+  const isObjEmpty = (obj: any) => Object.keys(obj ?? {}).length === 0;
+  const allWorkflowParameterErrors = useWorkflowParameterValidationErrors();
+  const haveWorkflowParameterErrors = !isObjEmpty(allWorkflowParameterErrors);
+  const allSettingsErrors = useAllSettingsValidationErrors();
+  const haveSettingsErrors = !isObjEmpty(allSettingsErrors);
+  const allConnectionErrors = useAllConnectionErrors();
+  const haveConnectionErrors = !isObjEmpty(allConnectionErrors);
+
+  const haveErrors = useMemo(
+    () => haveInputErrors || haveWorkflowParameterErrors || haveSettingsErrors || haveConnectionErrors,
+    [haveInputErrors, haveWorkflowParameterErrors, haveSettingsErrors, haveConnectionErrors]
+  );
 
   const isDirty = useIsDesignerDirty();
 
@@ -57,7 +85,15 @@ export const PseudoCommandBar = () => {
         onClick={() => dispatch(switchToWorkflowParameters())}
       />
       <ActionButton iconProps={{ iconName: 'Code' }} text="Code View" onClick={serializeCallback} />
-      <ActionButton iconProps={{ iconName: 'ErrorBadge' }} text="Errors" onClick={() => dispatch(switchToErrorsPanel())} />
+      <ActionButton
+        iconProps={{
+          iconName: haveErrors ? 'StatusErrorFull' : 'ErrorBadge',
+          style: haveErrors ? { color: RUN_AFTER_COLORS[isDarkMode ? 'dark' : 'light']['FAILED'] } : undefined,
+        }}
+        text="Errors"
+        onClick={() => dispatch(switchToErrorsPanel())}
+        disabled={!haveErrors}
+      />
 
       {/* Code view modal */}
       <Modal


### PR DESCRIPTION
## Main Changes
The `Errors` panel button now behaves as it does in portal, disabling itself when there are no errors, and enabling itself when there are