### PR TITLE
fix(Designer): Added catch for designer options race condition

### DIFF
--- a/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
@@ -9,7 +9,7 @@ import type { AppDispatch } from './store';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { equals } from '@microsoft/utils-logic-apps';
 import { useDeepCompareEffect } from '@react-hookz/web';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 export interface BJSWorkflowProviderProps {
@@ -33,18 +33,21 @@ const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({ workflow, child
 export const BJSWorkflowProvider: React.FC<BJSWorkflowProviderProps> = (props) => {
   const wrapped = useContext(ProviderWrappedContext);
   const dispatch = useDispatch<AppDispatch>();
-  const designerOptionsInitialized = useAreDesignerOptionsInitialized();
   const servicesInitialized = useAreServicesInitialized();
+  const designerOptionsInitialized = useAreDesignerOptionsInitialized();
+
   if (!wrapped) {
     throw new Error('BJSWorkflowProvider must be used inside of a DesignerProvider');
   }
 
+  useEffect(() => {
+    if (!servicesInitialized) {
+      dispatch(initializeServices(wrapped));
+    }
+  }, [dispatch, servicesInitialized, wrapped]);
+
   if (!designerOptionsInitialized) {
     return null;
-  }
-
-  if (!servicesInitialized) {
-    dispatch(initializeServices(wrapped));
   }
 
   return <DataProviderInner {...props} />;

--- a/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
@@ -1,17 +1,16 @@
 import type { Workflow } from '../common/models/workflow';
 import { ProviderWrappedContext } from './ProviderWrappedContext';
 import { initializeGraphState } from './parsers/ParseReduxAction';
-import type { DesignerOptionsState } from './state/designerOptions/designerOptionsInterfaces';
+import { useAreDesignerOptionsInitialized, useAreServicesInitialized } from './state/designerOptions/designerOptionsSelectors';
 import { initializeServices } from './state/designerOptions/designerOptionsSlice';
 import { WorkflowKind } from './state/workflow/workflowInterfaces';
 import { initWorkflowKind, initRunInstance, initWorkflowSpec } from './state/workflow/workflowSlice';
-import type { AppDispatch, RootState } from './store';
+import type { AppDispatch } from './store';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { equals } from '@microsoft/utils-logic-apps';
 import { useDeepCompareEffect } from '@react-hookz/web';
-import { createSelector } from '@reduxjs/toolkit';
 import React, { useContext } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 export interface BJSWorkflowProviderProps {
   workflow: Workflow;
@@ -34,14 +33,14 @@ const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({ workflow, child
 export const BJSWorkflowProvider: React.FC<BJSWorkflowProviderProps> = (props) => {
   const wrapped = useContext(ProviderWrappedContext);
   const dispatch = useDispatch<AppDispatch>();
-  const servicesInitialized = useSelector(
-    createSelector(
-      (state: RootState) => state.designerOptions,
-      (state: DesignerOptionsState) => state.servicesInitialized
-    )
-  );
+  const designerOptionsInitialized = useAreDesignerOptionsInitialized();
+  const servicesInitialized = useAreServicesInitialized();
   if (!wrapped) {
     throw new Error('BJSWorkflowProvider must be used inside of a DesignerProvider');
+  }
+
+  if (!designerOptionsInitialized) {
+    return null;
   }
 
   if (!servicesInitialized) {

--- a/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
@@ -46,7 +46,7 @@ export const BJSWorkflowProvider: React.FC<BJSWorkflowProviderProps> = (props) =
     }
   }, [dispatch, servicesInitialized, wrapped]);
 
-  if (!designerOptionsInitialized) {
+  if (!designerOptionsInitialized || !servicesInitialized) {
     return null;
   }
 

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -25,6 +25,7 @@ export interface DesignerOptionsState {
   isMonitoringView?: boolean;
   isDarkMode?: boolean;
   servicesInitialized?: boolean;
+  designerOptionsInitialized?: boolean;
   useLegacyWorkflowParameters?: boolean;
   isXrmConnectionReferenceMode?: boolean;
   suppressDefaultNodeSelectFunctionality?: boolean;

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
@@ -40,3 +40,11 @@ export const usePanelTabHideKeys = () => {
 export const useShowConnectionsPanel = () => {
   return useSelector((state: RootState) => state.designerOptions?.showConnectionsPanel ?? false);
 };
+
+export const useAreDesignerOptionsInitialized = () => {
+  return useSelector((state: RootState) => state.designerOptions?.designerOptionsInitialized ?? false);
+};
+
+export const useAreServicesInitialized = () => {
+  return useSelector((state: RootState) => state.designerOptions?.servicesInitialized ?? false);
+};

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -27,6 +27,7 @@ const initialState: DesignerOptionsState = {
   isMonitoringView: false,
   isDarkMode: false,
   servicesInitialized: false,
+  designerOptionsInitialized: false,
   useLegacyWorkflowParameters: false,
   isXrmConnectionReferenceMode: false,
   showConnectionsPanel: false,

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -111,6 +111,7 @@ export const designerOptionsSlice = createSlice({
         ...state.hostOptions,
         ...action.payload.hostOptions,
       };
+      state.designerOptionsInitialized = true;
     },
   },
   extraReducers: (builder) => {

--- a/libs/services/designer-client-services/src/lib/base/connection.ts
+++ b/libs/services/designer-client-services/src/lib/base/connection.ts
@@ -220,7 +220,10 @@ export abstract class BaseConnectionService implements IConnectionService {
 
     try {
       let response: HttpResponse<any> | undefined = undefined;
-      const requestOptions: HttpRequestOptions<any> = { uri };
+      const requestOptions: HttpRequestOptions<any> = {
+        headers: { noBatch: 'true' }, // Some requests fail specifically when run through batch
+        uri,
+      };
       if (equals(method, HTTP_METHODS.GET)) response = await httpClient.get<any>(requestOptions);
       else if (equals(method, HTTP_METHODS.POST)) response = await httpClient.post<any, any>(requestOptions);
       else if (equals(method, HTTP_METHODS.PUT)) response = await httpClient.put<any, any>(requestOptions);


### PR DESCRIPTION
## Main Changes

Added a catch to not load graph state until after the host options are available in redux.
Was just a race condition that wasn't accounted for.

Added explicit hooks for `useAreDesignerOptionsInitialized` and `useAreServicesInitialized`