### PR TITLE
fix(designer): Removed new OpenAPI token behavior added in #4122

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
@@ -2305,16 +2305,6 @@ describe('core/utils/parameters/helper', () => {
       ['outputs.$.headers', undefined, `triggerOutputs()`],
       ['outputs.$.relativePathParameters', undefined, `triggerOutputs()`],
 
-      // For nested properties (OpenAPI) within `outputs.$.body`, use BODY.
-      ['outputs.$.body.ID', undefined, `triggerBody()`],
-      ['outputs.$.body.Title', undefined, `triggerBody()`],
-      ['outputs.$.body.Author.DisplayName', undefined, `triggerBody()`],
-
-      // For nested path properties (OpenAPI) within `outputs.$.body/*`, use BODY.
-      ['outputs.$.body/value.ID', undefined, `triggerBody()`],
-      ['outputs.$.body/value.Title', undefined, `triggerBody()`],
-      ['outputs.$.body/value.Author.DisplayName', undefined, `triggerBody()`],
-
       // For values using `body/*` syntax, use OUTPUTS.
       ['outputs.$.body/subject', 'Get_event_(V3)', `outputs('Get_event_(V3)')`],
     ])('correctly gets the token expression for %p', (key, actionName, expected) => {

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1022,17 +1022,7 @@ function segmentsAreBodyReference(segments: Segment[]): boolean {
     return false;
   }
 
-  if (segments[0].value === OutputSource.Body) {
-    return true;
-  }
-
-  // For tokens of format `outputs.$.body.Title` or `outputs.$.body/Title`, where we are referring to a property within
-  // the body, we have to reference the body rather than the outputs field.
-  return (
-    segments.length >= 4 &&
-    isString(segments[2].value) &&
-    (segments[2].value === constants.OUTPUT_LOCATIONS.BODY || segments[2].value.startsWith(`${constants.OUTPUT_LOCATIONS.BODY}/`))
-  );
+  return segments[0].value === OutputSource.Body;
 }
 
 // NOTE: For example, if tokenKey is outputs.$.foo.[*].bar, which means


### PR DESCRIPTION
New behavior for handling of OpenAPI tokens was added in #4122. However, this turned out to be only a surface-level "mitigation" in that it did not address the root cause of the issue. The root cause was fixed in #4148. Therefore, with that fix, I am reverting the new behavior that was added in #4122 which is no longer needed.