### PR TITLE
fix(Designer): Initializing invoker settings causes workflow to be dirty

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -4,7 +4,7 @@ import { getConnectionsForConnector, getConnectorWithSwagger } from '../../queri
 import { getOperationManifest } from '../../queries/operation';
 import { initEmptyConnectionMap } from '../../state/connection/connectionSlice';
 import type { NodeData, NodeOperation, OperationMetadataState } from '../../state/operation/operationMetadataSlice';
-import { initializeNodes, initializeOperationInfo } from '../../state/operation/operationMetadataSlice';
+import { initializeNodes, initializeOperationInfo, updateNodeSettings } from '../../state/operation/operationMetadataSlice';
 import type { RelationshipIds } from '../../state/panel/panelInterfaces';
 import { changePanelNode, openPanel, setIsPanelLoading } from '../../state/panel/panelSlice';
 import { addResultSchema } from '../../state/staticresultschema/staticresultsSlice';
@@ -243,7 +243,9 @@ export const initializeOperationDetails = async (
   const triggerNodeManifest = await getTriggerNodeManifest(state.workflow, state.operations);
 
   if (triggerNodeManifest) {
-    updateInvokerSettings(isTrigger, triggerNodeManifest, nodeId, initData.settings as Settings, dispatch);
+    updateInvokerSettings(isTrigger, triggerNodeManifest, initData.settings as Settings, (invokerSettings: Settings) =>
+      dispatch(updateNodeSettings({ id: nodeId, settings: invokerSettings }))
+    );
   }
 
   updateAllUpstreamNodes(getState() as RootState, dispatch);

--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -523,20 +523,19 @@ const getSwaggerFromService = async (serviceDetails: CustomSwaggerServiceDetails
 
 export const updateInvokerSettings = (
   isTrigger: boolean,
-  tiggerNodeManifest: OperationManifest | undefined,
-  nodeId: string,
+  triggerNodeManifest: OperationManifest | undefined,
   settings: Settings,
-  dispatch: Dispatch,
+  updateNodeSettingsCallback: (invokerSettings: Settings) => void,
   references?: ConnectionReferences
 ): void => {
-  if (!isTrigger && tiggerNodeManifest?.properties?.settings?.invokerConnection) {
-    dispatch(updateNodeSettings({ id: nodeId, settings: { invokerConnection: { ...settings.invokerConnection, isSupported: true } } }));
+  if (!isTrigger && triggerNodeManifest?.properties?.settings?.invokerConnection) {
+    updateNodeSettingsCallback({ invokerConnection: { ...settings.invokerConnection, isSupported: true } });
   }
   if (references) {
     Object.keys(references).forEach((key) => {
       const impersonationSource = references[key].impersonation?.source;
       if (impersonationSource === ImpersonationSource.Invoker) {
-        dispatch(updateNodeSettings({ id: nodeId, settings: { invokerConnection: { isSupported: true, value: { enabled: true } } } }));
+        updateNodeSettingsCallback({ invokerConnection: { isSupported: true, value: { enabled: true } } });
       }
     });
   }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -116,6 +116,23 @@ export const initializeOperationMetadata = async (
   const allNodeData = aggregate((await Promise.all(promises)).filter((data) => !!data) as NodeDataWithOperationMetadata[][]);
   const repetitionInfos = await initializeRepetitionInfos(triggerNodeId, operations, allNodeData, nodesMetadata);
   updateTokenMetadataInParameters(allNodeData, operations, workflowParameters, nodesMetadata, triggerNodeId, repetitionInfos);
+
+  const triggerNodeManifest = allNodeData.find((nodeData) => nodeData.id === triggerNodeId)?.manifest;
+  if (triggerNodeManifest) {
+    for (const nodeData of allNodeData) {
+      const { id, settings } = nodeData;
+      if (settings) {
+        updateInvokerSettings(
+          id === triggerNodeId,
+          triggerNodeManifest,
+          settings,
+          (invokerSettings: Settings) => (nodeData.settings = { ...settings, ...invokerSettings }),
+          references
+        );
+      }
+    }
+  }
+
   dispatch(
     initializeNodes(
       allNodeData.map((data) => {
@@ -134,16 +151,6 @@ export const initializeOperationMetadata = async (
       })
     )
   );
-
-  const triggerNodeManifest = allNodeData.find((nodeData) => nodeData.id === triggerNodeId)?.manifest;
-  if (triggerNodeManifest) {
-    for (const nodeData of allNodeData) {
-      const { id, settings } = nodeData;
-      if (settings) {
-        updateInvokerSettings(id === triggerNodeId, triggerNodeManifest, id, settings, dispatch, references);
-      }
-    }
-  }
 
   const variables = initializeVariables(operations, allNodeData);
   dispatch(


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
[Bug 25856205](https://msazure.visualstudio.com/One/_workitems/edit/25856205): Test button is disabled in v3 designer when loading flow with Dataverse connector trigger
[Bug 26517779](https://msazure.visualstudio.com/One/_workitems/edit/26517779): [v3 designer]"Leave this page" popup appears when tried to navigate to the details page after saving a Dataverse triggered flow.

- **What is the current behavior?** (You can also link to an open issue here)
Workflow state gets set to dirty on initialization when invoker settings are updated for a trigger that has invoker connection option. Initialization initializes node data first, then calls updateNodeSettings to update invoker settings for node data, which sets the workflow to dirty. Due to this, test/run flow button in Power Automate is disabled on flow load and after flow save since designer thinks that the workflow is dirty.

- **What is the new behavior (if this is a feature change)?**
Workflow initialization will update invoker settings in node data variable before node initialization. This ensures the workflow is not set to dirty on initialization just to set invoker settings in node information.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

- **Please Include Screenshots or Videos of the intended change**:

**Before**:
initializeNodes would set invoker supported to false, then update invoker setting would set the invoker supported field back to true, which would cause workflow to get dirty on graph initialization:
![image](https://github.com/Azure/LogicAppsUX/assets/8736762/bfd96359-1a63-44d3-aa84-e2a80e884cd1)

Test flow is disabled after save:
<img width="536" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/8736762/43ae5087-27fb-4c84-9d79-9d34999b88e9">

**After**:
Workflow doesn't stay dirty since invoker settings are provided before node initialization. Test button gets enabled:
<img width="921" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/8736762/be9039be-540a-4d14-8874-84f47284d500">

