### PR TITLE
fix(Designer): Split on is now disabled for stateless workflows

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -7,6 +7,7 @@ import type { DependencyInfo, NodeInputs, NodeOperation, NodeOutputs, OutputInfo
 import { updateNodeSettings, updateNodeParameters, DynamicLoadStatus, updateOutputs } from '../../state/operation/operationMetadataSlice';
 import type { UpdateUpstreamNodesPayload } from '../../state/tokens/tokensSlice';
 import { updateTokens, updateUpstreamNodes } from '../../state/tokens/tokensSlice';
+import { WorkflowKind } from '../../state/workflow/workflowInterfaces';
 import type { WorkflowParameterDefinition } from '../../state/workflowparameters/workflowparametersSlice';
 import { initializeParameters } from '../../state/workflowparameters/workflowparametersSlice';
 import type { RootState } from '../../store';
@@ -294,7 +295,8 @@ export const updateOutputsAndTokens = async (
   isTrigger: boolean,
   inputs: NodeInputs,
   settings: Settings,
-  shouldProcessSettings = false
+  shouldProcessSettings = false,
+  workflowKind?: WorkflowKind
 ): Promise<void> => {
   const { type, kind, connectorId } = operationInfo;
   const supportsManifest = OperationManifestService().isSupported(type, kind);
@@ -330,7 +332,7 @@ export const updateOutputsAndTokens = async (
   dispatch(updateTokens({ id: nodeId, tokens }));
 
   // NOTE: Split On setting changes as outputs of trigger changes, so we will be recalculating such settings in this block for triggers.
-  if (shouldProcessSettings && isTrigger) {
+  if (shouldProcessSettings && isTrigger && workflowKind !== WorkflowKind.STATELESS) {
     const isSplitOnSupported = getSplitOnOptions(nodeOutputs, supportsManifest).length > 0;
     if (settings.splitOn?.isSupported !== isSplitOnSupported) {
       dispatch(updateNodeSettings({ id: nodeId, settings: { splitOn: { ...settings.splitOn, isSupported: isSplitOnSupported } } }));

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -24,7 +24,7 @@ import {
 import { addResultSchema } from '../../state/staticresultschema/staticresultsSlice';
 import type { NodeTokens, VariableDeclaration } from '../../state/tokens/tokensSlice';
 import { initializeTokensAndVariables } from '../../state/tokens/tokensSlice';
-import type { NodesMetadata, Operations } from '../../state/workflow/workflowInterfaces';
+import type { NodesMetadata, Operations, WorkflowKind } from '../../state/workflow/workflowInterfaces';
 import type { RootState } from '../../store';
 import { getConnectionReference, isConnectionReferenceValid } from '../../utils/connectors/connections';
 import { isRootNodeInGraph } from '../../utils/graph';
@@ -89,6 +89,7 @@ export const initializeOperationMetadata = async (
   deserializedWorkflow: DeserializedWorkflow,
   references: ConnectionReferences,
   workflowParameters: Record<string, WorkflowParameter>,
+  workflowKind: WorkflowKind,
   dispatch: Dispatch
 ): Promise<void> => {
   initializeConnectorsForReferences(references);
@@ -107,9 +108,9 @@ export const initializeOperationMetadata = async (
       triggerNodeId = operationId;
     }
     if (operationManifestService.isSupported(operation.type, operation.kind)) {
-      promises.push(initializeOperationDetailsForManifest(operationId, operation, !!isTrigger, dispatch));
+      promises.push(initializeOperationDetailsForManifest(operationId, operation, !!isTrigger, workflowKind, dispatch));
     } else {
-      promises.push(initializeOperationDetailsForSwagger(operationId, operation, references, !!isTrigger, dispatch) as any);
+      promises.push(initializeOperationDetailsForSwagger(operationId, operation, references, !!isTrigger, workflowKind, dispatch));
     }
   }
 
@@ -182,6 +183,7 @@ export const initializeOperationDetailsForManifest = async (
   nodeId: string,
   _operation: LogicAppsV2.ActionDefinition | LogicAppsV2.TriggerDefinition,
   isTrigger: boolean,
+  workflowKind: WorkflowKind,
   dispatch: Dispatch
 ): Promise<NodeDataWithOperationMetadata[] | undefined> => {
   const operation = { ..._operation };
@@ -228,7 +230,15 @@ export const initializeOperationDetailsForManifest = async (
     );
     const nodeDependencies = { inputs: inputDependencies, outputs: outputDependencies };
 
-    const settings = getOperationSettings(isTrigger, nodeOperationInfo, nodeOutputs, manifest, /* swagger */ undefined, operation);
+    const settings = getOperationSettings(
+      isTrigger,
+      nodeOperationInfo,
+      nodeOutputs,
+      manifest,
+      undefined /* swagger */,
+      operation,
+      workflowKind
+    );
 
     const childGraphInputs = processChildGraphAndItsInputs(manifest, operation);
 

--- a/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
@@ -123,8 +123,14 @@ export const getOperationSettings = (
 ): Settings => {
   const { operationId, type: nodeType } = operationInfo;
   return {
-    asynchronous: { isSupported: isAsynchronousSupported(isTrigger, nodeType, manifest), value: getAsynchronous(operation) },
-    correlation: { isSupported: isCorrelationSupported(isTrigger, manifest), value: getCorrelationSettings(operation) },
+    asynchronous: {
+      isSupported: isAsynchronousSupported(isTrigger, nodeType, manifest),
+      value: getAsynchronous(operation),
+    },
+    correlation: {
+      isSupported: isCorrelationSupported(isTrigger, manifest),
+      value: getCorrelationSettings(operation),
+    },
     secureInputs: {
       isSupported: isInputsPropertySupportedInSecureDataSetting(nodeType, manifest),
       value: getSecureInputsSetting(operation),
@@ -142,14 +148,17 @@ export const getOperationSettings = (
       value: getDisableAutomaticDecompression(isTrigger, nodeType, manifest, operation),
     },
     splitOn: {
-      isSupported: isSplitOnSupported(isTrigger, nodeOutputs, manifest, swagger, operationId, operation),
-      value: getSplitOn(manifest, swagger, operationId, operation),
+      isSupported: isSplitOnSupported(isTrigger, nodeOutputs, manifest, swagger, operationId, operation, workflowKind),
+      value: getSplitOn(manifest, swagger, operationId, operation, workflowKind),
     },
     retryPolicy: {
       isSupported: isRetryPolicySupported(isTrigger, operationInfo.type, manifest),
       value: getRetryPolicy(isTrigger, operationInfo.type, manifest, operation),
     },
-    requestOptions: { isSupported: areRequestOptionsSupported(isTrigger, nodeType), value: getRequestOptions(operation) },
+    requestOptions: {
+      isSupported: areRequestOptionsSupported(isTrigger, nodeType),
+      value: getRequestOptions(operation),
+    },
     sequential: getSequential(operation),
     suppressWorkflowHeaders: {
       isSupported: isSuppressWorkflowHeadersSupported(isTrigger, nodeType, manifest),
@@ -169,7 +178,10 @@ export const getOperationSettings = (
       isSupported: isTimeoutSupported(isTrigger, nodeType, manifest),
       value: getTimeout(nodeType, isTrigger, manifest, operation),
     },
-    paging: { isSupported: isPagingSupported(isTrigger, nodeType, manifest, swagger, operationId), value: getPaging(operation) },
+    paging: {
+      isSupported: isPagingSupported(isTrigger, nodeType, manifest, swagger, operationId),
+      value: getPaging(operation),
+    },
     uploadChunk: {
       isSupported: isChunkedTransferModeSupported(isTrigger, nodeType, manifest, swagger, operationId),
       value: getUploadChunk(isTrigger, nodeType, manifest, swagger, operationId, operation, workflowKind),
@@ -186,7 +198,10 @@ export const getOperationSettings = (
       isSupported: isRequestSchemaValidationSupported(isTrigger, manifest),
       value: getRequestSchemaValidation(operation),
     },
-    conditionExpressions: { isSupported: isTrigger, value: getConditionExpressions(operation) },
+    conditionExpressions: {
+      isSupported: isTrigger,
+      value: getConditionExpressions(operation),
+    },
     runAfter: {
       isSupported: getRunAfter(operation).length > 0,
       value: getRunAfter(operation),
@@ -500,8 +515,10 @@ const getSplitOn = (
   manifest?: OperationManifest,
   swagger?: SwaggerParser,
   operationId?: string,
-  definition?: LogicAppsV2.OperationDefinition
+  definition?: LogicAppsV2.OperationDefinition,
+  workflowKind?: WorkflowKind
 ): SimpleSetting<string> => {
+  if (workflowKind === WorkflowKind.STATELESS) return { enabled: false };
   const splitOnValue = getSplitOnValue(manifest, swagger, operationId, definition);
   return {
     enabled: !!splitOnValue,
@@ -562,8 +579,10 @@ const isSplitOnSupported = (
   manifest?: OperationManifest,
   swagger?: SwaggerParser,
   operationId?: string,
-  definition?: LogicAppsV2.OperationDefinition
+  definition?: LogicAppsV2.OperationDefinition,
+  workflowKind?: WorkflowKind
 ): boolean => {
+  if (workflowKind === WorkflowKind.STATELESS) return false;
   const existingSplitOn = getSplitOn(manifest, swagger, operationId, definition);
   return isTrigger && (getSplitOnOptions(nodeOutputs, !!manifest).length > 0 || existingSplitOn.enabled);
 };

--- a/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
+++ b/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
@@ -57,6 +57,7 @@ export const initializeGraphState = createAsyncThunk<
               deserializedWorkflow,
               thunkAPI.getState().connections.connectionReferences,
               parameters ?? {},
+              workflow.workflowKind,
               thunkAPI.dispatch
             ),
             getConnectionsApiAndMapping(deserializedWorkflow, thunkAPI.dispatch),

--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -142,6 +142,7 @@ export const addForeachToNode = createAsyncThunk(
         foreachNodeId,
         foreachOperation,
         /* isTrigger */ false,
+        state.workflow.workflowKind,
         dispatch
       )) as NodeDataWithOperationMetadata[];
 

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -7,6 +7,7 @@ import { getOperationManifest } from '../queries/operation';
 import type { DependencyInfo, NodeInputs, NodeOperation, NodeOutputs, OutputInfo } from '../state/operation/operationMetadataSlice';
 import { ErrorLevel, updateErrorDetails, clearDynamicOutputs, addDynamicOutputs } from '../state/operation/operationMetadataSlice';
 import { addDynamicTokens } from '../state/tokens/tokensSlice';
+import type { WorkflowKind } from '../state/workflow/workflowInterfaces';
 import type { WorkflowParameterDefinition } from '../state/workflowparameters/workflowparametersSlice';
 import { getBrandColorFromConnector, getIconUriFromConnector } from './card';
 import { getTokenExpressionValueForManifestBasedOperation } from './loops';
@@ -438,6 +439,7 @@ export const loadDynamicOutputsInNode = async (
   nodeInputs: NodeInputs,
   settings: Settings,
   workflowParameters: Record<string, WorkflowParameterDefinition>,
+  workflowKind: WorkflowKind | undefined,
   dispatch: Dispatch
 ): Promise<void> => {
   for (const outputKey of Object.keys(outputDependencies)) {
@@ -446,7 +448,16 @@ export const loadDynamicOutputsInNode = async (
 
     if (isDynamicDataReadyToLoad(info)) {
       if (info.dependencyType === 'StaticSchema') {
-        updateOutputsAndTokens(nodeId, operationInfo, dispatch, isTrigger, nodeInputs, settings, /* shouldProcessSettings */ true);
+        updateOutputsAndTokens(
+          nodeId,
+          operationInfo,
+          dispatch,
+          isTrigger,
+          nodeInputs,
+          settings,
+          true /* shouldProcessSettings */,
+          workflowKind
+        );
       } else {
         try {
           const outputSchema = await getDynamicSchema(

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1862,6 +1862,7 @@ async function loadDynamicData(
       nodeInputs,
       settings,
       rootState.workflowParameters.definitions,
+      rootState.workflow.workflowKind,
       dispatch
     );
   }

--- a/libs/designer/src/lib/core/utils/swagger/operation.ts
+++ b/libs/designer/src/lib/core/utils/swagger/operation.ts
@@ -15,6 +15,7 @@ import { getConnectorWithSwagger } from '../../queries/connections';
 import type { DependencyInfo, NodeInputs, NodeOperation, OutputInfo } from '../../state/operation/operationMetadataSlice';
 import { ErrorLevel, updateErrorDetails, DynamicLoadStatus, initializeOperationInfo } from '../../state/operation/operationMetadataSlice';
 import { addResultSchema } from '../../state/staticresultschema/staticresultsSlice';
+import type { WorkflowKind } from '../../state/workflow/workflowInterfaces';
 import { getBrandColorFromConnector, getIconUriFromConnector } from '../card';
 import { toOutputInfo, updateOutputsForBatchingTrigger } from '../outputs';
 import {
@@ -54,6 +55,7 @@ export const initializeOperationDetailsForSwagger = async (
   operation: LogicAppsV2.ActionDefinition | LogicAppsV2.TriggerDefinition,
   references: ConnectionReferences,
   isTrigger: boolean,
+  workflowKind: WorkflowKind,
   dispatch: Dispatch
 ): Promise<NodeDataWithOperationMetadata[] | undefined> => {
   try {
@@ -89,7 +91,15 @@ export const initializeOperationDetailsForSwagger = async (
         isTrigger ? (operation as LogicAppsV2.TriggerDefinition).splitOn : undefined
       );
       const nodeDependencies = { inputs: inputDependencies, outputs: outputDependencies };
-      const settings = getOperationSettings(isTrigger, nodeOperationInfo, nodeOutputs, /* manifest */ undefined, parsedSwagger, operation);
+      const settings = getOperationSettings(
+        isTrigger,
+        nodeOperationInfo,
+        nodeOutputs,
+        /* manifest */ undefined,
+        parsedSwagger,
+        operation,
+        workflowKind
+      );
 
       return [
         {


### PR DESCRIPTION
## Main Changes

The `Split-On` setting is now disabled for stateless workflows.
Stateless workflow triggers have no split-on values with this change, essentially defaulting to the previous "off" state.

Fixes https://github.com/Azure/LogicAppsUX/pull/4053