### PR TITLE
fix(designer): Fix toggle for collapsed and expanded dictionary view …

### DIFF
--- a/libs/designer-ui/src/lib/dictionary/plugins/CollapsedDictionaryValidation.tsx
+++ b/libs/designer-ui/src/lib/dictionary/plugins/CollapsedDictionaryValidation.tsx
@@ -36,7 +36,14 @@ export const CollapsedDictionaryValidation = ({
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    serializeDictionary(editor, setItems, setIsValid, keyType, valueType);
+    editor.getEditorState().read(() => {
+      const editorString = getChildrenNodes($getRoot());
+      if (!editorString.trim().length || editorString === '{}') {
+        setIsValid(true);
+      } else {
+        serializeDictionary(editor, setItems, setIsValid, keyType, valueType);
+      }
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
This pull request includes a single change to the `CollapsedDictionaryValidation` component in the `libs/designer-ui/src/lib/dictionary/plugins/CollapsedDictionaryValidation.tsx` file. The change involves adding a new `useEffect` hook to call `editor.getEditorState().read()` and execute a callback function.

Main change:

* `libs/designer-ui/src/lib/dictionary/plugins/CollapsedDictionaryValidation.tsx`: Added a new `useEffect` hook to call `editor.getEditorState().read()` and execute a callback function. (F20e3079L7R7)

https://github.com/Azure/LogicAppsUX/assets/13208452/9b9370f3-bfbd-460d-b76f-cbdb0eaf19a7



Fixes #3469