### PR TITLE
fix(designer): Fixes using a token in expression editor not getting correct segment value

### DIFF
--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -92,7 +92,7 @@ export const TokenPickerOptions = ({
   };
 
   const handleTokenExpressionClicked = async (token: OutputToken) => {
-    const expression = token.value ?? '';
+    const expression = (await getValueSegmentFromToken(token, !tokenClickedCallback)).value;
     insertExpressionText(expression, 0);
   };
 
@@ -169,10 +169,7 @@ export const TokenPickerOptions = ({
   const sectionHeaderColorCss = `rgb(${sectionHeaderColorRgb.red}, ${sectionHeaderColorRgb.green}, ${sectionHeaderColorRgb.blue})`;
 
   const maxRowsShown = selectedKey === TokenPickerMode.EXPRESSION ? section.tokens.length : maxTokensPerSection;
-  const showSeeMoreOrLessButton = !searchQuery && (
-    hasAdvanced(section.tokens) ||
-    section.tokens.length > maxRowsShown
-  );
+  const showSeeMoreOrLessButton = !searchQuery && (hasAdvanced(section.tokens) || section.tokens.length > maxRowsShown);
 
   return (
     <>


### PR DESCRIPTION
Fixes https://github.com/Azure/LogicAppsUX/issues/3437
![fixExpression](https://github.com/Azure/LogicAppsUX/assets/95886809/5135e44e-410f-428a-8d0a-0df8acbc87c7)
