### PR TITLE
fix(Designer): Skip non-dependent parameters in updateParameterAndDependencies

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1705,7 +1705,7 @@ export async function updateParameterAndDependencies(
           LoggerService().log({
             level: LogEntryLevel.Verbose,
             area: 'UpdateParameterAndDependencies',
-            message: `Connection name: ${connectionReference.connectionName} - Parameter key: ${key}`,
+            message: `Dependent parameter was not set. Connection name: ${connectionReference.connectionName} - Parameter key: ${key}`,
           });
           continue;
         }

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -55,7 +55,7 @@ import {
   isVariableToken,
   ValueSegmentConvertor,
 } from './segment';
-import { OperationManifestService, WorkflowService } from '@microsoft/designer-client-services-logic-apps';
+import { LogEntryLevel, LoggerService, OperationManifestService, WorkflowService } from '@microsoft/designer-client-services-logic-apps';
 import type {
   AuthProps,
   ComboboxItem,
@@ -1700,9 +1700,15 @@ export async function updateParameterAndDependencies(
     const inputDependencies = dependenciesToUpdate.inputs;
     for (const key of Object.keys(inputDependencies)) {
       if (inputDependencies[key].dependencyType === 'ListValues' && inputDependencies[key].dependentParameters[parameterId]) {
-        const dependentParameter = nodeInputs.parameterGroups[groupId].parameters.find(
-          (param) => param.parameterKey === key
-        ) as ParameterInfo;
+        const dependentParameter = nodeInputs.parameterGroups[groupId].parameters.find((param) => param.parameterKey === key);
+        if (!dependentParameter) {
+          LoggerService().log({
+            level: LogEntryLevel.Verbose,
+            area: 'UpdateParameterAndDependencies',
+            message: `Connection name: ${connectionReference.connectionName} - Parameter key: ${key}`,
+          });
+          continue;
+        }
         payload.parameters.push({
           groupId,
           parameterId: dependentParameter.id,


### PR DESCRIPTION
Add a nullcheck to prevent parameters that are not dependent from being added to the payload for update.

This fixes a bug whereby the Trello create a card action in Power Automate would fail. Currently, .[*] wildcard parameters missing the id field will cause updateParameterAndDependencies to fail. The result is that the value is never set in the designer. 

With fix:
![image](https://github.com/Azure/LogicAppsUX/assets/135278983/768169bd-263b-456f-b7b5-3e3cbc93f429)


![image](https://github.com/Azure/LogicAppsUX/assets/135278983/e52e365c-dbb0-4a24-afa7-df94d667926c)
