### PR TITLE
fix(Designer): String Expression Uncasting to Literal On Initialization

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/uncast.ts
+++ b/libs/designer/src/lib/core/utils/parameters/uncast.ts
@@ -105,8 +105,6 @@ export class UncastingUtility {
           return this._uncastSingleFunction(expression, 'byte');
         case 'BASE64TOSTRING':
           return this._uncastSingleFunction(expression, 'byte');
-        case 'STRING':
-          return this._uncastSingleFunction(expression, '');
         case 'ENCODEURICOMPONENT':
           return this._uncastSingleFunction(expression, '');
         case 'DECODEDATAURI':


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [X] The commit message follows our guidelines

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
leaves string expression token as an expression instead of uncasting to string literal
- **What is the current behavior?** (You can also link to an open issue here)
on initialization, automatically converts string expression into literal
- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**:

https://github.com/Azure/LogicAppsUX/assets/144840522/80524221-bc4d-416b-9bd7-d7047a214153

