### PR TITLE
fix(vscode): enable slot create/deploy extension commands.

### DIFF
--- a/apps/vs-code-designer/src/app/tree/slotsTree/SlotsTreeItem.ts
+++ b/apps/vs-code-designer/src/app/tree/slotsTree/SlotsTreeItem.ts
@@ -7,11 +7,11 @@ import { showSiteCreated } from '../../commands/createLogicApp/showSiteCreated';
 import { getIconPath } from '../../utils/tree/assets';
 import { LogicAppResourceTree } from '../LogicAppResourceTree';
 import { SlotTreeItem } from './SlotTreeItem';
-import type { Site, WebSiteManagementClient } from '@azure/arm-appservice';
+import type { Site, WebSiteManagementClient, SitePatchResource } from '@azure/arm-appservice';
 import { createSlot, createWebSiteClient, ParsedSite } from '@microsoft/vscode-azext-azureappservice';
 import { uiUtils } from '@microsoft/vscode-azext-azureutils';
 import type { AzExtTreeItem, IActionContext, TreeItemIconPath, ICreateChildImplContext } from '@microsoft/vscode-azext-utils';
-import { AzExtParentTreeItem } from '@microsoft/vscode-azext-utils';
+import { AzExtParentTreeItem, nonNullProp } from '@microsoft/vscode-azext-utils';
 
 export class SlotsTreeItem extends AzExtParentTreeItem {
   public static contextValue = 'azLogicAppsSlots';
@@ -62,13 +62,33 @@ export class SlotsTreeItem extends AzExtParentTreeItem {
 
   public async createChildImpl(context: ICreateChildImplContext): Promise<AzExtTreeItem> {
     const existingSlots: SlotTreeItem[] = (await this.getCachedChildren(context)) as SlotTreeItem[];
-    const newSite: Site = await createSlot(
+    let newSite: Site = await createSlot(
       this.parent.site,
       existingSlots.map((s) => s.site),
       context
     );
+
+    newSite = await this.updateSlotIdentity(context, newSite);
     const parsedSite = new ParsedSite(newSite, this.subscription);
     showSiteCreated(parsedSite, context);
     return new SlotTreeItem(this, new LogicAppResourceTree(this.subscription, newSite));
+  }
+
+  private async updateSlotIdentity(context: ICreateChildImplContext, site: Site): Promise<Site> {
+    const [siteName, slotName] = nonNullProp(site, 'name').split('/');
+
+    if (!slotName) {
+      return site;
+    }
+
+    const client: WebSiteManagementClient = await createWebSiteClient([context, this]);
+    const siteEnvelope: SitePatchResource = {
+      identity: {
+        type: 'SystemAssigned',
+      },
+    };
+
+    await client.webApps.updateSlot(site.resourceGroup, siteName, slotName, siteEnvelope);
+    return await client.webApps.getSlot(site.resourceGroup, siteName, slotName);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.106.0",
+  "version": "2.109.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.106.0",
+      "version": "2.109.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.109.0",
+  "version": "2.106.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.109.0",
+      "version": "2.106.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) Fixed deploy/create commands for slots

- **What is the current behavior? Deploy to slot, deploys to production slot only.  Create slot doesn't enable system identity.

- **What is the new behavior (if this is a feature change)? Deploy slot allow to select or create slot for deployment.  Create slot enables system identity for non-production slot.

- **Does this PR introduce a breaking change?** No
