### PR TITLE
fix(designer): Changes not serializing when token deleted without editor being focused

### DIFF
--- a/libs/designer-ui/src/lib/querybuilder/Row.tsx
+++ b/libs/designer-ui/src/lib/querybuilder/Row.tsx
@@ -278,7 +278,7 @@ export const Row = ({
         <RowDropdown disabled={readonly || key.length === 0} condition={operator} onChange={handleSelectedOption} key={operator} />
         <StringEditor
           valueType={constants.SWAGGER.TYPE.ANY}
-          readonly={readonly || key.length === 0}
+          readonly={readonly || (key.length === 0 && operand2.length === 0)}
           className={'msla-querybuilder-row-value-input'}
           initialValue={operand2}
           placeholder={rowValueInputPlaceholder}

--- a/libs/designer-ui/src/lib/token/inputToken.tsx
+++ b/libs/designer-ui/src/lib/token/inputToken.tsx
@@ -76,8 +76,8 @@ export const InputToken: React.FC<InputTokenProps> = ({ value, brandColor, icon,
 
   const handleTokenDeleteClicked = () => {
     if (nodeKey) {
-      editor.focus();
       editor.dispatchCommand(DELETE_TOKEN_NODE, nodeKey);
+      editor.focus();
     }
   };
 
@@ -92,7 +92,10 @@ export const InputToken: React.FC<InputTokenProps> = ({ value, brandColor, icon,
         aria-label={tokenDelete}
         className="msla-button msla-token-delete"
         data-automation-id={`msla-token-delete-${title}`}
-        onClick={handleTokenDeleteClicked}
+        onClick={(e) => {
+          e.stopPropagation();
+          handleTokenDeleteClicked();
+        }}
         onMouseDown={(e) => {
           e.preventDefault();
         }}


### PR DESCRIPTION
We were having an issue where the tokens deleted weren't focusing the editor after deletion, causing the blurring not to happen, causing serialization to never happen