### PR TITLE
fix(vscode): Remove deploy slot action to only slot and not slots tree item

### DIFF
--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -428,7 +428,7 @@
         },
         {
           "command": "azureLogicAppsStandard.deploySlot",
-          "when": "view == azureResourceGroups && viewItem =~ /azLogicAppsSlot/",
+          "when": "view == azureResourceGroups && viewItem =~ /azLogicAppsSlot(?!s)/",
           "group": "3@2"
         },
         {


### PR DESCRIPTION
The change modifies the condition for the `azureLogicAppsStandard.deploySlot` command to exclude matches that end in an 's'. This negative lookahead assertion ensures that the deploy action is not shown in the Slots tree item.