### PR TITLE
fix(vscode): Add set function core tools command right after installing an update

### DIFF
--- a/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -8,7 +8,12 @@ import { localize } from '../../../localize';
 import { executeOnFunctions } from '../../functionsExtension/executeOnFunctionsExt';
 import { binariesExist, getLatestFunctionCoreToolsVersion, useBinariesDependencies } from '../../utils/binaries';
 import { startDesignTimeApi, stopDesignTimeApi } from '../../utils/codeless/startDesignTimeApi';
-import { getFunctionsCommand, getLocalFuncCoreToolsVersion, tryParseFuncVersion } from '../../utils/funcCoreTools/funcVersion';
+import {
+  getFunctionsCommand,
+  getLocalFuncCoreToolsVersion,
+  setFunctionsCommand,
+  tryParseFuncVersion,
+} from '../../utils/funcCoreTools/funcVersion';
 import { getBrewPackageName } from '../../utils/funcCoreTools/getBrewPackageName';
 import { getFuncPackageManagers } from '../../utils/funcCoreTools/getFuncPackageManagers';
 import { getNpmDistTag } from '../../utils/funcCoreTools/getNpmDistTag';
@@ -71,6 +76,7 @@ export async function validateFuncCoreToolsIsLatestBinaries(majorVersion?: strin
           } else if (result === update) {
             stopDesignTimeApi();
             await installFuncCoreToolsBinaries(context, majorVersion);
+            await setFunctionsCommand();
             await startDesignTimeApi(ext.logicAppWorkspace);
           } else if (result === DialogResponses.dontWarnAgain) {
             await updateGlobalSetting(showCoreToolsWarningKey, false);


### PR DESCRIPTION
The change adds a new line of code to call the `setFunctionsCommand` function after installing the Func Core Tools binaries. Otherwise, the func executable will not have set the right permission until the user reloads vscode

* Added a new line of code to call the `setFunctionsCommand` function after installing the Func Core Tools binaries.



#### Issue
<img width="1147" alt="Screenshot 2024-01-03 at 10 55 45 AM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/4962d921-db03-4c64-9947-eead018caddd">
