### PR TITLE
fix(Designer): Fixed issue causing schema parameters to not appear as required

### DIFF
--- a/libs/parsers/src/lib/common/schemaprocessor.ts
+++ b/libs/parsers/src/lib/common/schemaprocessor.ts
@@ -275,9 +275,7 @@ export class SchemaProcessor {
             : this.options.prefix
             ? `${this.options.prefix}.${encodedChildPropertyName}`
             : encodedChildPropertyName;
-        const required = isNullOrUndefined(this.options.required)
-          ? requiredProperties.indexOf(key) !== -1
-          : this.options.required && requiredProperties.indexOf(key) !== -1;
+        const required = requiredProperties.indexOf(key) !== -1;
         const parentProperty = { ...this.options.parentProperty, visibility: this._getVisibility(schema) };
 
         const processor = new SchemaProcessor({


### PR DESCRIPTION
## Main Changes

Fixed issue causing schema parameters to not appear as required.
Parameters were ignoring the defined `required` key array prop if their parent in their path (like `body`) wasn't also `required: true`.
With APIM, the body param isn't able to be set as required, which was causing this issue.