### PR TITLE
fix(Data Mapper): Display Error Message for Failing Schema Load

### DIFF
--- a/libs/data-mapper/src/lib/components/configPanel/SelectExistingSchema.tsx
+++ b/libs/data-mapper/src/lib/components/configPanel/SelectExistingSchema.tsx
@@ -47,7 +47,7 @@ export const SelectExistingSchema = (props: SelectExistingSchemaProps) => {
   return (
     <FileDropdown
       allPathOptions={dataMapDropdownOptions}
-      errorMessage={''}
+      errorMessage={props.errorMessage}
       setSelectedPath={setSelectedSchema}
       relativePathMessage={`${folderLocationLabel} ${schemaRelativePath}`}
       placeholder={schemaDropdownPlaceholder}

--- a/libs/data-mapper/src/lib/components/fileDropdown/fileDropdown.tsx
+++ b/libs/data-mapper/src/lib/components/fileDropdown/fileDropdown.tsx
@@ -72,7 +72,6 @@ export const FileDropdown: React.FC<FileDropdownProps> = (props: FileDropdownPro
   return (
     <>
       <Text size={200}>{props.relativePathMessage}</Text>
-      <Text className={styles.errorMessage}>{props.errorMessage}</Text>
       <Combobox
         aria-label={props.ariaLabel}
         placeholder={props.placeholder}
@@ -90,6 +89,7 @@ export const FileDropdown: React.FC<FileDropdownProps> = (props: FileDropdownPro
       >
         {formattedOptions}
       </Combobox>
+      <Text className={styles.errorMessage}>{props.errorMessage}</Text>
     </>
   );
 };


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix for #3724 
- **What is the current behavior?** (You can also link to an open issue here)
doesn't display error messages for failing loading schema
- **What is the new behavior (if this is a feature change)?**
displays error messages for failing loading schema
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**: 
<img width="1034" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/144840522/54d894a6-d811-426f-9375-e17308c441b0">
<img width="937" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/144840522/f8d79c67-73d1-4642-89b4-e5239fcf1eb8">

