### PR TITLE
fix(Data Mapper): Disabled allowing undo add schema

### DIFF
--- a/libs/data-mapper/src/lib/core/state/Store.ts
+++ b/libs/data-mapper/src/lib/core/state/Store.ts
@@ -8,7 +8,6 @@ import { configureStore } from '@reduxjs/toolkit';
 import undoable, { includeAction } from 'redux-undo';
 
 const includedActions = [
-  'dataMap/setInitialSchema',
   'dataMap/doDataMapOperation',
   'dataMap/makeConnection',
   'dataMap/addFunctionNode',


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix #3507 
- **What is the current behavior?** (You can also link to an open issue here)
- can undo adding initial schemas
- **What is the new behavior (if this is a feature change)?**
- undo is disabled until adding both of the schemas and making an action
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**:
