### PR TITLE
fix(designer): Fix the token merge for FAM and entity outputs for hybrid triggers

### DIFF
--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -357,9 +357,17 @@ export const getUpdatedManifestForSchemaDependency = (manifest: OperationManifes
       let schemaValue: Schema;
       let shouldMerge: boolean;
       // if schema contains static object returned from RP, merge the current schema value and new schema value
-      if (isRequestApiConnectionTrigger && schemaToReplace && 'rows' in schemaToReplace) {
+      if (
+        isRequestApiConnectionTrigger &&
+        schemaToReplace &&
+        ('rows' in schemaToReplace || (schemaToReplace.properties && 'rows' in schemaToReplace.properties))
+      ) {
         if ('rows' in currentSchemaValue) {
-          schemaValue = { ...currentSchemaValue, ...schemaToReplace };
+          if (schemaToReplace.properties && 'rows' in schemaToReplace.properties) {
+            schemaValue = { ...currentSchemaValue, ...schemaToReplace.properties };
+          } else {
+            schemaValue = { ...currentSchemaValue, ...schemaToReplace };
+          }
           shouldMerge = true;
         } else {
           continue;


### PR DESCRIPTION
For hybrid triggers, the output tokens come from one of the three scenarios:
1. Floating action menu
2. Entity outputs/dynamic outputs
3. Header schema

We need to merge all three outputs for it to be available in next actions.
Issue: Currently after flow save, the schemaToReplace has a "properties" parent object and hence during the merge is adding an additional "properties" object inside one. This is causing a bad merge and hence the floating action menu tokens aren't being generated.

Fix: Merge the "rows" object based on where it's present.
