### PR TITLE
feat(vscode): Update unit test definition for vscode deserialization

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/runUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/runUnitTest.ts
@@ -3,35 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { localize } from '../../../../localize';
+import { getLogicAppProjectRoot } from '../../../utils/codeless/connection';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
 import * as child from 'child_process';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
-function getPathToRoot(dirItems: string[]) {
-  const DIRS_TO_ROOT = 4;
-  let path = dirItems[0];
-  for (let i = 1; i < dirItems.length - DIRS_TO_ROOT; i++) {
-    path = path.concat(`\\${dirItems[i]}`);
-  }
-  return path;
-}
-
-function getWorkflowName(dirItems: string[]) {
-  const DIRS_TO_WORKFLOWNAME = 1;
-  return dirItems[dirItems.length - DIRS_TO_WORKFLOWNAME - 1];
-}
-
-function getPathToExe(dirItems: string[]) {
-  const DIRS_TO_TESTS_FOLDER = 2;
-  let path = dirItems[0];
-  for (let i = 1; i < dirItems.length - DIRS_TO_TESTS_FOLDER; i++) {
-    path = path.concat(`\\${dirItems[i]}`);
-  }
-  const UNIT_TEST_EXE_NAME = 'LogicAppsTest.exe';
-  return `${path}\\${UNIT_TEST_EXE_NAME}`;
-}
-
-export async function runUnitTest(_context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
+export async function runUnitTest(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
   const options: vscode.ProgressOptions = {
     location: vscode.ProgressLocation.Notification,
     title: localize('azureFunctions.runUnitTest', 'Running Unit Test...'),
@@ -39,22 +17,22 @@ export async function runUnitTest(_context: IAzureConnectorsContext, node: vscod
 
   await vscode.window.withProgress(options, async () => {
     const pathToUnitTest = node.fsPath;
-    const dirItems = pathToUnitTest.split('\\');
+    const projectPath: string | undefined = await getLogicAppProjectRoot(this.context, pathToUnitTest);
+    const workflowName = path.basename(path.dirname(pathToUnitTest));
+
+    // TODO(ccastrotrejo): Need to confirm with BE and Nidhi on how we are going to execute the unit tests.
+    const UNIT_TEST_EXE_NAME = 'LogicAppsTest.exe';
+    const pathToExe = path.join(projectPath, UNIT_TEST_EXE_NAME);
 
     try {
-      const res = child.spawn(getPathToExe(dirItems), [
-        '-PathToRoot',
-        getPathToRoot(dirItems),
-        '-workflowName',
-        getWorkflowName(dirItems),
-        '-pathToUnitTest',
-        pathToUnitTest,
-      ]);
+      const res = child.spawn(pathToExe, ['-PathToRoot', projectPath, '-workflowName', workflowName, '-pathToUnitTest', pathToUnitTest]);
+
       for await (const chunk of res.stdout) {
         vscode.window.showInformationMessage(`${chunk}`);
       }
     } catch (error) {
       vscode.window.showErrorMessage(`${localize('runFailure', 'Error Running Unit Test.')} ${error.message}`, localize('OK', 'OK'));
+      context.telemetry.properties.errorMessage = error.message;
       throw error;
     }
   });

--- a/apps/vs-code-react/src/app/designer/app.tsx
+++ b/apps/vs-code-react/src/app/designer/app.tsx
@@ -35,6 +35,7 @@ export const DesignerApp = () => {
     runId,
     hostVersion,
     isUnitTest,
+    unitTestDefinition,
   } = vscodeState;
   const [standardApp, setStandardApp] = useState<StandardApp | undefined>(panelMetaData?.standardApp);
   const [runInstance, setRunInstance] = useState<LogicAppsV2.RunInstanceDefinition | null>(null);
@@ -169,6 +170,7 @@ export const DesignerApp = () => {
         kind: standardApp.kind,
       }}
       runInstance={runInstance}
+      unitTestDefinition={unitTestDefinition}
     >
       <Designer />
     </BJSWorkflowProvider>

--- a/apps/vs-code-react/src/state/DesignerSlice.ts
+++ b/apps/vs-code-react/src/state/DesignerSlice.ts
@@ -1,4 +1,5 @@
 import type { ApiHubServiceDetails, ListDynamicValue } from '@microsoft/designer-client-services-logic-apps';
+import type { UnitTestDefinition } from '@microsoft/utils-logic-apps';
 import type { ConnectionsData, ICallbackUrlResponse, IDesignerPanelMetadata } from '@microsoft/vscode-extension';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
@@ -19,6 +20,7 @@ export interface DesignerState {
   oauthRedirectUrl: string;
   hostVersion: string;
   isUnitTest: boolean;
+  unitTestDefinition: UnitTestDefinition | null;
 }
 
 const initialState: DesignerState = {
@@ -48,6 +50,7 @@ const initialState: DesignerState = {
   oauthRedirectUrl: '',
   hostVersion: '',
   isUnitTest: false,
+  unitTestDefinition: null,
 };
 
 export const designerSlice = createSlice({
@@ -68,6 +71,7 @@ export const designerSlice = createSlice({
         runId,
         hostVersion,
         isUnitTest,
+        unitTestDefinition,
       } = action.payload;
 
       state.panelMetaData = panelMetadata;
@@ -82,6 +86,7 @@ export const designerSlice = createSlice({
       state.oauthRedirectUrl = oauthRedirectUrl;
       state.hostVersion = hostVersion;
       state.isUnitTest = isUnitTest;
+      state.unitTestDefinition = unitTestDefinition;
     },
     updateCallbackUrl: (state, action: PayloadAction<any>) => {
       const { callbackInfo } = action.payload;

--- a/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
@@ -8,7 +8,7 @@ import { initUnitTestDefinition } from './state/unitTest/unitTestSlice';
 import { WorkflowKind } from './state/workflow/workflowInterfaces';
 import { initWorkflowKind, initRunInstance, initWorkflowSpec } from './state/workflow/workflowSlice';
 import type { AppDispatch, RootState } from './store';
-import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
+import type { LogicAppsV2, UnitTestDefinition } from '@microsoft/utils-logic-apps';
 import { equals } from '@microsoft/utils-logic-apps';
 import { useDeepCompareEffect } from '@react-hookz/web';
 import { createSelector } from '@reduxjs/toolkit';
@@ -19,7 +19,7 @@ export interface BJSWorkflowProviderProps {
   workflow: Workflow;
   runInstance?: LogicAppsV2.RunInstanceDefinition | null;
   children?: React.ReactNode;
-  unitTestDefinition?: string;
+  unitTestDefinition?: UnitTestDefinition | null;
 }
 
 const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({ workflow, children, runInstance, unitTestDefinition }) => {

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -7,7 +7,7 @@ import type { WorkflowNode, WorkflowEdge } from '../models/workflowNode';
 import { LoggerService, Status } from '@microsoft/designer-client-services-logic-apps';
 import { getDurationStringPanelMode } from '@microsoft/designer-ui';
 import { getIntl } from '@microsoft/intl-logic-apps';
-import type { Assertion, LogicAppsV2, SubgraphType } from '@microsoft/utils-logic-apps';
+import type { Assertion, LogicAppsV2, SubgraphType, UnitTestDefinition } from '@microsoft/utils-logic-apps';
 import {
   containsIdTag,
   WORKFLOW_NODE_TYPES,
@@ -110,7 +110,7 @@ export const Deserialize = (
   };
 };
 
-export const deserializeUnitTestDefinition = (unitTestDefinition: any | null): any => {
+export const deserializeUnitTestDefinition = (unitTestDefinition: UnitTestDefinition | null): any => {
   if (isNullOrUndefined(unitTestDefinition)) return null;
   // deserialize mocks
   const mockResults: { [key: string]: string } = {};

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/mockResultsTab/mockResultsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/mockResultsTab/mockResultsTab.tsx
@@ -14,7 +14,7 @@ export const MockResultsTab = () => {
   const nodeId = useSelectedNodeId();
   const isTriggerNode = useSelector((state: RootState) => isRootNodeInGraph(nodeId, 'root', state.workflow.nodesMetadata));
   const nodeName = isTriggerNode ? `&${nodeId}` : nodeId;
-  const nodeMockResults = useMockResultsByOperation(nodeId);
+  const nodeMockResults = useMockResultsByOperation(nodeName);
   const mockResults = isNullOrUndefined(nodeMockResults) ? '' : nodeMockResults;
 
   const dispatch = useDispatch<AppDispatch>();

--- a/libs/utils/src/lib/models/unitTest.ts
+++ b/libs/utils/src/lib/models/unitTest.ts
@@ -7,3 +7,9 @@ export interface Assertion {
   assertionString: string;
   description: string;
 }
+
+export interface UnitTestDefinition {
+  triggerMocks: Record<string, OperationMock>;
+  actionMocks: Record<string, OperationMock>;
+  assertions: Assertion[];
+}


### PR DESCRIPTION
This pull request includes various changes to different files in the codebase. The most important changes include adding a new interface `UnitTestDefinition` to the `libs/utils/src/lib/models/unitTest.ts` file, updating the `BJSDeserializer.ts` file to accept a `UnitTestDefinition` object as a parameter, and updating the `BJSWorkflowProvider.tsx` file to accept a `UnitTestDefinition` object or `null` as a prop.

Main interface changes:

* Added a new interface `UnitTestDefinition`.
* Updated the `BJSDeserializer.ts` file to accept a `UnitTestDefinition` object as a parameter in the `deserializeUnitTestDefinition` function. 
* Updated the type of the `unitTestDefinition` prop in `BJSWorkflowProviderProps` to accept a `UnitTestDefinition` object or `null`.

Other important changes:

* Added a new `unitTestDefinition` property to the `designerSlice` and updated the `DesignerState` interface. 
* Added the `unitTestDefinition` prop to the `DesignerApp` component. 


#### Screenshots

https://github.com/Azure/LogicAppsUX/assets/102700317/c5d4bddb-4dfe-4841-992f-a4d9d09e3054


