### PR TITLE
fix(Designer): Create connection button appearance to primary

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -620,7 +620,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
 
       {/* Action Buttons */}
       <div className="msla-edit-connection-actions-container">
-        <Button disabled={!canSubmit} aria-label={submitButtonAriaLabel} onClick={submitCallback}>
+        <Button appearance="primary" disabled={!canSubmit} aria-label={submitButtonAriaLabel} onClick={submitCallback}>
           {submitButtonText}
         </Button>
         {!hideCancelButton ? (


### PR DESCRIPTION
## Main Changes

Create connection button appearance changed back to primary.
(Was a regression with the connection panel refactor)

![image](https://github.com/Azure/LogicAppsUX/assets/25409734/fb2a3101-ae56-4257-adf9-0b48af50bb24)