### PR TITLE
fix(vscode): Remove update local.settings.json and api calls in deployment scripts

### DIFF
--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/azureScriptWizard.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/azureScriptWizard.ts
@@ -47,6 +47,7 @@ export function createAzureWizard(wizardContext: IAzureScriptWizard): AzureWizar
     promptSteps: [new ConfigureInitialLogicAppStep(), new setLogicappName(), new setStorageAccountName(), new setAppPlantName()],
     executeSteps: [new SourceControlPathListStep()],
     showLoadingPrompt: true,
+    title: localize('generateDeploymentScripts', 'Generate deployment scripts'),
   });
 }
 

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/azureScriptWizard.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/azureScriptWizard.ts
@@ -61,7 +61,7 @@ export class SourceControlPathListStep extends AzureWizardPromptStep<IAzureScrip
   public hideStepCount = true;
 
   private async createDeploymentFolder(rootDir: string): Promise<string> {
-    const deploymentsDir = path.join(rootDir, 'Deployment');
+    const deploymentsDir = path.join(rootDir, 'deployment');
     if (!fs.existsSync(deploymentsDir)) {
       fs.mkdirSync(deploymentsDir);
     }
@@ -88,7 +88,7 @@ export class SourceControlPathListStep extends AzureWizardPromptStep<IAzureScrip
 
     let deploymentFolderExists = false;
     if (rootDir) {
-      deploymentFolderExists = fs.existsSync(path.join(rootDir, 'Deployment'));
+      deploymentFolderExists = fs.existsSync(path.join(rootDir, 'deployment'));
     }
 
     const deploymentLabel = deploymentFolderExists ? 'Deployment folder in current workspace' : 'New deployment folder';

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/azureScriptWizard.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/azureScriptWizard.ts
@@ -32,13 +32,10 @@ export interface IAzureScriptWizard extends IProjectWizardContext, IActionContex
 /**
  * Creates an instance of the Azure Wizard for the Azure Script Wizard.
  * @param wizardContext - The wizard context.
- * @param projectPath - The path of the project.
  * @returns An instance of the Azure Wizard.
  */
 // Your existing function for creating the Azure Wizard
 export function createAzureWizard(wizardContext: IAzureScriptWizard): AzureWizard<IAzureScriptWizard> {
-  const promptSteps = [new ConfigureInitialLogicAppStep(), new setLogicappName(), new setStorageAccountName(), new setAppPlantName()];
-
   if (!isMultiRootWorkspace) {
     wizardContext.isValidWorkspace = false;
   } else {
@@ -47,8 +44,9 @@ export function createAzureWizard(wizardContext: IAzureScriptWizard): AzureWizar
 
   // Create the Azure Wizard with the modified steps
   return new AzureWizard(wizardContext, {
-    promptSteps,
+    promptSteps: [new ConfigureInitialLogicAppStep(), new setLogicappName(), new setStorageAccountName(), new setAppPlantName()],
     executeSteps: [new SourceControlPathListStep()],
+    showLoadingPrompt: true,
   });
 }
 
@@ -110,7 +108,7 @@ class ConfigureInitialLogicAppStep extends AzureWizardPromptStep<IAzureScriptWiz
     }
 
     azurePromptSteps.push(new ResourceGroupListStep());
-    return { promptSteps: azurePromptSteps };
+    return { promptSteps: azurePromptSteps, showLoadingPrompt: true };
   }
 }
 

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -376,6 +376,7 @@ async function gatherAndValidateInputs(scriptContext: IAzureScriptWizard, folder
     ext.outputChannel.appendLog(localize('AttemptingExecuteAzureWizardSuccess', 'Launching Azure Wizard...'));
     const wizard = createAzureWizard(scriptContext);
     await wizard.prompt();
+    await wizard.execute();
     ext.outputChannel.appendLog(localize('executeAzureWizardSuccess', 'Azure Wizard executed successfully.'));
   } catch (error) {
     ext.outputChannel.appendLog(localize('executeAzureWizardError', `Error executing Azure Wizard: ${error}`));

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -42,7 +42,7 @@ export async function generateDeploymentScripts(context: IActionContext, project
     const inputs = await gatherAndValidateInputs(scriptContext, projectRoot);
     const sourceControlPath = scriptContext.sourceControlPath;
     await callConsumptionApi(scriptContext, inputs);
-    const standardArtifactsContent = await callStandardApi(scriptContext, inputs);
+    const standardArtifactsContent = await callStandardApi(inputs);
     await handleApiResponse(standardArtifactsContent, sourceControlPath);
 
     const deploymentScriptLocation = `workspace/${scriptContext.sourceControlPath}`;
@@ -91,7 +91,7 @@ async function setupWizardScriptContext(context: IActionContext, projectRoot: vs
  * @param inputs - Object containing required inputs like subscriptionId, resourceGroup etc.
  * @returns - Promise<Buffer> containing the API response as a buffer.
  */
-async function callStandardApi(scriptContext: IAzureScriptWizard, inputs: any): Promise<Buffer> {
+async function callStandardApi(inputs: any): Promise<Buffer> {
   try {
     const { subscriptionId, resourceGroup, storageAccount, location, logicAppName, appServicePlan } = inputs;
     return await callStandardResourcesApi(subscriptionId, resourceGroup, storageAccount, location, logicAppName, appServicePlan);
@@ -110,13 +110,13 @@ export async function callConsumptionApi(scriptContext: IAzureScriptWizard, inpu
   try {
     ext.outputChannel.appendLog(localize('initCallConsumption', 'Initiating call to Consumption API for deployment artifacts.'));
 
-    const { subscriptionId, resourceGroup, logicAppName } = inputs;
+    const { localSubscriptionId, localResourceGroup, logicAppName } = inputs;
     ext.outputChannel.appendLog(
       localize(
         'operationalContext',
         'Operational context: Subscription ID: {0}, Resource Group: {1}, Logic App: {2}',
-        subscriptionId,
-        resourceGroup,
+        localSubscriptionId,
+        localResourceGroup,
         logicAppName
       )
     );
@@ -133,8 +133,8 @@ export async function callConsumptionApi(scriptContext: IAzureScriptWizard, inpu
 
         // The line below has been modified to pass both originalKey and refEndPoint
         const bufferData = await callManagedConnectionsApi(
-          subscriptionId,
-          resourceGroup,
+          localSubscriptionId,
+          localResourceGroup,
           logicAppName,
           connectionObj.originalKey,
           connectionObj.refEndPoint
@@ -373,14 +373,10 @@ async function gatherAndValidateInputs(scriptContext: IAzureScriptWizard, folder
   );
 
   try {
-    if (!subscriptionId || !resourceGroup.name || !logicAppName || !storageAccountName || !appServicePlan) {
-      ext.outputChannel.appendLog(
-        localize('AttemptingExecuteAzureWizardSuccess', 'One or more required values are missing. Launching Azure Wizard...')
-      );
-      const wizard = createAzureWizard(scriptContext);
-      await wizard.prompt();
-      ext.outputChannel.appendLog(localize('executeAzureWizardSuccess', 'Azure Wizard executed successfully.'));
-    }
+    ext.outputChannel.appendLog(localize('AttemptingExecuteAzureWizardSuccess', 'Launching Azure Wizard...'));
+    const wizard = createAzureWizard(scriptContext);
+    await wizard.prompt();
+    ext.outputChannel.appendLog(localize('executeAzureWizardSuccess', 'Azure Wizard executed successfully.'));
   } catch (error) {
     ext.outputChannel.appendLog(localize('executeAzureWizardError', `Error executing Azure Wizard: ${error}`));
     await handleError(error, localize('handleErrorExecuteAzureWizard', 'Error executing Azure Wizard'));
@@ -394,6 +390,8 @@ async function gatherAndValidateInputs(scriptContext: IAzureScriptWizard, folder
     storageAccount: scriptContext.storageAccountName || storageAccountName,
     location: scriptContext.resourceGroup.location || resourceGroup.location,
     appServicePlan: scriptContext.appServicePlan || appServicePlan,
+    localSubscriptionId: defaultSubscriptionId,
+    localResourceGroup: defaultResourceGroup,
   };
 }
 

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -291,15 +291,12 @@ async function callManagedConnectionsApi(
     const cloudHost = await getCloudHost(credentials);
     const baseGraphUri = getBaseGraphApi(cloudHost);
 
-    const targetLogicAppName = logicAppName;
-    const connectionReferenceName = connectionName;
-
     // Build the URL for the API call
     const apiUrl = `${baseGraphUri}/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Web/connections/${connectionId}/generateDeploymentArtifacts?api-version=${apiVersion}`;
     // Define the request body
     const requestBody = {
-      TargetLogicAppName: targetLogicAppName,
-      ConnectionReferenceName: connectionReferenceName,
+      TargetLogicAppName: logicAppName,
+      ConnectionReferenceName: connectionName,
     };
 
     // Execute the API call
@@ -380,9 +377,8 @@ async function gatherAndValidateInputs(scriptContext: IAzureScriptWizard, folder
       ext.outputChannel.appendLog(
         localize('AttemptingExecuteAzureWizardSuccess', 'One or more required values are missing. Launching Azure Wizard...')
       );
-      const wizard = createAzureWizard(scriptContext, folder.fsPath);
+      const wizard = createAzureWizard(scriptContext);
       await wizard.prompt();
-      await wizard.execute();
       ext.outputChannel.appendLog(localize('executeAzureWizardSuccess', 'Azure Wizard executed successfully.'));
     }
   } catch (error) {

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -699,6 +699,10 @@
         {
           "command": "azureLogicAppsStandard.viewProperties",
           "when": "never"
+        },
+        {
+          "command": "azureLogicAppsStandard.generateDeploymentScripts",
+          "when": "never"
         }
       ],
       "azureLogicAppsStandard.dataMapperMenu": [
@@ -933,7 +937,7 @@
     "onCommand:azureLogicAppsStandard.createNewCodeProject",
     "onCommand:azureLogicAppsStandard.createCodeless",
     "onCommand:azureLogicAppsStandard.deploy",
-    "onCommand: azureLogicAppsStandard.generateDeploymentScripts",
+    "onCommand:azureLogicAppsStandard.generateDeploymentScripts",
     "onCommand:azureLogicAppsStandard.deploySlot",
     "onCommand:azureLogicAppsStandard.createLogicApp",
     "onCommand:azureLogicAppsStandard.createLogicAppAdvanced",


### PR DESCRIPTION
The changes aim to streamline the codebase, improve the user experience, and enhance the maintainability of the code. 

* Removed unnecessary imports and the `SaveAzureContext` class. The `createAzureWizard` function no longer requires the `projectPath` parameter, and the `SourceControlPathListStep` class has been changed from a prompt step to an execute step. The `ConfigureInitialLogicAppStep` class now includes a `showLoadingPrompt` property. 

* The `callStandardApi` function no longer requires the `scriptContext` parameter. The `callConsumptionApi` function and the `callManagedConnectionsApi` function have been updated to use `localSubscriptionId` and `localResourceGroup` instead of `subscriptionId` and `resourceGroup`. The `gatherAndValidateInputs` function now always launches the Azure Wizard and includes `localSubscriptionId` and `localResourceGroup` in the returned object. 
