### PR TITLE
fix(vscode): Fix project path in workflow-designtime folder

### DIFF
--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -86,7 +86,7 @@ export async function startDesignTimeApi(projectPath: string): Promise<void> {
       );
 
       const designTimeDirectory: Uri | undefined = await getOrCreateDesignTimeDirectory(designTimeDirectoryName, projectPath);
-      settingsFileContent.Values[ProjectDirectoryPath] = path.join(designTimeDirectory.fsPath);
+      settingsFileContent.Values[ProjectDirectoryPath] = path.join(projectPath);
 
       if (designTimeDirectory) {
         await createJsonFile(designTimeDirectory, hostFileName, hostFileContent);


### PR DESCRIPTION
This pull request includes an update to the `startDesignTimeApi` function in `startDesignTimeApi.ts` file. The update modifies the value of `settingsFileContent.Values[ProjectDirectoryPath]`.

Fixes #3863 

Main change:

* Updated the `startDesignTimeApi` function to modify the value of `settingsFileContent.Values[ProjectDirectoryPath]`.