### PR TITLE
fix(designer): Split On is off by default in V3

### DIFF
--- a/libs/designer/src/lib/common/constants.ts
+++ b/libs/designer/src/lib/common/constants.ts
@@ -809,6 +809,9 @@ export default {
       INPUTS: 'inputs',
       OUTPUTS: 'outputs',
     },
+    SPLITON: {
+      AUTOLOAD: '@autoload()',
+    },
   },
   SWAGGER,
   SYSTEM_ASSIGNED_MANAGED_IDENTITY: 'SystemAssigned_Managed_Identity',

--- a/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
@@ -515,7 +515,7 @@ const getSplitOnValue = (
   operationId?: string,
   definition?: LogicAppsV2.TriggerDefinition
 ): string | undefined => {
-  if (definition) {
+  if (definition && definition.splitOn !== Constants.SETTINGS.SPLITON.AUTOLOAD) {
     return definition.splitOn;
   } else {
     if (manifest) {

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -120,7 +120,7 @@ export const getUpdatedManifestForSplitOn = (manifest: OperationManifest, splitO
     { splitOn }
   );
 
-  if (splitOn === undefined) {
+  if (splitOn === undefined || splitOn === Constants.SETTINGS.SPLITON.AUTOLOAD) {
     return manifest;
   } else if (typeof splitOn === 'string') {
     const updatedManifest = clone(manifest);


### PR DESCRIPTION
Fixing bug where V3 triggers chosen from the on-create trigger selection wizard are created with SplitOn off by default.

New behavior loads as on by default: 

<img width="311" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/135278983/2df3e63d-67ad-4448-9a87-9428a556050c">
