### PR TITLE
fix(vscode): Add validation for design-time folder

### DIFF
--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -114,6 +114,10 @@ export async function startDesignTimeApi(projectPath: string): Promise<void> {
 
 export async function getOrCreateDesignTimeDirectory(designTimeDirectory: string, projectRoot: string): Promise<Uri | undefined> {
   const directory: string = designTimeDirectory + path.sep;
+  if (projectRoot.includes(designTimeDirectoryName)) {
+    return Uri.file(projectRoot);
+  }
+
   const designTimeDirectoryUri: Uri = Uri.file(path.join(projectRoot, directory));
   if (!fs.existsSync(designTimeDirectoryUri.fsPath)) {
     await workspace.fs.createDirectory(designTimeDirectoryUri);


### PR DESCRIPTION
This pull request includes a change to the `getOrCreateDesignTimeDirectory` function in the `startDesignTimeApi.ts` file. The change adds a check to handle a specific case where the `designTimeDirectory` is already part of the `projectRoot`.

Main change:

* Added a check in the `getOrCreateDesignTimeDirectory` function to handle a specific case where the `designTimeDirectory` is already part of the `projectRoot`.

Fixes #3827 