### PR TITLE
fix(Designer): Re-added the scratch tab visibility check

### DIFF
--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -81,7 +81,13 @@ export const usePanelTabs = () => {
     [intl, isMonitoringView, runHistory]
   );
 
-  const scratchTabItem = useMemo(() => scratchTab, []);
+  const scratchTabItem = useMemo(
+    () => ({
+      ...scratchTab,
+      visible: process.env.NODE_ENV !== 'production',
+    }),
+    []
+  );
 
   const tabs = useMemo(() => {
     // Switch cases should only show parameters tab


### PR DESCRIPTION
## Main Changes

The scratch tab was being shown in production builds due to its visibility check not being carried over properly in the panel refactor that was done recently.
This PR just adds that visibility check back in, hiding the tab in production builds. 