### PR TITLE
feat(designer): enable support prevent casting in complex array editors

### DIFF
--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -27,6 +27,7 @@ export interface DesignerOptionsState {
   suppressDefaultNodeSelectFunctionality?: boolean;
   hostOptions: {
     displayRuntimeInfo: boolean; // show info about where the action is run(i.e. InApp/Shared/Custom)
+    suppressCastingForSerialize?: boolean; // suppress casting for serialize
   };
   nodeSelectAdditionalCallback?: (nodeId: string) => any;
   showConnectionsPanel?: boolean;

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -32,6 +32,7 @@ const initialState: DesignerOptionsState = {
   showConnectionsPanel: false,
   hostOptions: {
     displayRuntimeInfo: true,
+    suppressCastingForSerialize: false,
   },
 };
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -1,6 +1,6 @@
 import constants from '../../../../../common/constants';
 import { useShowIdentitySelectorQuery } from '../../../../../core/state/connection/connectionSelector';
-import { useReadOnly } from '../../../../../core/state/designerOptions/designerOptionsSelectors';
+import { useHostOptions, useReadOnly } from '../../../../../core/state/designerOptions/designerOptionsSelectors';
 import type { ParameterGroup } from '../../../../../core/state/operation/operationMetadataSlice';
 import { DynamicLoadStatus, ErrorLevel } from '../../../../../core/state/operation/operationMetadataSlice';
 import { useNodesInitialized, useOperationErrorInfo } from '../../../../../core/state/operation/operationSelector';
@@ -188,6 +188,8 @@ const ParameterSection = ({
   const rootState = useSelector((state: RootState) => state);
   const displayNameResult = useConnectorName(operationInfo);
   const panelLocation = usePanelLocation();
+
+  const { suppressCastingForSerialize } = useHostOptions();
 
   const [tokenMapping, setTokenMapping] = useState<Record<string, ValueSegment>>({});
 
@@ -406,7 +408,7 @@ const ParameterSection = ({
           tokenpickerButtonProps: {
             location: panelLocation === PanelLocation.Left ? TokenPickerButtonLocation.Right : TokenPickerButtonLocation.Left,
           },
-          suppressCastingForSerialize: /* TODO: Will need to determine how this is passed down */ false,
+          suppressCastingForSerialize: suppressCastingForSerialize ?? false,
           onCastParameter: (value: ValueSegment[], type?: string, format?: string, suppressCasting?: boolean) =>
             parameterValueToString(
               { value, type: type ?? 'string', info: { format }, suppressCasting } as ParameterInfo,


### PR DESCRIPTION
Modfified the designerOptionsInterface to accept suppressCastingForSerialize as optional and add it to parametersTab.

The cast no longer appears in the Power Automate V3 desginer.

![image](https://github.com/Azure/LogicAppsUX/assets/135278983/b55df07a-114c-4575-8e9a-2070d7666e61)
