### PR TITLE
fix(designer-ui): Prevent designer freezing when `@{` is typed into HTML editor

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/utils/editorToSegment.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/editorToSegment.ts
@@ -43,7 +43,12 @@ export const convertStringToSegments = (value: string, tokensEnabled?: boolean, 
       if (value.substring(prevIndex, currIndex - 2)) {
         returnSegments.push({ id: guid(), type: ValueSegmentType.LITERAL, value: value.substring(prevIndex, currIndex - 2) });
       }
-      const newIndex = value.indexOf('}', currIndex) + 1;
+      const endIndex = value.indexOf('}', currIndex);
+      if (endIndex < 0) {
+        currIndex++;
+        continue;
+      }
+      const newIndex = endIndex + 1;
       if (nodeMap && tokensEnabled) {
         const token = nodeMap.get(value.substring(currIndex - 2, newIndex));
         if (token) {

--- a/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
@@ -170,7 +170,12 @@ const appendStringSegment = (
       if (textSegment) {
         paragraph.append($createExtendedTextNode(textSegment, childNodeStyles, childNodeFormat));
       }
-      const newIndex = value.indexOf('}', currIndex) + 2;
+      const endIndex = value.indexOf('}', currIndex);
+      if (endIndex < 0) {
+        currIndex++;
+        continue;
+      }
+      const newIndex = endIndex + 2;
       // token is found in the text
       if (nodeMap && tokensEnabled) {
         const tokenSegment = nodeMap.get(value.substring(currIndex - 2, newIndex));


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

Note: I tried to add tests but if there is an infinite loop, Jest doesn't ever stop executing, and using mocks to stop the test early didn't yield useful results.

- **What is the current behavior?** (You can also link to an open issue here)

If `@{` is entered into the HTML editor, the designer freezes. See discussion entries here: #3996 

- **What is the new behavior (if this is a feature change)?**

The above will not freeze the designer.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

N/A