### PR TITLE
fix(vscode): Add validation for workspace folder path as string (#3659)

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createCodeless/createCodeless.ts
+++ b/apps/vs-code-designer/src/app/commands/createCodeless/createCodeless.ts
@@ -32,7 +32,7 @@ export async function createCodeless(
   workspacePath = isString(workspacePath) ? workspacePath : undefined;
   if (workspacePath === undefined) {
     workspaceFolder = await getWorkspaceFolder(context);
-    workspacePath = workspaceFolder.uri.fsPath;
+    workspacePath = isString(workspaceFolder) ? workspaceFolder : workspaceFolder.uri.fsPath;
   } else {
     workspaceFolder = getContainingWorkspace(workspacePath);
   }


### PR DESCRIPTION
Validation for workspace folder path as string

Fixes #3711 & #3734 
