### PR TITLE
fix(comsumption): Setting Default Recurrence Interval based on Sku

### DIFF
--- a/apps/designer-standalone/src/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/designer-standalone/src/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -257,6 +257,7 @@ const DesignerEditor = () => {
           isMonitoringView,
           hostOptions,
           showConnectionsPanel,
+          sku: 'standard',
         }}
       >
         {workflow?.definition ? (

--- a/apps/designer-standalone/src/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
+++ b/apps/designer-standalone/src/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
@@ -191,6 +191,7 @@ const DesignerEditorConsumption = () => {
           useLegacyWorkflowParameters: true,
           showConnectionsPanel,
           hostOptions,
+          sku: 'consumption',
         }}
       >
         {workflow?.definition ? (

--- a/libs/designer/src/lib/common/constants.ts
+++ b/libs/designer/src/lib/common/constants.ts
@@ -481,8 +481,22 @@ export default {
   },
   RAW: 'Raw',
   DEFAULT_RECURRENCE: {
-    interval: 3,
-    frequency: 'Minute',
+    FREE: {
+      interval: 1,
+      frequency: 'Hour',
+    },
+    STANDARD: {
+      interval: 1,
+      frequency: 'Minute',
+    },
+    PREMIUM: {
+      interval: 15,
+      frequency: 'Second',
+    },
+    CONSUMPTION: {
+      interval: 3,
+      frequency: 'Minute',
+    },
   },
   RECURRENCE_FREQUENCY_VALUES: ['Month', 'Week', 'Day', 'Hour', 'Minute', 'Second'],
   RECURRENCE_TITLE_JOIN_SEPARATOR: ',',

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -26,6 +26,7 @@ export interface DesignerOptionsState {
   isDarkMode?: boolean;
   servicesInitialized?: boolean;
   useLegacyWorkflowParameters?: boolean;
+  sku?: string;
   isXrmConnectionReferenceMode?: boolean;
   suppressDefaultNodeSelectFunctionality?: boolean;
   hostOptions: {

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
@@ -12,7 +12,9 @@ export const useMonitoringView = () => {
 export const useLegacyWorkflowParameters = () => {
   return useSelector((state: RootState) => state.designerOptions.useLegacyWorkflowParameters);
 };
-
+export const useSku = () => {
+  return useSelector((state: RootState) => state.designerOptions.sku);
+};
 export const useHostOptions = () => {
   return useSelector((state: RootState) => state.designerOptions.hostOptions);
 };

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -28,6 +28,7 @@ const initialState: DesignerOptionsState = {
   isDarkMode: false,
   servicesInitialized: false,
   useLegacyWorkflowParameters: false,
+  sku: undefined,
   isXrmConnectionReferenceMode: false,
   showConnectionsPanel: false,
   panelTabHideKeys: [],
@@ -102,6 +103,7 @@ export const designerOptionsSlice = createSlice({
       state.isMonitoringView = action.payload.isMonitoringView;
       state.isDarkMode = action.payload.isDarkMode;
       state.useLegacyWorkflowParameters = action.payload.useLegacyWorkflowParameters;
+      state.sku = action.payload.sku;
       state.isXrmConnectionReferenceMode = action.payload.isXrmConnectionReferenceMode;
       state.suppressDefaultNodeSelectFunctionality = action.payload.suppressDefaultNodeSelectFunctionality;
       state.nodeSelectAdditionalCallback = action.payload.nodeSelectAdditionalCallback;

--- a/libs/designer/src/lib/core/utils/parameters/recurrence.ts
+++ b/libs/designer/src/lib/core/utils/parameters/recurrence.ts
@@ -1,8 +1,9 @@
 import constants from '../../../common/constants';
+import { getReactQueryClient } from '../../ReactQueryProvider';
 import { loadParameterValuesFromDefault, toParameterInfoMap } from './helper';
 import type { ParameterInfo } from '@microsoft/designer-ui';
 import { OutputMapKey, SchemaProcessor, toInputParameter } from '@microsoft/parsers-logic-apps';
-import type { OpenAPIV2, RecurrenceSetting } from '@microsoft/utils-logic-apps';
+import type { OpenAPIV2, RecurrenceSetting, LogicApps } from '@microsoft/utils-logic-apps';
 import { map, RecurrenceType } from '@microsoft/utils-logic-apps';
 
 export interface Recurrence {
@@ -51,7 +52,9 @@ export const getRecurrenceParameters = (recurrence: RecurrenceSetting | undefine
     .getSchemaProperties(schema)
     .map((item) => toInputParameter(item, true /* suppressCasting */));
 
-  const defaultRecurrence = constants.DEFAULT_RECURRENCE;
+  const queryClient = getReactQueryClient();
+  const sku = queryClient.getQueryData(['sku']) as string;
+  const defaultRecurrence = getRecurrenceBySku(sku);
 
   for (const parameter of recurrenceParameters) {
     if (!parameter.default) {
@@ -69,3 +72,18 @@ export const getRecurrenceParameters = (recurrence: RecurrenceSetting | undefine
 
   return toParameterInfoMap(recurrenceParameters, operationDefinition);
 };
+
+function getRecurrenceBySku(sku: string): LogicApps.Recurrence {
+  switch (sku) {
+    case SKU.STANDARD:
+      return constants.DEFAULT_RECURRENCE.STANDARD;
+    case SKU.PREMIUM:
+      return constants.DEFAULT_RECURRENCE.PREMIUM;
+    case SKU.CONSUMPTION:
+      return constants.DEFAULT_RECURRENCE.CONSUMPTION;
+    default:
+      return constants.DEFAULT_RECURRENCE.FREE;
+  }
+}
+
+export const SKU = { STANDARD: 'standard', PREMIUM: 'premium', CONSUMPTION: 'consumption', FREE: 'free' };

--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -1,7 +1,7 @@
 import { openPanel, useNodesInitialized } from '../core';
 import { useLayout } from '../core/graphlayout';
 import { usePreloadOperationsQuery, usePreloadConnectorsQuery } from '../core/queries/browse';
-import { useMonitoringView, useReadOnly } from '../core/state/designerOptions/designerOptionsSelectors';
+import { useMonitoringView, useReadOnly, useSku } from '../core/state/designerOptions/designerOptionsSelectors';
 import { useClampPan } from '../core/state/designerView/designerViewSelectors';
 import { useIsPanelCollapsed } from '../core/state/panel/panelSelectors';
 import { clearPanel } from '../core/state/panel/panelSlice';
@@ -32,6 +32,7 @@ import KeyboardBackendFactory, { isKeyboardDragTrigger } from 'react-dnd-accessi
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { DndProvider, createTransition, MouseTransition } from 'react-dnd-multi-backend';
 import { useHotkeys } from 'react-hotkeys-hook';
+import { useQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { Background, ReactFlow, ReactFlowProvider, useNodes, useReactFlow, useStore, BezierEdge } from 'reactflow';
 import type { BackgroundProps, NodeChange } from 'reactflow';
@@ -215,6 +216,9 @@ export const Designer = (props: DesignerProps) => {
 
   const isInitialized = useNodesInitialized();
   const preloadSearch = useMemo(() => (isMonitoringView || isReadOnly) && isInitialized, [isMonitoringView, isReadOnly, isInitialized]);
+
+  const sku = useSku();
+  useQuery({ queryKey: ['sku'], initialData: sku }); // adding the sku to the query to access outside of functional components
 
   return (
     <DndProvider options={DND_OPTIONS}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.106.0",
+  "version": "2.107.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.106.0",
+      "version": "2.107.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Changes default interval values for the recurrence trigger to be based on the sku. Now, there are different default values for standard, consumption, premium, and free. 

To breakdown some of the main changes:

- This PR adds sku as a designer options parameter

- It also adds a custom hook to access the sku so that we can add it to the query. The reason we need to add it to the query is so that we are able to access outside of functional components, namely in the recurrence file.

- Finally, it access the sku in the recurrence file in order to set the correct interval value.

Examples:
-Standard default:
![image](https://github.com/Azure/LogicAppsUX/assets/125534835/543f9bc8-53a3-4f0f-9554-31f316ff42bb)
-Consumption default:
![image](https://github.com/Azure/LogicAppsUX/assets/125534835/47b315a3-5d7a-4e50-bb99-2fb2043c6529)

Fixes #3976 