### PR TITLE
fix(Designer): pass isLoading props to custom CredentialsMappingEditor component

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/_test__/createConnection.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/_test__/createConnection.spec.tsx
@@ -510,7 +510,26 @@ describe('ui/createConnection', () => {
         },
         setParameterValues: expect.any(Function),
         renderParameter: expect.any(Function),
+        isLoading: false,
       });
+    });
+
+    it('should render CustomCredentialMappingEditor in loading state', () => {
+      const connectionParameterSets = getConnectionParameterSetsWithCredentialMapping();
+      const props: CreateConnectionProps = {
+        isLoading: true,
+        connectorId: 'myConnectorId',
+        connectorDisplayName: 'My Connector',
+        connectionParameterSets,
+        checkOAuthCallback: jest.fn(),
+      };
+      renderer.render(<CreateConnection {...props} />);
+      const createConnectionContainer = renderer.getRenderOutput();
+      const createConnection = findConnectionCreateDiv(createConnectionContainer);
+      const mappingEditors = findParameterComponents(createConnection, CustomCredentialMappingEditor);
+      expect(mappingEditors).toHaveLength(1);
+      expect(mappingEditors[0].type).toEqual(CustomCredentialMappingEditor);
+      expect(mappingEditors[0].props.isLoading).toEqual(true);
     });
 
     it.each([

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -497,6 +497,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
           parameters,
           setParameterValues,
           renderParameter: renderConnectionParameter,
+          isLoading,
         };
         return <CredentialsMappingEditorComponent key={`mapping:${mappingName}`} {...props} />;
       }

--- a/libs/services/designer-client-services/src/lib/connectionParameterEditor.ts
+++ b/libs/services/designer-client-services/src/lib/connectionParameterEditor.ts
@@ -39,6 +39,7 @@ export interface IConnectionCredentialMappingEditorProps {
   };
   setParameterValues: React.Dispatch<React.SetStateAction<Record<string, unknown>>>;
   renderParameter: (key: string, parameter: ConnectionParameterSetParameter | ConnectionParameter) => JSX.Element;
+  isLoading?: boolean;
 }
 
 export interface IConnectionCredentialMappingOptions {


### PR DESCRIPTION
**Checklist**
* Type of change: fix.
* Breaking change: no.
* [x] The commit message follows our guidelines
* [X] Tests for the changes have been added (for bug fixes/features)
* N/A. Docs have been added / updated (for bug fixes / features)

**Changes**

_Current behavior:_ the custom editor for Credentials mapping (connections parameters) is not disabled while the panel is in loading state.

_Fix:_ pass the `isLoading` props to the custom component so it can handle it and be disabled during the loading.

<img width="454" alt="Screenshot 2024-01-19 135721" src="https://github.com/Azure/LogicAppsUX/assets/92312794/11567cd9-ac0f-41a9-98da-af35148557a5">
