### PR TITLE
fix(designer): OpenAPI tokens from SharePoint trigger use `triggerOutputs` instead of `triggerBody`

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
@@ -2301,6 +2301,7 @@ describe('core/utils/parameters/helper', () => {
       ['output', undefined, `triggerOutputs()`],
       ['outputs.$', undefined, `triggerOutputs()`],
       ['outputs.$.body', undefined, `triggerOutputs()`],
+      ['outputs.$.body/value', undefined, `triggerOutputs()`],
       ['outputs.$.headers', undefined, `triggerOutputs()`],
       ['outputs.$.relativePathParameters', undefined, `triggerOutputs()`],
 
@@ -2309,14 +2310,16 @@ describe('core/utils/parameters/helper', () => {
       ['outputs.$.body.Title', undefined, `triggerBody()`],
       ['outputs.$.body.Author.DisplayName', undefined, `triggerBody()`],
 
+      // For nested path properties (OpenAPI) within `outputs.$.body/*`, use BODY.
+      ['outputs.$.body/value.ID', undefined, `triggerBody()`],
+      ['outputs.$.body/value.Title', undefined, `triggerBody()`],
+      ['outputs.$.body/value.Author.DisplayName', undefined, `triggerBody()`],
+
       // For values using `body/*` syntax, use OUTPUTS.
       ['outputs.$.body/subject', 'Get_event_(V3)', `outputs('Get_event_(V3)')`],
-    ])(
-      'correctly gets the token expression for %p',
-      (key, actionName, expected) => {
-        expect(getTokenExpressionMethodFromKey(key, actionName)).toBe(expected);
-      }
-    )
+    ])('correctly gets the token expression for %p', (key, actionName, expected) => {
+      expect(getTokenExpressionMethodFromKey(key, actionName)).toBe(expected);
+    });
   });
 
   describe('updateParameterWithValues', () => {

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1027,7 +1027,11 @@ function segmentsAreBodyReference(segments: Segment[]): boolean {
 
   // For tokens of format `outputs.$.body.Title`, where we are referring to a property within the body,
   // we have to reference the body rather than the outputs field.
-  return segments.length >= 4 && isString(segments[2].value) && segments[2].value === constants.OUTPUT_LOCATIONS.BODY;
+  return (
+    segments.length >= 4 &&
+    isString(segments[2].value) &&
+    (segments[2].value === constants.OUTPUT_LOCATIONS.BODY || segments[2].value.startsWith(`${constants.OUTPUT_LOCATIONS.BODY}/`))
+  );
 }
 
 // NOTE: For example, if tokenKey is outputs.$.foo.[*].bar, which means

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1009,11 +1009,25 @@ export function getExpressionValueForOutputToken(token: OutputToken, nodeType: s
 
 export function getTokenExpressionMethodFromKey(key: string, actionName: string | undefined): string {
   const segments = parseEx(key);
-  if (segments.length >= 2 && segments[0].value === OutputSource.Body && segments[1].value === '$') {
+  if (segmentsAreBodyReference(segments)) {
     return actionName ? `${OutputSource.Body}(${convertToStringLiteral(actionName)})` : constants.TRIGGER_BODY_OUTPUT;
   } else {
     return actionName ? `${constants.OUTPUTS}(${convertToStringLiteral(actionName)})` : constants.TRIGGER_OUTPUTS_OUTPUT;
   }
+}
+
+function segmentsAreBodyReference(segments: Segment[]): boolean {
+  if (segments.length < 2 || segments[1].value !== '$') {
+    return false;
+  }
+
+  if (segments[0].value === OutputSource.Body) {
+    return true;
+  }
+
+  // For tokens of format `outputs.$.body.Title`, where we are referring to a property within the body,
+  // we have to reference the body rather than the outputs field.
+  return segments.length >= 4 && isString(segments[2].value) && segments[2].value === constants.OUTPUT_LOCATIONS.BODY;
 }
 
 // NOTE: For example, if tokenKey is outputs.$.foo.[*].bar, which means

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1025,8 +1025,8 @@ function segmentsAreBodyReference(segments: Segment[]): boolean {
     return true;
   }
 
-  // For tokens of format `outputs.$.body.Title`, where we are referring to a property within the body,
-  // we have to reference the body rather than the outputs field.
+  // For tokens of format `outputs.$.body.Title` or `outputs.$.body/Title`, where we are referring to a property within
+  // the body, we have to reference the body rather than the outputs field.
   return (
     segments.length >= 4 &&
     isString(segments[2].value) &&


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes/features)
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

In OpenAPI, when a trigger outputs a token of the format `outputs.$.body.Title` or `outputs.$.body/Title`, this is inserted into the workflow as `@triggerOutputs()?['Title']`, which is not valid.

- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**:

**Before:**

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/02f13ec7-3567-483c-9747-83e83a2c1d5a)

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/d237c532-ffc4-4841-a3b8-36938dc3573d)

**After:**

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/a992fa83-ff56-4ffd-809f-ae27958307e8)

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/fcc01e29-64ac-4aeb-b199-3d3e7690df57)