### PR TITLE
feat(vscode): Remove designer refresh and add window message

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -126,23 +126,12 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
     this.panel.onDidChangeViewState(
       async (event) => {
         const eventPanel: WebviewPanel = event.webviewPanel;
-        this.panelMetadata = await this._getDesignerPanelMetadata(this.migrationOptions);
-        eventPanel.webview.html = await this.getWebviewContent({
-          connectionsData: this.panelMetadata.connectionsData,
-          parametersData: this.panelMetadata.parametersData || {},
-          localSettings: this.panelMetadata.localSettings,
-          artifacts: this.panelMetadata.artifacts,
-          azureDetails: this.panelMetadata.azureDetails,
-          workflowDetails: this.panelMetadata.workflowDetails,
-        });
-        this.sendMsgToWebview({
-          command: ExtensionCommand.update_panel_metadata,
-          data: {
-            panelMetadata: this.panelMetadata,
-            connectionData: this.connectionData,
-            apiHubServiceDetails: this.apiHubServiceDetails,
-          },
-        });
+        if (eventPanel.visible) {
+          window.showInformationMessage(
+            localize('designer.restart', 'If changes were made to logic app files, restart designer to see the latest changes.'),
+            'OK'
+          );
+        }
       },
       undefined,
       ext.context.subscriptions


### PR DESCRIPTION
This pull request to the `vs-code-designer` app removes the code responsible for setting the HTML content of the webview panel and updating the panel metadata. Instead, it adds a new code block to show an information message to the user if changes were made to logic app files, instructing them to restart the designer.

Fixes #2908 

Main code changes:

* Removed code responsible for setting the HTML content of the webview panel and updating the panel metadata. Added code to show an information message to the user if changes were made to logic app files, instructing them to restart the designer.

### Implementation

https://github.com/Azure/LogicAppsUX/assets/102700317/85a5dc7a-368a-4b5f-a48d-78aca40ee731


