### PR TITLE
fix(designer): Prevent collapsed left panel from hiding minimap

### DIFF
--- a/libs/designer/src/lib/ui/styles.less
+++ b/libs/designer/src/lib/ui/styles.less
@@ -68,7 +68,7 @@
   gap: 8px;
   align-items: flex-end;
   box-sizing: border-box;
-  & .left-panel {
+  &.left-panel {
     left: 52px; // Add extra 32px taken from the collapsed panel
   }
 }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Due to a bug in #3557, styling w/ left panel was broken, causing collapsed left panel to overlap mini-map controls.

- **What is the new behavior (if this is a feature change)?**

Mini-map controls are now visible.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

**Before**

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/c4547b2f-2fd3-48fe-8aa2-b64363d83099)

**After**

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/f67d0114-a3e9-49c2-8a11-45e3a293c1cc)