### PR TITLE
feat(vscode): Binaries dependencies opt-in  by default

### DIFF
--- a/apps/vs-code-designer/src/app/commands/binaries/resetValidateAndInstallBinaries.ts
+++ b/apps/vs-code-designer/src/app/commands/binaries/resetValidateAndInstallBinaries.ts
@@ -14,6 +14,33 @@ import { updateGlobalSetting } from '../../utils/vsCodeConfig/settings';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 
+/**
+ * Resets the path settings for auto runtime dependencies, dotnet binary, node js binary, and func core tools binary.
+ * @param {vscode.Progress} progress - The progress object to report the progress of the reset operation.
+ */
+const resetBinariesPathSettings = async (
+  progress: vscode.Progress<{
+    message?: string;
+    increment?: number;
+  }>
+) => {
+  await updateGlobalSetting(autoRuntimeDependenciesPathSettingKey, undefined);
+  progress.report({ increment: 40, message: localize('resetDependenciesPath', 'Reset auto runtime dependencies path') });
+
+  await updateGlobalSetting(dotNetBinaryPathSettingKey, undefined);
+  progress.report({ increment: 60, message: localize('resetDotnet', 'Reset dotnet binary path') });
+
+  await updateGlobalSetting(nodeJsBinaryPathSettingKey, undefined);
+  progress.report({ increment: 80, message: localize('resetNodeJs', 'Reset node js binary path') });
+
+  await updateGlobalSetting(funcCoreToolsBinaryPathSettingKey, undefined);
+  progress.report({ increment: 100, message: localize('resetFuncCoreTools', 'Reset func core tools binary path') });
+};
+
+/**
+ * Resets the auto validation and installation of binaries dependencies.
+ * @param {IActionContext} context The action context.
+ */
 export const resetValidateAndInstallBinaries = async (context: IActionContext) => {
   await vscode.window.withProgress(
     {
@@ -22,22 +49,30 @@ export const resetValidateAndInstallBinaries = async (context: IActionContext) =
       cancellable: false, // Allow the user to cancel the task
     },
     async (progress) => {
-      await updateGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting, undefined);
+      await updateGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting, true);
       progress.report({ increment: 20, message: localize('resetValidation', 'Reset auto runtime validation and installation') });
-
-      await updateGlobalSetting(autoRuntimeDependenciesPathSettingKey, undefined);
-      progress.report({ increment: 40, message: localize('resetDependenciesPath', 'Reset auto runtime dependencies path') });
-
-      await updateGlobalSetting(dotNetBinaryPathSettingKey, undefined);
-      progress.report({ increment: 60, message: localize('resetDotnet', 'Reset dotnet binary path') });
-
-      await updateGlobalSetting(nodeJsBinaryPathSettingKey, undefined);
-      progress.report({ increment: 80, message: localize('resetNodeJs', 'Reset node js binary path') });
-
-      await updateGlobalSetting(funcCoreToolsBinaryPathSettingKey, undefined);
-      progress.report({ increment: 100, message: localize('resetFuncCoreTools', 'Reset func core tools binary path') });
-
+      await resetBinariesPathSettings(progress);
       context.telemetry.properties.resetBinariesDependencies = 'true';
+    }
+  );
+};
+
+/**
+ * Disables the auto validation and installation of binaries dependencies.
+ * @param {IActionContext} context The action context.
+ */
+export const disableValidateAndInstallBinaries = async (context: IActionContext) => {
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification, // Location of the progress indicator
+      title: localize('disableBinariesDependencies', 'Disabling binaries dependencies settings'), // Title displayed in the progress notification
+      cancellable: false, // Allow the user to cancel the task
+    },
+    async (progress) => {
+      await updateGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting, false);
+      progress.report({ increment: 20, message: localize('disableValidation', 'Disable auto runtime validation and installation') });
+      await resetBinariesPathSettings(progress);
+      context.telemetry.properties.disableBinariesDependencies = 'true';
     }
   );
 };

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -11,7 +11,7 @@ import { editAppSetting } from './appSettings/editAppSetting';
 import { renameAppSetting } from './appSettings/renameAppSetting';
 import { toggleSlotSetting } from './appSettings/toggleSlotSetting';
 import { uploadAppSettings } from './appSettings/uploadAppSettings';
-import { resetValidateAndInstallBinaries } from './binaries/resetValidateAndInstallBinaries';
+import { disableValidateAndInstallBinaries, resetValidateAndInstallBinaries } from './binaries/resetValidateAndInstallBinaries';
 import { validateAndInstallBinaries } from './binaries/validateAndInstallBinaries';
 import { browseWebsite } from './browseWebsite';
 import { configureDeploymentSource } from './configureDeploymentSource';
@@ -133,6 +133,7 @@ export function registerCommands(): void {
     validateAndInstallBinaries(context)
   );
   registerCommandWithTreeNodeUnwrapping(extensionCommand.resetValidateAndInstallBinaries, resetValidateAndInstallBinaries);
+  registerCommandWithTreeNodeUnwrapping(extensionCommand.disableValidateAndInstallBinaries, disableValidateAndInstallBinaries);
   // Data Mapper Commands
   registerCommand(extensionCommand.createNewDataMap, (context: IActionContext) => createNewDataMapCmd(context));
   registerCommand(extensionCommand.loadDataMapFile, (context: IActionContext, uri: Uri) => loadDataMapFileCmd(context, uri));

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -11,6 +11,10 @@ import {
   dotnetDependencyName,
   funcPackageName,
   defaultLogicAppsFolder,
+  dotNetBinaryPathSettingKey,
+  DependencyDefaultPath,
+  nodeJsBinaryPathSettingKey,
+  funcCoreToolsBinaryPathSettingKey,
 } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
@@ -356,6 +360,10 @@ export async function installBinaries(context: IActionContext) {
     await onboardBinaries(context);
     context.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting = 'true';
   } else if (binariesInstallation === false) {
+    await updateGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting, false);
+    await updateGlobalSetting(dotNetBinaryPathSettingKey, DependencyDefaultPath.dotnet);
+    await updateGlobalSetting(nodeJsBinaryPathSettingKey, DependencyDefaultPath.node);
+    await updateGlobalSetting(funcCoreToolsBinaryPathSettingKey, DependencyDefaultPath.funcCoreTools);
     context.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting = 'false';
   }
 }

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -353,14 +353,12 @@ export function getDependencyTimeout(): number {
  * @param {IActionContext} context - Activation context.
  */
 export async function installBinaries(context: IActionContext) {
-  const binariesInstallation = getGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting);
+  const useBinaries = useBinariesDependencies();
 
-  if (binariesInstallation === null) {
-    await updateGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting, true);
+  if (useBinaries) {
     await onboardBinaries(context);
     context.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting = 'true';
-  } else if (binariesInstallation === false) {
-    await updateGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting, false);
+  } else {
     await updateGlobalSetting(dotNetBinaryPathSettingKey, DependencyDefaultPath.dotnet);
     await updateGlobalSetting(nodeJsBinaryPathSettingKey, DependencyDefaultPath.node);
     await updateGlobalSetting(funcCoreToolsBinaryPathSettingKey, DependencyDefaultPath.funcCoreTools);

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -3,17 +3,13 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import {
-  DependencyDefaultPath,
   DependencyVersion,
   Platform,
   autoRuntimeDependenciesValidationAndInstallationSetting,
   autoRuntimeDependenciesPathSettingKey,
   dependencyTimeoutSettingKey,
-  dotNetBinaryPathSettingKey,
   dotnetDependencyName,
-  funcCoreToolsBinaryPathSettingKey,
   funcPackageName,
-  nodeJsBinaryPathSettingKey,
   defaultLogicAppsFolder,
 } from '../../constants';
 import { ext } from '../../extensionVariables';
@@ -23,7 +19,7 @@ import { isNodeJsInstalled } from '../commands/nodeJs/validateNodeJsInstalled';
 import { executeCommand } from './funcCoreTools/cpUtils';
 import { getNpmCommand } from './nodeJs/nodeJsVersion';
 import { getGlobalSetting, getWorkspaceSetting, updateGlobalSetting } from './vsCodeConfig/settings';
-import { DialogResponses, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import type { IGitHubReleaseInfo } from '@microsoft/vscode-extension';
 import axios from 'axios';
 import * as fs from 'fs';
@@ -352,26 +348,15 @@ export function getDependencyTimeout(): number {
  * Propmts warning message to decide the auto validation/installation of dependency binaries.
  * @param {IActionContext} context - Activation context.
  */
-export async function promptInstallBinariesOption(context: IActionContext) {
-  const message = localize('useBinaries', 'Allow auto runtime dependencies validation and installation at extension launch.');
-  const confirm = { title: localize('yesRecommended', 'Yes (Recommended)') };
-  let result: vscode.MessageItem;
-
+export async function installBinaries(context: IActionContext) {
   const binariesInstallation = getGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting);
 
   if (binariesInstallation === null) {
-    result = await context.ui.showWarningMessage(message, confirm, DialogResponses.dontWarnAgain);
-    if (result === confirm) {
-      await updateGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting, true);
-      await onboardBinaries(context);
-      context.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting = 'true';
-    } else if (result === DialogResponses.dontWarnAgain) {
-      await updateGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting, false);
-      await updateGlobalSetting(dotNetBinaryPathSettingKey, DependencyDefaultPath.dotnet);
-      await updateGlobalSetting(nodeJsBinaryPathSettingKey, DependencyDefaultPath.node);
-      await updateGlobalSetting(funcCoreToolsBinaryPathSettingKey, DependencyDefaultPath.funcCoreTools);
-      context.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting = 'false';
-    }
+    await updateGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting, true);
+    await onboardBinaries(context);
+    context.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting = 'true';
+  } else if (binariesInstallation === false) {
+    context.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting = 'false';
   }
 }
 

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -141,6 +141,7 @@ export const extensionCommand = {
   reportIssue: 'azureLogicAppsStandard.reportIssue',
   validateAndInstallBinaries: 'azureLogicAppsStandard.validateAndInstallBinaries',
   resetValidateAndInstallBinaries: 'azureLogicAppsStandard.resetValidateAndInstallBinaries',
+  disableValidateAndInstallBinaries: 'azureLogicAppsStandard.disableValidateAndInstallBinaries',
   azureAzuriteStart: 'azurite.start',
   loadDataMapFile: 'azureLogicAppsStandard.dataMap.loadDataMapFile',
   dataMapAddSchemaFromFile: 'azureLogicAppsStandard.dataMap.addSchemaFromFile',

--- a/apps/vs-code-designer/src/onboarding.ts
+++ b/apps/vs-code-designer/src/onboarding.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { validateAndInstallBinaries } from './app/commands/binaries/validateAndInstallBinaries';
-import { promptInstallBinariesOption } from './app/utils/binaries';
+import { installBinaries } from './app/utils/binaries';
 import { promptStartDesignTimeOption } from './app/utils/codeless/startDesignTimeApi';
 import { runWithDurationTelemetry } from './app/utils/telemetry';
 import { getGlobalSetting } from './app/utils/vsCodeConfig/settings';
@@ -43,7 +43,7 @@ export const startOnboarding = async (activateContext: IActionContext) => {
   callWithTelemetryAndErrorHandling(autoRuntimeDependenciesValidationAndInstallationSetting, async (actionContext: IActionContext) => {
     await runWithDurationTelemetry(actionContext, autoRuntimeDependenciesValidationAndInstallationSetting, async () => {
       activateContext.telemetry.properties.lastStep = autoRuntimeDependenciesValidationAndInstallationSetting;
-      await promptInstallBinariesOption(actionContext);
+      await installBinaries(actionContext);
     });
   });
 

--- a/apps/vs-code-designer/src/onboarding.ts
+++ b/apps/vs-code-designer/src/onboarding.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { validateAndInstallBinaries } from './app/commands/binaries/validateAndInstallBinaries';
-import { installBinaries } from './app/utils/binaries';
+import { installBinaries, useBinariesDependencies } from './app/utils/binaries';
 import { promptStartDesignTimeOption } from './app/utils/codeless/startDesignTimeApi';
 import { runWithDurationTelemetry } from './app/utils/telemetry';
-import { getGlobalSetting } from './app/utils/vsCodeConfig/settings';
 import { validateTasksJson } from './app/utils/vsCodeConfig/tasks';
 import {
   extensionCommand,
@@ -24,7 +23,7 @@ import * as vscode from 'vscode';
 export const onboardBinaries = async (activateContext: IActionContext) => {
   callWithTelemetryAndErrorHandling(extensionCommand.validateAndInstallBinaries, async (actionContext: IActionContext) => {
     await runWithDurationTelemetry(actionContext, extensionCommand.validateAndInstallBinaries, async () => {
-      const binariesInstallation = getGlobalSetting(autoRuntimeDependenciesValidationAndInstallationSetting);
+      const binariesInstallation = useBinariesDependencies();
       if (binariesInstallation) {
         activateContext.telemetry.properties.lastStep = extensionCommand.validateAndInstallBinaries;
         await validateAndInstallBinaries(actionContext);

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -317,6 +317,11 @@
         "category": "Azure Logic Apps"
       },
       {
+        "command": "azureLogicAppsStandard.disableValidateAndInstallBinaries",
+        "title": "Disable binaries dependency settings",
+        "category": "Azure Logic Apps"
+      },
+      {
         "command": "azureLogicAppsStandard.dataMap.createNewDataMap",
         "title": "Data Mapper: Create new data map",
         "icon": "$(add)"
@@ -886,7 +891,7 @@
           "azureLogicAppsStandard.autoRuntimeDependenciesValidationAndInstallation": {
             "type": "boolean",
             "description": "Enable automatic validation and installation for runtime dependencies at the configured path.",
-            "default": null
+            "default": true
           },
           "azureLogicAppsStandard.showAutoStartAzuriteWarning": {
             "type": "boolean",


### PR DESCRIPTION
This pull request primarily focuses on setting the opt-in as default for binaries installation.

- Reset binaries -> set the auto installation as true and binaries settings path to undefined
- Disabled binaries -> set the auto installation as false and binaries settings path to undefined
- Binaries settings paths are set later in logic.

* A new function `disableValidateAndInstallBinaries` has been added to disable the auto validation and installation of binary dependencies.
* The `promptInstallBinariesOption` function has been renamed to `installBinaries` and its install always installs the binaries unless the setting is set to true.
* The default value for the `autoRuntimeDependenciesValidationAndInstallation` setting has been changed from `null` to `true` in `package.json`.