### PR TITLE
fix(vscode): Add validate input for function name in workspace creation

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/setMethodName.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/setMethodName.ts
@@ -13,10 +13,19 @@ export class setMethodName extends AzureWizardPromptStep<IProjectWizardContext> 
     context.methodName = await context.ui.showInputBox({
       placeHolder: localize('setFunctioname', 'Function name'),
       prompt: localize('functionNamePrompt', 'Provide a function name for functions app project'),
+      validateInput: async (input: string): Promise<string | undefined> => await this.validateFunctionName(input),
     });
   }
 
   public shouldPrompt(_context: IProjectWizardContext): boolean {
     return true;
+  }
+
+  private async validateFunctionName(name: string | undefined): Promise<string | undefined> {
+    if (!name) {
+      return localize('emptyTemplateNameError', 'The function name cannot be empty.');
+    } else if (!/^[a-z][a-z\d_]*$/i.test(name)) {
+      return localize('functionNameInvalidMessage', 'Function name must start with a letter and can only contain letters, digits and "_".');
+    }
   }
 }


### PR DESCRIPTION
This pull request to `apps/vs-code-designer` adds a new method `validateFunctionName` to the `setMethodName` class in `setMethodName.ts`. This method checks if the function name is empty or invalid and returns an error message if so. It is used as the `validateInput` function for the `showInputBox` method in the `shouldPrompt` method.

Fixes #3830 

Main change:

* Added a new method `validateFunctionName` to the `setMethodName` class.