### PR TITLE
fix(designer): Allowing nodes to share names with built-in Object prototype functions

### DIFF
--- a/apps/vs-code-react/src/app/export/workflowsSelection/workflowsSelection.tsx
+++ b/apps/vs-code-react/src/app/export/workflowsSelection/workflowsSelection.tsx
@@ -11,7 +11,7 @@ import { SelectedList } from './selectedList';
 import { Separator, ShimmeredDetailsList, Text, SelectionMode, Selection, MessageBar, MessageBarType } from '@fluentui/react';
 import type { IDropdownOption } from '@fluentui/react';
 import { isNullOrUndefined } from '@microsoft/utils-logic-apps';
-import { useMemo, useRef, useState, useEffect } from 'react';
+import { useMemo, useRef, useState, useEffect, useCallback } from 'react';
 import { useIntl } from 'react-intl';
 import { useQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
@@ -81,21 +81,26 @@ export const WorkflowsSelection: React.FC = () => {
     return apiService.getWorkflows(selectedSubscription, selectedIse, location);
   };
 
-  const onWorkflowsSuccess = (workflows: WorkflowsList[]) => {
-    const resourceGroups: IDropdownOption[] = !workflows ? [] : parseResourceGroups(workflows);
-    setRenderWorkflows(workflows);
-    setResourceGroups(resourceGroups);
-    allWorkflows.current = workflows;
-    allItemsSelected.current = workflows.map((workflow) => {
-      return { ...workflow, selected: false, rendered: true };
-    });
-    selectedWorkflows.forEach((workflow: WorkflowsList) => {
-      const selectedIndex = allItemsSelected.current.findIndex((selectedItem: SelectedWorkflowsList) => selectedItem.key === workflow.key);
-      if (selectedIndex !== -1) {
-        allItemsSelected.current[selectedIndex].selected = true;
-      }
-    });
-  };
+  const onWorkflowsSuccess = useCallback(
+    (workflows: WorkflowsList[]) => {
+      const resourceGroups: IDropdownOption[] = !workflows ? [] : parseResourceGroups(workflows);
+      setRenderWorkflows(workflows);
+      setResourceGroups(resourceGroups);
+      allWorkflows.current = workflows;
+      allItemsSelected.current = workflows.map((workflow) => {
+        return { ...workflow, selected: false, rendered: true };
+      });
+      selectedWorkflows.forEach((workflow: WorkflowsList) => {
+        const selectedIndex = allItemsSelected.current.findIndex(
+          (selectedItem: SelectedWorkflowsList) => selectedItem.key === workflow.key
+        );
+        if (selectedIndex !== -1) {
+          allItemsSelected.current[selectedIndex].selected = true;
+        }
+      });
+    },
+    [selectedWorkflows]
+  );
 
   const { isLoading: isWorkflowsLoading, data: workflowsData } = useQuery<WorkflowsList[]>(
     [QueryKeys.workflowsData, selectedSubscription, selectedIse, location],

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -25,6 +25,7 @@ import {
   ConnectionParameterTypes,
   equals,
   ConnectionReferenceKeyFormat,
+  getRecordEntry,
 } from '@microsoft/utils-logic-apps';
 import type { Dispatch } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
@@ -78,18 +79,30 @@ const updateNodeConnectionAndProperties = async (
   dispatch(changeConnectionMapping(payload));
 
   const newState = getState() as RootState;
+  const operationInfo = getRecordEntry(newState.operations.operationInfo, nodeId);
+  const dependencies = getRecordEntry(newState.operations.dependencies, nodeId);
+  const inputParameters = getRecordEntry(newState.operations.inputParameters, nodeId);
+  const settings = getRecordEntry(newState.operations.settings, nodeId);
+  const newlyAddedOperations = getRecordEntry(newState.workflow.newlyAddedOperations, nodeId);
+  const operation = getRecordEntry(newState.workflow.operations, nodeId);
+
+  // Shouldn't happen, but required for type checking
+  if (!operationInfo || !dependencies || !inputParameters || !settings) {
+    return;
+  }
+
   return updateDynamicDataInNode(
     nodeId,
     isRootNodeInGraph(nodeId, 'root', newState.workflow.nodesMetadata),
-    newState.operations.operationInfo[nodeId],
+    operationInfo,
     getConnectionReference(newState.connections, nodeId),
-    newState.operations.dependencies[nodeId],
-    newState.operations.inputParameters[nodeId],
-    newState.operations.settings[nodeId],
+    dependencies,
+    inputParameters,
+    settings,
     getAllVariables(newState.tokens.variables),
     dispatch,
     getState,
-    newState.workflow.newlyAddedOperations[nodeId] ? undefined : newState.workflow.operations[nodeId]
+    newlyAddedOperations ? undefined : operation
   );
 };
 
@@ -189,7 +202,7 @@ async function getConnectionsMappingForNodes(deserializedWorkflow: DeserializedW
   const tasks: Promise<Record<string, string> | undefined>[] = [];
 
   for (const [nodeId, operation] of Object.entries(actionData)) {
-    const isTrigger = nodesMetadata?.[nodeId].isRoot ?? false;
+    const isTrigger = getRecordEntry(nodesMetadata, nodeId)?.isRoot ?? false;
     tasks.push(getConnectionMappingForNode(operation, nodeId, isTrigger, operationManifestService));
   }
 

--- a/libs/designer/src/lib/core/actions/bjsworkflow/copypaste.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/copypaste.ts
@@ -7,6 +7,7 @@ import type { RelationshipIds } from '../../state/panel/panelInterfaces';
 import { setIsPanelLoading } from '../../state/panel/panelSlice';
 import { pasteNode } from '../../state/workflow/workflowSlice';
 import { initializeOperationDetails } from './add';
+import { getRecordEntry } from '@microsoft/utils-logic-apps';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { batch } from 'react-redux';
 
@@ -21,26 +22,26 @@ export const copyOperation = createAsyncThunk('copyOperation', async (payload: C
     const state = getState() as RootState;
     const newNodeId = `${nodeId}_copy`;
 
-    const nodeOperationInfo = state.operations.operationInfo[nodeId];
+    const nodeOperationInfo = getRecordEntry(state.operations.operationInfo, nodeId);
 
-    const nodeData: NodeData = {
+    const nodeData = {
       id: newNodeId,
-      nodeInputs: state.operations.inputParameters[nodeId],
-      nodeOutputs: state.operations.outputParameters[nodeId],
-      nodeDependencies: state.operations.dependencies[nodeId],
-      operationMetadata: state.operations.operationMetadata[nodeId],
-      settings: state.operations.settings[nodeId],
-      staticResult: state.operations.staticResults[nodeId],
-      actionMetadata: state.operations.actionMetadata[nodeId],
-      repetitionInfo: state.operations.repetitionInfos[nodeId],
+      nodeInputs: getRecordEntry(state.operations.inputParameters, nodeId),
+      nodeOutputs: getRecordEntry(state.operations.outputParameters, nodeId),
+      nodeDependencies: getRecordEntry(state.operations.dependencies, nodeId),
+      operationMetadata: getRecordEntry(state.operations.operationMetadata, nodeId),
+      settings: getRecordEntry(state.operations.settings, nodeId),
+      staticResult: getRecordEntry(state.operations.staticResults, nodeId),
+      actionMetadata: getRecordEntry(state.operations.actionMetadata, nodeId),
+      repetitionInfo: getRecordEntry(state.operations.repetitionInfos, nodeId),
     };
-    const connectionReference = state.connections.connectionsMapping[nodeId];
+    const connectionReference = getRecordEntry(state.connections.connectionsMapping, nodeId);
     window.localStorage.setItem(
       'msla-clipboard',
       JSON.stringify({
         nodeId: newNodeId,
         operationInfo: nodeOperationInfo,
-        nodeData: nodeData,
+        nodeData,
         connectionData: connectionReference,
       })
     );
@@ -61,7 +62,8 @@ export const pasteOperation = createAsyncThunk('pasteOperation', async (payload:
   let count = 1;
   let nodeId = actionId;
 
-  while ((getState() as RootState).workflow.nodesMetadata[nodeId]) {
+  const nodesMetadata = (getState() as RootState).workflow.nodesMetadata;
+  while (getRecordEntry(nodesMetadata, nodeId)) {
     nodeId = `${actionId}_${count}`;
     count++;
   }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -60,7 +60,7 @@ import { getIntl } from '@microsoft/intl-logic-apps';
 import type { InputParameter, OutputParameter } from '@microsoft/parsers-logic-apps';
 import { ManifestParser } from '@microsoft/parsers-logic-apps';
 import type { LogicAppsV2, OperationManifest } from '@microsoft/utils-logic-apps';
-import { isArmResourceId, uniqueArray, getPropertyValue, map, aggregate, equals } from '@microsoft/utils-logic-apps';
+import { isArmResourceId, uniqueArray, getPropertyValue, map, aggregate, equals, getRecordEntry } from '@microsoft/utils-logic-apps';
 import type { Dispatch } from '@reduxjs/toolkit';
 
 export interface NodeDataWithOperationMetadata extends NodeData {
@@ -521,27 +521,29 @@ export const updateDynamicDataInNodes = async (getState: () => RootState, dispat
   const allVariables = getAllVariables(variables);
   for (const [nodeId, operation] of Object.entries(operations)) {
     if (nodeId === Constants.NODE.TYPE.PLACEHOLDER_TRIGGER) continue;
-    if (!errors[nodeId]?.[ErrorLevel.Critical]) {
-      const nodeDependencies = dependencies[nodeId];
-      const nodeInputs = inputParameters[nodeId];
-      const nodeSettings = settings[nodeId];
+    if (!getRecordEntry(errors, nodeId)?.[ErrorLevel.Critical]) {
+      const nodeDependencies = getRecordEntry(dependencies, nodeId);
+      const nodeInputs = getRecordEntry(inputParameters, nodeId);
+      const nodeSettings = getRecordEntry(settings, nodeId);
       const isTrigger = isRootNodeInGraph(nodeId, 'root', nodesMetadata);
-      const nodeOperationInfo = operationInfo[nodeId];
+      const nodeOperationInfo = getRecordEntry(operationInfo, nodeId);
       const connectionReference = getConnectionReference(connections, nodeId);
 
-      updateDynamicDataForValidConnection(
-        nodeId,
-        isTrigger,
-        nodeOperationInfo,
-        connectionReference,
-        nodeDependencies,
-        nodeInputs,
-        nodeSettings,
-        allVariables,
-        dispatch,
-        getState,
-        operation
-      );
+      if (nodeOperationInfo && nodeDependencies && nodeInputs && nodeSettings) {
+        updateDynamicDataForValidConnection(
+          nodeId,
+          isTrigger,
+          nodeOperationInfo,
+          connectionReference,
+          nodeDependencies,
+          nodeInputs,
+          nodeSettings,
+          allVariables,
+          dispatch,
+          getState,
+          operation
+        );
+      }
     }
   }
   dispatch(updateDynamicDataLoadStatus(true));
@@ -551,7 +553,7 @@ const updateDynamicDataForValidConnection = async (
   nodeId: string,
   isTrigger: boolean,
   operationInfo: NodeOperation,
-  reference: ConnectionReference,
+  reference: ConnectionReference | undefined,
   dependencies: NodeDependencies,
   nodeInputs: NodeInputs,
   settings: Settings,

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -149,8 +149,8 @@ export const initializeOperationMetadata = async (
           settings,
           operationMetadata,
           staticResult,
-          actionMetadata: nodesMetadata?.[id]?.actionMetadata,
-          repetitionInfo: repetitionInfos[id],
+          actionMetadata: getRecordEntry(nodesMetadata, id)?.actionMetadata,
+          repetitionInfo: getRecordEntry(repetitionInfos, id),
         };
       })
     )
@@ -339,6 +339,7 @@ const updateTokenMetadataInParameters = (
   for (const nodeData of nodes) {
     const { id, nodeInputs } = nodeData;
     const allParameters = getAllInputParameters(nodeInputs);
+    const repetitionInfo = getRecordEntry(repetitionInfos, id) ?? { repetitionReferences: [] };
     for (const parameter of allParameters) {
       const segments = parameter.value;
 
@@ -347,7 +348,7 @@ const updateTokenMetadataInParameters = (
           if (isTokenValueSegment(segment)) {
             return updateTokenMetadata(
               segment,
-              repetitionInfos[id],
+              repetitionInfo,
               actionNodes,
               triggerNodeId,
               nodesData,
@@ -365,7 +366,7 @@ const updateTokenMetadataInParameters = (
       const viewModel = parameter.editorViewModel;
       if (viewModel) {
         flattenAndUpdateViewModel(
-          repetitionInfos[id],
+          repetitionInfo,
           viewModel,
           actionNodes,
           triggerNodeId,
@@ -445,7 +446,7 @@ const initializeVariables = (
 
   for (const nodeData of allNodesData) {
     const { id, nodeInputs, manifest } = nodeData;
-    if (equals(operations[id]?.type, Constants.NODE.TYPE.INITIALIZE_VARIABLE)) {
+    if (equals(getRecordEntry(operations, id)?.type, Constants.NODE.TYPE.INITIALIZE_VARIABLE)) {
       if (!detailsInitialized && manifest) {
         setVariableMetadata(manifest.properties.iconUri, manifest.properties.brandColor);
         detailsInitialized = true;

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -17,6 +17,7 @@ import {
   isNullOrEmpty,
   isNullOrUndefined,
   getUniqueName,
+  getRecordEntry,
 } from '@microsoft/utils-logic-apps';
 
 const hasMultipleTriggers = (definition: LogicAppsV2.WorkflowDefinition): boolean => {
@@ -237,7 +238,9 @@ const processScopeActions = (
 
     // Connect graph header to all top level nodes
     for (const child of graph.children ?? []) {
-      if (metadata[child.id]?.isRoot) edges.push(createWorkflowEdge(headerId, child.id, WORKFLOW_EDGE_TYPES.HEADING_EDGE));
+      if (getRecordEntry(metadata, child.id)?.isRoot) {
+        edges.push(createWorkflowEdge(headerId, child.id, WORKFLOW_EDGE_TYPES.HEADING_EDGE));
+      }
     }
   };
 
@@ -268,7 +271,9 @@ const processScopeActions = (
     edges.push(createWorkflowEdge(headerId, subgraphId, isAddCase ? WORKFLOW_EDGE_TYPES.HIDDEN_EDGE : WORKFLOW_EDGE_TYPES.ONLY_EDGE));
     // Connect subgraph node to all top level nodes
     for (const child of graph.children ?? []) {
-      if (metadata[child.id]?.isRoot) graph.edges.push(createWorkflowEdge(rootId, child.id, WORKFLOW_EDGE_TYPES.HEADING_EDGE));
+      if (getRecordEntry(metadata, child.id)?.isRoot) {
+        graph.edges.push(createWorkflowEdge(rootId, child.id, WORKFLOW_EDGE_TYPES.HEADING_EDGE));
+      }
     }
 
     graph.children = [subgraphCardNode, ...(graph.children ?? [])];
@@ -314,7 +319,9 @@ const processScopeActions = (
 
     // Connect graph header to all top level nodes
     for (const child of graph.children ?? []) {
-      if (metadata[child.id]?.isRoot) edges.push(createWorkflowEdge(scopeCardNode.id, child.id, WORKFLOW_EDGE_TYPES.HEADING_EDGE));
+      if (getRecordEntry(metadata, child.id)?.isRoot) {
+        edges.push(createWorkflowEdge(scopeCardNode.id, child.id, WORKFLOW_EDGE_TYPES.HEADING_EDGE));
+      }
     }
 
     const footerId = `${graphId}-#footer`;

--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -144,7 +144,7 @@ const handleExtraScopeNodeSetup = (
     createSubgraphNode(node, `${node.id}-actions`, SUBGRAPH_TYPES.CONDITIONAL_TRUE, 'actions', nodesMetadata);
     createSubgraphNode(node, `${node.id}-elseActions`, SUBGRAPH_TYPES.CONDITIONAL_FALSE, 'else', nodesMetadata);
     state.operations[node.id] = {
-      ...state.operations[node.id],
+      ...(getRecordEntry(state.operations, node.id) ?? ({} as any)),
       actions: {},
       else: {},
       expression: '',
@@ -172,7 +172,7 @@ const handleExtraScopeNodeSetup = (
     createSubgraphNode(node, `${node.id}-defaultCase`, SUBGRAPH_TYPES.SWITCH_DEFAULT as any, 'default', nodesMetadata);
 
     state.operations[node.id] = {
-      ...state.operations[node.id],
+      ...(getRecordEntry(state.operations, node.id) ?? ({} as any)),
       cases: {},
       default: {},
       expression: '',

--- a/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
@@ -2,7 +2,7 @@
 import type { NodesMetadata, WorkflowState } from '../state/workflow/workflowInterfaces';
 import type { WorkflowNode } from './models/workflowNode';
 import { removeEdge, reassignEdgeSources, reassignEdgeTargets } from './restructuringHelpers';
-import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
+import { getRecordEntry, type LogicAppsV2 } from '@microsoft/utils-logic-apps';
 
 export interface DeleteNodePayload {
   nodeId: string;
@@ -18,14 +18,15 @@ export const deleteNodeFromWorkflow = (
   if (!workflowGraph.id) throw new Error('Workflow graph is missing an id');
   const { nodeId, isTrigger } = payload;
 
-  const currentRunAfter = (state.operations[nodeId] as LogicAppsV2.ActionDefinition)?.runAfter;
+  const currentRunAfter = (getRecordEntry(state.operations, nodeId) as LogicAppsV2.ActionDefinition)?.runAfter;
   const multipleParents = Object.keys(currentRunAfter ?? {}).length > 1;
 
-  const isRoot = nodesMetadata[nodeId]?.isRoot;
+  const isRoot = getRecordEntry(nodesMetadata, nodeId)?.isRoot;
   if (isRoot && !isTrigger) {
     const childIds = (workflowGraph.edges ?? []).filter((edge) => edge.source === nodeId).map((edge) => edge.target);
     childIds.forEach((childId) => {
-      if (nodesMetadata[childId]) nodesMetadata[childId].isRoot = true;
+      const childMetadata = getRecordEntry(nodesMetadata, childId);
+      if (childMetadata) childMetadata.isRoot = true;
     });
   }
 
@@ -47,7 +48,8 @@ export const deleteNodeFromWorkflow = (
   } else {
     const parentId = (workflowGraph.edges ?? []).find((edge) => edge.target === nodeId)?.source ?? '';
     const graphId = workflowGraph.id;
-    const isAfterTrigger = nodesMetadata[parentId ?? '']?.isRoot && graphId === 'root';
+    const parentMetadata = getRecordEntry(nodesMetadata, parentId);
+    const isAfterTrigger = parentMetadata?.isRoot && graphId === 'root';
     const shouldAddRunAfters = !isRoot && !isAfterTrigger;
     reassignEdgeSources(state, nodeId, parentId, workflowGraph, shouldAddRunAfters);
     removeEdge(state, parentId, nodeId, workflowGraph);
@@ -61,8 +63,9 @@ export const deleteNodeFromWorkflow = (
   state.isDirty = true;
 
   // Decrease action count of graph
-  if (nodesMetadata[workflowGraph.id]) {
-    nodesMetadata[workflowGraph.id].actionCount = (nodesMetadata[workflowGraph.id].actionCount ?? 1) - 1;
+  const currentActionCount = getRecordEntry(nodesMetadata, workflowGraph.id)?.actionCount;
+  if (currentActionCount) {
+    nodesMetadata[workflowGraph.id].actionCount = (currentActionCount ?? 1) - 1;
   }
 };
 

--- a/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
@@ -4,7 +4,7 @@ import type { NodesMetadata, WorkflowState } from '../state/workflow/workflowInt
 import type { WorkflowNode } from './models/workflowNode';
 import { addNewEdge, reassignEdgeSources, reassignEdgeTargets, removeEdge, applyIsRootNode } from './restructuringHelpers';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
-import { containsIdTag } from '@microsoft/utils-logic-apps';
+import { containsIdTag, getRecordEntry } from '@microsoft/utils-logic-apps';
 
 export interface MoveNodePayload {
   nodeId: string;
@@ -27,7 +27,7 @@ export const moveNodeInWorkflow = (
 
   const { parentId, childId } = relationshipIds;
 
-  const currentRunAfter = (state.operations[nodeId] as LogicAppsV2.ActionDefinition)?.runAfter;
+  const currentRunAfter = (getRecordEntry(state.operations, nodeId) as LogicAppsV2.ActionDefinition)?.runAfter;
   const multipleParents = Object.keys(currentRunAfter ?? {}).length > 1;
   const multipleChildren = (oldWorkflowGraph.edges ?? []).filter((edge) => edge.source === nodeId).length > 1;
 
@@ -44,12 +44,13 @@ export const moveNodeInWorkflow = (
   // Remove node from its current position in the graph
 
   // Set correct isRoot props
-  const isOldRoot = nodesMetadata[nodeId]?.isRoot;
+  const isOldRoot = getRecordEntry(nodesMetadata, nodeId)?.isRoot;
   if (isOldRoot) {
     const childIds = (oldWorkflowGraph.edges ?? []).filter((edge) => edge.source === nodeId).map((edge) => edge.target);
     childIds.forEach((childId) => {
-      if (nodesMetadata[childId]) nodesMetadata[childId].isRoot = true;
-      delete (state.operations[childId] as any)?.runAfter;
+      const childMetadata = getRecordEntry(nodesMetadata, childId);
+      if (childMetadata) childMetadata.isRoot = true;
+      delete (getRecordEntry(state.operations, childId) as any)?.runAfter;
     });
   }
 
@@ -67,7 +68,8 @@ export const moveNodeInWorkflow = (
   } else {
     const parentId = (oldWorkflowGraph.edges ?? []).find((edge) => edge.target === nodeId)?.source ?? '';
     const graphId = oldWorkflowGraph.id;
-    const isAfterTrigger = nodesMetadata[parentId ?? '']?.isRoot && graphId === 'root';
+    const parentMetadata = getRecordEntry(nodesMetadata, parentId);
+    const isAfterTrigger = parentMetadata?.isRoot && graphId === 'root';
     const shouldAddRunAfters = !isOldRoot && !isAfterTrigger;
     reassignEdgeSources(state, nodeId, parentId, oldWorkflowGraph, shouldAddRunAfters);
     removeEdge(state, parentId, nodeId, oldWorkflowGraph);
@@ -92,19 +94,22 @@ export const moveNodeInWorkflow = (
   const isNewRoot = containsIdTag(parentId ?? '');
   const parentNodeId = newGraphId !== 'root' ? newGraphId : undefined;
 
-  nodesMetadata[nodeId] = { ...nodesMetadata[nodeId], graphId: newGraphId, parentNodeId, isRoot: isNewRoot };
-  if (nodesMetadata[nodeId].isRoot === false) delete nodesMetadata[nodeId].isRoot;
+  nodesMetadata[nodeId] = { ...getRecordEntry(nodesMetadata, nodeId), graphId: newGraphId, parentNodeId, isRoot: isNewRoot };
+  if (getRecordEntry(nodesMetadata, nodeId)?.isRoot === false) delete nodesMetadata[nodeId].isRoot;
 
-  const isAfterTrigger = (nodesMetadata[parentId ?? '']?.isRoot && newGraphId === 'root') ?? false;
+  const parentMetadata = getRecordEntry(nodesMetadata, parentId);
+  const isAfterTrigger = (parentMetadata?.isRoot && newGraphId === 'root') ?? false;
   const shouldAddRunAfters = !isNewRoot && !isAfterTrigger;
 
   // 1 parent, 1 child
   if (parentId && childId) {
-    const childRunAfter = (state.operations?.[childId] as any)?.runAfter;
+    const childRunAfter = (getRecordEntry(state.operations, childId) as any)?.runAfter;
     addNewEdge(state, parentId, nodeId, newWorkflowGraph, shouldAddRunAfters);
     addNewEdge(state, nodeId, childId, newWorkflowGraph, true);
     removeEdge(state, parentId, childId, newWorkflowGraph);
-    if (childRunAfter && shouldAddRunAfters) (state.operations?.[nodeId] as any).runAfter[parentId] = childRunAfter[parentId];
+    if (childRunAfter && shouldAddRunAfters) {
+      (getRecordEntry(state.operations, nodeId) as any).runAfter[parentId] = getRecordEntry(childRunAfter, parentId);
+    }
   }
   // X parents, 1 child
   else if (childId) {
@@ -117,7 +122,7 @@ export const moveNodeInWorkflow = (
     addNewEdge(state, parentId, nodeId, newWorkflowGraph, shouldAddRunAfters);
   }
 
-  if (isNewRoot && (state.operations[nodeId] as any)) delete (state.operations[nodeId] as any).runAfter;
+  if (isNewRoot && (getRecordEntry(state.operations, nodeId) as any)) delete (getRecordEntry(state.operations, nodeId) as any)?.runAfter;
   applyIsRootNode(state, newWorkflowGraph, nodesMetadata);
 
   state.isDirty = true;

--- a/libs/designer/src/lib/core/parsers/restructuringHelpers.ts
+++ b/libs/designer/src/lib/core/parsers/restructuringHelpers.ts
@@ -4,7 +4,7 @@ import { isWorkflowOperationNode } from '../actions/bjsworkflow/serializer';
 import type { NodesMetadata, WorkflowState } from '../state/workflow/workflowInterfaces';
 import type { WorkflowEdge, WorkflowNode } from './models/workflowNode';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
-import { containsIdTag, RUN_AFTER_STATUS, WORKFLOW_EDGE_TYPES } from '@microsoft/utils-logic-apps';
+import { containsIdTag, getRecordEntry, RUN_AFTER_STATUS, WORKFLOW_EDGE_TYPES } from '@microsoft/utils-logic-apps';
 
 ///////////////////////////////////////////////////////////
 // EDGES
@@ -19,7 +19,7 @@ export const addNewEdge = (state: WorkflowState, source: string, target: string,
   if (!graph?.edges) graph.edges = [];
   graph?.edges.push(workflowEdge);
 
-  const targetOp = state.operations?.[target] as any;
+  const targetOp = getRecordEntry(state.operations, target) as any;
   if (targetOp && addRunAfter) {
     targetOp.runAfter = { ...targetOp.runAfter, [source]: [RUN_AFTER_STATUS.SUCCEEDED] };
   }
@@ -28,7 +28,7 @@ export const addNewEdge = (state: WorkflowState, source: string, target: string,
 export const removeEdge = (state: WorkflowState, sourceId: string, targetId: string, graph: WorkflowNode) => {
   if (!state) return;
   graph.edges = graph.edges?.filter((edge) => !(edge.source === sourceId && edge.target === targetId));
-  const targetRunAfter = (state.operations?.[targetId] as any)?.runAfter;
+  const targetRunAfter = (getRecordEntry(state.operations, targetId) as any)?.runAfter;
   if (targetRunAfter) delete targetRunAfter?.[sourceId as any];
 };
 
@@ -91,10 +91,10 @@ export const reassignEdgeTargets = (state: WorkflowState, oldTargetId: string, n
 
 export const moveRunAfterTarget = (state: WorkflowState | undefined, oldTargetId: string, newTargetId: string) => {
   if (!state) return;
-  const targetRunAfter = (state.operations?.[oldTargetId] as any)?.runAfter;
+  const targetRunAfter = (getRecordEntry(state.operations, oldTargetId) as any)?.runAfter;
   if (targetRunAfter) {
-    (state.operations[newTargetId] as LogicAppsV2.ActionDefinition).runAfter = targetRunAfter;
-    (state.operations[oldTargetId] as any).runAfter = {};
+    (getRecordEntry(state.operations, newTargetId) as LogicAppsV2.ActionDefinition).runAfter = targetRunAfter;
+    (getRecordEntry(state.operations, oldTargetId) as any).runAfter = {};
   }
 };
 
@@ -105,18 +105,18 @@ export const moveRunAfterSource = (
   newSourceId: string,
   shouldHaveRunAfters: boolean
 ) => {
-  if (!state?.operations?.[nodeId]) return;
-  const targetRunAfter = (state.operations[nodeId] as LogicAppsV2.ActionDefinition)?.runAfter ?? {};
-  if (shouldHaveRunAfters && !targetRunAfter?.[newSourceId]) {
-    targetRunAfter[newSourceId] = targetRunAfter[oldSourceId] ?? [RUN_AFTER_STATUS.SUCCEEDED];
+  if (!getRecordEntry(state?.operations, nodeId)) return;
+  const targetRunAfter = (getRecordEntry(state?.operations, nodeId) as LogicAppsV2.ActionDefinition)?.runAfter ?? {};
+  if (shouldHaveRunAfters && !getRecordEntry(targetRunAfter, newSourceId)) {
+    targetRunAfter[newSourceId] = getRecordEntry(targetRunAfter, oldSourceId) ?? [RUN_AFTER_STATUS.SUCCEEDED];
   }
 
   delete targetRunAfter[oldSourceId];
 
   if (Object.keys(targetRunAfter).length !== 0) {
-    (state.operations[nodeId] as LogicAppsV2.ActionDefinition).runAfter = targetRunAfter;
+    (getRecordEntry(state?.operations, nodeId) as LogicAppsV2.ActionDefinition).runAfter = targetRunAfter;
   } else {
-    delete (state.operations[nodeId] as LogicAppsV2.ActionDefinition).runAfter;
+    delete (getRecordEntry(state?.operations, nodeId) as LogicAppsV2.ActionDefinition).runAfter;
   }
 };
 
@@ -128,7 +128,8 @@ export const applyIsRootNode = (state: WorkflowState, graph: WorkflowNode, metad
 
   (graph.children ?? []).forEach((node) => {
     const isRoot = node.id === constants.NODE.TYPE.PLACEHOLDER_TRIGGER ? true : rootNodeIds?.includes(node.id) ?? false;
-    if (metadata[node.id]) metadata[node.id].isRoot = isRoot;
-    if (isRoot) delete (state.operations[node.id] as LogicAppsV2.ActionDefinition)?.runAfter;
+    const nodeMetadata = getRecordEntry(metadata, node.id);
+    if (nodeMetadata) nodeMetadata.isRoot = isRoot;
+    if (isRoot) delete (getRecordEntry(state.operations, node.id) as LogicAppsV2.ActionDefinition)?.runAfter;
   });
 };

--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -11,19 +11,21 @@ import {
   OperationManifestService,
   isServiceProviderOperation,
 } from '@microsoft/designer-client-services-logic-apps';
-import { type Connector } from '@microsoft/utils-logic-apps';
+import { getRecordEntry, type Connector } from '@microsoft/utils-logic-apps';
 import { useMemo } from 'react';
 import { useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
 
-export const useConnector = (connectorId: string, enabled = true) => {
+export const useConnector = (connectorId: string | undefined, enabled = true) => {
   const { data, ...rest } = useConnectorAndSwagger(connectorId, enabled);
   return { data: data?.connector, ...rest };
 };
-export const useConnectorAndSwagger = (connectorId: string, enabled = true) => {
+
+export const useConnectorAndSwagger = (connectorId: string | undefined, enabled = true) => {
   return useQuery(
     ['apiWithSwaggers', { connectorId }],
     async () => {
+      if (!connectorId) return;
       return await ConnectionService().getConnectorAndSwagger(connectorId);
     },
     {
@@ -69,8 +71,9 @@ export const useNodeConnectionId = (nodeId: string): string => {
   const connectionsMapping = useConnectionMapping();
   const connectionReferences = useConnectionRefs();
   return useMemo(() => {
-    const reference = connectionReferences[connectionsMapping[nodeId] ?? ''];
-    return reference ? reference.connection.id : '';
+    const mapping = getRecordEntry(connectionsMapping, nodeId) ?? '';
+    const reference = getRecordEntry(connectionReferences, mapping);
+    return reference?.connection?.id ?? '';
   }, [connectionsMapping, connectionReferences, nodeId]);
 };
 
@@ -79,7 +82,10 @@ const useConnectionByNodeId = (nodeId: string) => {
   const connectionId = useNodeConnectionId(nodeId);
   return useQuery(
     ['connection', { connectorId: operationInfo?.connectorId }, { connectionId }],
-    () => getConnection(connectionId, operationInfo?.connectorId),
+    () => {
+      if (!connectionId || !operationInfo?.connectorId) return;
+      return getConnection(connectionId, operationInfo.connectorId);
+    },
     {
       enabled: !!connectionId && !!operationInfo?.connectorId,
       placeholderData: undefined,
@@ -110,7 +116,7 @@ export const useConnectionRefsByConnectorId = (connectorId?: string) => {
 
 export const useIsOperationMissingConnection = (nodeId: string) => {
   const connectionsMapping = useSelector((state: RootState) => state.connections.connectionsMapping);
-  return Object.keys(connectionsMapping).includes(nodeId) && connectionsMapping[nodeId] === null;
+  return Object.keys(connectionsMapping).includes(nodeId) && getRecordEntry(connectionsMapping, nodeId) === null;
 };
 
 export const useShowIdentitySelectorQuery = (nodeId: string) => {

--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -302,7 +302,7 @@ export const operationMetadataSlice = createSlice({
       const { id, settings } = action.payload;
       const nodeSettings = getRecordEntry(state.settings, id);
       if (!nodeSettings) state.settings[id] = {};
-      state.settings[id] = { ...state.settings[id], ...settings };
+      state.settings[id] = { ...nodeSettings, ...settings };
 
       LoggerService().log({
         level: LogEntryLevel.Verbose,
@@ -409,7 +409,8 @@ export const operationMetadataSlice = createSlice({
     },
     updateOutputs: (state, action: PayloadAction<{ id: string; nodeOutputs: NodeOutputs }>) => {
       const { id, nodeOutputs } = action.payload;
-      if (state.outputParameters[id]) state.outputParameters[id] = nodeOutputs;
+      const outputParameters = getRecordEntry(state.outputParameters, id);
+      if (outputParameters) state.outputParameters[id] = nodeOutputs;
     },
     updateActionMetadata: (state, action: PayloadAction<{ id: string; actionMetadata: Record<string, any> }>) => {
       const { id, actionMetadata } = action.payload;

--- a/libs/designer/src/lib/core/state/operation/operationSelector.ts
+++ b/libs/designer/src/lib/core/state/operation/operationSelector.ts
@@ -1,9 +1,11 @@
 import type { NodeStaticResults } from '../../actions/bjsworkflow/staticresults';
 import type { RootState } from '../../store';
 import { shouldUseParameterInGroup } from '../../utils/parameters/helper';
-import type { ErrorInfo, NodeInputs } from './operationMetadataSlice';
+import type { ErrorInfo, NodeDependencies, NodeInputs } from './operationMetadataSlice';
 import { ErrorLevel } from './operationMetadataSlice';
+import type { NodeOutputs } from '@microsoft/designer-client-services-logic-apps';
 import type { ParameterInfo } from '@microsoft/designer-ui';
+import { getRecordEntry } from '@microsoft/utils-logic-apps';
 import { createSelector } from '@reduxjs/toolkit';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -11,10 +13,12 @@ import { useSelector } from 'react-redux';
 const getOperationState = (state: RootState) => state.operations;
 
 export const useOperationVisuals = (nodeId: string) =>
-  useSelector(createSelector(getOperationState, (state) => state.operationMetadata[nodeId] ?? {}));
+  useSelector(
+    createSelector(getOperationState, (state) => getRecordEntry(state.operationMetadata, nodeId) ?? { brandColor: '', iconUri: '' })
+  );
 
 export const getOperationInputParameters = (rootState: RootState, nodeId: string): ParameterInfo[] => {
-  const nodeInputs = rootState.operations.inputParameters[nodeId];
+  const nodeInputs = getRecordEntry(rootState.operations.inputParameters, nodeId);
   const allParameters: ParameterInfo[] = [];
 
   if (nodeInputs) {
@@ -34,7 +38,7 @@ export const getOperationInputParameters = (rootState: RootState, nodeId: string
 };
 
 export const useOperationInputParameters = (nodeId: string): ParameterInfo[] => {
-  const nodeInputs = useSelector((rootState: RootState) => rootState.operations.inputParameters[nodeId]);
+  const nodeInputs = useSelector((rootState: RootState) => getRecordEntry(rootState.operations.inputParameters, nodeId));
   return useMemo(() => {
     const allParameters: ParameterInfo[] = [];
     if (nodeInputs) {
@@ -54,7 +58,7 @@ export const useOperationInputParameters = (nodeId: string): ParameterInfo[] => 
 };
 
 export const useOperationErrorInfo = (nodeId: string): ErrorInfo | undefined =>
-  useSelector(createSelector(getOperationState, (state) => getTopErrorInOperation(state.errors[nodeId])));
+  useSelector(createSelector(getOperationState, (state) => getTopErrorInOperation(getRecordEntry(state.errors, nodeId))));
 
 export const useAllConnectionErrors = (): Record<string, string> =>
   useSelector(
@@ -73,17 +77,27 @@ export const useOperationsInputParameters = (): Record<string, NodeInputs> =>
 
 export const useSecureInputsOutputs = (nodeId: string): boolean =>
   useSelector(
-    createSelector(
-      getOperationState,
-      (state) => !!(state.settings?.[nodeId]?.secureInputs?.value || state.settings?.[nodeId]?.secureOutputs?.value)
-    )
+    createSelector(getOperationState, (state) => {
+      const nodeSettings = getRecordEntry(state.settings, nodeId);
+      return !!(nodeSettings?.secureInputs?.value || nodeSettings?.secureOutputs?.value);
+    })
   );
 
-export const useParameterStaticResult = (nodeId: string): NodeStaticResults =>
-  useSelector(createSelector(getOperationState, (state) => state.staticResults[nodeId]));
+export const useParameterStaticResult = (nodeId: string): NodeStaticResults | undefined =>
+  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.staticResults, nodeId)));
+
+export const useRawInputParameters = (nodeId: string): NodeInputs | undefined =>
+  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.inputParameters, nodeId)));
+
+export const useRawOutputParameters = (nodeId: string): NodeOutputs | undefined =>
+  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.outputParameters, nodeId)));
+
+const mockDeps: NodeDependencies = { inputs: {}, outputs: {} };
+export const useDependencies = (nodeId: string) =>
+  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.dependencies, nodeId) ?? mockDeps));
 
 export const useTokenDependencies = (nodeId: string) => {
-  const operationInputParameters = useSelector(createSelector(getOperationState, (op) => op.inputParameters?.[nodeId]));
+  const operationInputParameters = useRawInputParameters(nodeId);
   return useMemo(() => {
     if (!operationInputParameters) {
       return new Set();
@@ -121,7 +135,7 @@ export const useNodesInitialized = () => useSelector(createSelector(getOperation
 export const useNodesAndDynamicDataInitialized = () =>
   useSelector(createSelector(getOperationState, (state) => state.loadStatus.nodesAndDynamicDataInitialized));
 
-const getTopErrorInOperation = (errors: Record<ErrorLevel, ErrorInfo | undefined>): ErrorInfo | undefined => {
+const getTopErrorInOperation = (errors?: Record<ErrorLevel, ErrorInfo | undefined>): ErrorInfo | undefined => {
   if (!errors) {
     return undefined;
   } else if (errors[ErrorLevel.Critical]) {
@@ -140,10 +154,10 @@ const getTopErrorInOperation = (errors: Record<ErrorLevel, ErrorInfo | undefined
 };
 
 export const useBrandColor = (nodeId: string) =>
-  useSelector(createSelector(getOperationState, (state) => state.operationMetadata[nodeId]?.brandColor ?? ''));
+  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.operationMetadata, nodeId)?.brandColor ?? ''));
 
 export const useIconUri = (nodeId: string) =>
-  useSelector(createSelector(getOperationState, (state) => state.operationMetadata[nodeId]?.iconUri ?? ''));
+  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.operationMetadata, nodeId)?.iconUri ?? ''));
 
 export const useNodeConnectorId = (nodeId: string) =>
-  useSelector(createSelector(getOperationState, (state) => state.operationInfo[nodeId]?.connectorId));
+  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.operationInfo, nodeId)?.connectorId));

--- a/libs/designer/src/lib/core/state/selectors/actionMetadataSelector.ts
+++ b/libs/designer/src/lib/core/state/selectors/actionMetadataSelector.ts
@@ -7,7 +7,7 @@ import type { NodeOperation } from '../operation/operationMetadataSlice';
 import { OperationManifestService } from '@microsoft/designer-client-services-logic-apps';
 import type { Operation } from '@microsoft/parsers-logic-apps';
 import { SwaggerParser } from '@microsoft/parsers-logic-apps';
-import { getObjectPropertyValue } from '@microsoft/utils-logic-apps';
+import { getObjectPropertyValue, getRecordEntry } from '@microsoft/utils-logic-apps';
 import { createSelector } from '@reduxjs/toolkit';
 import { useMemo } from 'react';
 import { useQuery } from 'react-query';
@@ -47,26 +47,36 @@ export const useNodeConnectionName = (nodeId: string): QueryResult => {
   );
 };
 
+export const useAllOperations = () => useSelector((state: RootState) => state.operations.operationInfo);
 export const useOperationInfo = (nodeId: string) => {
   const selector = createSelector(
     [(state: RootState) => state.operations.operationInfo, (_, nodeId: string) => nodeId],
-    (operationInfo, id) => operationInfo[id]
+    (operationInfo, id) => getRecordEntry(operationInfo, id) ?? ({ type: '' } as NodeOperation)
   );
   return useSelector((state: RootState) => selector(state, nodeId));
 };
 
-export const useAllOperations = () => useSelector((state: RootState) => state.operations.operationInfo);
+export const useAllOutputParameters = () => useSelector((state: RootState) => state.operations.outputParameters);
+export const useOutputParameters = (nodeId: string) => {
+  const selector = createSelector(
+    [(state: RootState) => state.operations.outputParameters, (_, nodeId: string) => nodeId],
+    (outputParameters, id) => getRecordEntry(outputParameters, id)
+  );
+  return useSelector((state: RootState) => selector(state, nodeId));
+};
 
-export const useOperationManifest = (operationInfo: NodeOperation, enabled = true) => {
+export const useOperationManifest = (operationInfo?: NodeOperation, enabled = true) => {
   const operationManifestService = OperationManifestService();
   const connectorId = operationInfo?.connectorId?.toLowerCase();
   const operationId = operationInfo?.operationId?.toLowerCase();
   return useQuery(
     ['manifest', { connectorId }, { operationId }],
-    () =>
-      operationManifestService.isSupported(operationInfo.type, operationInfo.kind)
+    () => {
+      if (!operationInfo || !connectorId || !operationId) return;
+      return operationManifestService.isSupported(operationInfo.type, operationInfo.kind)
         ? operationManifestService.getOperationManifest(connectorId, operationId)
-        : undefined,
+        : undefined;
+    },
     {
       enabled: !!connectorId && !!operationId && enabled,
       placeholderData: undefined,

--- a/libs/designer/src/lib/core/state/setting/settingSelector.ts
+++ b/libs/designer/src/lib/core/state/setting/settingSelector.ts
@@ -1,4 +1,5 @@
 import type { RootState } from '../../store';
+import { getRecordEntry } from '@microsoft/utils-logic-apps';
 import { createSelector } from '@reduxjs/toolkit';
 import { useSelector } from 'react-redux';
 
@@ -13,5 +14,5 @@ export const useAllSettingsValidationErrors = () => {
 };
 
 export const useSettingValidationErrors = (nodeId: string) => {
-  return useSelector(createSelector(getSettingsState, (settings) => settings.validationErrors?.[nodeId] ?? []));
+  return useSelector(createSelector(getSettingsState, (settings) => getRecordEntry(settings.validationErrors, nodeId) ?? []));
 };

--- a/libs/designer/src/lib/core/state/tokens/tokenSelectors.ts
+++ b/libs/designer/src/lib/core/state/tokens/tokenSelectors.ts
@@ -1,5 +1,6 @@
 import type { RootState } from '../../store';
 import type { TokensState } from './tokensSlice';
+import { getRecordEntry } from '@microsoft/utils-logic-apps';
 import { createSelector } from '@reduxjs/toolkit';
 import { useSelector } from 'react-redux';
 
@@ -9,7 +10,7 @@ export const useUpstreamNodes = (id?: string) => {
   return useSelector(
     createSelector(getTokenState, (state: TokensState) => {
       // TODO: Support variables
-      return state.outputTokens[id ?? '']?.upstreamNodeIds ?? [];
+      return getRecordEntry(state.outputTokens, id)?.upstreamNodeIds ?? [];
     })
   );
 };

--- a/libs/designer/src/lib/core/state/tokens/tokensSlice.ts
+++ b/libs/designer/src/lib/core/state/tokens/tokensSlice.ts
@@ -52,31 +52,21 @@ export const tokensSlice = createSlice({
     },
     updateVariableInfo: (state, action: PayloadAction<{ id: string; name?: string; type?: string }>) => {
       const { id, name, type } = action.payload;
-      if (state.variables[id]) {
-        if (name) {
-          state.variables[id] = state.variables[id].map((variable) => ({
-            ...variable,
-            name: name,
-          }));
-        }
-        if (type) {
-          state.variables[id] = state.variables[id].map((variable) => ({
-            ...variable,
-            type: type,
-          }));
-        }
-      }
+      const variables = getRecordEntry(state.variables, id);
+      if (!variables) return;
+      if (name) state.variables[id] = variables.map((variable) => ({ ...variable, name }));
+      if (type) state.variables[id] = variables.map((variable) => ({ ...variable, type }));
     },
     updateTokens: (state, action: PayloadAction<{ id: string; tokens: Token[] }>) => {
       const { id, tokens } = action.payload;
-      if (state.outputTokens[id]) {
-        state.outputTokens[id].tokens = tokens;
-      }
+      const outputTokens = getRecordEntry(state.outputTokens, id);
+      if (outputTokens) outputTokens.tokens = tokens;
     },
     updateTokenSecureStatus: (state, action: PayloadAction<{ id: string; isSecure: boolean }>) => {
       const { id, isSecure } = action.payload;
-      if (state.outputTokens[id]) {
-        state.outputTokens[id].tokens = state.outputTokens[id].tokens.map((token) => ({
+      const outputTokens = getRecordEntry(state.outputTokens, id);
+      if (outputTokens) {
+        outputTokens.tokens = outputTokens.tokens.map((token) => ({
           ...token,
           outputInfo: { ...token.outputInfo, isSecure },
         }));

--- a/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
@@ -13,12 +13,7 @@ import Queue from 'yocto-queue';
 export const getWorkflowState = (state: RootState): WorkflowState => state.workflow;
 
 export const useNodeDisplayName = (id?: string) =>
-  useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      const newId = getRecordEntry(state.idReplacements, id);
-      return labelCase(newId ?? id ?? '');
-    })
-  );
+  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => labelCase(getRecordEntry(state.idReplacements, id) ?? id ?? '')));
 
 export const useNodeReplacedId = (id?: string) =>
   useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.idReplacements, id)));

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -358,10 +358,8 @@ export const workflowSlice = createSlice({
     addEdgeFromRunAfter: (state: WorkflowState, action: PayloadAction<{ childOperationId: string; parentOperationId: string }>) => {
       const { childOperationId, parentOperationId } = action.payload;
       const parentOperation = getRecordEntry(state.operations, parentOperationId);
-      const childOperation: LogicAppsV2.ActionDefinition = state.operations[childOperationId];
-      if (!parentOperation || !childOperation) {
-        return;
-      }
+      const childOperation: LogicAppsV2.ActionDefinition | undefined = getRecordEntry(state.operations, childOperationId);
+      if (!parentOperation || !childOperation) return;
       childOperation.runAfter = { ...(childOperation.runAfter ?? {}), [parentOperationId]: [RUN_AFTER_STATUS.SUCCEEDED] };
 
       const graphPath: string[] = [];

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -27,7 +27,7 @@ import { LogEntryLevel, LoggerService } from '@microsoft/designer-client-service
 import type { MessageLevel } from '@microsoft/designer-ui';
 import { getDurationStringPanelMode } from '@microsoft/designer-ui';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
-import { equals, RUN_AFTER_STATUS, WORKFLOW_EDGE_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/utils-logic-apps';
+import { equals, getRecordEntry, RUN_AFTER_STATUS, WORKFLOW_EDGE_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/utils-logic-apps';
 import { createSlice, isAnyOf } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { NodeChange, NodeDimensionChange } from 'reactflow';
@@ -74,7 +74,9 @@ export const workflowSlice = createSlice({
     },
     setNodeDescription: (state: WorkflowState, action: PayloadAction<{ nodeId: string; description?: string }>) => {
       const { nodeId, description } = action.payload;
-      state.operations[nodeId].description = description;
+      const nodeOperation = getRecordEntry(state.operations, nodeId);
+      if (!nodeOperation) return;
+      nodeOperation.description = description;
     },
     addNode: (state: WorkflowState, action: PayloadAction<AddNodePayload>) => {
       if (!state.graph) {
@@ -111,7 +113,7 @@ export const workflowSlice = createSlice({
     addImplicitForeachNode: (state: WorkflowState, action: PayloadAction<AddImplicitForeachPayload>) => {
       const { nodeId, foreachNodeId, operation } = action.payload;
       const currentNodeToBeReplaced = getWorkflowNodeFromGraphState(state, nodeId) as WorkflowNode;
-      const graphId = state.nodesMetadata[nodeId].graphId;
+      const graphId = getRecordEntry(state.nodesMetadata, nodeId)?.graphId ?? '';
       const currentGraph = (graphId === 'root' ? state.graph : getWorkflowNodeFromGraphState(state, graphId)) as WorkflowNode;
       const parentIds = getImmediateSourceNodeIds(currentGraph, nodeId);
       const parentId = parentIds.length > 1 ? undefined : parentIds[0];
@@ -121,7 +123,7 @@ export const workflowSlice = createSlice({
         state.nodesMetadata,
         state
       );
-      state.operations[foreachNodeId] = { ...state.operations[foreachNodeId], ...operation };
+      state.operations[foreachNodeId] = { ...getRecordEntry(state.operations, foreachNodeId), ...operation };
       const foreachNode = getWorkflowNodeFromGraphState(state, foreachNodeId) as WorkflowNode;
       moveNodeInWorkflow(
         currentNodeToBeReplaced,
@@ -176,7 +178,7 @@ export const workflowSlice = createSlice({
         return; // log exception
       }
       const { nodeId, isTrigger } = action.payload;
-      const graphId = state.nodesMetadata[nodeId]?.graphId;
+      const graphId = getRecordEntry(state.nodesMetadata, nodeId)?.graphId ?? '';
       const graph = getWorkflowNodeFromGraphState(state, graphId);
       if (!graph) throw new Error('graph not set');
 
@@ -212,7 +214,7 @@ export const workflowSlice = createSlice({
       });
     },
     deleteSwitchCase: (state: WorkflowState, action: PayloadAction<{ caseId: string; nodeId: string }>) => {
-      delete (state.operations?.[action.payload.nodeId] as any).cases?.[action.payload.caseId];
+      delete (getRecordEntry(state.operations, action.payload.nodeId) as any).cases?.[action.payload.caseId];
 
       LoggerService().log({
         level: LogEntryLevel.Verbose,
@@ -244,7 +246,7 @@ export const workflowSlice = createSlice({
       }, {});
       while (stack.length) {
         const node = stack.shift();
-        const change = dimensionChangesById[node?.id ?? ''];
+        const change = getRecordEntry(dimensionChangesById, node?.id ?? '');
         if (change && node && isWorkflowNode(node)) {
           const c = change as NodeDimensionChange;
           node.height = c.dimensions?.height ?? 0;
@@ -257,7 +259,7 @@ export const workflowSlice = createSlice({
       state.collapsedGraphIds = action.payload;
     },
     toggleCollapsedGraphId: (state: WorkflowState, action: PayloadAction<string>) => {
-      if (state.collapsedGraphIds?.[action.payload] === true) delete state.collapsedGraphIds[action.payload];
+      if (getRecordEntry(state.collapsedGraphIds, action.payload) === true) delete state.collapsedGraphIds[action.payload];
       else state.collapsedGraphIds[action.payload] = true;
 
       LoggerService().log({
@@ -269,25 +271,30 @@ export const workflowSlice = createSlice({
     },
     setRunIndex: (state: WorkflowState, action: PayloadAction<{ page: number; nodeId: string }>) => {
       const { page, nodeId } = action.payload;
-      state.nodesMetadata[nodeId].runIndex = page;
+      const nodeMetadata = getRecordEntry(state.nodesMetadata, nodeId);
+      if (!nodeMetadata) return;
+      nodeMetadata.runIndex = page;
     },
     setRepetitionRunData: (state: WorkflowState, action: PayloadAction<{ nodeId: string; runData: LogicAppsV2.WorkflowRunAction }>) => {
       const { nodeId, runData } = action.payload;
+      const nodeMetadata = getRecordEntry(state.nodesMetadata, nodeId);
+      if (!nodeMetadata) return;
       const nodeRunData = {
-        ...state.nodesMetadata[nodeId].runData,
+        ...nodeMetadata.runData,
         ...runData,
         inputsLink: runData?.inputsLink ?? null,
         outputsLink: runData?.outputsLink ?? null,
         duration: getDurationStringPanelMode(Date.parse(runData.endTime) - Date.parse(runData.startTime), /* abbreviated */ true),
       };
-      state.nodesMetadata[nodeId].runData = nodeRunData as LogicAppsV2.WorkflowRunAction;
+      nodeMetadata.runData = nodeRunData as LogicAppsV2.WorkflowRunAction;
     },
     addSwitchCase: (state: WorkflowState, action: PayloadAction<{ caseId: string; nodeId: string }>) => {
       if (!state.graph) {
         return; // log exception
       }
       const { caseId, nodeId } = action.payload;
-      const node = getWorkflowNodeFromGraphState(state, state.nodesMetadata[nodeId].graphId);
+      const graphId = getRecordEntry(state.nodesMetadata, nodeId)?.graphId ?? '';
+      const node = getWorkflowNodeFromGraphState(state, graphId);
       if (!node) throw new Error('node not set');
       addSwitchCaseToWorkflow(caseId, node, state.nodesMetadata, state);
 
@@ -314,8 +321,8 @@ export const workflowSlice = createSlice({
         const edges = graph.edges?.filter((e) => e.type !== WORKFLOW_EDGE_TYPES.HIDDEN_EDGE);
         if (edges) {
           edges.forEach((edge) => {
-            if (!output[edge.source]) output[edge.source] = [];
-            output[edge.source].push(edge.target);
+            if (!getRecordEntry(output, edge.source)) output[edge.source] = [];
+            getRecordEntry(output, edge.source)?.push(edge.target);
           });
         }
         if (graph.children) graph.children.forEach((child) => traverseGraph(child));
@@ -325,19 +332,19 @@ export const workflowSlice = createSlice({
     },
     removeEdgeFromRunAfter: (state: WorkflowState, action: PayloadAction<{ childOperationId: string; parentOperationId: string }>) => {
       const { childOperationId, parentOperationId } = action.payload;
-      const parentOperation = state.operations[parentOperationId];
-      const childOperation: LogicAppsV2.ActionDefinition = state.operations[childOperationId];
+      const parentOperation = getRecordEntry(state.operations, parentOperationId);
+      const childOperation: LogicAppsV2.ActionDefinition | undefined = getRecordEntry(state.operations, childOperationId);
       if (!parentOperation || !childOperation) {
         return;
       }
       delete childOperation.runAfter?.[parentOperationId];
 
       const graphPath: string[] = [];
-      let operationGraph = state.nodesMetadata[childOperationId];
+      let operationGraph = getRecordEntry(state.nodesMetadata, childOperationId);
 
-      while (!equals(operationGraph.graphId, 'root')) {
+      while (operationGraph && !equals(operationGraph?.graphId, 'root')) {
         graphPath.push(operationGraph.graphId);
-        operationGraph = state.nodesMetadata[operationGraph.graphId];
+        operationGraph = getRecordEntry(state.nodesMetadata, operationGraph?.graphId);
       }
       let graph = state.graph;
       for (const id of graphPath.reverse()) {
@@ -350,7 +357,7 @@ export const workflowSlice = createSlice({
     },
     addEdgeFromRunAfter: (state: WorkflowState, action: PayloadAction<{ childOperationId: string; parentOperationId: string }>) => {
       const { childOperationId, parentOperationId } = action.payload;
-      const parentOperation = state.operations[parentOperationId];
+      const parentOperation = getRecordEntry(state.operations, parentOperationId);
       const childOperation: LogicAppsV2.ActionDefinition = state.operations[childOperationId];
       if (!parentOperation || !childOperation) {
         return;
@@ -358,9 +365,9 @@ export const workflowSlice = createSlice({
       childOperation.runAfter = { ...(childOperation.runAfter ?? {}), [parentOperationId]: [RUN_AFTER_STATUS.SUCCEEDED] };
 
       const graphPath: string[] = [];
-      let operationGraph = state.nodesMetadata[childOperationId];
+      let operationGraph = getRecordEntry(state.nodesMetadata, childOperationId);
 
-      while (!equals(operationGraph.graphId, 'root')) {
+      while (operationGraph && !equals(operationGraph.graphId, 'root')) {
         graphPath.push(operationGraph.graphId);
         operationGraph = state.nodesMetadata[operationGraph.graphId];
       }
@@ -379,13 +386,9 @@ export const workflowSlice = createSlice({
       state: WorkflowState,
       action: PayloadAction<{ childOperation: string; parentOperation: string; statuses: string[] }>
     ) => {
-      const childOperation = state.operations[action.payload.childOperation] as LogicAppsV2.ActionDefinition;
-      if (!childOperation) {
-        return;
-      }
-      if (!childOperation.runAfter) {
-        childOperation.runAfter = {};
-      }
+      const childOperation = getRecordEntry(state.operations, action.payload.childOperation) as LogicAppsV2.ActionDefinition;
+      if (!childOperation) return;
+      if (!childOperation.runAfter) childOperation.runAfter = {};
       childOperation.runAfter[action.payload.parentOperation] = action.payload.statuses;
     },
     replaceId: (state: WorkflowState, action: PayloadAction<{ originalId: string; newId: string }>) => {

--- a/libs/designer/src/lib/core/state/workflowparameters/workflowparametersSlice.ts
+++ b/libs/designer/src/lib/core/state/workflowparameters/workflowparametersSlice.ts
@@ -7,7 +7,7 @@ import { resetWorkflowState } from '../global';
 import type { WorkflowParameterUpdateEvent } from '@microsoft/designer-ui';
 import { UIConstants } from '@microsoft/designer-ui';
 import { getIntl } from '@microsoft/intl-logic-apps';
-import { equals, guid } from '@microsoft/utils-logic-apps';
+import { equals, getRecordEntry, guid } from '@microsoft/utils-logic-apps';
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
@@ -151,14 +151,14 @@ export const workflowParametersSlice = createSlice({
       };
 
       state.definitions[id] = {
-        ...state.definitions[id],
+        ...(getRecordEntry(state.definitions, id) ?? ({} as any)),
         type,
         value,
         name: name ?? '',
         ...(useLegacy ? { defaultValue } : {}),
       };
       const newErrorObj = {
-        ...(state.validationErrors?.[id] ?? {}),
+        ...(getRecordEntry(state.validationErrors, id) ?? {}),
         ...validationErrors,
       };
       if (!newErrorObj.name) delete newErrorObj.name;

--- a/libs/designer/src/lib/core/utils/connectors/connections.ts
+++ b/libs/designer/src/lib/core/utils/connectors/connections.ts
@@ -21,18 +21,28 @@ import type {
   ManagedIdentity,
   OperationManifest,
 } from '@microsoft/utils-logic-apps';
-import { ConnectionParameterTypes, ResourceIdentityType, equals, ConnectionType, getResourceName } from '@microsoft/utils-logic-apps';
+import {
+  ConnectionParameterTypes,
+  ResourceIdentityType,
+  equals,
+  ConnectionType,
+  getResourceName,
+  getRecordEntry,
+} from '@microsoft/utils-logic-apps';
 
 export function getConnectionId(state: ConnectionsStoreState, nodeId: string): string {
-  const { connectionsMapping, connectionReferences } = state;
-  const reference = connectionReferences[connectionsMapping[nodeId] ?? ''];
-  return reference ? reference.connection.id : '';
+  return getConnectionReference(state, nodeId)?.connection?.id ?? '';
 }
 
 export function getConnectionReference(state: ConnectionsStoreState, nodeId: string): ConnectionReference {
   const { connectionsMapping, connectionReferences } = state;
-  return connectionReferences[connectionsMapping[nodeId] ?? ''];
+  return getRecordEntry(connectionReferences, getRecordEntry(connectionsMapping, nodeId) ?? '') ?? mockConnectionReference;
 }
+
+const mockConnectionReference: ConnectionReference = {
+  api: { id: 'apiId' },
+  connection: { id: 'connectionId' },
+};
 
 export async function isConnectionReferenceValid(
   operationInfo: NodeOperation,

--- a/libs/designer/src/lib/core/utils/graph.ts
+++ b/libs/designer/src/lib/core/utils/graph.ts
@@ -3,15 +3,16 @@ import type { WorkflowEdge, WorkflowNode } from '../parsers/models/workflowNode'
 import type { NodesMetadata, Operations, WorkflowState } from '../state/workflow/workflowInterfaces';
 import { isTemplateExpression } from '@microsoft/parsers-logic-apps';
 import type { WorkflowEdgeType, WorkflowNodeType } from '@microsoft/utils-logic-apps';
-import { hasInvalidChars, startsWith, equals, WORKFLOW_EDGE_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/utils-logic-apps';
+import { hasInvalidChars, startsWith, equals, WORKFLOW_EDGE_TYPES, WORKFLOW_NODE_TYPES, getRecordEntry } from '@microsoft/utils-logic-apps';
 import type { ElkExtendedEdge, ElkNode } from 'elkjs';
 
 export const isRootNodeInGraph = (nodeId: string, graphId: string, nodesMetadata: NodesMetadata): boolean => {
-  return nodesMetadata[nodeId]?.graphId === graphId && !!nodesMetadata[nodeId]?.isRoot;
+  const nodeMetadata = getRecordEntry(nodesMetadata, nodeId);
+  return nodeMetadata?.graphId === graphId && !!nodeMetadata?.isRoot;
 };
 
 export const isRootNode = (nodeId: string, nodesMetadata: NodesMetadata) => {
-  return !!nodesMetadata[nodeId]?.isRoot;
+  return !!getRecordEntry(nodesMetadata, nodeId)?.isRoot;
 };
 
 export const getTriggerNode = (state: WorkflowState): WorkflowNode => {
@@ -103,8 +104,9 @@ export const getNode = (nodeId: string, currentNode: WorkflowNode): WorkflowNode
 };
 
 export const getGraphNode = (nodeId: string, node: WorkflowNode, nodesMetadata: NodesMetadata): WorkflowNode | undefined => {
-  if (!nodesMetadata[nodeId]) return undefined;
-  return getNode(nodesMetadata[nodeId].graphId, node);
+  const nodeMetadata = getRecordEntry(nodesMetadata, nodeId);
+  if (!nodeMetadata) return undefined;
+  return getNode(nodeMetadata.graphId, node);
 };
 
 export const getImmediateSourceNodeIds = (graph: WorkflowNode, nodeId: string): string[] => {
@@ -114,7 +116,7 @@ export const getImmediateSourceNodeIds = (graph: WorkflowNode, nodeId: string): 
 export const getNewNodeId = (state: WorkflowState, nodeId: string): string => {
   let newNodeId = nodeId;
   let count = 1;
-  while (state.operations[newNodeId]) {
+  while (getRecordEntry(state.operations, newNodeId)) {
     newNodeId = `${nodeId}_${count}`;
     count++;
   }
@@ -137,12 +139,12 @@ const getAllSourceNodeIds = (graph: WorkflowNode, nodeId: string, operationMap: 
 };
 
 export const getAllParentsForNode = (nodeId: string, nodesMetadata: NodesMetadata): string[] => {
-  let currentParent = nodesMetadata[nodeId]?.parentNodeId;
+  let currentParent = getRecordEntry(nodesMetadata, nodeId)?.parentNodeId;
   const result: string[] = [];
 
   while (currentParent) {
     result.push(currentParent);
-    currentParent = nodesMetadata[currentParent].parentNodeId;
+    currentParent = getRecordEntry(nodesMetadata, currentParent)?.parentNodeId;
   }
 
   return result;
@@ -155,7 +157,7 @@ export const getAllNodesInsideNode = (nodeId: string, graph: WorkflowNode, opera
   if (isWorkflowGraph(currentGraph)) {
     for (const child of currentGraph.children as WorkflowNode[]) {
       const childId = child.id;
-      if (operationMap[childId]) {
+      if (getRecordEntry(operationMap, childId)) {
         result.push(childId);
       }
 
@@ -172,15 +174,15 @@ export const getFirstParentOfType = (
   nodesMetadata: NodesMetadata,
   operations: Operations
 ): string | undefined => {
-  const parentNodeId = nodesMetadata[nodeId]?.parentNodeId;
+  const parentNodeId = getRecordEntry(nodesMetadata, nodeId)?.parentNodeId;
 
   if (parentNodeId) {
-    if (equals(operations[parentNodeId]?.type, type)) {
+    if (equals(getRecordEntry(operations, parentNodeId)?.type, type)) {
       return parentNodeId;
     }
 
-    return nodesMetadata[parentNodeId]?.parentNodeId
-      ? getFirstParentOfType(nodesMetadata[parentNodeId].parentNodeId as string, type, nodesMetadata, operations)
+    return getRecordEntry(nodesMetadata, parentNodeId)?.parentNodeId
+      ? getFirstParentOfType(getRecordEntry(nodesMetadata, parentNodeId)?.parentNodeId as string, type, nodesMetadata, operations)
       : getFirstParentOfType(parentNodeId, type, nodesMetadata, operations);
   }
 
@@ -197,7 +199,7 @@ export const isOperationNameValid = (
   const name = transformOperationTitle(newName);
 
   // Check for invalid characters.
-  if (!nodesMetadata[nodeId]?.subgraphType && !isTrigger && startsWith(name, 'internal.')) {
+  if (!getRecordEntry(nodesMetadata, nodeId)?.subgraphType && !isTrigger && startsWith(name, 'internal.')) {
     return false;
   }
 
@@ -206,7 +208,7 @@ export const isOperationNameValid = (
   }
 
   // Check for name uniqueness.
-  const allNodes = Object.keys(nodesMetadata).map((id) => idReplacements[id] ?? id);
+  const allNodes = Object.keys(nodesMetadata).map((id) => getRecordEntry(idReplacements, id) ?? id);
   return !allNodes.some((nodeName) => equals(nodeName, name));
 };
 

--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -46,7 +46,7 @@ import {
   SegmentType,
 } from '@microsoft/parsers-logic-apps';
 import type { OperationManifest } from '@microsoft/utils-logic-apps';
-import { clone, equals, first, isNullOrUndefined } from '@microsoft/utils-logic-apps';
+import { clone, equals, first, getRecordEntry, isNullOrUndefined } from '@microsoft/utils-logic-apps';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 interface ImplicitForeachArrayDetails {
@@ -70,8 +70,11 @@ export const shouldAddForeach = async (
     return { shouldAdd: false };
   }
 
-  const operationInfo = state.operations.operationInfo[nodeId];
-  const parameter = getParameterFromId(state.operations.inputParameters[nodeId], parameterId);
+  const operationInfo = getRecordEntry(state.operations.operationInfo, nodeId);
+  if (!operationInfo) return { shouldAdd: false };
+
+  const inputParameters = getRecordEntry(state.operations.inputParameters, nodeId) ?? { parameterGroups: {} };
+  const parameter = getParameterFromId(inputParameters, parameterId);
   const manifest = OperationManifestService().isSupported(operationInfo.type, operationInfo.kind)
     ? await getOperationManifest(operationInfo)
     : undefined;
@@ -405,7 +408,7 @@ const checkArrayInRepetition = (
 // Directly checking the node type, because cannot make async calls while adding token from picker to editor.
 // TODO - See if this can be made async and looked at manifest.
 export const isLoopingNode = (nodeId: string, operationInfos: Record<string, NodeOperation>): boolean => {
-  const nodeType = operationInfos[nodeId]?.type;
+  const nodeType = getRecordEntry(operationInfos, nodeId)?.type;
   return equals(nodeType, Constants.NODE.TYPE.FOREACH) || equals(nodeType, Constants.NODE.TYPE.UNTIL);
 };
 
@@ -465,12 +468,14 @@ const getRepetitionReference = async (
   allInputs: Record<string, NodeInputs>,
   idReplacements?: Record<string, string>
 ): Promise<RepetitionReference | undefined> => {
-  const operationInfo = operationInfos[nodeId];
+  const operationInfo = getRecordEntry(operationInfos, nodeId);
+  if (!operationInfo) return undefined;
   const service = OperationManifestService();
   if (service.isSupported(operationInfo.type, operationInfo.kind)) {
     const manifest = await getOperationManifest(operationInfo);
     const parameterName = manifest.properties.repetition?.loopParameter;
-    const parameter = parameterName ? getParameterFromName(allInputs[nodeId], parameterName) : undefined;
+    const nodeInputs = getRecordEntry(allInputs, nodeId) ?? { parameterGroups: {} };
+    const parameter = parameterName ? getParameterFromName(nodeInputs, parameterName) : undefined;
     if (parameter) {
       const repetitionValue = getJSONValueFromString(
         parameterValueToString(parameter, /* isDefinitionValue */ true, idReplacements),

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -258,8 +258,8 @@ export const isSupportedSplitOnExpression = (expression: Expression): boolean =>
   return true;
 };
 
-export const getSplitOnOptions = (outputs: NodeOutputs, isManifestBasedOperation: boolean): string[] => {
-  let arrayOutputs = unmap(outputs.originalOutputs ?? outputs.outputs).filter((output) =>
+export const getSplitOnOptions = (outputs: NodeOutputs | undefined, isManifestBasedOperation: boolean): string[] => {
+  let arrayOutputs = unmap(outputs?.originalOutputs ?? outputs?.outputs).filter((output) =>
     equals(output.type, Constants.SWAGGER.TYPE.ARRAY)
   );
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2687,9 +2687,9 @@ export function updateTokenMetadataInParameters(nodeId: string, parameters: Para
     (data: Record<string, Partial<NodeDataWithOperationMetadata>>, id: string) => ({
       ...data,
       [id]: {
-        settings: settings[id],
-        nodeOutputs: outputParameters[id],
-        operationMetadata: operationMetadata[id],
+        settings: getRecordEntry(settings, id),
+        nodeOutputs: getRecordEntry(outputParameters, id),
+        operationMetadata: getRecordEntry(operationMetadata, id),
       },
     }),
     {}
@@ -3318,7 +3318,7 @@ export function remapTokenSegmentValue(
       if (!didRemap && newSegmentValue?.includes(`'${id}`)) {
         didRemap = true;
       }
-      newSegmentValue = newSegmentValue?.replaceAll(`'${id}'`, `'${idReplacements[id]}'`);
+      newSegmentValue = newSegmentValue?.replaceAll(`'${id}'`, `'${getRecordEntry(idReplacements, id)}'`);
     }
 
     newSegment = { ...segment, value: newSegmentValue, token: { ...segment.token, value: newSegmentValue } } as ValueSegment;

--- a/libs/designer/src/lib/core/utils/variables.ts
+++ b/libs/designer/src/lib/core/utils/variables.ts
@@ -4,7 +4,7 @@ import type { NodeTokens, VariableDeclaration } from '../state/tokens/tokensSlic
 import { ParameterGroupKeys } from './parameters/helper';
 import type { OutputToken as Token } from '@microsoft/designer-ui';
 import { TokenType } from '@microsoft/designer-ui';
-import { aggregate } from '@microsoft/utils-logic-apps';
+import { aggregate, getRecordEntry } from '@microsoft/utils-logic-apps';
 
 let variableIcon = '';
 let variableBrandColor = '';
@@ -26,14 +26,14 @@ export const getVariableDeclarations = (nodeInputs: NodeInputs): VariableDeclara
 };
 
 export const getAllVariables = (variables: Record<string, VariableDeclaration[]>): VariableDeclaration[] => {
-  return aggregate(Object.keys(variables).map((nodeId) => variables[nodeId]));
+  return aggregate(Object.keys(variables).map((nodeId) => getRecordEntry(variables, nodeId) ?? []));
 };
 
 export const getAvailableVariables = (
   variables: Record<string, VariableDeclaration[]>,
   upstreamNodeIds: string[]
 ): VariableDeclaration[] => {
-  const allVariables = upstreamNodeIds.map((nodeId) => variables[nodeId] ?? []);
+  const allVariables = upstreamNodeIds.map((nodeId) => getRecordEntry(variables, nodeId) ?? []);
   return aggregate(allVariables);
 };
 

--- a/libs/designer/src/lib/ui/common/LoopsPager/helper.ts
+++ b/libs/designer/src/lib/ui/common/LoopsPager/helper.ts
@@ -2,7 +2,7 @@ import constants from '../../../common/constants';
 import type { NodeOperation } from '../../../core/state/operation/operationMetadataSlice';
 import type { NodesMetadata } from '../../../core/state/workflow/workflowInterfaces';
 import { getAllParentsForNode } from '../../../core/utils/graph';
-import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
+import { getRecordEntry, type LogicAppsV2 } from '@microsoft/utils-logic-apps';
 
 /**
  * Gets number of loops for loop nodes.
@@ -51,12 +51,10 @@ export const getRepetitionName = (
   let repetitionName = '';
   const parentsForNode = getAllParentsForNode(id, nodesMetadata);
   parentsForNode.forEach((parent) => {
-    const isLoopScope = operationInfo[parent]?.type
-      ? operationInfo[parent]?.type.toLowerCase() === constants.NODE.TYPE.FOREACH ||
-        operationInfo[parent]?.type.toLowerCase() === constants.NODE.TYPE.UNTIL
-      : false;
+    const parentType = getRecordEntry(operationInfo, parent)?.type?.toLowerCase();
+    const isLoopScope = parentType ? parentType === constants.NODE.TYPE.FOREACH || parentType === constants.NODE.TYPE.UNTIL : false;
     if (isLoopScope) {
-      const zeroBasedCurrent = nodesMetadata[parent]?.runIndex;
+      const zeroBasedCurrent = getRecordEntry(nodesMetadata, parent)?.runIndex;
       repetitionName = repetitionName ? `${String(zeroBasedCurrent).padStart(6, '0')}-${repetitionName}` : String(index).padStart(6, '0');
     }
   });

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/allConnections.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/allConnections.tsx
@@ -8,6 +8,7 @@ import {
 import { useConnector } from '../../../../core/state/connection/connectionSelector';
 import { ConnectorConnectionsCard } from './connectorConnectionsCard';
 import { Accordion, AccordionItem, type AccordionToggleEventHandler } from '@fluentui/react-components';
+import { getRecordEntry } from '@microsoft/utils-logic-apps';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -38,7 +39,7 @@ export const AllConnections = () => {
     const groups: Record<string, string[]> = {};
     for (const [nodeId, connectionReference] of Object.entries(connectionMapping)) {
       if (!connectionReference) {
-        const apiId = allOperationInfo[nodeId]?.connectorId;
+        const apiId = getRecordEntry(allOperationInfo, nodeId)?.connectorId;
         if (!apiId) continue;
         groups[apiId] = groups?.[apiId] || [];
         groups[apiId].push(nodeId);

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
@@ -30,6 +30,7 @@ import { Spinner } from '@fluentui/react-components';
 import type { ConnectionCreationInfo, ConnectionParametersMetadata } from '@microsoft/designer-client-services-logic-apps';
 import { ConnectionService, LogEntryLevel, LoggerService, WorkflowService } from '@microsoft/designer-client-services-logic-apps';
 import {
+  getRecordEntry,
   safeSetObjectPropertyValue,
   type Connection,
   type ConnectionParameterSet,
@@ -52,7 +53,7 @@ export const CreateConnectionWrapper = () => {
   const operationInfo = useOperationInfo(nodeId);
   const { data: operationManifest } = useOperationManifest(operationInfo);
   const connectionMetadata = getConnectionMetadata(operationManifest);
-  const hasExistingConnection = useSelector((state: RootState) => !!state.connections.connectionsMapping[nodeId]);
+  const hasExistingConnection = useSelector((state: RootState) => !!getRecordEntry(state.connections.connectionsMapping, nodeId));
 
   const subscriptionsQuery = useSubscriptions();
   const subscriptions = useMemo(() => subscriptionsQuery.data, [subscriptionsQuery.data]);

--- a/libs/designer/src/lib/ui/panel/errorsPanel/tabs/errorsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/errorsPanel/tabs/errorsTab.tsx
@@ -15,6 +15,7 @@ import {
 import { Text } from '@fluentui/react';
 import type { NodeMessage } from '@microsoft/designer-ui';
 import { MessageLevel } from '@microsoft/designer-ui';
+import { getRecordEntry } from '@microsoft/utils-logic-apps';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
@@ -100,10 +101,10 @@ export const ErrorsTab = () => {
             level={MessageLevel.Error}
             nodeId={nodeId}
             messagesBySubtitle={{
-              [inputErrorsSubsectionHeader]: (allInputErrors?.[nodeId] || []).map(toNodeMessageFromString),
-              [settingErrorsSubsectionHeader]: (allSettingErrors?.[nodeId] || []).map(toNodeMessageFromString),
-              [connectionErrorsSubsectionHeader]: [allConnectionErrors?.[nodeId]].map(toNodeMessageFromString),
-              ...hostCheckerErrors[nodeId],
+              [inputErrorsSubsectionHeader]: (getRecordEntry(allInputErrors, nodeId) || []).map(toNodeMessageFromString),
+              [settingErrorsSubsectionHeader]: (getRecordEntry(allSettingErrors, nodeId) || []).map(toNodeMessageFromString),
+              [connectionErrorsSubsectionHeader]: [getRecordEntry(allConnectionErrors, nodeId) ?? ''].map(toNodeMessageFromString),
+              ...getRecordEntry(hostCheckerErrors, nodeId),
             }}
           />
         ))}

--- a/libs/designer/src/lib/ui/panel/errorsPanel/tabs/warningsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/errorsPanel/tabs/warningsTab.tsx
@@ -3,6 +3,7 @@ import { NodeErrors } from '../nodeErrors';
 import { useHostCheckerWarnings, useTotalNumWarnings } from './warningsTab.hooks';
 import { Text } from '@fluentui/react';
 import { MessageLevel } from '@microsoft/designer-ui';
+import { getRecordEntry } from '@microsoft/utils-logic-apps';
 import { useIntl } from 'react-intl';
 
 export const WarningsTab = () => {
@@ -31,9 +32,7 @@ export const WarningsTab = () => {
             key={nodeId}
             level={MessageLevel.Warning}
             nodeId={nodeId}
-            messagesBySubtitle={{
-              ...hostCheckerWarnings[nodeId],
-            }}
+            messagesBySubtitle={{ ...getRecordEntry(hostCheckerWarnings, nodeId) }}
           />
         ))}
       </ErrorCategory>

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/codeViewTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/codeViewTab.tsx
@@ -1,17 +1,17 @@
 import constants from '../../../../common/constants';
 import { serializeOperation } from '../../../../core/actions/bjsworkflow/serializer';
 import { useSelectedNodeId } from '../../../../core/state/panel/panelSelectors';
+import { useActionMetadata } from '../../../../core/state/workflow/workflowSelectors';
 import type { RootState } from '../../../../core/store';
 import type { PanelTabFn } from '@microsoft/designer-ui';
 import { Peek } from '@microsoft/designer-ui';
-import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { isNullOrEmpty } from '@microsoft/utils-logic-apps';
 import { useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
 
 export const CodeViewTab = () => {
   const nodeId = useSelectedNodeId();
-  const nodeMetaData = useSelector<RootState, any>((state) => state.workflow.operations[nodeId] as LogicAppsV2.OperationDefinition);
+  const nodeMetaData = useActionMetadata(nodeId) as any;
   const rootState = useSelector((state: RootState) => state);
   const queryData = useQuery(['serialization', { nodeId }], () => serializeOperation(rootState, nodeId), {
     retry: false,
@@ -23,7 +23,7 @@ export const CodeViewTab = () => {
 
   const content = queryData.isLoading
     ? 'Loading ...'
-    : JSON.stringify(isNullOrEmpty(queryData.data) ? { inputs: (nodeMetaData?.inputs as any) ?? {} } : queryData.data, null, 2);
+    : JSON.stringify(isNullOrEmpty(queryData.data) ? { inputs: nodeMetaData?.inputs ?? {} } : queryData.data, null, 2);
 
   return <Peek input={content} />;
 };

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -3,7 +3,12 @@ import { useShowIdentitySelectorQuery } from '../../../../../core/state/connecti
 import { useHostOptions, useReadOnly } from '../../../../../core/state/designerOptions/designerOptionsSelectors';
 import type { ParameterGroup } from '../../../../../core/state/operation/operationMetadataSlice';
 import { DynamicLoadStatus, ErrorLevel } from '../../../../../core/state/operation/operationMetadataSlice';
-import { useNodesInitialized, useOperationErrorInfo } from '../../../../../core/state/operation/operationSelector';
+import {
+  useDependencies,
+  useNodesInitialized,
+  useOperationErrorInfo,
+  useRawInputParameters,
+} from '../../../../../core/state/operation/operationSelector';
 import { usePanelLocation, useSelectedNodeId } from '../../../../../core/state/panel/panelSelectors';
 import {
   useAllowUserToChangeConnection,
@@ -46,7 +51,7 @@ import {
 } from '@microsoft/designer-ui';
 import type { ChangeState, ParameterInfo, ValueSegment, OutputToken, TokenPickerMode, PanelTabFn } from '@microsoft/designer-ui';
 import type { OperationInfo } from '@microsoft/utils-logic-apps';
-import { equals, getPropertyValue } from '@microsoft/utils-logic-apps';
+import { equals, getPropertyValue, getRecordEntry } from '@microsoft/utils-logic-apps';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
@@ -162,11 +167,11 @@ const ParameterSection = ({
 }) => {
   const dispatch = useDispatch<AppDispatch>();
   const [sectionExpanded, setSectionExpanded] = useState<boolean>(false);
+  const isTrigger = useSelector((state: RootState) => isRootNodeInGraph(nodeId, 'root', state.workflow.nodesMetadata));
+  const nodeInputs = useRawInputParameters(nodeId) ?? { parameterGroups: {} };
+  const operationInfo = useOperationInfo(nodeId);
+  const dependencies = useDependencies(nodeId);
   const {
-    isTrigger,
-    nodeInputs,
-    operationInfo,
-    dependencies,
     settings: nodeSettings,
     variables,
     upstreamNodeIds,
@@ -176,14 +181,12 @@ const ParameterSection = ({
     workflowParameters,
   } = useSelector((state: RootState) => {
     return {
-      isTrigger: isRootNodeInGraph(nodeId, 'root', state.workflow.nodesMetadata),
-      nodeInputs: state.operations.inputParameters[nodeId],
-      operationInfo: state.operations.operationInfo[nodeId],
-      dependencies: state.operations.dependencies[nodeId],
-      settings: state.operations.settings[nodeId],
-      upstreamNodeIds: state.tokens.outputTokens[nodeId]?.upstreamNodeIds,
+      settings: getRecordEntry(state.operations.settings, nodeId) ?? {},
+      upstreamNodeIds: getRecordEntry(state.tokens.outputTokens, nodeId)?.upstreamNodeIds,
       variables: state.tokens.variables,
-      operationDefinition: state.workflow.newlyAddedOperations[nodeId] ? undefined : state.workflow.operations[nodeId],
+      operationDefinition: getRecordEntry(state.workflow.newlyAddedOperations, nodeId)
+        ? undefined
+        : getRecordEntry(state.workflow.operations, nodeId),
       connectionReference: getConnectionReference(state.connections, nodeId),
       idReplacements: state.workflow.idReplacements,
       workflowParameters: state.workflowParameters.definitions,
@@ -207,7 +210,7 @@ const ParameterSection = ({
       if (viewModel !== undefined) {
         propertiesToUpdate.editorViewModel = viewModel;
       }
-      if (variables[nodeId]) {
+      if (getRecordEntry(variables, nodeId)) {
         if (parameter?.parameterKey === 'inputs.$.name') {
           dispatch(updateVariableInfo({ id: nodeId, name: value[0]?.value }));
         } else if (parameter?.parameterKey === 'inputs.$.type') {

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/testingTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/testingTab/index.tsx
@@ -20,9 +20,10 @@ export const TestingPanel: React.FC = () => {
   const operationInfo = useOperationInfo(selectedNode);
   const { connectorId, operationId } = operationInfo;
   const staticResultSchema = useStaticResultSchema(connectorId, operationId);
-  const parameterStaticResult = useParameterStaticResult(selectedNode) ?? {};
+  const parameterStaticResult = useParameterStaticResult(selectedNode);
 
-  const { name = selectedNode + 0, staticResultOptions } = parameterStaticResult;
+  const name = parameterStaticResult?.name ?? selectedNode + 0;
+  const staticResultOptions = parameterStaticResult?.staticResultOptions;
   const properties = useStaticResultProperties(name);
 
   const savePropertiesCallback = useCallback(

--- a/libs/designer/src/lib/ui/settings/index.tsx
+++ b/libs/designer/src/lib/ui/settings/index.tsx
@@ -1,8 +1,10 @@
 import constants from '../../common/constants';
+import { useOperationInfo } from '../../core';
 import { updateOutputsAndTokens } from '../../core/actions/bjsworkflow/initialize';
 import type { Settings } from '../../core/actions/bjsworkflow/settings';
 import { useReadOnly } from '../../core/state/designerOptions/designerOptionsSelectors';
 import { updateNodeSettings } from '../../core/state/operation/operationMetadataSlice';
+import { useRawInputParameters } from '../../core/state/operation/operationSelector';
 import { useSelectedNodeId } from '../../core/state/panel/panelSelectors';
 import { useExpandedSections } from '../../core/state/setting/settingSelector';
 import { setExpandedSections } from '../../core/state/setting/settingSlice';
@@ -20,7 +22,7 @@ import type { ValidationError } from './validation/validation';
 import { ValidationErrorKeys, validateNodeSettings } from './validation/validation';
 import type { IDropdownOption } from '@fluentui/react';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
-import { equals, isObject } from '@microsoft/utils-logic-apps';
+import { equals, getRecordEntry, isObject } from '@microsoft/utils-logic-apps';
 import { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -68,8 +70,8 @@ export const SettingsPanel = (): JSX.Element => {
 
   const { nodeSettings, nodeSettingValidationErrors } = useSelector((state: RootState) => {
     return {
-      nodeSettings: state.operations.settings?.[selectedNode] ?? {},
-      nodeSettingValidationErrors: state.settings.validationErrors?.[selectedNode] ?? [],
+      nodeSettings: getRecordEntry(state.operations.settings, selectedNode) ?? {},
+      nodeSettingValidationErrors: getRecordEntry(state.settings.validationErrors, selectedNode) ?? [],
     };
   });
 
@@ -213,17 +215,13 @@ function GeneralSettings({
   dispatch,
   updateSettings,
 }: SettingSectionProps): JSX.Element | null {
-  const { isTrigger, nodeInputs, operationInfo } = useSelector((state: RootState) => {
-    return {
-      isTrigger: isRootNodeInGraph(nodeId, 'root', state.workflow.nodesMetadata),
-      nodeInputs: state.operations.inputParameters[nodeId],
-      operationInfo: state.operations.operationInfo[nodeId],
-      operations: state.operations,
-    };
-  });
+  const isTrigger = useSelector((state: RootState) => isRootNodeInGraph(nodeId, 'root', state.workflow.nodesMetadata));
+
+  const operationInfo = useOperationInfo(nodeId) ?? ({} as any);
+  const nodeInputs = useRawInputParameters(nodeId) ?? ({} as any);
 
   const { timeout, splitOn, splitOnConfiguration, concurrency, conditionExpressions, invokerConnection } = useSelector(
-    (state: RootState) => state.operations.settings?.[nodeId] ?? {}
+    (state: RootState) => getRecordEntry(state.operations.settings, nodeId) ?? {}
   );
 
   const onConcurrencyToggle = (checked: boolean): void => {
@@ -579,7 +577,7 @@ function NetworkingSettings({
 }
 
 function RunAfterSettings({ nodeId, readOnly, isExpanded, validationErrors, dispatch }: SettingSectionProps): JSX.Element | null {
-  const nodeData = useSelector((state: RootState) => state.workflow.operations[nodeId] as LogicAppsV2.ActionDefinition);
+  const nodeData = useSelector((state: RootState) => getRecordEntry(state.workflow.operations, nodeId) as LogicAppsV2.ActionDefinition);
   const showRunAfterSettings = useMemo(() => Object.keys(nodeData?.runAfter ?? {}).length > 0, [nodeData]);
 
   return showRunAfterSettings ? (
@@ -602,10 +600,10 @@ function SecuritySettings({
   updateSettings,
 }: SettingSectionProps): JSX.Element | null {
   const { secureInputs, secureOutputs } = nodeSettings;
-  const operationInfo = useSelector((state: RootState) => state.operations.operationInfo[nodeId]);
+  const operationInfo = useOperationInfo(nodeId);
   const onSecureInputsChange = (checked: boolean): void => {
     updateSettings({ secureInputs: { isSupported: !!secureInputs?.isSupported, value: checked } });
-    if (isSecureOutputsLinkedToInputs(operationInfo.type)) {
+    if (isSecureOutputsLinkedToInputs(operationInfo?.type)) {
       dispatch(updateTokenSecureStatus({ id: nodeId, isSecure: checked }));
     }
   };

--- a/libs/designer/src/lib/ui/settings/index.tsx
+++ b/libs/designer/src/lib/ui/settings/index.tsx
@@ -21,9 +21,7 @@ import { Tracking } from './sections/tracking';
 import type { ValidationError } from './validation/validation';
 import { ValidationErrorKeys, validateNodeSettings } from './validation/validation';
 import type { IDropdownOption } from '@fluentui/react';
-import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { equals, getRecordEntry, isObject } from '@microsoft/utils-logic-apps';
-import { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 export type ToggleHandler = (checked: boolean) => void;
@@ -577,10 +575,11 @@ function NetworkingSettings({
 }
 
 function RunAfterSettings({ nodeId, readOnly, isExpanded, validationErrors, dispatch }: SettingSectionProps): JSX.Element | null {
-  const nodeData = useSelector((state: RootState) => getRecordEntry(state.workflow.operations, nodeId) as LogicAppsV2.ActionDefinition);
-  const showRunAfterSettings = useMemo(() => Object.keys(nodeData?.runAfter ?? {}).length > 0, [nodeData]);
+  // const nodeData = useActionMetadata(nodeId) as LogicAppsV2.ActionDefinition;
+  // const showRunAfterSettings = useMemo(() => Object.keys(nodeData?.runAfter ?? {}).length > 0, [nodeData]);
 
-  return showRunAfterSettings ? (
+  // return showRunAfterSettings ? (
+  return (
     <RunAfter
       nodeId={nodeId}
       readOnly={readOnly}
@@ -588,7 +587,8 @@ function RunAfterSettings({ nodeId, readOnly, isExpanded, validationErrors, disp
       validationErrors={validationErrors}
       onHeaderClick={(sectionName) => dispatch(setExpandedSections(sectionName))}
     />
-  ) : null;
+  );
+  // ) : null;
 }
 
 function SecuritySettings({

--- a/libs/designer/src/lib/ui/settings/index.tsx
+++ b/libs/designer/src/lib/ui/settings/index.tsx
@@ -9,6 +9,7 @@ import { useSelectedNodeId } from '../../core/state/panel/panelSelectors';
 import { useExpandedSections } from '../../core/state/setting/settingSelector';
 import { setExpandedSections } from '../../core/state/setting/settingSlice';
 import { updateTokenSecureStatus } from '../../core/state/tokens/tokensSlice';
+import { useActionMetadata } from '../../core/state/workflow/workflowSelectors';
 import type { AppDispatch, RootState } from '../../core/store';
 import { isRootNodeInGraph } from '../../core/utils/graph';
 import { isSecureOutputsLinkedToInputs } from '../../core/utils/setting';
@@ -21,7 +22,8 @@ import { Tracking } from './sections/tracking';
 import type { ValidationError } from './validation/validation';
 import { ValidationErrorKeys, validateNodeSettings } from './validation/validation';
 import type { IDropdownOption } from '@fluentui/react';
-import { equals, getRecordEntry, isObject } from '@microsoft/utils-logic-apps';
+import { type LogicAppsV2, equals, getRecordEntry, isObject } from '@microsoft/utils-logic-apps';
+import { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 export type ToggleHandler = (checked: boolean) => void;
@@ -575,11 +577,10 @@ function NetworkingSettings({
 }
 
 function RunAfterSettings({ nodeId, readOnly, isExpanded, validationErrors, dispatch }: SettingSectionProps): JSX.Element | null {
-  // const nodeData = useActionMetadata(nodeId) as LogicAppsV2.ActionDefinition;
-  // const showRunAfterSettings = useMemo(() => Object.keys(nodeData?.runAfter ?? {}).length > 0, [nodeData]);
+  const nodeData = useActionMetadata(nodeId) as LogicAppsV2.ActionDefinition;
+  const showRunAfterSettings = useMemo(() => Object.keys(nodeData?.runAfter ?? {}).length > 0, [nodeData]);
 
-  // return showRunAfterSettings ? (
-  return (
+  return showRunAfterSettings ? (
     <RunAfter
       nodeId={nodeId}
       readOnly={readOnly}
@@ -587,8 +588,7 @@ function RunAfterSettings({ nodeId, readOnly, isExpanded, validationErrors, disp
       validationErrors={validationErrors}
       onHeaderClick={(sectionName) => dispatch(setExpandedSections(sectionName))}
     />
-  );
-  // ) : null;
+  ) : null;
 }
 
 function SecuritySettings({

--- a/libs/designer/src/lib/ui/settings/sections/general.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/general.tsx
@@ -1,15 +1,15 @@
 import type { SectionProps, ToggleHandler, TextChangeHandler, NumberChangeHandler } from '..';
 import { SettingSectionName } from '..';
 import constants from '../../../common/constants';
-import type { RootState } from '../../../core';
+import { useOperationInfo } from '../../../core';
 import { useSelectedNodeId } from '../../../core/state/panel/panelSelectors';
+import { useOutputParameters } from '../../../core/state/selectors/actionMetadataSelector';
 import { getSplitOnOptions } from '../../../core/utils/outputs';
 import type { SettingsSectionProps } from '../settingsection';
 import { SettingsSection } from '../settingsection';
 import { OperationManifestService } from '@microsoft/designer-client-services-logic-apps';
 import { getSettingLabel, type DropdownSelectionChangeHandler, type ExpressionChangeHandler } from '@microsoft/designer-ui';
 import { useIntl } from 'react-intl';
-import { useSelector } from 'react-redux';
 
 export interface GeneralSectionProps extends SectionProps {
   onConcurrencyToggle: ToggleHandler;
@@ -44,10 +44,9 @@ export const General = ({
 }: GeneralSectionProps): JSX.Element => {
   const intl = useIntl();
   const nodeId = useSelectedNodeId();
-  const { nodeOutputs, operationInfo } = useSelector((state: RootState) => ({
-    nodeOutputs: state.operations.outputParameters[nodeId],
-    operationInfo: state.operations.operationInfo[nodeId],
-  }));
+  const operationInfo = useOperationInfo(nodeId);
+  const nodeOutputs = useOutputParameters(nodeId);
+
   const generalTitle = intl.formatMessage({
     defaultMessage: 'General',
     description: 'title for general setting section',

--- a/libs/designer/src/lib/ui/settings/sections/runafter.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/runafter.tsx
@@ -9,7 +9,7 @@ import { SettingsSection } from '../settingsection';
 import type { ValidationError } from '../validation/validation';
 import { ValidationErrorKeys, ValidationErrorType } from '../validation/validation';
 import type { RunAfterActionDetailsProps } from './runafterconfiguration';
-import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
+import { getRecordEntry, type LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
@@ -19,11 +19,10 @@ export const RunAfter = ({ nodeId, readOnly = false, expanded, onHeaderClick }: 
   const dispatch = useDispatch<AppDispatch>();
   const [errors, setErrors] = useState<ValidationError[]>([]);
 
-  const showRunAfter = useMemo(() => {
-    return Object.keys(nodeData?.runAfter ?? {}).length > 0;
-  }, [nodeData?.runAfter]);
+  const showRunAfter = useMemo(() => Object.keys(nodeData?.runAfter ?? {}).length > 0, [nodeData?.runAfter]);
 
   const intl = useIntl();
+
   const runAfterTitle = intl.formatMessage({
     defaultMessage: 'Run After',
     description: 'title for run after setting section',
@@ -38,10 +37,10 @@ export const RunAfter = ({ nodeId, readOnly = false, expanded, onHeaderClick }: 
   });
 
   const handleStatusChange = (predecessorId: string, status: string, checked?: boolean) => {
-    if (!nodeData.runAfter) {
-      return;
-    }
-    const updatedStatus: string[] = [...nodeData.runAfter[predecessorId]].filter((x) => x.toLowerCase() !== status.toLowerCase());
+    if (!nodeData?.runAfter) return;
+    const updatedStatus: string[] = [...(getRecordEntry(nodeData.runAfter, predecessorId) ?? [])].filter(
+      (x) => x?.toLowerCase() !== status?.toLowerCase()
+    );
 
     if (checked) {
       updatedStatus.push(status);

--- a/libs/designer/src/lib/ui/settings/sections/runafter.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/runafter.tsx
@@ -1,7 +1,8 @@
 import type { SectionProps } from '../';
 import { SettingSectionName } from '../';
-import type { AppDispatch, RootState } from '../../../core';
+import type { AppDispatch } from '../../../core';
 import { addEdgeFromRunAfterOperation, removeEdgeFromRunAfterOperation } from '../../../core/actions/bjsworkflow/runafter';
+import { useActionMetadata } from '../../../core/state/workflow/workflowSelectors';
 import { updateRunAfter } from '../../../core/state/workflow/workflowSlice';
 import type { SettingsSectionProps } from '../settingsection';
 import { SettingsSection } from '../settingsection';
@@ -11,10 +12,10 @@ import type { RunAfterActionDetailsProps } from './runafterconfiguration';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
 import { useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 export const RunAfter = ({ nodeId, readOnly = false, expanded, onHeaderClick }: SectionProps): JSX.Element | null => {
-  const nodeData = useSelector((state: RootState) => state.workflow.operations[nodeId] as LogicAppsV2.ActionDefinition);
+  const nodeData = useActionMetadata(nodeId) as LogicAppsV2.ActionDefinition;
   const dispatch = useDispatch<AppDispatch>();
   const [errors, setErrors] = useState<ValidationError[]>([]);
 

--- a/libs/designer/src/lib/ui/settings/sections/runafterconfiguration/runafterActionSelector.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/runafterconfiguration/runafterActionSelector.tsx
@@ -30,7 +30,7 @@ const getSuccessorNodes = (state: RootState, nodeId: string) => {
 };
 
 const ActionMenuItem = ({ id, readOnly }: { id: string; readOnly: boolean }) => {
-  const { iconUri } = useOperationVisuals(id);
+  const iconUri = useOperationVisuals(id)?.iconUri;
   const actionName = useNodeDisplayName(id);
   return (
     <MenuItemCheckbox

--- a/libs/designer/src/lib/ui/settings/sections/security.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/security.tsx
@@ -1,12 +1,11 @@
 import type { SectionProps, ToggleHandler } from '..';
 import { SettingSectionName } from '..';
-import type { RootState } from '../../../core';
+import { useOperationInfo } from '../../../core';
 import { isSecureOutputsLinkedToInputs } from '../../../core/utils/setting';
 import type { SettingsSectionProps } from '../settingsection';
 import { SettingsSection } from '../settingsection';
 import { getSettingLabel } from '@microsoft/designer-ui';
 import { useIntl } from 'react-intl';
-import { useSelector } from 'react-redux';
 
 export interface SecuritySectionProps extends SectionProps {
   onSecureInputsChange: ToggleHandler;
@@ -24,7 +23,7 @@ export const Security = ({
   onHeaderClick,
 }: SecuritySectionProps): JSX.Element | null => {
   const intl = useIntl();
-  const operationInfo = useSelector((state: RootState) => state.operations.operationInfo[nodeId]);
+  const operationInfo = useOperationInfo(nodeId);
   const onText = intl.formatMessage({
     defaultMessage: 'On',
     description: 'label when setting is on',

--- a/libs/designer/src/lib/ui/settings/settingsection.tsx
+++ b/libs/designer/src/lib/ui/settings/settingsection.tsx
@@ -166,27 +166,21 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
     <>
       {expanded || !showHeading ? <Setting id={id} isReadOnly={isReadOnly} settings={settings} /> : null}
       {expanded
-        ? (validationErrors ?? []).map(({ key: errorKey, errorType, message }, i) => {
-            return (
-              <CustomizableMessageBar
-                key={i}
-                type={matchErrorTypeToMessageBar(errorType)}
-                message={message}
-                onWarningDismiss={onDismiss ? () => onDismiss?.(errorKey) : undefined}
-              />
-            );
-          })
+        ? (validationErrors ?? []).map(({ key: errorKey, errorType, message }, i) => (
+            <CustomizableMessageBar
+              key={i}
+              type={matchErrorTypeToMessageBar(errorType)}
+              message={message}
+              onWarningDismiss={onDismiss ? () => onDismiss?.(errorKey) : undefined}
+            />
+          ))
         : null}
       {showSeparator ? <Separator className="msla-setting-section-separator" styles={separatorStyles} /> : null}
     </>
   );
-  if (!showHeading) {
-    return internalSettings;
-  }
+  if (!showHeading) return internalSettings;
   const handleSectionClick = (sectionName?: SettingSectionName): void => {
-    if (onHeaderClick && sectionName) {
-      onHeaderClick(sectionName);
-    }
+    if (onHeaderClick && sectionName) onHeaderClick(sectionName);
   };
 
   return (
@@ -410,7 +404,7 @@ const Setting = ({ id, settings, isReadOnly }: { id?: string; settings: Settings
         </div>
       ) : null}
       {/* Render all advanced parameters that are conditionally visible */}
-      {settings?.filter((setting) => (setting.settingProp as any).conditionalVisibility === true).map(renderSetting)}
+      {settings?.filter((setting) => (setting.settingProp as any)?.conditionalVisibility === true).map(renderSetting)}
     </div>
   );
 };

--- a/libs/services/designer-client-services/src/lib/base/operationmanifest.ts
+++ b/libs/services/designer-client-services/src/lib/base/operationmanifest.ts
@@ -223,9 +223,9 @@ export abstract class BaseOperationManifestService implements IOperationManifest
     }
   }
 
-  isSupported(operationType: string, _operationKind?: string): boolean {
+  isSupported(operationType?: string, _operationKind?: string): boolean {
     const { supportedTypes } = this.options;
-    const normalizedOperationType = operationType.toLowerCase();
+    const normalizedOperationType = operationType?.toLowerCase() ?? '';
     return supportedTypes
       ? supportedTypes.indexOf(normalizedOperationType) > -1
       : supportedBaseManifestTypes.indexOf(normalizedOperationType) > -1;

--- a/libs/services/designer-client-services/src/lib/consumption/operationmanifest.ts
+++ b/libs/services/designer-client-services/src/lib/consumption/operationmanifest.ts
@@ -71,9 +71,9 @@ export class ConsumptionOperationManifestService extends BaseOperationManifestSe
     throw new UnsupportedException(`Operation type: ${definition.type} does not support manifest.`);
   }
 
-  override isSupported(operationType: string, _operationKind?: string): boolean {
+  override isSupported(operationType?: string, _operationKind?: string): boolean {
     const { supportedTypes } = this.options;
-    const normalizedOperationType = operationType.toLowerCase();
+    const normalizedOperationType = operationType?.toLowerCase() ?? '';
     return supportedTypes
       ? supportedTypes.indexOf(normalizedOperationType) > -1
       : supportedConsumptionManifestTypes.indexOf(normalizedOperationType) > -1;

--- a/libs/services/designer-client-services/src/lib/consumption/run.ts
+++ b/libs/services/designer-client-services/src/lib/consumption/run.ts
@@ -13,6 +13,7 @@ import {
   getCallbackUrl,
   isNullOrUndefined,
   isBoolean,
+  getRecordEntry,
 } from '@microsoft/utils-logic-apps';
 
 export interface ConsumptionRunServiceOptions {
@@ -223,8 +224,8 @@ export class ConsumptionRunService implements IRunService {
     let outputs: Record<string, any> = {};
 
     if (this._isDev) {
-      inputs = inputsResponse[nodeId] ?? {};
-      outputs = outputsResponse[nodeId] ?? {};
+      inputs = getRecordEntry(inputsResponse, nodeId) ?? {};
+      outputs = getRecordEntry(outputsResponse, nodeId) ?? {};
       return Promise.resolve({ inputs: this.parseActionLink(inputs, true), outputs: this.parseActionLink(outputs, false) });
     }
 

--- a/libs/services/designer-client-services/src/lib/operationmanifest.ts
+++ b/libs/services/designer-client-services/src/lib/operationmanifest.ts
@@ -7,11 +7,11 @@ import { AssertionErrorCode, AssertionException } from '@microsoft/utils-logic-a
 export interface IOperationManifestService {
   /**
    * Checks if the operation type is supported.
-   * @arg {string} operationType - The operation type.
+   * @arg [string] operationType - The operation type.
    * @arg [string] operationKind - The operation kind.
    * @return {boolean}
    */
-  isSupported(operationType: string, operationKind?: string): boolean;
+  isSupported(operationType?: string, operationKind?: string): boolean;
 
   /**
    * Gets the operation info.

--- a/libs/services/designer-client-services/src/lib/standard/operationmanifest.ts
+++ b/libs/services/designer-client-services/src/lib/standard/operationmanifest.ts
@@ -62,6 +62,6 @@ export class StandardOperationManifestService extends BaseOperationManifestServi
   }
 }
 
-export function isServiceProviderOperation(operationType: string): boolean {
+export function isServiceProviderOperation(operationType?: string): boolean {
   return equals(operationType, 'ServiceProvider');
 }

--- a/libs/services/designer-client-services/src/lib/standard/run.ts
+++ b/libs/services/designer-client-services/src/lib/standard/run.ts
@@ -13,6 +13,7 @@ import {
   getCallbackUrl,
   isNullOrUndefined,
   isBoolean,
+  getRecordEntry,
 } from '@microsoft/utils-logic-apps';
 
 export interface RunServiceOptions {
@@ -223,8 +224,8 @@ export class StandardRunService implements IRunService {
     let outputs: Record<string, any> = {};
 
     if (this._isDev) {
-      inputs = inputsResponse[nodeId] ?? {};
-      outputs = outputsResponse[nodeId] ?? {};
+      inputs = getRecordEntry(inputsResponse, nodeId) ?? {};
+      outputs = getRecordEntry(outputsResponse, nodeId) ?? {};
       return Promise.resolve({ inputs: this.parseActionLink(inputs, true), outputs: this.parseActionLink(outputs, false) });
     }
 

--- a/libs/utils/src/lib/exception/assertion.ts
+++ b/libs/utils/src/lib/exception/assertion.ts
@@ -30,6 +30,7 @@ export const AssertionErrorCode = {
   OPEN_API_OPERATION_CAN_NOT_FIND_PROPERTY_FOR_ALIAS: 'OpenApiOperationCanNotFindPropertyForAlias',
   OPEN_API_OPERATION_CAN_NOT_REFERENCE_SWAGGER: 'OpenApiOperationCanNotReferenceSwagger',
   OPERATION_NOT_IMPLEMENTED: 'OperationNotImplemented',
+  OPERATION_NOT_FOUND: 'OperationNotFound',
   OPERATION_MANIFEST_MISSING: 'OperationManifestMissing',
   PARAMETER_UPDATE_GROUP_ID_OR_PARAMETERS_FOR_NODE_UNDEFINED: 'ParameterUpdateGroupIdOrParametersForNodeUndefined',
   UNDEFINED_CONNECTOR_OR_CONNECTOR_PROPERTIES: 'UndefinedConnectorOrConnectorProperties',

--- a/libs/utils/src/lib/helpers/functions.ts
+++ b/libs/utils/src/lib/helpers/functions.ts
@@ -1035,3 +1035,14 @@ export const filterRecord = <T>(data: Record<string, T>, filter: (_key: string, 
     .filter(([key, value]) => filter(key, value))
     .reduce((res: any, [key, value]: any) => ({ ...res, [key]: value }), {});
 };
+
+/**
+ * Returns the value of the key in the record, if found. Otherwise, undefined.
+ * @param record - The record to search.
+ * @param key - The key to search for in the record.
+ * @returns {T | undefined} - The value of the key in the record, if found. Otherwise, undefined.
+ */
+export const getRecordEntry = <T>(record: Record<string, T> | undefined, key: string | undefined) => {
+  if (!record || !key || !Object.hasOwn(record, key)) return undefined;
+  return record[key];
+};


### PR DESCRIPTION
## Main Changes

Changed all record references using a NodeId to be "safe" with regards to the records incorrectly returning prototype functions when there is a naming overlap.
Allows users to name nodes things like `toString` and `toLocaleString` etc.

The new reference function `getRecordEntry` first makes a check to see if the record has the property of its own and not as a prototype function, if it exists it returns it, otherwise it returns null.
Previously we had a few places that record references were potentially undefined, but the type checking didn't pick up on it. We had null safe references so there were never any issues, but switching over to this new type-defined function for referencing record data started giving some type errors.  I fixed them best I could without making any huge changes, so you might see some `??` with dummy data following the `getRecordEntry` to appease type checking.

I tried to implement the function as an extension on the Record object but for some reason the Record object wasn't allowing me to give it extension methods.  I might look into this more in the future if I have time.
___
### Using `getRecordEntry` going forward
Anytime we want to access record data with a key that might overlap prototype functions (ie. anything user-defined like node ids), we should be using this `getRecordEntry` function to access that data so we prevent errors like the one mentioned below.

This function is only needed when _accessing_ data, so instead of `console.log(record[id])` it would just be `console.log(getRecordEntry(record, id))`.
If you are doing things like deleting an entry with `delete record[id]` or assigning data with `record[id] = 'data'`, those are safe and should still use array-notation.

___
Fixes: https://github.com/Azure/LogicAppsUX/issues/4087

// This includes a lot of changes across the whole app, I'm still testing everything out and making sure I covered everything