### PR TITLE
chore: Fix `{methode}` in Dutch language

### DIFF
--- a/Localize/lang/strings.nl.json
+++ b/Localize/lang/strings.nl.json
@@ -1003,7 +1003,7 @@
   "fKYuwf": "Selecteer bestand of installatiekopie",
   "fVG5aD": "(UTC-05:00) Haïti",
   "faUrud": "Verbindingsgegevens laden...",
-  "fc1AV8": "URL van de HTTP-{methode}",
+  "fc1AV8": "URL van de HTTP-{method}",
   "fg/34o": "Logische functies",
   "fifSPb": "(UTC-03:30) Newfoundland",
   "fmm7Ik": "Functie",

--- a/Localize/loc/nl/strings.json.lcl
+++ b/Localize/loc/nl/strings.json.lcl
@@ -9223,7 +9223,7 @@
         <Str Cat="Text">
           <Val><![CDATA[HTTP {method} URL]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[URL van de HTTP-{methode}]]></Val>
+            <Val><![CDATA[URL van de HTTP-{method}]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/libs/services/intl/src/compiled-lang/strings.nl.json
+++ b/libs/services/intl/src/compiled-lang/strings.nl.json
@@ -6686,7 +6686,7 @@
     },
     {
       "type": 1,
-      "value": "methode"
+      "value": "method"
     }
   ],
   "fg/34o": [


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Loc fix for #3972.

- **What is the current behavior?** (You can also link to an open issue here)

`{methode}` is not a valid interpolation:

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/db38e204-aa6c-49d0-802b-31705a0b0550)

- **What is the new behavior (if this is a feature change)?**

Fixed interpolation.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

- **Please Include Screenshots or Videos of the intended change**:

N/A