### PR TITLE
feat(Consumption): Changing XML Transform Options to have Custom Option

### DIFF
--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -154,6 +154,7 @@ export const TokenField = ({
           getTokenPicker={getTokenPicker}
           onChange={onValueChange}
           onMenuOpen={onComboboxMenuOpen}
+          multiSelect={editorOptions?.multiSelect}
           dataAutomationId={`msla-setting-token-editor-combobox-${labelForAutomationId}`}
           tokenMapping={tokenMapping}
           loadParameterValueFromString={loadParameterValueFromString}

--- a/libs/services/designer-client-services/src/lib/consumption/manifests/xml.ts
+++ b/libs/services/designer-client-services/src/lib/consumption/manifests/xml.ts
@@ -76,7 +76,7 @@ export const xmlTransformManifest = {
           description: 'The transform options',
           type: 'string',
           visibility: 'advanced',
-          'x-ms-editor': 'dropdown',
+          'x-ms-editor': 'combobox',
           'x-ms-editor-options': {
             multiSelect: true,
             titleSeparator: ',',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.103.0",
+  "version": "2.104.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.103.0",
+      "version": "2.104.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Changing the XML transform options parameter to have the option of a custom option. This is done by changing it to a combo box from a drop down and adding multi select functionality to the implementation of combo box. The implementation of multi select was largely taken from how it is implemented in the dropdpwn currently. A new option of multiSelect, which is defaulted to false, must be passed down from the manifest and when not set to true, the old behavior of Combobox remains with only one item selected at a time. 

If the custom option is selected, the rest of the selected options are erased and user must use only the custom option. 

Addresses #3965 