### PR TITLE
fix(vscode): Parse interpolated connections data as JSON

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
@@ -94,15 +94,9 @@ export abstract class OpenDesignerBase {
     }
 
     const parametersResolutionService = new ResolutionService(parameters, localSettings);
+    const resolvedConnections: ConnectionsData = parametersResolutionService.resolve(JSON.parse(connectionsData));
 
-    const resolvedConnections = parametersResolutionService.resolve(connectionsData);
-    let parsedConnections: ConnectionsData = {};
-    try {
-      parsedConnections = JSON.parse(resolvedConnections);
-    } catch (e) {
-      console.log(e);
-    }
-    this.connectionData = parsedConnections;
+    this.connectionData = resolvedConnections;
     this.apiHubServiceDetails = this.getApiHubServiceDetails(azureDetails);
     this.mapArtifacts = mapArtifacts;
     this.schemaArtifacts = artifacts.schemas;


### PR DESCRIPTION
The changes primarily simplify the handling of resolved connections by removing unnecessary parsing and error handling.

The key changes are:

* The `connectionsData` is now directly resolved and assigned to `this.connectionData`, eliminating the need for parsing and error handling. The `resolvedConnections` variable is now of type `ConnectionsData`, which is directly assigned to `this.connectionData`. Previously, `resolvedConnections` was parsed into `parsedConnections` inside a try-catch block, and `parsedConnections` was then assigned to `this.connectionData`. This change simplifies the code and reduces the risk of errors by removing the parsing and error handling step.

Fixes #3987 