### PR TITLE
fix(Designer): Fixed issue causing schema parameters to not appear as required

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -263,6 +263,7 @@ export async function getDynamicInputsFromSchema(
   operationDefinition?: any
 ): Promise<InputParameter[]> {
   const isParameterNested = dynamicParameter.isNested;
+  const schemaHasRequiredParameters = schema?.required && schema.required.length > 0;
   const processorOptions: SchemaProcessorOptions = {
     prefix: isParameterNested ? dynamicParameter.name : '',
     currentKey: isParameterNested ? undefined : dynamicParameter.name,
@@ -270,7 +271,7 @@ export async function getDynamicInputsFromSchema(
     parentProperty: {
       visibility: dynamicParameter.visibility,
     },
-    required: dynamicParameter.required,
+    required: dynamicParameter.required || schemaHasRequiredParameters,
     useAliasedIndexing: true,
     excludeAdvanced: false,
     excludeInternal: false,

--- a/libs/parsers/src/lib/common/schemaprocessor.ts
+++ b/libs/parsers/src/lib/common/schemaprocessor.ts
@@ -275,9 +275,7 @@ export class SchemaProcessor {
             : this.options.prefix
             ? `${this.options.prefix}.${encodedChildPropertyName}`
             : encodedChildPropertyName;
-        const required = isNullOrUndefined(this.options.required)
-          ? requiredProperties.indexOf(key) !== -1
-          : this.options.required && requiredProperties.indexOf(key) !== -1;
+        const required = requiredProperties.indexOf(key) !== -1;
         const parentProperty = { ...this.options.parentProperty, visibility: this._getVisibility(schema) };
 
         const processor = new SchemaProcessor({

--- a/libs/parsers/src/lib/common/schemaprocessor.ts
+++ b/libs/parsers/src/lib/common/schemaprocessor.ts
@@ -275,7 +275,9 @@ export class SchemaProcessor {
             : this.options.prefix
             ? `${this.options.prefix}.${encodedChildPropertyName}`
             : encodedChildPropertyName;
-        const required = requiredProperties.indexOf(key) !== -1;
+        const required = isNullOrUndefined(this.options.required)
+          ? requiredProperties.indexOf(key) !== -1
+          : this.options.required && requiredProperties.indexOf(key) !== -1;
         const parentProperty = { ...this.options.parentProperty, visibility: this._getVisibility(schema) };
 
         const processor = new SchemaProcessor({

--- a/libs/services/designer-client-services/src/lib/base/apimanagement.ts
+++ b/libs/services/designer-client-services/src/lib/base/apimanagement.ts
@@ -135,6 +135,13 @@ export class BaseApiManagementService implements IApiManagementService {
       }
     }
 
+    // APIM apis in portal do not allow marking the body as required, so we are doing it here
+    //     Users can mark body parameters as required,
+    //     and to show them as required the body needs to also be marked as required
+    if ((schema?.properties?.['body']?.required ?? []).length > 0) {
+      schema.required.push('body');
+    }
+
     return schema;
   }
 


### PR DESCRIPTION
##Main Changes

Fixed issue causing schema body parameters to not appear as required.
Parameters marked as required do not render as required if their parent in their path (like body) isn't also required.
With APIM, in Portal the body param isn't able to be set as required, which was causing this issue.

With this change, dynamic data parameters now render as required when the schema is defined as required, and on APIM schemas specifically I've added a check to make `body` required if it has required parameters (since you can't do it yourself in portal).
