### PR TITLE
fix(designer-ui): Prevent expression `<>`s from being parsed by DOM parser

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
@@ -56,7 +56,10 @@ export const parseHtmlSegments = (value: ValueSegment[], options?: SegmentParser
   const nodeMap = new Map<string, ValueSegment>();
 
   const stringValue = convertSegmentsToString(value, nodeMap);
-  const encodedStringValue = encodeStringSegmentTokensInLexicalContext(stringValue, nodeMap);
+  const encodedStringValue = encodeStringSegmentTokensInDomContext(
+    encodeStringSegmentTokensInLexicalContext(stringValue, nodeMap),
+    nodeMap
+  );
 
   const dom = parser.parseFromString(encodedStringValue, 'text/html');
   const nodes = $generateNodesFromDOM(editor, dom);
@@ -126,7 +129,9 @@ const appendChildrenNode = (
   // if is a text node, parse for tokens
   if ($isTextNode(childNode)) {
     const textContent = childNode.getTextContent();
-    const decodedTextContent = tokensEnabled ? decodeSegmentValueInLexicalContext(textContent) : textContent;
+    const decodedTextContent = tokensEnabled
+      ? decodeStringSegmentTokensInDomContext(decodeSegmentValueInLexicalContext(textContent), nodeMap)
+      : textContent;
 
     // we need to pass in the styles and format of the parent node to the children node
     // because Lexical text nodes do not have styles or format


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

If `<br>` (or any HTML entity) is used in an expression token, it will be consumed by the Lexical DOM parser, and thus the token mapping will not properly substitute the token.

- **What is the new behavior (if this is a feature change)?**

See screenshots.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

Before:

![br-fix-before](https://github.com/Azure/LogicAppsUX/assets/1350074/4c92cf47-162e-4689-acbe-815e4a51cd8d)

After:

![br-fix-after](https://github.com/Azure/LogicAppsUX/assets/1350074/e0e5f44b-69f7-45ab-96b4-7f09b858f7d0)