### PR TITLE
feat(designer): Resizable side panel

### DIFF
--- a/libs/designer/src/lib/ui/panel/panelRoot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelRoot.tsx
@@ -59,15 +59,13 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
 
   const collapsed = useIsPanelCollapsed();
   const currentPanelMode = useCurrentPanelMode();
+
   const [isResizing, setIsResizing] = useState(false);
-  const [width, setWidth] = useState<any>(PanelSize.Auto);
-  const [mouseX, setMouseX] = useState(0);
-  const startResizing = useCallback((test: any) => {
-    setMouseX(test.clientX);
-    return setIsResizing(true);
-  }, []);
+  const [width, setWidth] = useState<PanelSize | string>(PanelSize.Auto);
+  const startResizing = useCallback(() => setIsResizing(true), []);
   const stopResizing = useCallback(() => setIsResizing(false), []);
   const animationFrame = useRef<number>(0);
+  const isResizable = currentPanelMode === 'Assertions';
 
   useEffect(() => {
     setWidth(collapsed ? PanelSize.Auto : PanelSize.Medium);
@@ -105,13 +103,12 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
     ({ clientX }: MouseEvent) => {
       animationFrame.current = requestAnimationFrame(() => {
         if (isResizing) {
-          const newSize = mouseX - clientX;
-          console.log('charlie', newSize, mouseX);
-          setWidth(newSize.toString() + 'px');
+          const newWidth = window.innerWidth - clientX < 300 ? 300 : window.innerWidth - clientX;
+          setWidth(newWidth.toString() + 'px');
         }
       });
     },
-    [isResizing, mouseX]
+    [isResizing]
   );
 
   useEffect(() => {
@@ -132,7 +129,9 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
       className={`msla-panel-root-${currentPanelMode}`}
       isLightDismiss
       isBlocking={!isLoadingPanel && !nonBlockingPanels.includes(currentPanelMode ?? '')}
-      type={commonPanelProps.panelLocation === PanelLocation.Right ? PanelType.custom : PanelType.customNear}
+      type={
+        commonPanelProps.panelLocation === PanelLocation.Right ? (isResizable ? PanelType.custom : PanelType.medium) : PanelType.customNear
+      }
       isOpen={!collapsed}
       onDismiss={dismissPanel}
       hasCloseButton={false}
@@ -148,7 +147,9 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
         },
       })}
     >
-      <div className={mergeClasses(styles.resizer, isResizing && styles.resizerActive)} onMouseDown={startResizing} />
+      {isResizable ? (
+        <div className={mergeClasses(styles.resizer, isResizing && styles.resizerActive)} onMouseDown={startResizing} />
+      ) : null}
       {
         isLoadingPanel ? (
           <LoadingComponent />

--- a/libs/designer/src/lib/ui/panel/panelRoot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelRoot.tsx
@@ -103,7 +103,7 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
     ({ clientX }: MouseEvent) => {
       animationFrame.current = requestAnimationFrame(() => {
         if (isResizing) {
-          const newWidth = window.innerWidth - clientX < 300 ? 300 : window.innerWidth - clientX;
+          const newWidth = Math.max(window.innerWidth - clientX, 300);
           setWidth(newWidth.toString() + 'px');
         }
       });

--- a/libs/designer/src/lib/ui/panel/panelRoot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelRoot.tsx
@@ -11,11 +11,11 @@ import { RecommendationPanelContext } from './recommendation/recommendationPanel
 import { WorkflowParametersPanel } from './workflowParametersPanel/workflowParametersPanel';
 import { WorkflowParametersPanelFooter } from './workflowParametersPanel/workflowParametersPanelFooter';
 import { Panel, PanelType } from '@fluentui/react';
-import { Spinner } from '@fluentui/react-components';
+import { Spinner, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
 import { isUndefined } from '@microsoft/applicationinsights-core-js';
 import type { CommonPanelProps, CustomPanelLocation } from '@microsoft/designer-ui';
 import { PanelLocation, PanelSize } from '@microsoft/designer-ui';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 export interface PanelRootProps {
@@ -28,15 +28,46 @@ const layerProps = {
   eventBubblingEnabled: true,
 };
 
+const useStyles = makeStyles({
+  resizer: {
+    ...shorthands.borderLeft('1px', 'solid', tokens.colorNeutralBackground5),
+
+    width: '8px',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    cursor: 'col-resize',
+    resize: 'horizontal',
+
+    ':hover': {
+      borderLeftWidth: '4px',
+    },
+  },
+
+  resizerActive: {
+    borderLeftWidth: '4px',
+    borderLeftColor: tokens.colorNeutralBackground5Pressed,
+  },
+});
+
 export const PanelRoot = (props: PanelRootProps): JSX.Element => {
   const { panelLocation, customPanelLocations } = props;
   const dispatch = useDispatch<AppDispatch>();
   const isDarkMode = useIsDarkMode();
+  const styles = useStyles();
 
   const collapsed = useIsPanelCollapsed();
   const currentPanelMode = useCurrentPanelMode();
-
-  const [width, setWidth] = useState<PanelSize>(PanelSize.Auto);
+  const [isResizing, setIsResizing] = useState(false);
+  const [width, setWidth] = useState<any>(PanelSize.Auto);
+  const [mouseX, setMouseX] = useState(0);
+  const startResizing = useCallback((test: any) => {
+    setMouseX(test.clientX);
+    return setIsResizing(true);
+  }, []);
+  const stopResizing = useCallback(() => setIsResizing(false), []);
+  const animationFrame = useRef<number>(0);
 
   useEffect(() => {
     setWidth(collapsed ? PanelSize.Auto : PanelSize.Medium);
@@ -70,6 +101,30 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
     </div>
   );
 
+  const resize = useCallback(
+    ({ clientX }: MouseEvent) => {
+      animationFrame.current = requestAnimationFrame(() => {
+        if (isResizing) {
+          const newSize = mouseX - clientX;
+          console.log('charlie', newSize, mouseX);
+          setWidth(newSize.toString() + 'px');
+        }
+      });
+    },
+    [isResizing, mouseX]
+  );
+
+  useEffect(() => {
+    window.addEventListener('mousemove', resize);
+    window.addEventListener('mouseup', stopResizing);
+
+    return () => {
+      cancelAnimationFrame(animationFrame.current);
+      window.removeEventListener('mousemove', resize);
+      window.removeEventListener('mouseup', stopResizing);
+    };
+  }, [resize, stopResizing]);
+
   return (!isLoadingPanel && isUndefined(currentPanelMode)) || currentPanelMode === 'Operation' ? (
     <NodeDetailsPanel {...commonPanelProps} />
   ) : (
@@ -77,7 +132,7 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
       className={`msla-panel-root-${currentPanelMode}`}
       isLightDismiss
       isBlocking={!isLoadingPanel && !nonBlockingPanels.includes(currentPanelMode ?? '')}
-      type={commonPanelProps.panelLocation === PanelLocation.Right ? PanelType.medium : PanelType.customNear}
+      type={commonPanelProps.panelLocation === PanelLocation.Right ? PanelType.custom : PanelType.customNear}
       isOpen={!collapsed}
       onDismiss={dismissPanel}
       hasCloseButton={false}
@@ -93,6 +148,7 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
         },
       })}
     >
+      <div className={mergeClasses(styles.resizer, isResizing && styles.resizerActive)} onMouseDown={startResizing} />
       {
         isLoadingPanel ? (
           <LoadingComponent />


### PR DESCRIPTION
The changes include the introduction of a resizable panel feature and the addition of new styles and dependencies.


* Introduced state variables `isResizing` and `width` to manage the resizing process. Also, added `startResizing` and `stopResizing` functions to control the resizing state.
* Added a `resize` function to handle the resizing process and attached it to the `mousemove` event. The `mouseup` event is attached to the `stopResizing` function. Both event listeners are cleaned up in the `useEffect` hook.
* Modified the `Panel` component to support the new resizable feature and added a new `div` element which triggers the resizing process on `mousedown` event. 
* Minimum size is 300px


https://github.com/Azure/LogicAppsUX/assets/102700317/f5baef75-dfed-438b-a55e-3532e9c13298

