### PR TITLE
fix(designer-ui): Prevent users from switching to WYSIWYG view if raw HTML is not supported

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -67,6 +67,7 @@ export interface BaseEditorProps {
   tokenPickerButtonProps?: TokenPickerButtonEditorProps;
   dataAutomationId?: string;
   tokenMapping?: Record<string, ValueSegment>;
+  isSwitchFromPlaintextBlocked?: boolean;
   loadParameterValueFromString?: (value: string) => ValueSegment[];
   onChange?: ChangeHandler;
   onBlur?: () => void;
@@ -98,6 +99,7 @@ export const BaseEditor = ({
   valueType,
   dataAutomationId,
   tokenMapping,
+  isSwitchFromPlaintextBlocked,
   loadParameterValueFromString,
   onFocus,
   onBlur,
@@ -182,7 +184,7 @@ export const BaseEditor = ({
         {htmlEditor ? (
           <Toolbar
             isRawText={htmlEditor === 'raw-html'}
-            isSwitchToWysiwygBlocked={false}
+            isSwitchFromPlaintextBlocked={isSwitchFromPlaintextBlocked}
             readonly={readonly}
             setIsRawText={setIsValuePlaintext}
           />

--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -179,7 +179,14 @@ export const BaseEditor = ({
         data-automation-id={dataAutomationId}
         title={placeholder}
       >
-        {htmlEditor ? <Toolbar isRawText={htmlEditor === 'raw-html'} readonly={readonly} setIsRawText={setIsValuePlaintext} /> : null}
+        {htmlEditor ? (
+          <Toolbar
+            isRawText={htmlEditor === 'raw-html'}
+            isSwitchToWysiwygBlocked={false}
+            readonly={readonly}
+            setIsRawText={setIsValuePlaintext}
+          />
+        ) : null}
         <TextPlugin
           contentEditable={
             <ContentEditable className={css('editor-input', readonly && 'readonly')} ariaLabelledBy={labelId} ariaDescribedBy={id} />

--- a/libs/designer-ui/src/lib/html/index.tsx
+++ b/libs/designer-ui/src/lib/html/index.tsx
@@ -12,6 +12,7 @@ export const HTMLEditor = ({ initialValue, onChange, ...baseEditorProps }: BaseE
     const initialValueString = convertSegmentsToString(initialValue, blankNodeMap);
     return !isHtmlStringValueSafeForLexical(initialValueString, blankNodeMap);
   });
+  const [isSwitchFromPlaintextBlocked, setIsSwitchFromPlaintextBlocked] = useState(() => isValuePlaintext);
   const [value, setValue] = useState<ValueSegment[]>(initialValue);
 
   const onValueChange = (newValue: ValueSegment[]): void => {
@@ -36,10 +37,16 @@ export const HTMLEditor = ({ initialValue, onChange, ...baseEditorProps }: BaseE
         ...baseEditorProps.tokenPickerButtonProps,
         newlineVerticalOffset: 20,
       }}
+      isSwitchFromPlaintextBlocked={isSwitchFromPlaintextBlocked}
       onBlur={handleBlur}
       setIsValuePlaintext={setIsValuePlaintext}
     >
-      <HTMLChangePlugin isValuePlaintext={isValuePlaintext} setIsValuePlaintext={setIsValuePlaintext} setValue={onValueChange} />
+      <HTMLChangePlugin
+        isValuePlaintext={isValuePlaintext}
+        setIsSwitchFromPlaintextBlocked={setIsSwitchFromPlaintextBlocked}
+        setIsValuePlaintext={setIsValuePlaintext}
+        setValue={onValueChange}
+      />
     </EditorWrapper>
   );
 };

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/Toolbar.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/Toolbar.tsx
@@ -56,11 +56,12 @@ export type blockTypeToBlockName = (typeof blockTypeToBlockName)[keyof typeof bl
 
 interface ToolbarProps {
   isRawText?: boolean;
+  isSwitchToWysiwygBlocked?: boolean;
   readonly?: boolean;
   setIsRawText?: (newValue: boolean) => void;
 }
 
-export const Toolbar = ({ isRawText, readonly = false, setIsRawText }: ToolbarProps): JSX.Element => {
+export const Toolbar = ({ isRawText, isSwitchToWysiwygBlocked, readonly = false, setIsRawText }: ToolbarProps): JSX.Element => {
   const [editor] = useLexicalComposerContext();
   const [activeEditor, setActiveEditor] = useState(editor);
   const { isInverted } = useTheme();
@@ -233,7 +234,7 @@ export const Toolbar = ({ isRawText, readonly = false, setIsRawText }: ToolbarPr
         <button
           aria-label="Raw code toggle"
           className={css('toolbar-item', isRawText && 'active')}
-          disabled={readonly}
+          disabled={readonly || (isRawText && isSwitchToWysiwygBlocked)}
           onMouseDown={(e) => {
             e.preventDefault();
           }}

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/Toolbar.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/Toolbar.tsx
@@ -239,36 +239,22 @@ export const Toolbar = ({ isRawText, isSwitchToWysiwygBlocked, readonly = false,
             e.preventDefault();
           }}
           onClick={() => {
-            const enterRawHtmlMode = () => {
-              const nodeMap = new Map<string, ValueSegment>();
-              activeEditor.getEditorState().read(() => {
-                getChildrenNodes($getRoot(), nodeMap);
-              });
-
-              convertEditorState(activeEditor, nodeMap, { isValuePlaintext: false }).then((valueSegments) => {
-                activeEditor.update(() => {
-                  $getRoot().clear().select();
-                  parseSegments(valueSegments, { tokensEnabled: true, readonly });
-                  setIsRawText(true);
-                });
-              });
-            };
-
-            const exitRawHtmlMode = () => {
-              const nodeMap = new Map<string, ValueSegment>();
-              activeEditor.getEditorState().read(() => {
-                getChildrenNodes($getRoot(), nodeMap);
-              });
-              convertEditorState(activeEditor, nodeMap, { isValuePlaintext: true }).then((valueSegments) => {
-                activeEditor.update(() => {
-                  $getRoot().clear().select();
+            const nodeMap = new Map<string, ValueSegment>();
+            activeEditor.getEditorState().read(() => {
+              getChildrenNodes($getRoot(), nodeMap);
+            });
+            convertEditorState(activeEditor, nodeMap, { isValuePlaintext: !!isRawText }).then((valueSegments) => {
+              activeEditor.update(() => {
+                $getRoot().clear().select();
+                if (isRawText) {
                   parseHtmlSegments(valueSegments, { tokensEnabled: true, readonly });
                   setIsRawText(false);
-                });
+                } else {
+                  parseSegments(valueSegments, { tokensEnabled: true, readonly });
+                  setIsRawText(true);
+                }
               });
-            };
-
-            isRawText ? exitRawHtmlMode() : enterRawHtmlMode();
+            });
           }}
           title={toggleCodeViewMessage}
         >

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/Toolbar.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/Toolbar.tsx
@@ -56,12 +56,12 @@ export type blockTypeToBlockName = (typeof blockTypeToBlockName)[keyof typeof bl
 
 interface ToolbarProps {
   isRawText?: boolean;
-  isSwitchToWysiwygBlocked?: boolean;
+  isSwitchFromPlaintextBlocked?: boolean;
   readonly?: boolean;
   setIsRawText?: (newValue: boolean) => void;
 }
 
-export const Toolbar = ({ isRawText, isSwitchToWysiwygBlocked, readonly = false, setIsRawText }: ToolbarProps): JSX.Element => {
+export const Toolbar = ({ isRawText, isSwitchFromPlaintextBlocked, readonly = false, setIsRawText }: ToolbarProps): JSX.Element => {
   const [editor] = useLexicalComposerContext();
   const [activeEditor, setActiveEditor] = useState(editor);
   const { isInverted } = useTheme();
@@ -234,7 +234,7 @@ export const Toolbar = ({ isRawText, isSwitchToWysiwygBlocked, readonly = false,
         <button
           aria-label="Raw code toggle"
           className={css('toolbar-item', isRawText && 'active')}
-          disabled={readonly || (isRawText && isSwitchToWysiwygBlocked)}
+          disabled={readonly || (isRawText && isSwitchFromPlaintextBlocked)}
           onMouseDown={(e) => {
             e.preventDefault();
           }}

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
@@ -21,18 +21,27 @@ import { $getRoot } from 'lexical';
 
 interface HTMLChangePluginProps {
   isValuePlaintext: boolean;
+  setIsSwitchFromPlaintextBlocked: (value: boolean) => void;
   setIsValuePlaintext: (isValuePlaintext: boolean) => void;
   setValue: (newVal: ValueSegment[]) => void;
 }
 
-export const HTMLChangePlugin = ({ isValuePlaintext, setIsValuePlaintext, setValue }: HTMLChangePluginProps) => {
+export const HTMLChangePlugin = ({
+  isValuePlaintext,
+  setIsSwitchFromPlaintextBlocked,
+  setIsValuePlaintext,
+  setValue,
+}: HTMLChangePluginProps) => {
   const onChange = (editorState: EditorState, editor: LexicalEditor) => {
     const nodeMap = new Map<string, ValueSegment>();
     let isNewValuePlaintext = isValuePlaintext;
 
     editorState.read(() => {
       const editorString = getChildrenNodes($getRoot(), nodeMap);
-      if (!isHtmlStringValueSafeForLexical(editorString, nodeMap)) {
+      const isSafeForLexical = isHtmlStringValueSafeForLexical(editorString, nodeMap);
+
+      setIsSwitchFromPlaintextBlocked(!isSafeForLexical);
+      if (!isSafeForLexical) {
         isNewValuePlaintext = true;
         setIsValuePlaintext(isNewValuePlaintext);
       }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Users are able to switch to Lexical WYSIWYG view in raw HTML editor, even if their raw HTML is not supported by Lexical. #3857 

- **What is the new behavior (if this is a feature change)?**

The "toggle code view" button is disabled if the user is in plaintext editor mode and the plaintext HTML is not supported by Lexical.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

![wysiwyg-block-fix](https://github.com/Azure/LogicAppsUX/assets/1350074/e62a3fa1-bc3c-4a6a-a6c3-9f6ee3ddf442)