### PR TITLE
fix(designer): Add default text color for token picker pivot

### DIFF
--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickerpivot.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickerpivot.tsx
@@ -11,6 +11,7 @@ const pivotStyles: Partial<IPivotStyles> = {
     },
     fontSize: '16px',
     padding: '10px',
+    color: '#323130',
   },
   root: {
     padding: '0 5px 5px 5px',


### PR DESCRIPTION
This pull request includes a single change in the `libs/designer-ui/src/lib/tokenpicker/tokenpickerpivot.tsx` file. The change sets the color of the pivot styles to `#323130`.

Fixes #3826 

Main change:

*  Set the color of the pivot styles to `#323130`.

#### Light theme
<img width="640" alt="Screenshot 2023-12-13 at 1 59 12 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/d0afcb10-6bb0-43d6-a4be-b9ea474cc78a">

#### Dark theme

<img width="988" alt="Screenshot 2023-12-13 at 1 59 21 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/666058cd-fd41-41e1-9bc8-84c55d0653d3">
