### PR TITLE
fix(designer): Prevent Key Stroke propagation in Lexical

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -14,6 +14,7 @@ import IgnoreTab from './plugins/IgnoreTab';
 import InsertTokenNode from './plugins/InsertTokenNode';
 import OpenTokenPicker from './plugins/OpenTokenPicker';
 import { PastePlugin } from './plugins/Paste';
+import { PreventPropagationPlugin } from './plugins/PreventPropagation';
 import { ReadOnly } from './plugins/ReadOnly';
 import SingleValueSegment from './plugins/SingleValueSegment';
 import { TokenTypeAheadPlugin } from './plugins/TokenTypeahead';
@@ -81,6 +82,7 @@ export interface BasePlugins {
   history?: boolean;
   tokens?: boolean;
   treeView?: boolean;
+  preventPropagation?: boolean;
   htmlEditor?: 'rich-html' | 'raw-html' | false;
   tabbable?: boolean;
   singleValueSegment?: boolean;
@@ -135,6 +137,7 @@ export const BaseEditor = ({
     htmlEditor = false,
     tabbable,
     singleValueSegment = false,
+    preventPropagation = true,
   } = basePlugins;
 
   const describedByMessage = intl.formatMessage({
@@ -205,6 +208,7 @@ export const BaseEditor = ({
         {autoLink ? <AutoLink /> : null}
         {clearEditor ? <ClearEditor showButton={false} /> : null}
         {singleValueSegment ? <SingleValueSegment /> : null}
+        {preventPropagation ? <PreventPropagationPlugin /> : null}
         <FocusChangePlugin onFocus={handleFocus} onBlur={handleBlur} onClick={handleClick} />
         <ReadOnly readonly={readonly} />
         {tabbable ? null : <IgnoreTab />}

--- a/libs/designer-ui/src/lib/editor/base/plugins/PreventPropagation.tsx
+++ b/libs/designer-ui/src/lib/editor/base/plugins/PreventPropagation.tsx
@@ -1,0 +1,15 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { COMMAND_PRIORITY_EDITOR, KEY_DOWN_COMMAND } from 'lexical';
+
+export const PreventPropagationPlugin = () => {
+  const [editor] = useLexicalComposerContext();
+  editor.registerCommand(
+    KEY_DOWN_COMMAND,
+    (event: KeyboardEvent) => {
+      event.stopPropagation();
+      return false;
+    },
+    COMMAND_PRIORITY_EDITOR
+  );
+  return null;
+};

--- a/libs/designer-ui/src/lib/editor/base/tokenpickerbutton.less
+++ b/libs/designer-ui/src/lib/editor/base/tokenpickerbutton.less
@@ -41,7 +41,7 @@
   background: #fff;
   box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.3);
   border-radius: 8px;
-  margin-top: 25px;
+  margin-top: 10px;
   z-index: 1000000;
   position: fixed;
   ul {


### PR DESCRIPTION
Fixes https://github.com/Azure/LogicAppsUX/issues/4136

Creating a Plugin to prevent keystrokes from being propagated outside of the eidtor