### PR TITLE
fix(vscode): Add validation for no connections

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
@@ -6,6 +6,7 @@ import { tryGetWebviewPanel } from '../../../utils/codeless/common';
 import { getWebViewHTML } from '../../../utils/codeless/getWebViewHTML';
 import type { IAzureConnectorsContext } from '../azureConnectorWizard';
 import { ResolutionService } from '@microsoft/parsers-logic-apps';
+import { isEmptyString } from '@microsoft/utils-logic-apps';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { Artifacts, AzureConnectorDetails, ConnectionsData, FileDetails, Parameter } from '@microsoft/vscode-extension';
 import type { WebviewPanel, WebviewOptions, WebviewPanelOptions } from 'vscode';
@@ -94,7 +95,8 @@ export abstract class OpenDesignerBase {
     }
 
     const parametersResolutionService = new ResolutionService(parameters, localSettings);
-    const resolvedConnections: ConnectionsData = parametersResolutionService.resolve(JSON.parse(connectionsData));
+    const parsedConnections = isEmptyString(connectionsData) ? {} : JSON.parse(connectionsData);
+    const resolvedConnections: ConnectionsData = parametersResolutionService.resolve(parsedConnections);
 
     this.connectionData = resolvedConnections;
     this.apiHubServiceDetails = this.getApiHubServiceDetails(azureDetails);


### PR DESCRIPTION
The changes focus on improving the handling of connections data and reducing the risk of errors during the parsing process.

* Replaced the direct parsing of `connectionsData` with a conditional parsing. Now, `connectionsData` is parsed only if it's not an empty string, otherwise an empty object is used. This change reduces the risk of JSON parsing errors when `connectionsData` is an empty string.

Fixes #4151 