### PR TITLE
fix(Designer): Removed resolving app settings within connection parameters during initialization

### DIFF
--- a/apps/designer-standalone/src/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
+++ b/apps/designer-standalone/src/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
@@ -58,11 +58,7 @@ export class WorkflowUtility {
     return references;
   }
 
-  public static resolveConnectionsReferences(
-    content: string,
-    parameters: ParametersData | undefined,
-    appsettings?: Record<string, string> | undefined
-  ): any {
+  public static resolveConnectionsReferences(content: string, parameters: ParametersData | undefined): any {
     let result = content;
 
     if (parameters) {
@@ -70,14 +66,6 @@ export class WorkflowUtility {
         const parameterValue = parameters[parameterName].value !== undefined ? parameters[parameterName].value : '';
         result = replaceAllOccurrences(result, `@parameters('${parameterName}')`, parameterValue);
         result = replaceAllOccurrences(result, `@{parameters('${parameterName}')}`, parameterValue);
-      }
-    }
-
-    if (appsettings) {
-      for (const settingName of Object.keys(appsettings)) {
-        const settingValue = appsettings[settingName] !== undefined ? appsettings[settingName] : '';
-        result = replaceAllOccurrences(result, `@appsetting('${settingName}')`, settingValue);
-        result = replaceAllOccurrences(result, `@{appsetting('${settingName}')}`, settingValue);
       }
     }
 

--- a/apps/designer-standalone/src/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/designer-standalone/src/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -93,13 +93,8 @@ const DesignerEditor = () => {
   const { data: runInstanceData } = useRunInstanceStandard(workflowName, onRunInstanceSuccess, appId, runId);
 
   const connectionsData = useMemo(
-    () =>
-      WorkflowUtility.resolveConnectionsReferences(
-        JSON.stringify(clone(originalConnectionsData ?? {})),
-        parameters,
-        settingsData?.properties ?? {}
-      ),
-    [originalConnectionsData, parameters, settingsData?.properties]
+    () => WorkflowUtility.resolveConnectionsReferences(JSON.stringify(clone(originalConnectionsData ?? {})), parameters),
+    [originalConnectionsData, parameters]
   );
 
   const addConnectionData = async (connectionAndSetting: ConnectionAndAppSetting): Promise<void> => {
@@ -118,11 +113,7 @@ const DesignerEditor = () => {
 
     if (connectionInfo) {
       // TODO(psamband): Add new settings in this blade so that we do not resolve all the appsettings in the connectionInfo.
-      const resolvedConnectionInfo = WorkflowUtility.resolveConnectionsReferences(
-        JSON.stringify(connectionInfo),
-        {},
-        settingsData?.properties
-      );
+      const resolvedConnectionInfo = WorkflowUtility.resolveConnectionsReferences(JSON.stringify(connectionInfo), {});
       delete resolvedConnectionInfo.displayName;
 
       return {


### PR DESCRIPTION
## Main Changes

Removed resolving app settings within connection parameters during initialization.
Previously we treated app settings like we do workflow parameters, where we resolve them to get their actual values.
This caused issues when app settings held key-vault values, since we can't and shouldn't resolve key-vault values in Designer.

Currently, dynamic data requests made by sending the key-vault value doesn't get resolved and the request fails.
Now that we keep the app-setting values as-is, the request backend evaluates both the app-setting and the key-vault for us.

### Old
![image](https://github.com/Azure/LogicAppsUX/assets/25409734/78e22db1-dda4-4eb0-a3ac-e68c6ea52756)

### New
![image](https://github.com/Azure/LogicAppsUX/assets/25409734/3c4a47c2-5250-48db-849f-5f0e23ee0eee)
