### PR TITLE
fix(designer): fix spliton token references for newly added triggers

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -28,7 +28,7 @@ import {
 } from './initialize';
 import type { NodeDataWithOperationMetadata } from './operationdeserializer';
 import type { Settings } from './settings';
-import { getOperationSettings } from './settings';
+import { getOperationSettings, getSplitOnValue } from './settings';
 import { ConnectionService, OperationManifestService, StaticResultService } from '@microsoft/designer-client-services-logic-apps';
 import type { SwaggerParser } from '@microsoft/parsers-logic-apps';
 import { ManifestParser } from '@microsoft/parsers-logic-apps';
@@ -120,7 +120,7 @@ export const initializeOperationDetails = async (
       manifest,
       isTrigger,
       nodeInputs,
-      /* splitOnValue */ undefined,
+      isTrigger ? getSplitOnValue(manifest, undefined, undefined, undefined) : undefined,
       operationInfo,
       nodeId
     );

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -48,7 +48,7 @@ import {
   updateCallbackUrlInInputs,
   updateInvokerSettings,
 } from './initialize';
-import { getOperationSettings } from './settings';
+import { getOperationSettings, getSplitOnValue } from './settings';
 import type { Settings } from './settings';
 import {
   LogEntryLevel,
@@ -235,7 +235,7 @@ export const initializeOperationDetailsForManifest = async (
       manifest,
       isTrigger,
       nodeInputs,
-      isTrigger ? (operation as LogicAppsV2.TriggerDefinition).splitOn : undefined,
+      isTrigger ? getSplitOnValue(manifest, undefined, undefined, operation) : undefined,
       operationInfo,
       nodeId
     );

--- a/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
@@ -530,7 +530,7 @@ const getSplitOn = (
   };
 };
 
-const getSplitOnValue = (
+export const getSplitOnValue = (
   manifest?: OperationManifest,
   swagger?: SwaggerParser,
   operationId?: string,


### PR DESCRIPTION
As the node initialization happens in the designer today, the spliton that's used to generate the output token keys from the manifest is either retrieved from the manifest or explicitly null. this causes the token outputs to ignore spliton and assume it's off when spliton is yet to be computed, causing the node dependency keys to be incorrect.