### PR TITLE
fix(consumption): Disabled Spec Validation for incoming Swagger

### DIFF
--- a/libs/parsers/src/lib/swagger/parser.ts
+++ b/libs/parsers/src/lib/swagger/parser.ts
@@ -76,6 +76,7 @@ export class SwaggerParser {
       },
       validate: {
         schema: false,
+        spec: false,
       },
     });
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.101.0",
+  "version": "2.103.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.101.0",
+      "version": "2.103.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes #3940 by adding extra option on SwaggerParser to skip spec validation.
This was causing errors in new designer for swaggers that were failing validation even if they still functioned correctly.
By adding this new parameter in the validation, it allows the swaggers to pass validation and the app to continue running.

Very similar fix to this previous fix: https://github.com/Azure/LogicAppsUX/pull/3066 
