### PR TITLE
fix(Designer): wrong parameter key for CreateConnection with Credentials enabled

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/_test__/createConnection.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/_test__/createConnection.spec.tsx
@@ -549,6 +549,12 @@ describe('ui/createConnection', () => {
 
       const parameters = findParameterComponents(createConnection, UniversalConnectionParameter);
       expect(parameters).toHaveLength(3);
+      expect(parameters[0].type).toEqual(UniversalConnectionParameter);
+      expect(parameters[0].props.parameterKey).toEqual('parameterA');
+      expect(parameters[1].type).toEqual(UniversalConnectionParameter);
+      expect(parameters[1].props.parameterKey).toEqual('parameterB');
+      expect(parameters[2].type).toEqual(UniversalConnectionParameter);
+      expect(parameters[2].props.parameterKey).toEqual('parameterD');
 
       const mappingEditors = findParameterComponents(createConnection, CustomCredentialMappingEditor);
       expect(mappingEditors).toHaveLength(0);

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -467,7 +467,11 @@ export const CreateConnection = (props: CreateConnectionProps) => {
   // Keep track of encountered and active mappings to avoid rendering the same mapping multiple times, or rendering the included parameters.
   const allParameterMappings = new Set<string>();
   const activeParameterMappings = new Set<string>();
-  const renderCredentialsMappingParameter = (mappingName: string, parameter: ConnectionParameterSetParameter | ConnectionParameter) => {
+  const renderCredentialsMappingParameter = (
+    parameterKey: string,
+    parameter: ConnectionParameterSetParameter | ConnectionParameter,
+    mappingName: string
+  ) => {
     if (!allParameterMappings.has(mappingName)) {
       allParameterMappings.add(mappingName);
       // This is the first time this mapping has been encountered,
@@ -505,7 +509,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
     }
 
     // Default case: render the parameter. No custom Editor was found for this mapping.
-    return renderConnectionParameter(mappingName, parameter);
+    return renderConnectionParameter(parameterKey, parameter);
   };
 
   // RENDER
@@ -603,7 +607,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
                 const mappingName = parameter?.uiDefinition?.credentialMapping?.mappingName;
                 if (mappingName) {
                   // This parameter belongs to a mapping - try to render a custom editor if supported.
-                  return renderCredentialsMappingParameter(mappingName, parameter);
+                  return renderCredentialsMappingParameter(key, parameter, mappingName);
                 }
                 return renderConnectionParameter(key, parameter);
               }


### PR DESCRIPTION
Fix for #4004 _Connection fields are duplicated and invalid for connector with Credentials support (Desktop Flow)_

**Checklist**

* Type of change: Fix.
* Breaking change: No.
* [X] The commit message follows our guidelines
* [X] Tests for the changes have been added (for bug fixes/features)
* Docs have been added / updated: N/A. 

**Change description**

The issue is only applicable when using Credentials annotations in connector definition - only Power Automate Desktop Flow is concerned.

The connection parameter component is using the react `key` props as the parameter key used in the create connection payload. 
The code path using Credentials may default to the default parameters (non-credentials), but then passed another `key` value. Consequently, the payload did not contain the expected values for these parameters.

This PR fixes this inconsistency by passing the right "parameter key" to the `key` props in this code path.

Unit-tests have been updated to validate the expected behavior.