### PR TITLE
feat(Designer): Search preload is now delayed until nodes are initialized

### DIFF
--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -1,4 +1,4 @@
-import { openPanel } from '../core';
+import { openPanel, useNodesInitialized } from '../core';
 import { useLayout } from '../core/graphlayout';
 import { usePreloadOperationsQuery, usePreloadConnectorsQuery } from '../core/queries/browse';
 import { useMonitoringView, useReadOnly } from '../core/state/designerOptions/designerOptionsSelectors';
@@ -213,9 +213,12 @@ export const Designer = (props: DesignerProps) => {
     marginLeft: props.rightShift,
   };
 
+  const isInitialized = useNodesInitialized();
+  const preloadSearch = useMemo(() => (isMonitoringView || isReadOnly) && isInitialized, [isMonitoringView, isReadOnly, isInitialized]);
+
   return (
     <DndProvider options={DND_OPTIONS}>
-      {isMonitoringView || isReadOnly ? null : <SearchPreloader />}
+      {preloadSearch ? <SearchPreloader /> : null}
       <div className="msla-designer-canvas msla-panel-mode" style={copilotPadding}>
         <ReactFlowProvider>
           <ReactFlow


### PR DESCRIPTION
## Main Changes

Added another check to our search preloading so that it doesn't batch with the rest of our requests in Portal.
**This shaves off about 4~5 seconds of waiting** on each initialization in most cases, since it was including the first heavy operation request with all of the node initialization requests, so we wouldn't show nodes as initialized until that request was returned.

We had this feature a while back but was removed when the batch API  was going through changes because it actually sped things up at the time.  After the batch api reverted most of those changes we didn't revert ours.

I'm embarrassed I didn't notice this sooner

---

## Timing summary from `Frame load` => `Designer idle`

### OLD
![image](https://github.com/Azure/LogicAppsUX/assets/25409734/5c8e54ba-3107-4450-9398-67d59b1f546c)

### NEW
![image](https://github.com/Azure/LogicAppsUX/assets/25409734/50a3cc6b-bfad-4e93-8274-91e05d9f17d0)

