### PR TITLE
test(designer): Fix automation id of search cards to be operation id so it's unique

### DIFF
--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/index.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/index.tsx
@@ -38,7 +38,7 @@ export const OperationSearchCard = (props: OperationSearchCardProps) => {
       className="msla-op-search-card-container"
       onClick={() => onCardClick()}
       style={style}
-      data-automation-id={`msla-op-search-result-${convertUIElementNameToAutomationId(title)}`}
+      data-automation-id={`msla-op-search-result-${convertUIElementNameToAutomationId(operationActionData.id)}`}
       aria-label={`${title} ${description}`}
     >
       <div className="msla-op-search-card-color-line" style={{ background: brandColor }} />


### PR DESCRIPTION
This pull request includes a single change to the `OperationSearchCard` component in the `libs/designer-ui` library. The `data-automation-id` attribute in the component was updated to use the `id` property from the `operationActionData` object, ensuring unique and specific automation ids for each operation action.

Main change:

* <a href="diffhunk://#diff-083a65d862371639bfa34480567b11d48cc733fad9a5762c79e9333ad3e75ee7L41-R41">`libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/index.tsx`</a>: Updated the `data-automation-id` attribute in the `OperationSearchCard` component to use the `id` property from the `operationActionData` object.