### PR TITLE
feat(vscode): Remove preview flags for onboarding experience

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createNewCodeProject.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createNewCodeProject.ts
@@ -2,10 +2,16 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { funcVersionSetting, projectLanguageSetting, projectOpenBehaviorSetting, projectTemplateKeySetting } from '../../../constants';
+import {
+  extensionCommand,
+  funcVersionSetting,
+  projectLanguageSetting,
+  projectOpenBehaviorSetting,
+  projectTemplateKeySetting,
+} from '../../../constants';
 import { localize } from '../../../localize';
-import * as packageJson from '../../../package.json';
 import { addLocalFuncTelemetry, tryGetLocalFuncVersion, tryParseFuncVersion } from '../../utils/funcCoreTools/funcVersion';
+import { showPreviewWarning } from '../../utils/taskUtils';
 import { getGlobalSetting, getWorkspaceSetting } from '../../utils/vsCodeConfig/settings';
 import { OpenBehaviorStep } from '../createNewProject/OpenBehaviorStep';
 import { FolderListStep } from '../createNewProject/createProjectSteps/FolderListStep';
@@ -46,7 +52,7 @@ export async function createNewCodeProjectFromCommand(
 
 export async function createNewCodeProjectInternal(context: IActionContext, options: ICreateFunctionOptions): Promise<void> {
   addLocalFuncTelemetry(context);
-  showPreviewWarning(); //Show warning if command is set to preview
+  showPreviewWarning(extensionCommand.createNewCodeProject); //Show warning if command is set to preview
 
   const language: ProjectLanguage | undefined = (options.language as ProjectLanguage) || getGlobalSetting(projectLanguageSetting);
   const version: string = options.version || getGlobalSetting(funcVersionSetting) || (await tryGetLocalFuncVersion()) || latestGAVersion;
@@ -92,13 +98,4 @@ export async function createNewCodeProjectInternal(context: IActionContext, opti
 async function createArtifactsFolder(context: IFunctionWizardContext): Promise<void> {
   fse.mkdirSync(path.join(context.projectPath, 'Artifacts', 'Maps'), { recursive: true });
   fse.mkdirSync(path.join(context.projectPath, 'Artifacts', 'Schemas'), { recursive: true });
-}
-
-function showPreviewWarning() {
-  const createNewCodeProjectCommand = packageJson.contributes.commands.find(
-    (command) => command.command === 'azureLogicAppsStandard.createNewCodeProject'
-  );
-  if (createNewCodeProjectCommand.preview) {
-    window.showInformationMessage('The "Create new logic app workspace" command is a preview feature and may be subject to change.');
-  }
 }

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -353,7 +353,7 @@ export function getDependencyTimeout(): number {
  * @param {IActionContext} context - Activation context.
  */
 export async function promptInstallBinariesOption(context: IActionContext) {
-  const message = localize('useBinaries', 'Allow auto runtime dependencies validation and installation at extension launch (Preview)');
+  const message = localize('useBinaries', 'Allow auto runtime dependencies validation and installation at extension launch.');
   const confirm = { title: localize('yesRecommended', 'Yes (Recommended)') };
   let result: vscode.MessageItem;
 

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -309,13 +309,11 @@
       {
         "command": "azureLogicAppsStandard.validateAndInstallBinaries",
         "title": "Validate and install dependency binaries",
-        "preview": true,
         "category": "Azure Logic Apps"
       },
       {
         "command": "azureLogicAppsStandard.resetValidateAndInstallBinaries",
         "title": "Reset binaries dependency settings",
-        "preview": true,
         "category": "Azure Logic Apps"
       },
       {
@@ -751,7 +749,7 @@
           "azureLogicAppsStandard.autoRuntimeDependenciesPath": {
             "scope": "resource",
             "type": "string",
-            "description": "The path for Azure Logic Apps extension runtime dependencies. (Preview)"
+            "description": "The path for Azure Logic Apps extension runtime dependencies."
           },
           "azureLogicAppsStandard.dotnetBinaryPath": {
             "scope": "resource",
@@ -887,7 +885,7 @@
           },
           "azureLogicAppsStandard.autoRuntimeDependenciesValidationAndInstallation": {
             "type": "boolean",
-            "description": "Enable automatic validation and installation for runtime dependencies at the configured path. (Preview)",
+            "description": "Enable automatic validation and installation for runtime dependencies at the configured path.",
             "default": null
           },
           "azureLogicAppsStandard.showAutoStartAzuriteWarning": {


### PR DESCRIPTION
The most significant changes involve the removal of the `showPreviewWarning` function from `createNewCodeProject.ts` and the removal of the "preview" status from several features in `package.json` and `binaries.ts`.


* The `showPreviewWarning` function was removed and its functionality was moved to the `createNewCodeProjectInternal` function. The `extensionCommand` was added to the import statement from `../../../constants`. 

* The "preview" label was removed from the message in the `promptInstallBinariesOption` function.
* The "preview" status was removed from several features, including the "Validate and install dependency binaries" and "Reset binaries dependency settings" commands, and the "autoRuntimeDependenciesPath" and "autoRuntimeDependenciesValidationAndInstallation" settings. The descriptions of these features were updated accordingly.