### PR TITLE
fix(Designer): CustomEditor missing readonly/disabled state

### DIFF
--- a/apps/designer-standalone/src/app/LocalDesigner/customEditorService.tsx
+++ b/apps/designer-standalone/src/app/LocalDesigner/customEditorService.tsx
@@ -34,7 +34,7 @@ export class CustomEditorService implements IEditorService {
   };
 }
 
-const IncrementVariableEditor = ({ value, onValueChange, renderDefaultEditor, editor, editorOptions }: IEditorProps) => {
+const IncrementVariableEditor = ({ value, onValueChange, renderDefaultEditor, editor, editorOptions, disabled }: IEditorProps) => {
   const inputValue = +(value?.[0]?.value ?? 0);
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onValueChange?.({
@@ -51,6 +51,8 @@ const IncrementVariableEditor = ({ value, onValueChange, renderDefaultEditor, ed
     });
   }
 
+  const color = disabled ? 'rgb(200, 200, 250)' : 'rgb(119, 11, 214)';
+
   return (
     <div
       style={{
@@ -61,10 +63,10 @@ const IncrementVariableEditor = ({ value, onValueChange, renderDefaultEditor, ed
       <div
         style={{
           textAlign: 'center',
-          color: 'rgb(119, 11, 214)',
+          color,
           fontSize: 'xxx-large',
           fontWeight: '600',
-          border: '6px solid rgb(119, 11, 214)',
+          border: `6px solid ${color}`,
           borderRadius: '16px',
           display: 'flex',
           alignItems: 'baseline',
@@ -79,10 +81,11 @@ const IncrementVariableEditor = ({ value, onValueChange, renderDefaultEditor, ed
           step={10}
           value={inputValue}
           onChange={onChange}
+          disabled={disabled}
           style={{
             height: '100px',
             width: '100px',
-            color: 'rgb(119, 11, 214)',
+            color,
             fontSize: 'xxx-large',
             fontWeight: '600',
             border: 'unset',
@@ -94,7 +97,8 @@ const IncrementVariableEditor = ({ value, onValueChange, renderDefaultEditor, ed
   );
 };
 
-const InitializeVariableEditor = ({ value, onValueChange, renderDefaultEditor, editor, editorOptions }: IEditorProps) => {
+const InitializeVariableEditor = ({ value, onValueChange, renderDefaultEditor, editor, editorOptions, disabled }: IEditorProps) => {
+  const color = disabled ? 'rgb(200, 200, 250)' : 'rgb(119, 11, 214)';
   return (
     <div
       style={{
@@ -106,7 +110,7 @@ const InitializeVariableEditor = ({ value, onValueChange, renderDefaultEditor, e
           textAlign: 'center',
           fontSize: 'xxx-large',
           fontWeight: '600',
-          border: '6px solid rgb(119, 11, 214)',
+          border: `6px solid ${color}`,
           display: 'flex',
           alignItems: 'baseline',
         }}

--- a/libs/designer-ui/src/lib/settings/settingsection/__tests__/customTokenField.spec.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/__tests__/customTokenField.spec.tsx
@@ -55,30 +55,31 @@ describe('ui/settings/customTokenField', () => {
       renderer.unmount();
     });
 
-    it('should render the custom editor component', () => {
-      const MyCustomEditor = () => <div>My Custom Editor</div>;
-      const props: CustomTokenFieldProps = {
-        label: 'name',
-        labelId: 'msla-editor-label1',
-        value: [
-          {
-            value: 'test',
-            type: ValueSegmentType.LITERAL,
-            id: '8713da12-1afb-48ce-8fec-429bdb8599b8',
-          },
-        ],
-        tokenEditor: true,
-        onCastParameter: jest.fn(),
-        getTokenPicker: jest.fn(),
-        editor: 'internal-custom-editor',
-        editorOptions: {
-          EditorComponent: MyCustomEditor,
-          editor: 'dropdown',
-          editorOptions: { options: [{ key: '1', value: 'option 1', displayName: 'Option 1' }] },
-          hideLabel: true,
+    const MyCustomEditor = () => <div>My Custom Editor</div>;
+    const getCustomTokenFieldProps = (): CustomTokenFieldProps => ({
+      label: 'name',
+      labelId: 'msla-editor-label1',
+      value: [
+        {
+          value: 'test',
+          type: ValueSegmentType.LITERAL,
+          id: '8713da12-1afb-48ce-8fec-429bdb8599b8',
         },
-      };
+      ],
+      tokenEditor: true,
+      onCastParameter: jest.fn(),
+      getTokenPicker: jest.fn(),
+      editor: 'internal-custom-editor',
+      editorOptions: {
+        EditorComponent: MyCustomEditor,
+        editor: 'dropdown',
+        editorOptions: { options: [{ key: '1', value: 'option 1', displayName: 'Option 1' }] },
+        hideLabel: true,
+      },
+    });
 
+    it('should render the custom editor component', () => {
+      const props = getCustomTokenFieldProps();
       renderer.render(<CustomTokenField {...props} />);
       const customTokenField = renderer.getRenderOutput();
 
@@ -111,6 +112,24 @@ describe('ui/settings/customTokenField', () => {
       expect(defaultEditor.props.label).toBe(props.label);
       expect(defaultEditor.props.onCastParameter).toBe(props.onCastParameter);
       expect(defaultEditor.props.getTokenPicker).toBe(props.getTokenPicker);
+    });
+
+    it.each([true, false, undefined])(`should render the custom editor with "disabled" set to %s`, (disabled) => {
+      const props = getCustomTokenFieldProps();
+      props.readOnly = disabled;
+
+      renderer.render(<CustomTokenField {...props} />);
+      const customTokenField = renderer.getRenderOutput();
+
+      expect(customTokenField.type).toBe(MyCustomEditor);
+      expect(customTokenField.props).toEqual({
+        editor: props.editorOptions?.editor,
+        editorOptions: props.editorOptions?.editorOptions,
+        value: props.value,
+        onValueChange: props.onValueChange,
+        renderDefaultEditor: expect.any(Function),
+        disabled: props.readOnly,
+      });
     });
   });
 });

--- a/libs/designer-ui/src/lib/settings/settingsection/customTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/customTokenField.tsx
@@ -24,6 +24,7 @@ export const CustomTokenField = (props: CustomTokenFieldProps) => {
     value: props.value,
     onValueChange: props.onValueChange as CustomEditorChangeHandler,
     renderDefaultEditor,
+    disabled: props.readOnly,
   };
   return <EditorComponent {...customEditorProps} />;
 };

--- a/libs/services/designer-client-services/src/lib/editor.ts
+++ b/libs/services/designer-client-services/src/lib/editor.ts
@@ -76,6 +76,10 @@ export interface IEditorProps {
    * Render the base (non-custom) editor corresponding to the provided options.
    */
   renderDefaultEditor: (params: IRenderDefaultEditorParams) => JSX.Element;
+  /**
+   * Whether the editor is disabled.
+   */
+  disabled?: boolean;
 }
 
 export interface IEditorParameterInfo {


### PR DESCRIPTION
# Change

Bug fix. Addressing _CustomEditor missing readonly/disabled state_ #3788 

New behavior: pass the current `disabled` value as props to the Custom Editor. 
The new prop is additive and optional, no breaking change.

# Checklist

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes/features)
* [x] N/A regarding Docs
* [x] Not a breaking change

# Screenshots  
| custom editor in local designer   |
|---|
| ![laux-custom-editor-disabled](https://github.com/Azure/LogicAppsUX/assets/92312794/a4f66f19-80e8-4a6a-9788-43b9c9f5b5e4)
 |