### PR TITLE
feat(designer):  [ConnectionCreation] Adding hidden parameter field in ConnectionCreationInfo to pass selected credential id

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/_test__/createConnection.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/_test__/createConnection.spec.tsx
@@ -1,5 +1,5 @@
 import { MockHttpClient } from '../../../../../__test__/mock-http-client';
-import { CreateConnection, type CreateConnectionProps } from '../createConnection';
+import { CreateConnection, parseParameterValues, type CreateConnectionProps } from '../createConnection';
 import { UniversalConnectionParameter } from '../formInputs/universalConnectionParameter';
 import {
   InitConnectionParameterEditorService,
@@ -577,6 +577,35 @@ describe('ui/createConnection', () => {
 
       const mappingEditors = findParameterComponents(createConnection, CustomCredentialMappingEditor);
       expect(mappingEditors).toHaveLength(0);
+    });
+
+    test('parseParameterValues', () => {
+      const parameterValues: Record<string, any> = {
+        a: 'foobar',
+        b: 42,
+        c: null,
+        d: undefined,
+        e: { foo: 'bar' },
+        f: ['id', 66],
+      };
+      const capabilityEnabledParameters: Record<string, ConnectionParameter> = {
+        a: { type: 'connection' },
+        z: { type: 'other' },
+      };
+
+      const { visibleParameterValues, additionalParameterValues } = parseParameterValues(parameterValues, capabilityEnabledParameters);
+      expect(visibleParameterValues).toStrictEqual({ a: 'foobar' });
+      expect(additionalParameterValues).toStrictEqual({
+        b: 42,
+        c: null,
+        d: undefined,
+        e: { foo: 'bar' },
+        f: ['id', 66],
+      });
+
+      const emptyParameters = parseParameterValues({}, capabilityEnabledParameters);
+      expect(emptyParameters.visibleParameterValues).toStrictEqual({});
+      expect(emptyParameters.additionalParameterValues).toStrictEqual({});
     });
   });
 

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -302,12 +302,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
   const canSubmit = useMemo(() => !isLoading && validParams, [isLoading, validParams]);
 
   const submitCallback = useCallback(() => {
-    const visibleParameterValues = Object.fromEntries(
-      Object.entries(parameterValues).filter(([key]) => Object.keys(capabilityEnabledParameters).includes(key)) ?? []
-    );
-    const additionalParameterValues = Object.fromEntries(
-      Object.entries(parameterValues).filter(([key]) => !Object.keys(capabilityEnabledParameters).includes(key)) ?? []
-    );
+    const { visibleParameterValues, additionalParameterValues } = parseParameterValues(parameterValues, capabilityEnabledParameters);
 
     // This value needs to be passed conditionally but the parameter is hidden, so we're manually inputting it here
     if (
@@ -659,3 +654,17 @@ const isServicePrincipalParameterVisible = (key: string, parameter: any): boolea
   if (constraints?.hidden === 'true' || constraints?.hideInUI === 'true') return false;
   return true;
 };
+
+export function parseParameterValues(
+  parameterValues: Record<string, any>,
+  capabilityEnabledParameters: Record<string, ConnectionParameter | ConnectionParameterSetParameter>
+) {
+  const visibleParameterValues = Object.fromEntries(
+    Object.entries(parameterValues).filter(([key]) => Object.keys(capabilityEnabledParameters).includes(key)) ?? []
+  );
+  const additionalParameterValues = Object.fromEntries(
+    Object.entries(parameterValues).filter(([key]) => !Object.keys(capabilityEnabledParameters).includes(key)) ?? []
+  );
+
+  return { visibleParameterValues, additionalParameterValues };
+}

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -60,7 +60,8 @@ export interface CreateConnectionProps {
     parameterValues?: Record<string, any>,
     isOAuthConnection?: boolean,
     alternativeParameterValues?: Record<string, any>,
-    identitySelected?: string
+    identitySelected?: string,
+    additionalParameterValues?: Record<string, any>
   ) => void;
   cancelCallback?: () => void;
   hideCancelButton?: boolean;
@@ -304,6 +305,9 @@ export const CreateConnection = (props: CreateConnectionProps) => {
     const visibleParameterValues = Object.fromEntries(
       Object.entries(parameterValues).filter(([key]) => Object.keys(capabilityEnabledParameters).includes(key)) ?? []
     );
+    const additionalParameterValues = Object.fromEntries(
+      Object.entries(parameterValues).filter(([key]) => !Object.keys(capabilityEnabledParameters).includes(key)) ?? []
+    );
 
     // This value needs to be passed conditionally but the parameter is hidden, so we're manually inputting it here
     if (
@@ -326,7 +330,8 @@ export const CreateConnection = (props: CreateConnectionProps) => {
       visibleParameterValues,
       isUsingOAuth,
       alternativeParameterValues,
-      identitySelected
+      identitySelected,
+      additionalParameterValues
     );
   }, [
     parameterValues,

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
@@ -129,7 +129,8 @@ export const CreateConnectionWrapper = () => {
       parameterValues: Record<string, any> = {},
       isOAuthConnection?: boolean,
       alternativeParameterValues?: Record<string, any>,
-      identitySelected?: string
+      identitySelected?: string,
+      additionalParameterValues?: Record<string, any>
     ) => {
       if (!connector?.id) return;
 
@@ -188,6 +189,7 @@ export const CreateConnectionWrapper = () => {
             : undefined,
           connectionParameters: outputParameterValues,
           alternativeParameterValues,
+          additionalParameterValues,
         };
 
         const parametersMetadata: ConnectionParametersMetadata = {

--- a/libs/services/designer-client-services/src/lib/connection.ts
+++ b/libs/services/designer-client-services/src/lib/connection.ts
@@ -21,6 +21,7 @@ export interface ConnectionCreationInfo {
   displayName?: string;
   parameterName?: string;
   appSettings?: Record<string, string>;
+  additionalParameterValues?: Record<string, string>;
 }
 
 export interface ConnectionParametersMetadata {

--- a/libs/services/designer-client-services/src/lib/standard/connection.ts
+++ b/libs/services/designer-client-services/src/lib/standard/connection.ts
@@ -48,6 +48,7 @@ interface ServiceProviderConnectionModel {
   };
   parameterSetName?: string;
   displayName?: string;
+  additionalParameterValues?: Record<string, string>;
 }
 
 interface FunctionsConnectionModel {
@@ -605,6 +606,7 @@ function convertToServiceProviderConnectionsData(
     displayName,
     connectionParameters: connectionParameterValues,
     connectionParametersSet: connectionParametersSetValues,
+    additionalParameterValues,
   } = connectionInfo;
   const connectionParameters = connectionParametersSetValues
     ? connectionParameterMetadata.connectionParameterSet?.parameters
@@ -626,6 +628,7 @@ function convertToServiceProviderConnectionsData(
       ...optional('parameterSetName', connectionParametersSetValues?.name),
       serviceProvider: { id: connectorId },
       displayName,
+      ...optional('additionalParameterValues', additionalParameterValues),
     },
     settings: connectionInfo.appSettings ?? {},
     pathLocation: [serviceProviderLocation],


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
Following the update of the connection creation API in [this PR](https://msazure.visualstudio.com/One/_git/PowerApps-PowerApps-RP/pullrequest/9399971), it is now possible to pass a credential id in the call.
This PR updates the `ConnectionCreationInfo` contract to pass additional properties.
This field will be leverage in the caller to read the selected credential id, when used.

This update will be used in the Power Automate portal to create a connection with the passed credential id (in [this PR](https://msazure.visualstudio.com/OneAgile/_git/power-platform-ux/pullrequest/9531232))


* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?**
The `ConnectionCreation` component is passing a `setParameterValues` callback to the credential mapping sub component.
Some of the fields that are set through that callback are used to craft the connection info, but the others are lost.
Here, we are passing all the "other" fields as an additional parameter.

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** 
No

- **Please Include Screenshots or Videos of the intended change**:
