### PR TITLE
fix(Designer): Added connection name check to avoid known connection name strings

### DIFF
--- a/libs/services/designer-client-services/src/lib/base/connection.ts
+++ b/libs/services/designer-client-services/src/lib/base/connection.ts
@@ -342,7 +342,7 @@ export abstract class BaseConnectionService implements IConnectionService {
     connectorId: string,
     connectionName: string,
     i: number,
-    connectionNames: string[]
+    connectionNames: string[] = []
   ): Promise<string> {
     if (!connectionNames.includes(connectionName)) {
       const connectionId = this.getAzureConnectionRequestPath(connectionName);

--- a/libs/services/designer-client-services/src/lib/base/connection.ts
+++ b/libs/services/designer-client-services/src/lib/base/connection.ts
@@ -333,7 +333,7 @@ export abstract class BaseConnectionService implements IConnectionService {
   async getUniqueConnectionName(connectorId: string, connectionNames: string[], connectorName: string): Promise<string> {
     const { name: connectionName, index } = getUniqueName(connectionNames, connectorName);
     return isArmResourceId(connectorId)
-      ? this._getUniqueConnectionNameInApiHub(connectorName, connectorId, connectionName, index)
+      ? this._getUniqueConnectionNameInApiHub(connectorName, connectorId, connectionName, index, connectionNames)
       : connectionName;
   }
 
@@ -341,17 +341,16 @@ export abstract class BaseConnectionService implements IConnectionService {
     connectorName: string,
     connectorId: string,
     connectionName: string,
-    i: number
+    i: number,
+    connectionNames: string[]
   ): Promise<string> {
-    const connectionId = this.getAzureConnectionRequestPath(connectionName);
-    const isUnique = await this._testConnectionIdUniquenessInApiHub(connectionId);
-
-    if (isUnique) {
-      return connectionName;
-    } else {
-      connectionName = `${connectorName}-${i++}`;
-      return this._getUniqueConnectionNameInApiHub(connectorName, connectorId, connectionName, i);
+    if (!connectionNames.includes(connectionName)) {
+      const connectionId = this.getAzureConnectionRequestPath(connectionName);
+      const isUnique = await this._testConnectionIdUniquenessInApiHub(connectionId);
+      if (isUnique) return connectionName;
     }
+    connectionName = `${connectorName}-${++i}`;
+    return this._getUniqueConnectionNameInApiHub(connectorName, connectorId, connectionName, i, connectionNames);
   }
 
   protected _testConnectionIdUniquenessInApiHub(id: string): Promise<boolean> {

--- a/libs/utils/src/lib/helpers/connections.ts
+++ b/libs/utils/src/lib/helpers/connections.ts
@@ -204,7 +204,7 @@ function _isConnectionParameterHidden(connectionParameter: ConnectionParameter):
 export const getUniqueName = (keys: string[], prefix: string): { name: string; index: number } => {
   const set = new Set(keys.map((name) => name.split('::')[0]));
 
-  let index = 1;
+  let index = 0;
   let name = prefix;
   while (set.has(name)) {
     name = `${prefix}-${++index}`;


### PR DESCRIPTION
## Main Changes

Added more logic to avoid checking uniqueness on connection names that are already known.
This avoids some edge cases that would lead to us checking lots of known connection ids and making connection creation feel very slow.

**TLDR: Connection creation should feel much faster in some situations**