### PR TITLE
fix(designer-ui): Indicate Lexical support for `<a>` and `<u>` tags

### DIFF
--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/__test__/util.spec.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/__test__/util.spec.ts
@@ -126,15 +126,20 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
   });
 
   describe('isHtmlStringValueSafeForLexical', () => {
-    const case1 = `<h3>dfg<span style="background-color: rgb(184, 233, 134);">dfg</span><span style="background-color: rgb(184, 233, 134); font-size: 11px;">dfg</span><a href="https://www.bing.com"><span style="background-color: rgb(184, 233, 134); font-family: Georgia; font-size: 11px;">dfgdfg dfgdfg dg zd</span></a><span style="background-color: rgb(184, 233, 134); font-family: Georgia; font-size: 11px;"> </span><u>asa</u></h3>`;
+    const case1 = '';
+    const case2 = '<h1>hello</h1>';
+    const case3 = `<h3>dfg<span style="background-color: rgb(184, 233, 134);">dfg</span><span style="background-color: rgb(184, 233, 134); font-size: 11px;">dfg</span><a href="https://www.bing.com"><span style="background-color: rgb(184, 233, 134); font-family: Georgia; font-size: 11px;">dfgdfg dfgdfg dg zd</span></a><span style="background-color: rgb(184, 233, 134); font-family: Georgia; font-size: 11px;"> </span><u>asa</u></h3>`;
+    const case4 = '<section>hello</section>';
 
-    it.each<[string, boolean, string]>([['large string using h3, links, and spans', true, case1]])(
-      'should return %p as supported=%p',
-      (_caseName, expected, inputString) => {
-        const nodeMap = new Map<string, ValueSegment>();
-        expect(isHtmlStringValueSafeForLexical(inputString, nodeMap)).toBe(expected);
-      }
-    );
+    it.each<[string, boolean, string]>([
+      ['empty string', true, case1],
+      ['small string using <h1>', true, case2],
+      ['large string using <a>, <u>, <h3>, <span>', true, case3],
+      ['small string using <section>', false, case4],
+    ])('should return %p as supported=%p', (_caseName, expected, inputString) => {
+      const nodeMap = new Map<string, ValueSegment>();
+      expect(isHtmlStringValueSafeForLexical(inputString, nodeMap)).toBe(expected);
+    });
   });
 
   describe('isTagNameSupportedByLexical', () => {

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/__test__/util.spec.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/__test__/util.spec.ts
@@ -6,8 +6,10 @@ import {
   encodeSegmentValueInDomContext,
   encodeSegmentValueInLexicalContext,
   isAttributeSupportedByLexical,
+  isHtmlStringValueSafeForLexical,
   isTagNameSupportedByLexical,
 } from '../util';
+import type { ValueSegment } from '@microsoft/designer-client-services-logic-apps';
 
 describe('lib/html/plugins/toolbar/helper/util', () => {
   describe('cleanHtmlString', () => {
@@ -123,13 +125,28 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
     });
   });
 
+  describe('isHtmlStringValueSafeForLexical', () => {
+    const case1 = `<h3>dfg<span style="background-color: rgb(184, 233, 134);">dfg</span><span style="background-color: rgb(184, 233, 134); font-size: 11px;">dfg</span><a href="https://www.bing.com"><span style="background-color: rgb(184, 233, 134); font-family: Georgia; font-size: 11px;">dfgdfg dfgdfg dg zd</span></a><span style="background-color: rgb(184, 233, 134); font-family: Georgia; font-size: 11px;"> </span><u>asa</u></h3>`;
+
+    it.each<[string, boolean, string]>([['large string using h3, links, and spans', true, case1]])(
+      'should return %p as supported=%p',
+      (_caseName, expected, inputString) => {
+        const nodeMap = new Map<string, ValueSegment>();
+        expect(isHtmlStringValueSafeForLexical(inputString, nodeMap)).toBe(expected);
+      }
+    );
+  });
+
   describe('isTagNameSupportedByLexical', () => {
     it.each<[string, boolean]>([
       ['', false],
       ['*', false],
+      ['SeCtIoN', false],
       ['section', false],
       ['script', false],
       ['style', false],
+      ['a', true],
+      ['A', true],
       ['b', true],
       ['br', true],
       ['em', true],
@@ -144,7 +161,9 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ['ol', true],
       ['p', true],
       ['span', true],
+      ['sTrOnG', true],
       ['strong', true],
+      ['u', true],
       ['ul', true],
     ])('should return <%s /> as supported=%p', (inputTag, expected) => {
       expect(isTagNameSupportedByLexical(inputTag)).toBe(expected);

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
@@ -22,6 +22,7 @@ const lexicalUnsafeCharacterDecodingMap: Record<string, string> = lexicalUnsafeC
 );
 
 const lexicalSupportedTagNames = new Set([
+  'a',
   'b',
   'br',
   'em',
@@ -37,6 +38,7 @@ const lexicalSupportedTagNames = new Set([
   'p',
   'span',
   'strong',
+  'u',
   'ul',
 ]);
 const lexicalSupportedAttributes: { '*': string[] } & Record<string, string[]> = {
@@ -122,6 +124,7 @@ export const isHtmlStringValueSafeForLexical = (htmlEditorString: string, nodeMa
   for (let i = 0; i < elements.length; i++) {
     const element = elements[i];
     if (!isTagNameSupportedByLexical(element.tagName)) {
+      console.log('unsupported1', `'${element.tagName.toLowerCase()}'`);
       return false;
     }
 
@@ -129,6 +132,7 @@ export const isHtmlStringValueSafeForLexical = (htmlEditorString: string, nodeMa
     for (let j = 0; j < attributes.length; j++) {
       const attribute = attributes[j];
       if (!isAttributeSupportedByLexical(element.tagName, attribute.name)) {
+        console.log('unsupported2', `'${element.tagName.toLowerCase()}'`, `'${attribute.name.toLowerCase()}'`);
         return false;
       }
     }

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
@@ -124,7 +124,6 @@ export const isHtmlStringValueSafeForLexical = (htmlEditorString: string, nodeMa
   for (let i = 0; i < elements.length; i++) {
     const element = elements[i];
     if (!isTagNameSupportedByLexical(element.tagName)) {
-      console.log('unsupported1', `'${element.tagName.toLowerCase()}'`);
       return false;
     }
 
@@ -132,7 +131,6 @@ export const isHtmlStringValueSafeForLexical = (htmlEditorString: string, nodeMa
     for (let j = 0; j < attributes.length; j++) {
       const attribute = attributes[j];
       if (!isAttributeSupportedByLexical(element.tagName, attribute.name)) {
-        console.log('unsupported2', `'${element.tagName.toLowerCase()}'`, `'${attribute.name.toLowerCase()}'`);
         return false;
       }
     }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Strings with `<a>` or `<u>` in them are valid in Lexical, but the current checker code does not support them and so users cannot switch from raw editor to rich editor if their strings contain one of these tags.

- **What is the new behavior (if this is a feature change)?**

Strings with `<a>` or `<u>` in them are considered valid when switching to Lexical.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

Before:

![a-u-broken](https://github.com/Azure/LogicAppsUX/assets/1350074/624c901f-b217-4435-b316-60cc2e85586b)

After:

![a-u-working](https://github.com/Azure/LogicAppsUX/assets/1350074/b7131f69-e7d6-4f34-830d-94caf807044c)