### PR TITLE
fix(designer): Fix stateless workflow check in `getSplitOn`

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
@@ -150,7 +150,7 @@ export const getOperationSettings = (
     },
     splitOn: {
       isSupported: isSplitOnSupported(isTrigger, nodeOutputs, manifest, swagger, operationId, operation, workflowKind, forceEnableSplitOn),
-      value: getSplitOn(manifest, swagger, operationId, operation, workflowKind),
+      value: getSplitOn(manifest, swagger, operationId, operation, workflowKind, forceEnableSplitOn),
     },
     retryPolicy: {
       isSupported: isRetryPolicySupported(isTrigger, operationInfo.type, manifest),
@@ -166,7 +166,7 @@ export const getOperationSettings = (
       value: getSuppressWorkflowHeaders(isTrigger, nodeType, manifest, operation),
     },
     suppressWorkflowHeadersOnResponse: {
-      isSupported: isSuppressWorklowHeadersOnResponseSupported(isTrigger, manifest),
+      isSupported: isSuppressWorkflowHeadersOnResponseSupported(isTrigger, manifest),
       value: getSuppressWorkflowHeadersOnResponse(operation),
     },
     concurrency: {
@@ -344,7 +344,7 @@ const getSuppressWorkflowHeadersOnResponse = (definition?: LogicAppsV2.Operation
   return isOperationOptionSet(Constants.SETTINGS.OPERATION_OPTIONS.SUPPRESS_WORKFLOW_HEADERS_ON_RESPONSE, operationOptions);
 };
 
-const isSuppressWorklowHeadersOnResponseSupported = (isTrigger: boolean, manifest?: OperationManifest): boolean => {
+const isSuppressWorkflowHeadersOnResponseSupported = (isTrigger: boolean, manifest?: OperationManifest): boolean => {
   if (manifest) {
     const operationOptionsSetting = getOperationSettingFromManifest(manifest, 'operationOptions') as
       | OperationManifestSetting<OperationOptions[]>
@@ -517,9 +517,12 @@ const getSplitOn = (
   swagger?: SwaggerParser,
   operationId?: string,
   definition?: LogicAppsV2.OperationDefinition,
-  workflowKind?: WorkflowKind
+  workflowKind?: WorkflowKind,
+  forceEnableSplitOn?: boolean
 ): SimpleSetting<string> => {
-  if (workflowKind === WorkflowKind.STATELESS) return { enabled: false };
+  if (workflowKind === WorkflowKind.STATELESS && !forceEnableSplitOn) {
+    return { enabled: false };
+  }
   const splitOnValue = getSplitOnValue(manifest, swagger, operationId, definition);
   return {
     enabled: !!splitOnValue,


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Currently, stateless workflows in LAUX do not support split on, but do in PAuto. A host option was added to allow this behavior, but does not cover `settings.ts:getSplitOn()`.

- **What is the new behavior (if this is a feature change)?**

Stateless workflows in PAuto will return the correct value from `settings.ts:getSplitOn()`.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

N/A