### PR TITLE
fix(designer): Inconsistency in IGatewayService interface

### DIFF
--- a/libs/services/designer-client-services/src/lib/gateway.ts
+++ b/libs/services/designer-client-services/src/lib/gateway.ts
@@ -16,7 +16,7 @@ export interface IGatewayService {
   /**
    * Gets configuration values for GatewayService.
    */
-  getConfig?(): Promise<GatewayServiceConfig>;
+  getConfig?(): GatewayServiceConfig;
 }
 
 export interface GatewayServiceConfig {


### PR DESCRIPTION
@rllyy97 & @pranaydubeymicrosoft Came to the agreement previously that the `getConfig` method will not return a promise but instead a config dictionary. This change seeks to address an inconsistency between that thought process and the interface.

https://github.com/Azure/LogicAppsUX/pull/3404/files/ae3f4d9c138c127e538f8f09217cedb4684f6954#r1350657553

This is also linked to the work done to enable OPDG dropdown for Enterprise connectors in V3 Designer for Power Automate as without it the functionality causes a build error in that PR.

https://msazure.visualstudio.com/OneAgile/_git/power-platform-ux/pullrequest/9089007?path=/packages/powerautomate-core/src/shared/models/gateways/gateway.ts

- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, was unable to compile power-platform-ux PR because the interface was expecting an Promise returned by the `getConfig` function when the usage showed that we did not return a Promise.

https://msazure.visualstudio.com/OneAgile/_build/results?buildId=83594423&view=logs&j=a11cdf60-0d11-5130-c801-1b4953009464&t=cc441d3e-6496-5cf7-7cf6-a0940db61605&l=4113

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:
