### PR TITLE
chore: Bump minimum node version to 18 and move official build version to 20

### DIFF
--- a/.github/workflows/Deploy-Documentation.yml
+++ b/.github/workflows/Deploy-Documentation.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Node.js version 16.x
+      - name: Set up Node.js version 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - run: npm ci
       - run: npm run build:docs

--- a/.github/workflows/compile-loc.yml
+++ b/.github/workflows/compile-loc.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
 
       - run: npm ci
 
@@ -59,10 +59,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Node.js version 16
+      - name: Set up Node.js version 20
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
 
       - run: npm ci
 
@@ -119,7 +119,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci
       - name: 'Local Version Bump'
         run: ${{ env.BUMP_COMMAND }} --skip.commit --skip.tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 19.x]
+        node-version: [18.x, 20.x]
 
     steps:
       # checkout the repo

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "start:arm": "npm run generateArmToken && npm run start"
   },
   "engines": {
-    "node": ">=16",
-    "npm": ">=8"
+    "node": ">=18",
+    "npm": ">=9"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This pull request includes updates to the Node.js and npm versions in various files to require a minimum Node.js version of 18 and npm version of 9. The most important changes include updating the Node.js version in the `jobs` section of `.github/workflows/production-build.yml` and updating the Node.js versions in the `matrix` section of `.github/workflows/test.yml`.

Main version updates:

* <a href="diffhunk://#diff-20fbc76be4bae1652559385109766d3a3a185d70ae392c77fab423e41f5b6b16L62-R65">`.github/workflows/production-build.yml`</a>: Updated the Node.js version in the `jobs` section from 16 to 20. <a href="diffhunk://#diff-20fbc76be4bae1652559385109766d3a3a185d70ae392c77fab423e41f5b6b16L62-R65">[1]</a> <a href="diffhunk://#diff-20fbc76be4bae1652559385109766d3a3a185d70ae392c77fab423e41f5b6b16L122-R122">[2]</a> <a href="diffhunk://#diff-20fbc76be4bae1652559385109766d3a3a185d70ae392c77fab423e41f5b6b16L38-R38">[3]</a>
* <a href="diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L41-R42">`package.json`</a>: Updated Node.js and npm versions to require Node.js version `>=18` and npm version `>=9`.
* <a href="diffhunk://#diff-135f6f856103174c203583f87e79b72194d8a28e31e917aa69f5f95b9bd1a33fL21-R21">`.github/workflows/compile-loc.yml`</a>: Updated Node.js version requirement from "16.x" to "20.x".
* <a href="diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L14-R14">`.github/workflows/test.yml`</a>: Updated Node.js versions in the `matrix` section from "16.x, 18.x, 19.x" to "18.x, 20.x".
* <a href="diffhunk://#diff-644cc4091ba9cdbb8de950bd69ea1757244e73ceaf1bcd5ce28ca755aafff8caL33-R36">`.github/workflows/Deploy-Documentation.yml`</a>: Updated Node.js version requirement from "16.x" to "20.x".