### PR TITLE
fix(designer): Fix two places where `undefined` switch `cases` caused fatal errors

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -292,7 +292,7 @@ const processChildGraphAndItsInputs = (
   if (subGraphDetails) {
     for (const subGraphKey of Object.keys(subGraphDetails)) {
       const { inputs, inputsLocation, isAdditive } = subGraphDetails[subGraphKey];
-      const subOperation = getPropertyValue(operation, subGraphKey) || {};
+      const subOperation = getPropertyValue(operation, subGraphKey) ?? {};
       if (inputs) {
         const subManifest = { properties: { inputs, inputsLocation } } as any;
         if (isAdditive) {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -293,7 +293,7 @@ const processChildGraphAndItsInputs = (
     for (const subGraphKey of Object.keys(subGraphDetails)) {
       const { inputs, inputsLocation, isAdditive } = subGraphDetails[subGraphKey];
       const subOperation = getPropertyValue(operation, subGraphKey);
-      if (inputs) {
+      if (inputs && subOperation) {
         const subManifest = { properties: { inputs, inputsLocation } } as any;
         if (isAdditive) {
           for (const subNodeKey of Object.keys(subOperation)) {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -292,8 +292,8 @@ const processChildGraphAndItsInputs = (
   if (subGraphDetails) {
     for (const subGraphKey of Object.keys(subGraphDetails)) {
       const { inputs, inputsLocation, isAdditive } = subGraphDetails[subGraphKey];
-      const subOperation = getPropertyValue(operation, subGraphKey);
-      if (inputs && subOperation) {
+      const subOperation = getPropertyValue(operation, subGraphKey) || {};
+      if (inputs) {
         const subManifest = { properties: { inputs, inputsLocation } } as any;
         if (isAdditive) {
           for (const subNodeKey of Object.keys(subOperation)) {

--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -5,7 +5,7 @@ import type { NodesMetadata, WorkflowState } from '../state/workflow/workflowInt
 import { createWorkflowNode, createWorkflowEdge } from '../utils/graph';
 import type { WorkflowEdge, WorkflowNode } from './models/workflowNode';
 import { reassignEdgeSources, reassignEdgeTargets, addNewEdge, applyIsRootNode, removeEdge } from './restructuringHelpers';
-import type { DiscoveryOperation, DiscoveryResultTypes, SubgraphType } from '@microsoft/utils-logic-apps';
+import type { DiscoveryOperation, DiscoveryResultTypes, LogicAppsV2, SubgraphType } from '@microsoft/utils-logic-apps';
 import {
   removeIdTag,
   SUBGRAPH_TYPES,
@@ -203,7 +203,12 @@ export const addSwitchCaseToWorkflow = (caseId: string, switchNode: WorkflowNode
   addChildEdge(switchNode, createWorkflowEdge(`${switchNode.id}-#scope`, caseId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
 
   // Add Case to Switch operation data
-  (state.operations[switchNode.id] as any).cases[caseId] = { actions: {}, case: '' };
+  const switchAction = state.operations[switchNode.id] as LogicAppsV2.SwitchAction;
+  switchAction.cases = {
+    ...switchAction.cases,
+    [caseId]: { actions: {}, case: '' },
+  };
+
   // Increase action count of graph
   if (nodesMetadata[switchNode.id]) {
     nodesMetadata[switchNode.id].actionCount = nodesMetadata[switchNode.id].actionCount ?? 0 + 1;


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

If an empty switch block is loaded into designer, it will break the panel, and cannot have any cases added to it.

- **What is the new behavior (if this is a feature change)?**

Above are fixed and behave as expected.

Context: `subOperation` could be `undefined`, and so `Object.keys()` call would fail. Also, use of `any` prevented the `cases == undefined` case from being type-checked.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

**Before**

![switch-broken](https://github.com/Azure/LogicAppsUX/assets/1350074/36488339-4985-49e1-a03f-2b4095174d6c)

**After**

![switch-working](https://github.com/Azure/LogicAppsUX/assets/1350074/f8016fa4-21aa-46b1-8164-6c283a26c3c1)