### PR TITLE
fix(designer): Update condition on when to render monitoring view

### DIFF
--- a/apps/logic-apps-ux-docs/docs/intro.md
+++ b/apps/logic-apps-ux-docs/docs/intro.md
@@ -11,7 +11,7 @@ Welcome to the LogicApps UX documentation! This guide will help new engineers se
 
 Ensure you have the following installed on your system:
 
-- Node.js v16 or higher
+- Node.js v18 or higher
 - MkCert
 - (Optional) Nx CLI
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -1,3 +1,4 @@
+import constants from '../../../common/constants';
 import type { RootState } from '../../../core';
 import { useNodeMetadata, useOperationInfo } from '../../../core';
 import { useMonitoringView } from '../../../core/state/designerOptions/designerOptionsSelectors';
@@ -31,16 +32,17 @@ export const usePanelTabs = () => {
   const nodeMetaData = useNodeMetadata(selectedNode);
   const hasSchema = useHasSchema(operationInfo?.connectorId, operationInfo?.operationId);
   const runHistory = useRetryHistory(selectedNode);
-
+  const isScopeNode = operationInfo?.type.toLowerCase() !== constants.NODE.TYPE.SCOPE;
   const parameterValidationErrors = useParameterValidationErrors(selectedNode);
   const settingValidationErrors = useSettingValidationErrors(selectedNode);
 
   const monitoringTabItem = useMemo(
     () => ({
       ...monitoringTab(intl),
-      visible: isMonitoringView,
+      visible: isScopeNode,
+      isMonitoringView,
     }),
-    [intl, isMonitoringView]
+    [intl, isMonitoringView, isScopeNode]
   );
 
   const parametersTabItem = useMemo(

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -32,14 +32,14 @@ export const usePanelTabs = () => {
   const nodeMetaData = useNodeMetadata(selectedNode);
   const hasSchema = useHasSchema(operationInfo?.connectorId, operationInfo?.operationId);
   const runHistory = useRetryHistory(selectedNode);
-  const isScopeNode = operationInfo?.type.toLowerCase() !== constants.NODE.TYPE.SCOPE;
+  const isScopeNode = operationInfo?.type.toLowerCase() === constants.NODE.TYPE.SCOPE;
   const parameterValidationErrors = useParameterValidationErrors(selectedNode);
   const settingValidationErrors = useSettingValidationErrors(selectedNode);
 
   const monitoringTabItem = useMemo(
     () => ({
       ...monitoringTab(intl),
-      visible: isScopeNode && isMonitoringView,
+      visible: !isScopeNode && isMonitoringView,
     }),
     [intl, isMonitoringView, isScopeNode]
   );

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -39,8 +39,7 @@ export const usePanelTabs = () => {
   const monitoringTabItem = useMemo(
     () => ({
       ...monitoringTab(intl),
-      visible: isScopeNode,
-      isMonitoringView,
+      visible: isScopeNode && isMonitoringView,
     }),
     [intl, isMonitoringView, isScopeNode]
   );

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -29,7 +29,6 @@ export const usePanelTabs = () => {
   const isTriggerNode = useSelector((state: RootState) => isRootNodeInGraph(selectedNode, 'root', state.workflow.nodesMetadata));
   const operationInfo = useOperationInfo(selectedNode);
   const nodeMetaData = useNodeMetadata(selectedNode);
-  const isScopeNode = nodeMetaData?.subgraphType === SUBGRAPH_TYPES.SCOPE;
   const hasSchema = useHasSchema(operationInfo?.connectorId, operationInfo?.operationId);
   const runHistory = useRetryHistory(selectedNode);
 
@@ -39,9 +38,9 @@ export const usePanelTabs = () => {
   const monitoringTabItem = useMemo(
     () => ({
       ...monitoringTab(intl),
-      visible: !isScopeNode && isMonitoringView,
+      visible: isMonitoringView,
     }),
-    [intl, isMonitoringView, isScopeNode]
+    [intl, isMonitoringView]
   );
 
   const parametersTabItem = useMemo(


### PR DESCRIPTION
This pull request includes changes to improve the code and documentation. The most important changes include updating the `visible` property of an object in a TypeScript file and updating the required version of Node.js in the documentation.

Code changes:

* Updated the `visible` property of the `monitoringTabItem` object in `usePanelTabs` to `isMonitoringView` instead of `!isScopeNode && isMonitoringView`, and removed the `isScopeNode` variable from the function.

Documentation changes:

* Updated the required version of Node.js in the documentation to v18 or higher.

#### Screenshots
<img width="1110" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/102700317/aaaff54a-ec20-4253-aef6-770633db9153">
