### PR TITLE
fix(Designer): Added host option to force enable split-on

### DIFF
--- a/apps/designer-standalone/src/app/SettingsSections/contextSettings.tsx
+++ b/apps/designer-standalone/src/app/SettingsSections/contextSettings.tsx
@@ -66,6 +66,11 @@ const ContextSettings = () => {
         checked={hostOptions.displayRuntimeInfo}
         onChange={(_, checked) => dispatch(setHostOptions({ displayRuntimeInfo: !!checked }))}
       />
+      <Checkbox
+        label="Force Enable Split-On"
+        checked={hostOptions.forceEnableSplitOn}
+        onChange={(_, checked) => dispatch(setHostOptions({ forceEnableSplitOn: !!checked }))}
+      />
     </div>
   );
 };

--- a/apps/designer-standalone/src/state/workflowLoadingSlice.ts
+++ b/apps/designer-standalone/src/state/workflowLoadingSlice.ts
@@ -26,6 +26,7 @@ export interface WorkflowLoadingState {
   areCustomEditorsEnabled?: boolean;
   hostOptions: {
     displayRuntimeInfo: boolean; // show info about where the action is run(i.e. InApp/Shared/Custom)
+    forceEnableSplitOn?: boolean; // force enable split on for all actions
   };
 }
 
@@ -158,7 +159,7 @@ export const workflowLoadingSlice = createSlice({
     setAreCustomEditorsEnabled: (state, action: PayloadAction<boolean>) => {
       state.areCustomEditorsEnabled = action.payload;
     },
-    setHostOptions: (state, action: PayloadAction<WorkflowLoadingState['hostOptions']>) => {
+    setHostOptions: (state, action: PayloadAction<Partial<WorkflowLoadingState['hostOptions']>>) => {
       state.hostOptions = { ...state.hostOptions, ...action.payload };
     },
   },

--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -134,7 +134,8 @@ export const initializeOperationDetails = async (
       manifest,
       /* swagger */ undefined,
       /* operation */ undefined,
-      state.workflow.workflowKind
+      state.workflow.workflowKind,
+      state.designerOptions.hostOptions.forceEnableSplitOn
     );
 
     // We should update the outputs when splitOn is enabled.
@@ -188,7 +189,8 @@ export const initializeOperationDetails = async (
       /* manifest */ undefined,
       parsedSwagger,
       /* operation */ undefined,
-      state.workflow.workflowKind
+      state.workflow.workflowKind,
+      state.designerOptions.hostOptions.forceEnableSplitOn
     );
 
     // We should update the outputs when splitOn is enabled.

--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -296,7 +296,8 @@ export const updateOutputsAndTokens = async (
   inputs: NodeInputs,
   settings: Settings,
   shouldProcessSettings = false,
-  workflowKind?: WorkflowKind
+  workflowKind?: WorkflowKind,
+  forceEnableSplitOn?: boolean
 ): Promise<void> => {
   const { type, kind, connectorId } = operationInfo;
   const supportsManifest = OperationManifestService().isSupported(type, kind);
@@ -332,7 +333,7 @@ export const updateOutputsAndTokens = async (
   dispatch(updateTokens({ id: nodeId, tokens }));
 
   // NOTE: Split On setting changes as outputs of trigger changes, so we will be recalculating such settings in this block for triggers.
-  if (shouldProcessSettings && isTrigger && workflowKind !== WorkflowKind.STATELESS) {
+  if (shouldProcessSettings && isTrigger && (workflowKind !== WorkflowKind.STATELESS || forceEnableSplitOn)) {
     const isSplitOnSupported = getSplitOnOptions(nodeOutputs, supportsManifest).length > 0;
     if (settings.splitOn?.isSupported !== isSplitOnSupported) {
       dispatch(updateNodeSettings({ id: nodeId, settings: { splitOn: { ...settings.splitOn, isSupported: isSplitOnSupported } } }));

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -90,6 +90,7 @@ export const initializeOperationMetadata = async (
   references: ConnectionReferences,
   workflowParameters: Record<string, WorkflowParameter>,
   workflowKind: WorkflowKind,
+  forceEnableSplitOn: boolean,
   dispatch: Dispatch
 ): Promise<void> => {
   initializeConnectorsForReferences(references);
@@ -108,9 +109,11 @@ export const initializeOperationMetadata = async (
       triggerNodeId = operationId;
     }
     if (operationManifestService.isSupported(operation.type, operation.kind)) {
-      promises.push(initializeOperationDetailsForManifest(operationId, operation, !!isTrigger, workflowKind, dispatch));
+      promises.push(initializeOperationDetailsForManifest(operationId, operation, !!isTrigger, workflowKind, forceEnableSplitOn, dispatch));
     } else {
-      promises.push(initializeOperationDetailsForSwagger(operationId, operation, references, !!isTrigger, workflowKind, dispatch));
+      promises.push(
+        initializeOperationDetailsForSwagger(operationId, operation, references, !!isTrigger, workflowKind, forceEnableSplitOn, dispatch)
+      );
     }
   }
 
@@ -184,6 +187,7 @@ export const initializeOperationDetailsForManifest = async (
   _operation: LogicAppsV2.ActionDefinition | LogicAppsV2.TriggerDefinition,
   isTrigger: boolean,
   workflowKind: WorkflowKind,
+  forceEnableSplitOn: boolean,
   dispatch: Dispatch
 ): Promise<NodeDataWithOperationMetadata[] | undefined> => {
   const operation = { ..._operation };
@@ -237,7 +241,8 @@ export const initializeOperationDetailsForManifest = async (
       manifest,
       undefined /* swagger */,
       operation,
-      workflowKind
+      workflowKind,
+      forceEnableSplitOn
     );
 
     const childGraphInputs = processChildGraphAndItsInputs(manifest, operation);

--- a/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
@@ -119,7 +119,8 @@ export const getOperationSettings = (
   manifest?: OperationManifest,
   swagger?: SwaggerParser,
   operation?: LogicAppsV2.OperationDefinition,
-  workflowKind?: WorkflowKind
+  workflowKind?: WorkflowKind,
+  forceEnableSplitOn?: boolean
 ): Settings => {
   const { operationId, type: nodeType } = operationInfo;
   return {
@@ -148,7 +149,7 @@ export const getOperationSettings = (
       value: getDisableAutomaticDecompression(isTrigger, nodeType, manifest, operation),
     },
     splitOn: {
-      isSupported: isSplitOnSupported(isTrigger, nodeOutputs, manifest, swagger, operationId, operation, workflowKind),
+      isSupported: isSplitOnSupported(isTrigger, nodeOutputs, manifest, swagger, operationId, operation, workflowKind, forceEnableSplitOn),
       value: getSplitOn(manifest, swagger, operationId, operation, workflowKind),
     },
     retryPolicy: {
@@ -580,9 +581,10 @@ const isSplitOnSupported = (
   swagger?: SwaggerParser,
   operationId?: string,
   definition?: LogicAppsV2.OperationDefinition,
-  workflowKind?: WorkflowKind
+  workflowKind?: WorkflowKind,
+  forceEnableSplitOn?: boolean
 ): boolean => {
-  if (workflowKind === WorkflowKind.STATELESS) return false;
+  if (workflowKind === WorkflowKind.STATELESS && !forceEnableSplitOn) return false;
   const existingSplitOn = getSplitOn(manifest, swagger, operationId, definition);
   return isTrigger && (getSplitOnOptions(nodeOutputs, !!manifest).length > 0 || existingSplitOn.enabled);
 };

--- a/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
+++ b/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
@@ -25,7 +25,7 @@ export const initializeGraphState = createAsyncThunk<
   { state: RootState }
 >('parser/deserialize', async (graphState: { workflowDefinition: Workflow; runInstance: any }, thunkAPI): Promise<InitWorkflowPayload> => {
   const { workflowDefinition, runInstance } = graphState;
-  const { workflow } = thunkAPI.getState() as RootState;
+  const { workflow, designerOptions } = thunkAPI.getState() as RootState;
   const spec = workflow.workflowSpec;
 
   if (spec === undefined) {
@@ -58,6 +58,7 @@ export const initializeGraphState = createAsyncThunk<
               thunkAPI.getState().connections.connectionReferences,
               parameters ?? {},
               workflow.workflowKind,
+              designerOptions.hostOptions.forceEnableSplitOn ?? false,
               thunkAPI.dispatch
             ),
             getConnectionsApiAndMapping(deserializedWorkflow, thunkAPI.dispatch),

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -31,6 +31,7 @@ export interface DesignerOptionsState {
   hostOptions: {
     displayRuntimeInfo: boolean; // show info about where the action is run(i.e. InApp/Shared/Custom)
     suppressCastingForSerialize?: boolean; // suppress casting for serialize
+    forceEnableSplitOn?: boolean; // force enable split on (by default it is disabled on stateless workflows)
   };
   nodeSelectAdditionalCallback?: (nodeId: string) => any;
   showConnectionsPanel?: boolean;

--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -143,6 +143,7 @@ export const addForeachToNode = createAsyncThunk(
         foreachOperation,
         /* isTrigger */ false,
         state.workflow.workflowKind,
+        state.designerOptions.hostOptions.forceEnableSplitOn ?? false,
         dispatch
       )) as NodeDataWithOperationMetadata[];
 

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -440,6 +440,7 @@ export const loadDynamicOutputsInNode = async (
   settings: Settings,
   workflowParameters: Record<string, WorkflowParameterDefinition>,
   workflowKind: WorkflowKind | undefined,
+  forceEnableSplitOn: boolean,
   dispatch: Dispatch
 ): Promise<void> => {
   for (const outputKey of Object.keys(outputDependencies)) {
@@ -456,7 +457,8 @@ export const loadDynamicOutputsInNode = async (
           nodeInputs,
           settings,
           true /* shouldProcessSettings */,
-          workflowKind
+          workflowKind,
+          forceEnableSplitOn
         );
       } else {
         try {

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1863,6 +1863,7 @@ async function loadDynamicData(
       settings,
       rootState.workflowParameters.definitions,
       rootState.workflow.workflowKind,
+      rootState.designerOptions.hostOptions.forceEnableSplitOn ?? false,
       dispatch
     );
   }

--- a/libs/designer/src/lib/core/utils/swagger/operation.ts
+++ b/libs/designer/src/lib/core/utils/swagger/operation.ts
@@ -56,6 +56,7 @@ export const initializeOperationDetailsForSwagger = async (
   references: ConnectionReferences,
   isTrigger: boolean,
   workflowKind: WorkflowKind,
+  forceEnableSplitOn: boolean,
   dispatch: Dispatch
 ): Promise<NodeDataWithOperationMetadata[] | undefined> => {
   try {
@@ -98,7 +99,8 @@ export const initializeOperationDetailsForSwagger = async (
         /* manifest */ undefined,
         parsedSwagger,
         operation,
-        workflowKind
+        workflowKind,
+        forceEnableSplitOn
       );
 
       return [

--- a/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
@@ -1,3 +1,4 @@
+import { useHostOptions } from '../../../core/state/designerOptions/designerOptionsSelectors';
 import { useOperationVisuals } from '../../../core/state/operation/operationSelector';
 import { clearPanel } from '../../../core/state/panel/panelSlice';
 import { useNodeDisplayName, useNodeIds } from '../../../core/state/workflow/workflowSelectors';
@@ -42,12 +43,8 @@ const NodeSearchCard = ({ node, displayRuntimeInfo }: { node: string; displayRun
   );
 };
 
-export type NodeSearchPanelProps = {
-  displayRuntimeInfo: boolean;
-} & CommonPanelProps;
-
-export const NodeSearchPanel = (props: NodeSearchPanelProps) => {
-  const { displayRuntimeInfo } = props;
+export const NodeSearchPanel = (props: CommonPanelProps) => {
+  const { displayRuntimeInfo } = useHostOptions();
   const allNodeNames = useNodeIds();
   const [searchTerm, setSearchTerm] = useState<string | null>(null);
   const intl = useIntl();

--- a/libs/designer/src/lib/ui/panel/panelRoot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelRoot.tsx
@@ -1,5 +1,5 @@
 import type { AppDispatch } from '../../core';
-import { useHostOptions, useIsDarkMode } from '../../core/state/designerOptions/designerOptionsSelectors';
+import { useIsDarkMode } from '../../core/state/designerOptions/designerOptionsSelectors';
 import { useCurrentPanelMode, useIsLoadingPanel, useIsPanelCollapsed } from '../../core/state/panel/panelSelectors';
 import { clearPanel } from '../../core/state/panel/panelSlice';
 import { ConnectionPanel } from './connectionsPanel/connectionsPanel';
@@ -30,7 +30,6 @@ const layerProps = {
 export const PanelRoot = (props: PanelRootProps): JSX.Element => {
   const { panelLocation, customPanelLocations } = props;
   const dispatch = useDispatch<AppDispatch>();
-  const { displayRuntimeInfo } = useHostOptions();
   const isDarkMode = useIsDarkMode();
 
   const collapsed = useIsPanelCollapsed();
@@ -99,9 +98,9 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
         ) : currentPanelMode === 'WorkflowParameters' ? (
           <WorkflowParametersPanel {...commonPanelProps} />
         ) : currentPanelMode === 'Discovery' ? (
-          <RecommendationPanelContext {...commonPanelProps} displayRuntimeInfo={displayRuntimeInfo} />
+          <RecommendationPanelContext {...commonPanelProps} />
         ) : currentPanelMode === 'NodeSearch' ? (
-          <NodeSearchPanel {...commonPanelProps} displayRuntimeInfo={displayRuntimeInfo} />
+          <NodeSearchPanel {...commonPanelProps} />
         ) : currentPanelMode === 'Connection' ? (
           <ConnectionPanel {...commonPanelProps} />
         ) : currentPanelMode === 'Error' ? (

--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -1,6 +1,7 @@
 import type { AppDispatch } from '../../../core';
 import { addOperation } from '../../../core/actions/bjsworkflow/add';
 import { useAllConnectors, useAllOperations } from '../../../core/queries/browse';
+import { useHostOptions } from '../../../core/state/designerOptions/designerOptionsSelectors';
 import {
   useIsAddingTrigger,
   useIsParallelBranch,
@@ -35,12 +36,9 @@ const SELECTION_STATES = {
   CUSTOM_SWAGGER: 'HTTP_SWAGGER',
 };
 
-export type RecommendationPanelContextProps = {
-  displayRuntimeInfo: boolean;
-} & CommonPanelProps;
-
-export const RecommendationPanelContext = (props: RecommendationPanelContextProps) => {
-  const { displayRuntimeInfo, toggleCollapse } = props;
+export const RecommendationPanelContext = (props: CommonPanelProps) => {
+  const { toggleCollapse } = props;
+  const { displayRuntimeInfo } = useHostOptions();
   const dispatch = useDispatch<AppDispatch>();
   const isTrigger = useIsAddingTrigger();
   const [searchTerm, setSearchTerm] = useState('');


### PR DESCRIPTION
## Main Changes

Added designer host option to force enable split-on.
Recently we added a change that disabled split-on automatically on stateless workflows, which caused a regression in PA since they are all stateless but still use split-on.
When this option is set to `true`, the split-on setting will appear as normal on stateless workflows

Fixes https://github.com/Azure/LogicAppsUX/issues/4091
