### PR TITLE
fix(vscode): Add troubleshoot dependencies message

### DIFF
--- a/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
+++ b/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
@@ -86,9 +86,15 @@ export async function validateAndInstallBinaries(context: IActionContext) {
         );
       } catch (error) {
         ext.outputChannel.appendLog(
-          localize('azureLogicApsBinariesError', 'Error in dependencies validation and installation: "{0}"...', error)
+          localize('azureLogicApsBinariesError', 'Error in dependencies validation and installation: "{0}"...', error?.message)
         );
-        context.telemetry.properties.dependenciesError = error;
+        vscode.window.showErrorMessage(
+          localize(
+            'binariesTroubleshoot',
+            'The Validation and Installation of Runtime Dependencies encountered an error. To resolve this issue, please click [here](https://aka.ms/lastandard/onboarding/troubleshoot) to access our troubleshooting documentation for step-by-step instructions.'
+          )
+        );
+        context.telemetry.properties.dependenciesError = error?.message;
       }
     }
   );


### PR DESCRIPTION
This pull request modifies the error message logging and display in the `validateAndInstallBinaries` function in the `validateAndInstallBinaries.ts` file of the `vs-code-designer` app. The changes improve the user experience by showing only the error message and providing a link to troubleshooting documentation. The telemetry context is also updated to include only the error message.

Main changes:

* Modified error message logging and display in the `validateAndInstallBinaries` function to show only the error message and provide a link to troubleshooting documentation. Updated the telemetry context to include only the error message.