### PR TITLE
fix(Designer): Operation parameters are now sorted by their dependent parameters

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -197,11 +197,18 @@ export interface RepetitionReference {
 }
 
 export function getParametersSortedByVisibility(parameters: ParameterInfo[]): ParameterInfo[] {
-  // Sorted by ( Required, Important, Advanced, Other )
   return parameters.sort((a, b) => {
+    // Sort by dynamic data dependencies
+    const aDeps = Object.keys(a?.schema?.['x-ms-dynamic-values']?.parameters ?? {});
+    if (aDeps.includes(b.parameterName)) return 1;
+    const bDeps = Object.keys(b?.schema?.['x-ms-dynamic-values']?.parameters ?? {});
+    if (bDeps.includes(a.parameterName)) return -1;
+
+    // Sorted by Required first
     if (a.required && !b.required) return -1;
     if (!a.required && b.required) return 1;
 
+    // Sorted by visibility ( Important, Advanced, Other )
     const aVisibility = getVisibility(a);
     const bVisibility = getVisibility(b);
     if (aVisibility === bVisibility) return 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "2.107.0",
+  "version": "2.111.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "2.107.0",
+      "version": "2.111.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Main Changes

Added an operation parameter sort case that makes parameters with data that depends on other parameters always come after the parameter it sources data from.  This overrides sorting by visibility which was causing the parameters to be out of order previously

![image](https://github.com/Azure/LogicAppsUX/assets/25409734/3b23e198-fcaa-4a6e-a3cf-39551749168a)


Fixes: https://github.com/Azure/LogicAppsUX/issues/3900
