### PR TITLE
refactor(vscode): Update functions name to get logic app project in vscode

### DIFF
--- a/apps/vs-code-designer/src/app/commands/appSettings/getLocalSettingsFile.ts
+++ b/apps/vs-code-designer/src/app/commands/appSettings/getLocalSettingsFile.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { localSettingsFileName } from '../../../constants';
-import { tryGetFunctionProjectRoot } from '../../utils/verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../../utils/verifyIsProject';
 import { selectWorkspaceFile } from '../../utils/workspace';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
@@ -25,7 +25,7 @@ export async function getLocalSettingsFile(
 ): Promise<string> {
   workspaceFolder = workspaceFolder || workspace.workspaceFolders?.[0];
   if (workspaceFolder) {
-    const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspaceFolder, true /* suppressPrompt */);
+    const projectPath: string | undefined = await tryGetLogicAppProjectRoot(context, workspaceFolder, true /* suppressPrompt */);
     if (projectPath) {
       const localSettingsFile: string = path.join(projectPath, localSettingsFileName);
       if (await fse.pathExists(localSettingsFile)) {
@@ -35,7 +35,7 @@ export async function getLocalSettingsFile(
   }
 
   return await selectWorkspaceFile(context, placeHolder, async (f: WorkspaceFolder): Promise<string> => {
-    const projectPath: string = (await tryGetFunctionProjectRoot(context, f, true /* suppressPrompt */)) || f.uri.fsPath;
+    const projectPath: string = (await tryGetLogicAppProjectRoot(context, f, true /* suppressPrompt */)) || f.uri.fsPath;
     return path.relative(f.uri.fsPath, path.join(projectPath, localSettingsFileName));
   });
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/configureWebhookRedirectEndpoint/configureWebhookRedirectEndpoint.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/configureWebhookRedirectEndpoint/configureWebhookRedirectEndpoint.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { localSettingsFileName, webhookRedirectHostUri } from '../../../../constants';
 import { getLocalSettingsJson } from '../../../utils/appSettings/localSettings';
-import { tryGetFunctionProjectRoot } from '../../../utils/verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
 import { getContainingWorkspace, getWorkspaceFolder } from '../../../utils/workspace';
 import { createWebhookWizard } from './webhookWizard';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -23,7 +23,7 @@ export async function configureWebhookRedirectEndpoint(context: IActionContext, 
   }
 
   const workspacePath = workspaceFolder.uri.fsPath;
-  const projectPath = (await tryGetFunctionProjectRoot(context, workspacePath)) || workspacePath;
+  const projectPath = (await tryGetLogicAppProjectRoot(context, workspacePath)) || workspacePath;
   const localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName));
   const redirectEndpoint: string = localSettings.Values[webhookRedirectHostUri] || '';
   const wizard = createWebhookWizard({ ...context, redirectEndpoint }, projectPath);

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -15,7 +15,7 @@ import {
   containsApiHubConnectionReference,
   getConnectionsAndSettingsToUpdate,
   getConnectionsFromFile,
-  getFunctionProjectRoot,
+  getLogicAppProjectRoot,
   getParametersFromFile,
   saveConnectionReferences,
 } from '../../../utils/codeless/connection';
@@ -83,7 +83,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
       return;
     }
 
-    this.projectPath = await getFunctionProjectRoot(this.context, this.workflowFilePath);
+    this.projectPath = await getLogicAppProjectRoot(this.context, this.workflowFilePath);
     if (!this.projectPath) {
       throw new Error(localize('FunctionRootFolderError', 'Unable to determine function project root folder.'));
     }
@@ -391,7 +391,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
     const workflowContent: any = JSON.parse(readFileSync(this.workflowFilePath, 'utf8'));
     this._migrate(workflowContent, migrationOptions);
     const connectionsData: string = await getConnectionsFromFile(this.context, this.workflowFilePath);
-    const projectPath: string | undefined = await getFunctionProjectRoot(this.context, this.workflowFilePath);
+    const projectPath: string | undefined = await getLogicAppProjectRoot(this.context, this.workflowFilePath);
     const parametersData: Record<string, Parameter> = await getParametersFromFile(this.context, this.workflowFilePath);
     let localSettings: Record<string, string>;
     let azureDetails: AzureConnectorDetails;

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
@@ -14,7 +14,7 @@ import {
   getArtifactsInLocalProject,
   getStandardAppData,
 } from '../../../utils/codeless/common';
-import { getConnectionsFromFile, getFunctionProjectRoot, getParametersFromFile } from '../../../utils/codeless/connection';
+import { getConnectionsFromFile, getLogicAppProjectRoot, getParametersFromFile } from '../../../utils/codeless/connection';
 import { sendRequest } from '../../../utils/requestUtils';
 import { OpenMonitoringViewBase } from './openMonitoringViewBase';
 import { HTTP_METHODS } from '@microsoft/utils-logic-apps';
@@ -56,7 +56,7 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
       this.getPanelOptions()
     );
 
-    this.projectPath = await getFunctionProjectRoot(this.context, this.workflowFilePath);
+    this.projectPath = await getLogicAppProjectRoot(this.context, this.workflowFilePath);
     const connectionsData = await getConnectionsFromFile(this.context, this.workflowFilePath);
     const parametersData = await getParametersFromFile(this.context, this.workflowFilePath);
     this.baseUrl = `http://localhost:${ext.workflowRuntimePort}${managementApiPrefix}`;
@@ -155,7 +155,7 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
 
   private async _getDesignerPanelMetadata(): Promise<IDesignerPanelMetadata> {
     const connectionsData: string = await getConnectionsFromFile(this.context, this.workflowFilePath);
-    const projectPath: string | undefined = await getFunctionProjectRoot(this.context, this.workflowFilePath);
+    const projectPath: string | undefined = await getLogicAppProjectRoot(this.context, this.workflowFilePath);
     const workflowContent: any = JSON.parse(readFileSync(this.workflowFilePath, 'utf8'));
     const parametersData: Record<string, Parameter> = await getParametersFromFile(this.context, this.workflowFilePath);
     let localSettings: Record<string, string>;

--- a/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
@@ -14,7 +14,7 @@ import {
   removeWebviewPanelFromCache,
   tryGetWebviewPanel,
 } from '../../utils/codeless/common';
-import { getFunctionProjectRoot } from '../../utils/codeless/connection';
+import { getLogicAppProjectRoot } from '../../utils/codeless/connection';
 import { getAuthorizationToken } from '../../utils/codeless/getAuthorizationToken';
 import { getWebViewHTML } from '../../utils/codeless/getWebViewHTML';
 import { sendRequest } from '../../utils/requestUtils';
@@ -59,7 +59,7 @@ export async function openOverview(context: IAzureConnectorsContext, node: vscod
       `${baseUrl}/workflows/${workflowName}/triggers/${triggerName}/listCallbackUrl?api-version=${apiVersion}`
     );
 
-    const projectPath = await getFunctionProjectRoot(context, workflowFilePath);
+    const projectPath = await getLogicAppProjectRoot(context, workflowFilePath);
     localSettings = projectPath ? (await getLocalSettingsJson(context, join(projectPath, localSettingsFileName))).Values || {} : {};
   } else if (workflowNode instanceof RemoteWorkflowTreeItem) {
     workflowName = workflowNode.name;

--- a/apps/vs-code-designer/src/app/commands/workflows/switchDebugMode/switchDebugMode.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/switchDebugMode/switchDebugMode.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { localize } from '../../../../localize';
-import { tryGetFunctionProjectRoot } from '../../../utils/verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
 import { selectWorkspaceFile } from '../../../utils/workspace';
 import { StatelessWorkflowsListStep } from './StatelessWorkflowsListStep';
 import { UpdateDebugModeStep } from './UpdateDebugModeStep';
@@ -13,7 +13,7 @@ import * as vscode from 'vscode';
 
 export async function switchDebugMode(context: IActionContext): Promise<void> {
   const workspacePath = await getWorkspaceFolderPath(context);
-  const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath, true /* suppressPrompt */);
+  const projectPath: string | undefined = await tryGetLogicAppProjectRoot(context, workspacePath, true /* suppressPrompt */);
 
   if (projectPath) {
     const wizardContext = { ...context, projectPath, workflowName: '' };

--- a/apps/vs-code-designer/src/app/commands/workflows/useSQLStorage.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/useSQLStorage.ts
@@ -5,7 +5,7 @@
 import { sqlStorageConnectionStringKey } from '../../../constants';
 import { localize } from '../../../localize';
 import { addOrUpdateLocalAppSettings } from '../../utils/appSettings/localSettings';
-import { getFunctionProjectRoot } from '../../utils/codeless/connection';
+import { getLogicAppProjectRoot } from '../../utils/codeless/connection';
 import { getLocalSettingsFile } from '../appSettings/getLocalSettingsFile';
 import { validateSQLConnectionString } from '../deploy/storageAccountSteps/SQLStringNameStep';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -20,7 +20,7 @@ export async function useSQLStorage(context: IActionContext) {
 
   const message: string = localize('selectLocalSettings', 'Select your local settings file.');
   const localSettingsFile: string = await getLocalSettingsFile(context, message);
-  const projectPath = await getFunctionProjectRoot(context, localSettingsFile);
+  const projectPath = await getLogicAppProjectRoot(context, localSettingsFile);
 
   if (!projectPath) {
     throw new Error(localize('FunctionRootFolderError', 'Unable to determine logic app project root folder.'));

--- a/apps/vs-code-designer/src/app/debug/validatePreDebug.ts
+++ b/apps/vs-code-designer/src/app/debug/validatePreDebug.ts
@@ -13,7 +13,7 @@ import {
 import { localize } from '../../localize';
 import { validateFuncCoreToolsInstalled } from '../commands/funcCoreTools/validateFuncCoreToolsInstalled';
 import { getAzureWebJobsStorage, setLocalAppSetting } from '../utils/appSettings/localSettings';
-import { tryGetFunctionProjectRoot } from '../utils/verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../utils/verifyIsProject';
 import { getDebugConfigs, isDebugConfigEqual } from '../utils/vsCodeConfig/launch';
 import { getWorkspaceSetting, getFunctionsWorkerRuntime } from '../utils/vsCodeConfig/settings';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -44,7 +44,7 @@ export async function preDebugValidate(context: IActionContext, debugConfig: vsc
 
     if (shouldContinue) {
       context.telemetry.properties.lastValidateStep = 'getProjectRoot';
-      const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspace, true /* suppressPrompt */);
+      const projectPath: string | undefined = await tryGetLogicAppProjectRoot(context, workspace, true /* suppressPrompt */);
 
       if (projectPath) {
         const projectLanguage: string | undefined = getWorkspaceSetting(projectLanguageSetting, projectPath);

--- a/apps/vs-code-designer/src/app/utils/azurite/activateAzurite.ts
+++ b/apps/vs-code-designer/src/app/utils/azurite/activateAzurite.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../constants';
 import { localize } from '../../../localize';
 import { executeOnAzurite } from '../../azuriteExtension/executeOnAzuriteExt';
-import { tryGetFunctionProjectRoot } from '../verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
 import { getWorkspaceSetting, updateGlobalSetting, updateWorkspaceSetting } from '../vsCodeConfig/settings';
 import { getWorkspaceFolder } from '../workspace';
 import { DialogResponses, type IActionContext } from '@microsoft/vscode-azext-utils';
@@ -29,7 +29,7 @@ import type { MessageItem } from 'vscode';
 export async function activateAzurite(context: IActionContext): Promise<void> {
   if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
     const workspaceFolder = await getWorkspaceFolder(context);
-    const projectPath = await tryGetFunctionProjectRoot(context, workspaceFolder);
+    const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
 
     if (projectPath) {
       const globalAzuriteLocationSetting: string = getWorkspaceSetting<string>(azuriteLocationSetting, projectPath, azuriteExtensionPrefix);

--- a/apps/vs-code-designer/src/app/utils/codeless/connection.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/connection.ts
@@ -5,7 +5,7 @@ import type { SlotTreeItem } from '../../tree/slotsTree/SlotTreeItem';
 import { addOrUpdateLocalAppSettings } from '../appSettings/localSettings';
 import { writeFormattedJson } from '../fs';
 import { sendAzureRequest } from '../requestUtils';
-import { tryGetFunctionProjectRoot } from '../verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
 import { getContainingWorkspace } from '../workspace';
 import { getAuthorizationToken } from './getAuthorizationToken';
 import { getParametersJson } from './parameter';
@@ -28,12 +28,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 export async function getConnectionsFromFile(context: IActionContext, workflowFilePath: string): Promise<string> {
-  const projectRoot: string = await getFunctionProjectRoot(context, workflowFilePath);
+  const projectRoot: string = await getLogicAppProjectRoot(context, workflowFilePath);
   return getConnectionsJson(projectRoot);
 }
 
 export async function getParametersFromFile(context: IActionContext, workflowFilePath: string): Promise<Record<string, Parameter>> {
-  const projectRoot: string = await getFunctionProjectRoot(context, workflowFilePath);
+  const projectRoot: string = await getLogicAppProjectRoot(context, workflowFilePath);
   return getParametersJson(projectRoot);
 }
 
@@ -54,7 +54,7 @@ export async function addConnectionData(
   filePath: string,
   ConnectionAndAppSetting: ConnectionAndAppSetting
 ): Promise<void> {
-  const projectPath = await getFunctionProjectRoot(context, filePath);
+  const projectPath = await getLogicAppProjectRoot(context, filePath);
 
   await addConnectionDataInJson(context, projectPath ?? '', ConnectionAndAppSetting);
 
@@ -63,11 +63,11 @@ export async function addConnectionData(
   await vscode.window.showInformationMessage(localize('azureFunctions.addConnection', 'Connection added.'));
 }
 
-export async function getFunctionProjectRoot(context: IActionContext, workflowFilePath: string): Promise<string> {
+export async function getLogicAppProjectRoot(context: IActionContext, workflowFilePath: string): Promise<string> {
   const workspaceFolder = nonNullValue(getContainingWorkspace(workflowFilePath), 'workspaceFolder');
   const workspacePath: string = workspaceFolder.uri.fsPath;
 
-  const projectRoot: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath);
+  const projectRoot: string | undefined = await tryGetLogicAppProjectRoot(context, workspacePath);
 
   if (projectRoot === undefined) {
     throw new Error('Error in determining project root. Please confirm project structure is correct.');
@@ -160,7 +160,7 @@ export async function getConnectionsAndSettingsToUpdate(
   azureTenantId: string,
   workflowBaseManagementUri: string
 ): Promise<ConnectionAndSettings> {
-  const projectPath = await getFunctionProjectRoot(context, workflowFilePath);
+  const projectPath = await getLogicAppProjectRoot(context, workflowFilePath);
   const connectionsDataString = projectPath ? await getConnectionsJson(projectPath) : '';
   const connectionsData = connectionsDataString === '' ? {} : JSON.parse(connectionsDataString);
 
@@ -196,7 +196,7 @@ export async function saveConnectionReferences(
   workflowFilePath: string,
   connectionAndSettingsToUpdate: ConnectionAndSettings
 ): Promise<void> {
-  const projectPath = await getFunctionProjectRoot(context, workflowFilePath);
+  const projectPath = await getLogicAppProjectRoot(context, workflowFilePath);
   const { connections, settings } = connectionAndSettingsToUpdate;
   const connectionsFilePath = path.join(projectPath, connectionsFileName);
   const connectionsFileExists = fse.pathExistsSync(connectionsFilePath);

--- a/apps/vs-code-designer/src/app/utils/codeless/parameter.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/parameter.ts
@@ -3,7 +3,7 @@ import { localize } from '../../../localize';
 import { isCSharpProject } from '../../commands/initProjectForVSCode/detectProjectLanguage';
 import { writeFormattedJson } from '../fs';
 import { parseJson } from '../parseJson';
-import { getFunctionProjectRoot } from './connection';
+import { getLogicAppProjectRoot } from './connection';
 import { addNewFileInCSharpProject } from './updateBuildFile';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { parseError } from '@microsoft/vscode-azext-utils';
@@ -29,7 +29,7 @@ export async function getParametersJson(workflowFilePath: string): Promise<Recor
 }
 
 export async function saveParameters(context: IActionContext, workflowFilePath: string, parameters: WorkflowParameter): Promise<void> {
-  const projectPath = await getFunctionProjectRoot(context, workflowFilePath);
+  const projectPath = await getLogicAppProjectRoot(context, workflowFilePath);
   const parametersFilePath = path.join(projectPath, parametersFileName);
   const parametersFileExists = fse.pathExistsSync(parametersFilePath);
 

--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -21,7 +21,7 @@ import { localize } from '../../../localize';
 import { updateFuncIgnore } from '../codeless/common';
 import { writeFormattedJson } from '../fs';
 import { getFunctionsCommand } from '../funcCoreTools/funcVersion';
-import { tryGetFunctionProjectRoot } from '../verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
 import { getWorkspaceSetting, updateGlobalSetting } from '../vsCodeConfig/settings';
 import { getWorkspaceFolder } from '../workspace';
 import { delay } from '@azure/ms-rest-js';
@@ -205,7 +205,7 @@ export function stopDesignTimeApi(): void {
 export async function promptStartDesignTimeOption(context: IActionContext) {
   if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
     const workspaceFolder = await getWorkspaceFolder(context);
-    const projectPath = await tryGetFunctionProjectRoot(context, workspaceFolder);
+    const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
     const autoStartDesignTime = !!getWorkspaceSetting<boolean>(autoStartDesignTimeSetting);
     const showStartDesignTimeMessage = !!getWorkspaceSetting<boolean>(showStartDesignTimeMessageSetting);
     if (projectPath) {

--- a/apps/vs-code-designer/src/app/utils/dotnet/dotnet.ts
+++ b/apps/vs-code-designer/src/app/utils/dotnet/dotnet.ts
@@ -14,7 +14,7 @@ import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { executeCommand } from '../funcCoreTools/cpUtils';
 import { runWithDurationTelemetry } from '../telemetry';
-import { tryGetFunctionProjectRoot } from '../verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
 import { getGlobalSetting, updateGlobalSetting, updateWorkspaceSetting } from '../vsCodeConfig/settings';
 import { findFiles, getWorkspaceFolder } from '../workspace';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -240,7 +240,7 @@ export async function setDotNetCommand(context: IActionContext): Promise<void> {
     try {
       if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
         const workspaceFolder = await getWorkspaceFolder(context);
-        const projectPath = await tryGetFunctionProjectRoot(context, workspaceFolder);
+        const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
 
         if (projectPath) {
           const pathEnv = {

--- a/apps/vs-code-designer/src/app/utils/funcCoreTools/funcHostTask.ts
+++ b/apps/vs-code-designer/src/app/utils/funcCoreTools/funcHostTask.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { defaultFuncPort, localSettingsFileName, stopFuncTaskPostDebugSetting } from '../../../constants';
 import { getLocalSettingsJson } from '../appSettings/localSettings';
-import { tryGetFunctionProjectRoot } from '../verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
 import { delay } from '@azure/ms-rest-js';
 import { isString } from '@microsoft/utils-logic-apps';
@@ -117,7 +117,7 @@ export async function getFuncPortFromTaskOrProject(
     if (isString(projectPathOrTaskScope)) {
       projectPath = projectPathOrTaskScope;
     } else if (typeof projectPathOrTaskScope === 'object') {
-      projectPath = await tryGetFunctionProjectRoot(context, projectPathOrTaskScope);
+      projectPath = await tryGetLogicAppProjectRoot(context, projectPathOrTaskScope);
     }
 
     if (projectPath) {

--- a/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
+++ b/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
@@ -38,7 +38,7 @@ export async function isLogicAppProject(folderPath: string): Promise<boolean> {
  * If a single logic app project is found, return that path.
  * If multiple projects are found, prompt to pick the project.
  */
-export async function tryGetFunctionProjectRoot(
+export async function tryGetLogicAppProjectRoot(
   context: IActionContext,
   workspaceFolder: WorkspaceFolder | string,
   suppressPrompt = false
@@ -108,7 +108,7 @@ export async function verifyAndPromptToCreateProject(
 ): Promise<string | undefined> {
   options = options || {};
 
-  const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, fsPath);
+  const projectPath: string | undefined = await tryGetLogicAppProjectRoot(context, fsPath);
   if (!projectPath) {
     if (!options.suppressCreateProjectPrompt) {
       const message: string = localize('notLogicApp', 'The selected folder is not a logic app project. Create new project?');

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/tasks.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/tasks.ts
@@ -6,7 +6,7 @@ import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import type { ProjectFile } from '../dotnet/dotnet';
 import { getDotnetDebugSubpath, getProjFiles, getTargetFramework } from '../dotnet/dotnet';
-import { tryGetFunctionProjectRoot } from '../verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
 import { DialogResponses, openUrl, type IActionContext } from '@microsoft/vscode-azext-utils';
 import { ProjectLanguage, type ITask, type ITaskInputs } from '@microsoft/vscode-extension';
 import * as fse from 'fs-extra';
@@ -91,7 +91,7 @@ export async function validateTasksJson(context: IActionContext, folders: Readon
   try {
     if (folders) {
       for (const folder of folders) {
-        const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder);
+        const projectPath: string | undefined = await tryGetLogicAppProjectRoot(context, folder);
         context.telemetry.properties.projectPath = projectPath;
         if (projectPath) {
           const tasksJsonPath: string = path.join(projectPath, '.vscode', 'tasks.json');

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -7,7 +7,7 @@ import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { initProjectForVSCode } from '../../commands/initProjectForVSCode/initProjectForVSCode';
 import { tryParseFuncVersion } from '../funcCoreTools/funcVersion';
-import { tryGetFunctionProjectRoot } from '../verifyIsProject';
+import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
 import { getWorkspaceSetting, updateGlobalSetting } from './settings';
 import { verifyTargetFramework } from './verifyTargetFramework';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -28,7 +28,7 @@ export async function verifyVSCodeConfigOnActivate(
   if (folders) {
     for (const folder of folders) {
       const workspacePath: string = folder.uri.fsPath;
-      const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder);
+      const projectPath: string | undefined = await tryGetLogicAppProjectRoot(context, folder);
 
       if (projectPath) {
         ext.logicAppWorkspace = projectPath;

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -6,7 +6,7 @@ import { localize } from '../../localize';
 import type { RemoteWorkflowTreeItem } from '../tree/remoteWorkflowsTree/RemoteWorkflowTreeItem';
 import { NoWorkspaceError } from './errors';
 import { isPathEqual, isSubpath } from './fs';
-import { tryGetFunctionProjectRoot } from './verifyIsProject';
+import { tryGetLogicAppProjectRoot } from './verifyIsProject';
 import { isNullOrUndefined, isString } from '@microsoft/utils-logic-apps';
 import { UserCancelledError } from '@microsoft/vscode-azext-utils';
 import type { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
@@ -62,7 +62,7 @@ export async function getWorkspaceFolder(context: IActionContext): Promise<vscod
     const logicAppsWorkspaces = [];
 
     for (const folder of vscode.workspace.workspaceFolders) {
-      const projectRoot = await tryGetFunctionProjectRoot(context, folder);
+      const projectRoot = await tryGetLogicAppProjectRoot(context, folder);
       if (projectRoot) {
         logicAppsWorkspaces.push(projectRoot);
       }


### PR DESCRIPTION
This pull request to `apps/vs-code-designer` replaces occurrences of the function `getFunctionProjectRoot` with `getLogicAppProjectRoot` and `tryGetFunctionProjectRoot` with `tryGetLogicAppProjectRoot` in multiple files. This change reflects a change in terminology and ensures the correct function is used in the logic app context.
