### PR TITLE
fix(designer): Add focus border to search cards for keyboard nav

### DIFF
--- a/libs/designer-ui/src/lib/connectorsummarycard/connectorsummarycard.less
+++ b/libs/designer-ui/src/lib/connectorsummarycard/connectorsummarycard.less
@@ -81,6 +81,10 @@
   .msla-connector-summary-card {
     background: @ms-color-primaryBackground;
 
+    &:focus {
+      outline: 1px solid #fff;
+    }
+
     &:hover {
       background: @ms-color-primaryBackgroundHover;
     }

--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/operationSearchCard.less
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/operationSearchCard.less
@@ -15,7 +15,7 @@
   overflow: hidden;
 
   &:focus {
-    outline: 0;
+    outline: 1px solid #605e5c;
   }
 
   &:focus,
@@ -65,6 +65,10 @@
 .msla-theme-dark {
   .msla-op-search-card-container {
     background-color: @ms-color-primaryBackground;
+
+    &:focus {
+      outline: 1px solid #fff;
+    }
 
     &:hover {
       background-color: @ms-color-primaryBackgroundHover;


### PR DESCRIPTION
https://github.com/Azure/LogicAppsUX/assets/13208452/7d75f55a-ee50-4932-bed4-cb91e1fa3003
![CleanShot 2024-01-24 at 22 07 04@2x](https://github.com/Azure/LogicAppsUX/assets/13208452/af2f24ad-bd75-46c4-baa3-ec4001c211cc)

This pull request includes changes to the `operationSearchCard.less` file in the `libs/designer-ui` library. The changes primarily focus on improving the visibility of focus outlines on elements to enhance accessibility.

Here are the key changes:

* [`libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/operationSearchCard.less`](diffhunk://#diff-3be4d70dbd9f99e1cae7bcb90ee822dce51f3611cfa521633f8defa44e8ba7ddL18-R18): The focus outline has been changed from having no outline to a 1px solid outline with the color #605e5c. This change improves the visibility of the focus state on elements.
* [`libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/operationSearchCard.less`](diffhunk://#diff-3be4d70dbd9f99e1cae7bcb90ee822dce51f3611cfa521633f8defa44e8ba7ddR69-R72): A new focus outline has been added to the `.msla-op-search-card-container` class with a 1px solid white outline. This change further enhances the visibility of the focus state on elements within this container.