### PR TITLE
fix(Designer): Changed test connection request to not run through batch api

### DIFF
--- a/libs/services/designer-client-services/src/lib/base/connection.ts
+++ b/libs/services/designer-client-services/src/lib/base/connection.ts
@@ -220,7 +220,10 @@ export abstract class BaseConnectionService implements IConnectionService {
 
     try {
       let response: HttpResponse<any> | undefined = undefined;
-      const requestOptions: HttpRequestOptions<any> = { uri };
+      const requestOptions: HttpRequestOptions<any> = {
+        headers: { noBatch: 'true' }, // Some requests fail specifically when run through batch
+        uri,
+      };
       if (equals(method, HTTP_METHODS.GET)) response = await httpClient.get<any>(requestOptions);
       else if (equals(method, HTTP_METHODS.POST)) response = await httpClient.post<any, any>(requestOptions);
       else if (equals(method, HTTP_METHODS.PUT)) response = await httpClient.put<any, any>(requestOptions);


### PR DESCRIPTION
## Main Changes

Adjusted our connection test request function to not run the request through batch.
During my investigation, running some connector test requests through batch would fail _specifically_ when going through the batch api, with no other changes in the request.
We have a catch over in the portal httpClient where if a request has any explicit headers set, it will not go through batch, so I've just added a dummy header for now.

Fixes https://github.com/Azure/LogicAppsUX/issues/3781
