### PR TITLE
fix(designer): Revert change "tokens with 'body/value' should use triggerBody rather than triggerOutput"

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1006,11 +1006,7 @@ export function generateExpressionFromKey(
   const result = [];
   // NOTE: Use @body for tokens that come from the body path like outputs.$.Body.weather
   let rootMethod = method;
-  if (
-    overrideMethod &&
-    !isInsideArray &&
-    [OutputSource.Body, OutputSource.BodyValue].includes(segments[0]?.value?.toString()?.toLowerCase() ?? '')
-  ) {
+  if (overrideMethod && !isInsideArray && segments[0]?.value?.toString()?.toLowerCase() === OutputSource.Body) {
     segments.shift();
     rootMethod = actionName ? `${OutputSource.Body}(${convertToStringLiteral(actionName)})` : constants.TRIGGER_BODY_OUTPUT;
   }

--- a/libs/parsers/src/lib/common/constants.ts
+++ b/libs/parsers/src/lib/common/constants.ts
@@ -137,7 +137,6 @@ export const OutputSource = {
   Queries: 'queries',
   Headers: 'headers',
   Body: 'body',
-  BodyValue: 'body/value',
   Outputs: 'outputs',
 };
 


### PR DESCRIPTION
Reverts Azure/LogicAppsUX#3782