### PR TITLE
refactor(repo): Remove unused host.json files

### DIFF
--- a/host.json
+++ b/host.json
@@ -1,7 +1,0 @@
-{
-  "version": "2.0",
-  "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[2.*, 3.0.0)"
-  }
-}

--- a/workflow-designtime/host.json
+++ b/workflow-designtime/host.json
@@ -1,7 +1,0 @@
-{
-  "version": "2.0",
-  "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[2.*, 3.0.0)"
-  }
-}


### PR DESCRIPTION
This pull request removes the `host.json` and `workflow-designtime/host.json` files used for configuring the Azure Functions host and the workflow design-time host. The removed content includes the version of the host and the extension bundle information. These files are only used in Logic Apps project. Removing these as our repo is not a Logic App project

Main change:

* Removed the `host.json` and `workflow-designtime/host.json` files used for configuring the Azure Functions host and the workflow design-time host.