### PR TITLE
fix(vscode): Register unit test commands

### DIFF
--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -136,4 +136,9 @@ export function registerCommands(): void {
   // Data Mapper Commands
   registerCommand(extensionCommand.createNewDataMap, (context: IActionContext) => createNewDataMapCmd(context));
   registerCommand(extensionCommand.loadDataMapFile, (context: IActionContext, uri: Uri) => loadDataMapFileCmd(context, uri));
+  // Unit Test Commands
+  registerCommand('azureLogicAppsStandard.createUnitTest', createUnitTest);
+  registerCommand('azureLogicAppsStandard.editUnitTest', editUnitTest);
+  registerCommand('azureLogicAppsStandard.openUnitTestResults', openUnitTestResults);
+  registerCommand('azureLogicAppsStandard.runUnitTest', runUnitTest);
 }

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -51,6 +51,10 @@ import { openOverview } from './workflows/openOverview';
 import { reviewValidation } from './workflows/reviewValidation';
 import { switchDebugMode } from './workflows/switchDebugMode/switchDebugMode';
 import { switchToDotnetProject } from './workflows/switchToDotnetProject';
+import { createUnitTest } from './workflows/unitTest/createUnitTest';
+import { editUnitTest } from './workflows/unitTest/editUnitTest';
+import { openUnitTestResults } from './workflows/unitTest/openUnitTestResults';
+import { runUnitTest } from './workflows/unitTest/runUnitTest';
 import { useSQLStorage } from './workflows/useSQLStorage';
 import { viewContent } from './workflows/viewContent';
 import { AppSettingsTreeItem, AppSettingTreeItem, registerSiteCommand } from '@microsoft/vscode-azext-azureappservice';
@@ -137,8 +141,8 @@ export function registerCommands(): void {
   registerCommand(extensionCommand.createNewDataMap, (context: IActionContext) => createNewDataMapCmd(context));
   registerCommand(extensionCommand.loadDataMapFile, (context: IActionContext, uri: Uri) => loadDataMapFileCmd(context, uri));
   // Unit Test Commands
-  registerCommand('azureLogicAppsStandard.createUnitTest', createUnitTest);
-  registerCommand('azureLogicAppsStandard.editUnitTest', editUnitTest);
-  registerCommand('azureLogicAppsStandard.openUnitTestResults', openUnitTestResults);
-  registerCommand('azureLogicAppsStandard.runUnitTest', runUnitTest);
+  registerCommandWithTreeNodeUnwrapping(extensionCommand.createUnitTest, createUnitTest);
+  registerCommandWithTreeNodeUnwrapping(extensionCommand.editUnitTest, editUnitTest);
+  registerCommandWithTreeNodeUnwrapping(extensionCommand.openUnitTestResults, openUnitTestResults);
+  registerCommandWithTreeNodeUnwrapping(extensionCommand.runUnitTest, runUnitTest);
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
@@ -38,6 +38,8 @@ export abstract class OpenDesignerBase {
   protected oauthRedirectUrl?: string;
   protected schemaArtifacts?: FileDetails[] | undefined;
   protected mapArtifacts?: Record<string, FileDetails[]> | undefined;
+  protected unitTestName: string;
+  protected isUnitTest: boolean;
 
   protected constructor(
     context: IActionContext | IAzureConnectorsContext,

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -40,14 +40,15 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
   private projectPath: string | undefined;
   private panelMetadata: IDesignerPanelMetadata;
 
-  constructor(context: IActionContext, node: Uri) {
+  constructor(context: IActionContext, node: Uri, unitTestName?: string) {
     const workflowName = path.basename(path.dirname(node.fsPath));
     const apiVersion = '2018-11-01';
-    const panelName = `${workspace.name}-${workflowName}`;
+    const panelName = `${workspace.name}-${workflowName}${unitTestName ? `-${unitTestName}` : ''}`;
     const panelGroupKey = ext.webViewKey.designerLocal;
 
     super(context, workflowName, panelName, apiVersion, panelGroupKey, false, true, false);
-
+    this.unitTestName = unitTestName;
+    this.isUnitTest = !!unitTestName;
     this.workflowFilePath = node.fsPath;
   }
 
@@ -167,6 +168,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
             workflowDetails: this.workflowDetails,
             oauthRedirectUrl: this.oauthRedirectUrl,
             hostVersion: ext.extensionVersion,
+            isUnitTest: this.isUnitTest,
           },
         });
         await this.validateWorkflow(this.panelMetadata.workflowContent);

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -22,6 +22,7 @@ import {
 import { saveParameters } from '../../../utils/codeless/parameter';
 import { startDesignTimeApi } from '../../../utils/codeless/startDesignTimeApi';
 import { sendRequest } from '../../../utils/requestUtils';
+import { saveUnitTestDefinition } from '../../../utils/unitTests';
 import { OpenDesignerBase } from './openDesignerBase';
 import { HTTP_METHODS } from '@microsoft/utils-logic-apps';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -183,6 +184,10 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
           this.panelMetadata.azureDetails?.workflowManagementBaseUrl
         );
         await this.validateWorkflow(this.panelMetadata.workflowContent);
+        break;
+      }
+      case ExtensionCommand.saveUnitTest: {
+        await saveUnitTestDefinition(this.projectPath, this.workflowName, this.unitTestName, msg.definition);
         break;
       }
       case ExtensionCommand.addConnection: {

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -3,15 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { localize } from '../../../../localize';
+import { getWorkflowNode } from '../../../utils/workspace';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
+import OpenDesignerForLocalProject from '../openDesigner/openDesignerForLocalProject';
 import type * as vscode from 'vscode';
 
-export async function createUnitTest(context: IAzureConnectorsContext, _node: vscode.Uri): Promise<void> {
+export async function createUnitTest(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
   const unitTestName = await context.ui.showInputBox({
     prompt: localize('unitTestNamePrompt', 'Provide Unit Test name'),
   });
-  console.log(`createUnitTest: ${unitTestName}`);
-  //const openDesignerObj = new OpenDesignerForUnitTest(context, node, unitTestName);
-  // tslint:disable-next-line: no-unnecessary-type-assertion
-  //await openDesignerObj!.createPanel(false);
+  const workflowNode = getWorkflowNode(node) as vscode.Uri;
+
+  const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName);
+  await openDesignerObj?.createPanel();
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { localize } from '../../../../localize';
+import { type IAzureConnectorsContext } from '../azureConnectorWizard';
+import type * as vscode from 'vscode';
+
+export async function createUnitTest(context: IAzureConnectorsContext, _node: vscode.Uri): Promise<void> {
+  const unitTestName = await context.ui.showInputBox({
+    prompt: localize('unitTestNamePrompt', 'Provide Unit Test name'),
+  });
+  console.log(`createUnitTest: ${unitTestName}`);
+  //const openDesignerObj = new OpenDesignerForUnitTest(context, node, unitTestName);
+  // tslint:disable-next-line: no-unnecessary-type-assertion
+  //await openDesignerObj!.createPanel(false);
+}

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
@@ -2,20 +2,15 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { getUnitTestName } from '../../../utils/unitTests';
+import { getWorkflowNode } from '../../../utils/workspace';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
-import * as path from 'path';
+import OpenDesignerForLocalProject from '../openDesigner/openDesignerForLocalProject';
 import type * as vscode from 'vscode';
 
-function getUnitTestName(filePath: string) {
-  const unitTestFileName = path.basename(filePath);
-  const fileNameItems = unitTestFileName.split('.');
-  return fileNameItems[0];
-}
-
-export async function editUnitTest(_context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
+export async function editUnitTest(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
   const unitTestName = getUnitTestName(node.fsPath);
-  console.log(`editUnitTest: ${unitTestName}`);
-  // const openDesignerObj = new OpenDesignerForUnitTest(context, node, unitTestName);
-  // // tslint:disable-next-line: no-unnecessary-type-assertion
-  // await openDesignerObj!.createPanel(true);
+  const workflowNode = getWorkflowNode(node) as vscode.Uri;
+  const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName);
+  await openDesignerObj?.createPanel();
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { type IAzureConnectorsContext } from '../azureConnectorWizard';
+import * as path from 'path';
+import type * as vscode from 'vscode';
+
+function getUnitTestName(filePath: string) {
+  const unitTestFileName = path.basename(filePath);
+  const fileNameItems = unitTestFileName.split('.');
+  return fileNameItems[0];
+}
+
+export async function editUnitTest(_context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
+  const unitTestName = getUnitTestName(node.fsPath);
+  console.log(`editUnitTest: ${unitTestName}`);
+  // const openDesignerObj = new OpenDesignerForUnitTest(context, node, unitTestName);
+  // // tslint:disable-next-line: no-unnecessary-type-assertion
+  // await openDesignerObj!.createPanel(true);
+}

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { type IAzureConnectorsContext } from '../azureConnectorWizard';
+import * as path from 'path';
+import type * as vscode from 'vscode';
+
+// TODO: MAKE SURE THIS IS CORRECT
+function getUnitTestName(filePath: string) {
+  const unitTestFileName = path.basename(filePath);
+  const fileNameItems = unitTestFileName.split('.');
+  return fileNameItems[0];
+}
+
+export async function openUnitTestResults(_context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
+  const unitTestName = getUnitTestName(node.fsPath);
+  console.log(`openUnitTestResults: ${unitTestName}`);
+  // const openDesignerObj = new OpenDesignerForUnitTestResults(context, node, unitTestName);
+  // // tslint:disable-next-line: no-unnecessary-type-assertion
+  // await openDesignerObj!.createPanel();
+}

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -2,21 +2,15 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { getUnitTestName } from '../../../utils/unitTests';
+import { getWorkflowNode } from '../../../utils/workspace';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
-import * as path from 'path';
+import OpenDesignerForLocalProject from '../openDesigner/openDesignerForLocalProject';
 import type * as vscode from 'vscode';
 
-// TODO: MAKE SURE THIS IS CORRECT
-function getUnitTestName(filePath: string) {
-  const unitTestFileName = path.basename(filePath);
-  const fileNameItems = unitTestFileName.split('.');
-  return fileNameItems[0];
-}
-
-export async function openUnitTestResults(_context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
+export async function openUnitTestResults(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
   const unitTestName = getUnitTestName(node.fsPath);
-  console.log(`openUnitTestResults: ${unitTestName}`);
-  // const openDesignerObj = new OpenDesignerForUnitTestResults(context, node, unitTestName);
-  // // tslint:disable-next-line: no-unnecessary-type-assertion
-  // await openDesignerObj!.createPanel();
+  const workflowNode = getWorkflowNode(node) as vscode.Uri;
+  const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName);
+  await openDesignerObj?.createPanel();
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/runUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/runUnitTest.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { localize } from '../../../../localize';
+import { type IAzureConnectorsContext } from '../azureConnectorWizard';
+import * as child from 'child_process';
+import * as vscode from 'vscode';
+
+function getPathToRoot(dirItems: string[]) {
+  const DIRS_TO_ROOT = 4;
+  let path = dirItems[0];
+  for (let i = 1; i < dirItems.length - DIRS_TO_ROOT; i++) {
+    path = path.concat(`\\${dirItems[i]}`);
+  }
+  return path;
+}
+
+function getWorkflowName(dirItems: string[]) {
+  const DIRS_TO_WORKFLOWNAME = 1;
+  return dirItems[dirItems.length - DIRS_TO_WORKFLOWNAME - 1];
+}
+
+function getPathToExe(dirItems: string[]) {
+  const DIRS_TO_TESTS_FOLDER = 2;
+  let path = dirItems[0];
+  for (let i = 1; i < dirItems.length - DIRS_TO_TESTS_FOLDER; i++) {
+    path = path.concat(`\\${dirItems[i]}`);
+  }
+  const UNIT_TEST_EXE_NAME = 'LogicAppsTest.exe';
+  return `${path}\\${UNIT_TEST_EXE_NAME}`;
+}
+
+export async function runUnitTest(_context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
+  const options: vscode.ProgressOptions = {
+    location: vscode.ProgressLocation.Notification,
+    title: localize('azureFunctions.runUnitTest', 'Running Unit Test...'),
+  };
+
+  await vscode.window.withProgress(options, async () => {
+    const pathToUnitTest = node.fsPath;
+    const dirItems = pathToUnitTest.split('\\');
+
+    try {
+      const res = child.spawn(getPathToExe(dirItems), [
+        '-PathToRoot',
+        getPathToRoot(dirItems),
+        '-workflowName',
+        getWorkflowName(dirItems),
+        '-pathToUnitTest',
+        pathToUnitTest,
+      ]);
+      for await (const chunk of res.stdout) {
+        vscode.window.showInformationMessage(`${chunk}`);
+      }
+    } catch (error) {
+      vscode.window.showErrorMessage(`${localize('runFailure', 'Error Running Unit Test.')} ${error.message}`, localize('OK', 'OK'));
+      throw error;
+    }
+  });
+}

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { localize } from '../../localize';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export const saveUnitTestDefinition = async (
+  projectPath: string,
+  workflowName: string,
+  unitTestName: string,
+  unitTestDefinition: any
+): Promise<void> => {
+  const options: vscode.ProgressOptions = {
+    location: vscode.ProgressLocation.Notification,
+    title: localize('azureFunctions.savingWorkflow', 'Saving Unit Test Definition...'),
+  };
+
+  await vscode.window.withProgress(options, async () => {
+    const unitTestsPath = getUnitTestsPath(projectPath, workflowName, unitTestName);
+    const workflowTestsPath = getWorkflowTestsPath(projectPath, workflowName);
+
+    if (!fs.existsSync(workflowTestsPath)) {
+      fs.mkdirSync(workflowTestsPath, { recursive: true });
+    }
+    try {
+      fs.writeFileSync(unitTestsPath, JSON.stringify(unitTestDefinition, null, 4));
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        `${localize('saveFailure', 'Unit Test Definition not saved.')} ${error.message}`,
+        localize('OK', 'OK')
+      );
+      throw error;
+    }
+  });
+};
+
+const getUnitTestsPath = (projectPath: string, workflowName: string, unitTestName: string) => {
+  return path.join(projectPath, workflowName, 'development', 'tests', workflowName, `${unitTestName}.unit-test.json`);
+};
+
+const getWorkflowTestsPath = (projectPath: string, workflowName: string) => {
+  return path.join(projectPath, workflowName, 'development', 'tests', workflowName);
+};

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -37,6 +37,12 @@ export const saveUnitTestDefinition = async (
   });
 };
 
+export const getUnitTestName = (filePath: string) => {
+  const unitTestFileName = path.basename(filePath);
+  const fileNameItems = unitTestFileName.split('.');
+  return fileNameItems[0];
+};
+
 const getUnitTestsPath = (projectPath: string, workflowName: string, unitTestName: string) => {
   return path.join(projectPath, workflowName, 'development', 'tests', workflowName, `${unitTestName}.unit-test.json`);
 };

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -150,6 +150,10 @@ export const extensionCommand = {
   dataMapSetSupportedFileExts: 'azureLogicAppsStandard.dataMap.setSupportedFileExts',
   dataMapSaveMapDefinition: 'azureLogicAppsStandard.dataMap.saveMapDefinition',
   dataMapSaveMapXslt: 'azureLogicAppsStandard.dataMap.saveMapXslt',
+  createUnitTest: 'azureLogicAppsStandard.createUnitTest',
+  editUnitTest: 'azureLogicAppsStandard.editUnitTest',
+  openUnitTestResults: 'azureLogicAppsStandard.openUnitTestResults',
+  runUnitTest: 'azureLogicAppsStandard.runUnitTest',
 } as const;
 export type extensionCommand = (typeof extensionCommand)[keyof typeof extensionCommand];
 

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -326,6 +326,26 @@
       {
         "command": "azureLogicAppsStandard.dataMap.loadDataMapFile",
         "title": "Data Mapper: Load existing data map"
+      },
+      {
+        "command": "azureLogicAppsStandard.createUnitTest",
+        "title": "Create Unit Test",
+        "category": "Azure Logic Apps"
+      },
+      {
+        "command": "azureLogicAppsStandard.openUnitTestResults",
+        "title": "View Unit Test Results",
+        "category": "Azure Logic Apps"
+      },
+      {
+        "command": "azureLogicAppsStandard.editUnitTest",
+        "title": "Edit Unit Test",
+        "category": "Azure Logic Apps"
+      },
+      {
+        "command": "azureLogicAppsStandard.runUnitTest",
+        "title": "Run Unit Test",
+        "category": "Azure Logic Apps"
       }
     ],
     "submenus": [
@@ -659,6 +679,26 @@
           "submenu": "azureLogicAppsStandard.dataMapperMenu",
           "group": "navigation",
           "when": "resourceExtname in azureLogicAppsStandard.dataMap.setSupportedFileExts"
+        },
+        {
+          "command": "azureLogicAppsStandard.createUnitTest",
+          "when": "resourceFilename==workflow.json",
+          "group": "navigation@4"
+        },
+        {
+          "command": "azureLogicAppsStandard.openUnitTestResults",
+          "when": "resourceFilename=~/.unit-test.[0-9]{14}/",
+          "group": "navigation@5"
+        },
+        {
+          "command": "azureLogicAppsStandard.editUnitTest",
+          "when": "resourceFilename=~/.unit-test.json/",
+          "group": "navigation@4"
+        },
+        {
+          "command": "azureLogicAppsStandard.runUnitTest",
+          "when": "resourceFilename=~/.unit-test.json/",
+          "group": "navigation@4"
         }
       ],
       "commandPalette": [

--- a/apps/vs-code-react/src/app/designer/DesignerCommandBar/index.tsx
+++ b/apps/vs-code-react/src/app/designer/DesignerCommandBar/index.tsx
@@ -24,14 +24,15 @@ export interface DesignerCommandBarProps {
   isDisabled: boolean;
   onRefresh(): void;
   isDarkMode: boolean;
+  isUnitTest: boolean;
 }
 
-export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({ isRefreshing, isDisabled, onRefresh, isDarkMode }) => {
+export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({ isRefreshing, isDisabled, onRefresh, isDarkMode, isUnitTest }) => {
   const intl = useIntl();
   const vscode = useContext(VSCodeContext);
   const dispatch = useDispatch();
 
-  const isMonitoringView = useSelector(
+  const isMonitoringView: boolean = useSelector(
     createSelector(
       (state: RootState) => state.designerOptions,
       (state: any) => state.isMonitoringView
@@ -92,6 +93,14 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({ isRefres
     MONITORING_VIEW_RESUBMIT: intl.formatMessage({
       defaultMessage: 'Resubmit',
       description: 'Button text for resubmit',
+    }),
+    UNIT_TEST_SAVE: intl.formatMessage({
+      defaultMessage: 'Save unit test definition',
+      description: 'Button text for save unit test definition',
+    }),
+    UNIT_TEST_ASSERTIONS: intl.formatMessage({
+      defaultMessage: 'Assertions',
+      description: 'Button text for unit test asssertions',
     }),
   };
 
@@ -195,9 +204,41 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({ isRefres
     },
   ];
 
+  const unitTestItems: ICommandBarItemProps[] = [
+    {
+      key: 'Save',
+      disabled: isSaveDisabled,
+      text: Resources.UNIT_TEST_SAVE,
+      ariaLabel: Resources.UNIT_TEST_SAVE,
+      onRenderIcon: () => {
+        return isSaving ? (
+          <Spinner size={SpinnerSize.small} />
+        ) : (
+          <FontIcon
+            aria-label={Resources.DESIGNER_SAVE}
+            iconName="Save"
+            className={isSaveDisabled ? classNames.disableGrey : classNames.azureBlue}
+          />
+        );
+      },
+      onClick: () => {
+        console.log('Unit test save clicked');
+      },
+    },
+    {
+      key: 'Assertions',
+      text: Resources.UNIT_TEST_ASSERTIONS,
+      ariaLabel: Resources.UNIT_TEST_ASSERTIONS,
+      iconProps: { iconName: 'CheckMark' },
+      onClick: () => {
+        console.log('Assertions clicked');
+      },
+    },
+  ];
+
   return (
     <CommandBar
-      items={isMonitoringView ? monitoringViewItems : desingerItems}
+      items={isUnitTest ? unitTestItems : isMonitoringView ? monitoringViewItems : desingerItems}
       ariaLabel="Use left and right arrow keys to navigate between commands"
       styles={{
         root: { borderBottom: `1px solid ${isDarkMode ? '#333333' : '#d6d6d6'}` },

--- a/apps/vs-code-react/src/app/designer/app.tsx
+++ b/apps/vs-code-react/src/app/designer/app.tsx
@@ -34,6 +34,7 @@ export const DesignerApp = () => {
     isMonitoringView,
     runId,
     hostVersion,
+    isUnitTest,
   } = vscodeState;
   const [standardApp, setStandardApp] = useState<StandardApp | undefined>(panelMetaData?.standardApp);
   const [runInstance, setRunInstance] = useState<LogicAppsV2.RunInstanceDefinition | null>(null);
@@ -155,6 +156,7 @@ export const DesignerApp = () => {
         isRefreshing={isRefetching}
         onRefresh={refetch}
         isDarkMode={theme === Theme.Dark}
+        isUnitTest={isUnitTest}
       />
     );
 

--- a/apps/vs-code-react/src/state/DesignerSlice.ts
+++ b/apps/vs-code-react/src/state/DesignerSlice.ts
@@ -18,6 +18,7 @@ export interface DesignerState {
   iaMapArtifacts: ListDynamicValue[];
   oauthRedirectUrl: string;
   hostVersion: string;
+  isUnitTest: boolean;
 }
 
 const initialState: DesignerState = {
@@ -46,6 +47,7 @@ const initialState: DesignerState = {
   iaMapArtifacts: [],
   oauthRedirectUrl: '',
   hostVersion: '',
+  isUnitTest: false,
 };
 
 export const designerSlice = createSlice({
@@ -65,6 +67,7 @@ export const designerSlice = createSlice({
         isMonitoringView,
         runId,
         hostVersion,
+        isUnitTest,
       } = action.payload;
 
       state.panelMetaData = panelMetadata;
@@ -78,6 +81,7 @@ export const designerSlice = createSlice({
       state.runId = runId;
       state.oauthRedirectUrl = oauthRedirectUrl;
       state.hostVersion = hostVersion;
+      state.isUnitTest = isUnitTest;
     },
     updateCallbackUrl: (state, action: PayloadAction<any>) => {
       const { callbackInfo } = action.payload;

--- a/libs/vscode-extension/src/lib/models/extensioncommand.ts
+++ b/libs/vscode-extension/src/lib/models/extensioncommand.ts
@@ -38,6 +38,7 @@ export const ExtensionCommand = {
   completeOauthLogin: 'CompleteOauthLogin',
   webviewLoaded: 'webviewLoaded',
   webviewRscLoadError: 'webviewRscLoadError',
+  saveUnitTest: 'saveUnitTest',
 } as const;
 export type ExtensionCommand = (typeof ExtensionCommand)[keyof typeof ExtensionCommand];
 


### PR DESCRIPTION
This pull request includes various changes to enhance the unit testing functionality in the `vs-code-designer` and `vs-code-react` apps. The most important changes include adding new files and functions related to unit tests, updating the `DesignerCommandBar` component to support saving unit test definitions, and adding new commands and imports for unit tests.

Main unit testing changes:

* Added new functions `saveUnitTestDefinition` and `getUnitTestName` to the `unitTests.ts` file in the `utils` folder of the `vs-code-designer` app. (apps/vs-code-designer/src/app/utils/unitTests.ts)
* Added new commands related to unit tests in the `package.json` file of the `vs-code-designer` app. (apps/vs-code-designer/src/package.json)
* Updated the `DesignerCommandBar` component to include a save button and functionality for saving unit test definitions.
* Added support for appending a unit test name to the panel name when opening the designer for a local project. (apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts)
* Added a new function `openUnitTestResults` to the `unitTest` module for opening the results of a unit test. (apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts)

