### PR TITLE
fix(designer): issue where designer would constantly rerender if anything about hte window changed

### DIFF
--- a/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
@@ -8,8 +8,9 @@ import { initWorkflowKind, initRunInstance, initWorkflowSpec } from './state/wor
 import type { AppDispatch, RootState } from './store';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { equals } from '@microsoft/utils-logic-apps';
+import { useDeepCompareEffect } from '@react-hookz/web';
 import { createSelector } from '@reduxjs/toolkit';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 export interface BJSWorkflowProviderProps {
@@ -20,12 +21,12 @@ export interface BJSWorkflowProviderProps {
 
 const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({ workflow, children, runInstance }) => {
   const dispatch = useDispatch<AppDispatch>();
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     dispatch(initWorkflowSpec('BJS'));
     dispatch(initWorkflowKind(equals(workflow?.kind, 'stateful') ? WorkflowKind.STATEFUL : WorkflowKind.STATELESS));
     dispatch(initRunInstance(runInstance ?? null));
     dispatch(initializeGraphState({ workflowDefinition: workflow, runInstance }));
-  }, [dispatch, workflow, runInstance]);
+  }, [runInstance, workflow]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
This pull request to the `libs/designer` repository makes a change to the `BJSWorkflowProvider` component in the `BJSWorkflowProvider.tsx` file. The code adds an import statement for the `useDeepCompareEffect` hook and replaces the usage of `useEffect` with `useDeepCompareEffect`. This change ensures that side effects are only triggered when the dependencies have actually changed, even if they are complex objects.

* <a href="diffhunk://#diff-d5e57861a3fd496fe4efcb77979f90fa2fa7a7b25731ebd2d5ed26b81db74064R11-R13">`libs/designer/src/lib/core/BJSWorkflowProvider.tsx`</a>: Replaced the usage of `useEffect` with `useDeepCompareEffect` in the `BJSWorkflowProvider` component. <a href="diffhunk://#diff-d5e57861a3fd496fe4efcb77979f90fa2fa7a7b25731ebd2d5ed26b81db74064R11-R13">[1]</a> <a href="diffhunk://#diff-d5e57861a3fd496fe4efcb77979f90fa2fa7a7b25731ebd2d5ed26b81db74064L23-R29">[2]</a>


**Before:**

https://github.com/Azure/LogicAppsUX/assets/13208452/0b9d7f57-5e74-4997-bbb5-2012cabfe441


**After:**

https://github.com/Azure/LogicAppsUX/assets/13208452/70acc2bf-e99b-40d4-ab10-91c3b68d2dab

