### PR TITLE
fix(localization): Adding Indonesian as a language to intl provider

### DIFF
--- a/apps/designer-standalone/src/components/LocalizationSettings.tsx
+++ b/apps/designer-standalone/src/components/LocalizationSettings.tsx
@@ -38,6 +38,10 @@ export const LocalizationSettings = () => {
           text: 'French',
         },
         {
+          key: 'id',
+          text: 'Indonesian',
+        },
+        {
           key: 'en-XA',
           text: 'Test Language (en-XA)',
         },

--- a/libs/services/intl/src/IntlProvider.tsx
+++ b/libs/services/intl/src/IntlProvider.tsx
@@ -56,6 +56,9 @@ const loadLocaleData = async (locale: string): Promise<Record<string, string> | 
     case 'hu':
       messages = await import('./compiled-lang/strings.hu.json');
       break;
+    case 'id':
+      messages = await import('./compiled-lang/strings.id.json');
+      break;
     case 'it':
       messages = await import('./compiled-lang/strings.it.json');
       break;


### PR DESCRIPTION
We had indonesian translated, however we weren't using it. This should enable it to be used