### PR TITLE
feat(designer): Add Resubmit from action to the action panel for easier visibility

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -46,6 +46,8 @@ export type PanelContainerProps = {
   nodeId: string;
   title?: string;
   layerProps?: ILayerProps;
+  canResubmit?: boolean;
+  resubmitOperation?: () => void;
   trackEvent(data: PageActionTelemetryData): void;
   toggleCollapse: () => void;
   onCommentChange: (panelCommentChangeEvent?: string) => void;
@@ -66,6 +68,8 @@ export const PanelContainer = ({
   headerMenuItems,
   selectedTab,
   selectTab,
+  canResubmit,
+  resubmitOperation,
   showCommentBox,
   readOnlyMode,
   tabs,
@@ -99,6 +103,8 @@ export const PanelContainer = ({
           isError={isError}
           isLoading={isLoading}
           comment={comment}
+          canResubmit={canResubmit}
+          resubmitOperation={resubmitOperation}
           horizontalPadding={horizontalPadding}
           commentChange={onCommentChange}
           toggleCollapse={toggleCollapse}
@@ -120,6 +126,8 @@ export const PanelContainer = ({
       isError,
       isLoading,
       comment,
+      canResubmit,
+      resubmitOperation,
       onCommentChange,
       toggleCollapse,
       onTitleChange,

--- a/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
@@ -38,6 +38,8 @@ export interface PanelHeaderProps {
   title?: string;
   nodeId: string;
   horizontalPadding: string;
+  canResubmit?: boolean;
+  resubmitOperation?: () => void;
   commentChange(panelCommentChangeEvent?: string): void;
   onRenderWarningMessage?(): JSX.Element;
   toggleCollapse: () => void;
@@ -64,6 +66,8 @@ export const PanelHeader = ({
   title,
   nodeId,
   horizontalPadding,
+  canResubmit,
+  resubmitOperation,
   commentChange,
   onRenderWarningMessage,
   toggleCollapse,
@@ -73,6 +77,10 @@ export const PanelHeader = ({
 
   const menuButtonRef = React.createRef<IButton>();
 
+  const resubmitButtonText = intl.formatMessage({
+    defaultMessage: 'Submit from this action',
+    description: 'Button label for submitting a workflow to rerun from this action',
+  });
   useEffect(() => {
     menuButtonRef.current?.focus();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -181,6 +189,15 @@ export const PanelHeader = ({
               readOnlyMode={readOnlyMode}
               commentChange={commentChange}
             />
+          ) : null}
+          {canResubmit ? (
+            <Button
+              style={{ marginLeft: '2rem', marginTop: '1rem', marginBottom: 0 }}
+              icon={<Icon iconName="PlaybackRate1x" />}
+              onClick={() => resubmitOperation?.()}
+            >
+              {resubmitButtonText}
+            </Button>
           ) : null}
         </>
       ) : null}

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -15,12 +15,13 @@ import { useIconUri, useOperationErrorInfo } from '../../../core/state/operation
 import { useIsPanelCollapsed, useSelectedPanelTabId } from '../../../core/state/panel/panelSelectors';
 import { expandPanel, updatePanelLocation, selectPanelTab, setSelectedNodeId } from '../../../core/state/panel/panelSlice';
 import { useOperationQuery } from '../../../core/state/selectors/actionMetadataSelector';
-import { useNodeDescription } from '../../../core/state/workflow/workflowSelectors';
+import { useNodeDescription, useRunData, useRunInstance } from '../../../core/state/workflow/workflowSelectors';
 import { setNodeDescription, replaceId } from '../../../core/state/workflow/workflowSlice';
 import { isRootNodeInGraph, isOperationNameValid } from '../../../core/utils/graph';
 import { CommentMenuItem } from '../../menuItems/commentMenuItem';
 import { DeleteMenuItem } from '../../menuItems/deleteMenuItem';
 import { usePanelTabs } from './usePanelTabs';
+import { WorkflowService } from '@microsoft/designer-client-services-logic-apps';
 import type { CommonPanelProps, PageActionTelemetryData } from '@microsoft/designer-ui';
 import { PanelContainer, PanelLocation, PanelScope, PanelSize } from '@microsoft/designer-ui';
 import { isNullOrUndefined } from '@microsoft/utils-logic-apps';
@@ -39,6 +40,7 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
 
   const collapsed = useIsPanelCollapsed();
   const selectedNode = useSelectedNodeId();
+  const runData = useRunData(selectedNode);
   const { isTriggerNode, nodesMetadata, idReplacements } = useSelector((state: RootState) => ({
     isTriggerNode: isRootNodeInGraph(selectedNode, 'root', state.workflow.nodesMetadata),
     nodesMetadata: state.workflow.nodesMetadata,
@@ -107,6 +109,14 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
     return opQuery.isLoading;
   }, [nodeMetaData?.subgraphType, opQuery.isLoading]);
 
+  const runInstance = useRunInstance();
+
+  const resubmitClick = useCallback(() => {
+    if (!runInstance) return;
+    WorkflowService().resubmitWorkflow?.(runInstance?.name ?? '', [selectedNode]);
+    dispatch(clearPanel());
+  }, [dispatch, runInstance, selectedNode]);
+
   const layerProps = {
     hostId: 'msla-layer-host',
     eventBubblingEnabled: true,
@@ -137,6 +147,8 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
       selectTab={(tabId: string) => dispatch(selectPanelTab(tabId))}
       nodeId={selectedNode}
       readOnlyMode={readOnly}
+      canResubmit={runData?.canResubmit ?? false}
+      resubmitOperation={resubmitClick}
       toggleCollapse={() => {
         // Only run validation when collapsing the panel
         if (!collapsed) {


### PR DESCRIPTION
Fixes #4163
This pull request primarily introduces the ability to resubmit operations in the `PanelContainer` and `PanelHeader` components, and the `NodeDetailsPanel` component is updated to use this new functionality. The changes also include the addition of new properties to the `PanelContainerProps` and `PanelHeaderProps` interfaces, and the use of additional selectors in `NodeDetailsPanel`.

Interface changes:
* [`libs/designer-ui/src/lib/panel/panelcontainer.tsx`](diffhunk://#diff-e44f6b12c96ecc0e646b5ea7f2609188da7ab3066c4933c9cbd5bf0d65801f8eR49-R50): Added `canResubmit` and `resubmitOperation` properties to the `PanelContainerProps` interface.
* [`libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx`](diffhunk://#diff-5a1880da0b1bc21498495219375ceaa05eaf3d940a1a2d76ce22f2ab892d5379R41-R42): Added `canResubmit` and `resubmitOperation` properties to the `PanelHeaderProps` interface.

Component changes:
* [`libs/designer-ui/src/lib/panel/panelcontainer.tsx`](diffhunk://#diff-e44f6b12c96ecc0e646b5ea7f2609188da7ab3066c4933c9cbd5bf0d65801f8eR71-R72): Updated the `PanelContainer` component to use the new `canResubmit` and `resubmitOperation` properties. [[1]](diffhunk://#diff-e44f6b12c96ecc0e646b5ea7f2609188da7ab3066c4933c9cbd5bf0d65801f8eR71-R72) [[2]](diffhunk://#diff-e44f6b12c96ecc0e646b5ea7f2609188da7ab3066c4933c9cbd5bf0d65801f8eR106-R107) [[3]](diffhunk://#diff-e44f6b12c96ecc0e646b5ea7f2609188da7ab3066c4933c9cbd5bf0d65801f8eR129-R130)
* [`libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx`](diffhunk://#diff-5a1880da0b1bc21498495219375ceaa05eaf3d940a1a2d76ce22f2ab892d5379R69-R70): Updated the `PanelHeader` component to use the new `canResubmit` and `resubmitOperation` properties, and added a new button for resubmitting operations. [[1]](diffhunk://#diff-5a1880da0b1bc21498495219375ceaa05eaf3d940a1a2d76ce22f2ab892d5379R69-R70) [[2]](diffhunk://#diff-5a1880da0b1bc21498495219375ceaa05eaf3d940a1a2d76ce22f2ab892d5379R80-R83) [[3]](diffhunk://#diff-5a1880da0b1bc21498495219375ceaa05eaf3d940a1a2d76ce22f2ab892d5379R193-R201)

Updates to `NodeDetailsPanel`:
* [`libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx`](diffhunk://#diff-0146e9fd09d879c76bb0b259ff157302e2e1554a40b6a865e00ca46e5973534aL18-R24): Imported new selectors, added a callback for resubmitting workflows, and updated the `NodeDetailsPanel` component to use the new `canResubmit` and `resubmitOperation` properties. [[1]](diffhunk://#diff-0146e9fd09d879c76bb0b259ff157302e2e1554a40b6a865e00ca46e5973534aL18-R24) [[2]](diffhunk://#diff-0146e9fd09d879c76bb0b259ff157302e2e1554a40b6a865e00ca46e5973534aR43) [[3]](diffhunk://#diff-0146e9fd09d879c76bb0b259ff157302e2e1554a40b6a865e00ca46e5973534aR112-R119) [[4]](diffhunk://#diff-0146e9fd09d879c76bb0b259ff157302e2e1554a40b6a865e00ca46e5973534aR150-R151)

https://github.com/Azure/LogicAppsUX/assets/13208452/0748c97a-8ce9-4666-bb4e-9c128f20c2a2




