### PR TITLE
fix(designer-ui): Retain tokens inserted into HTML editor if they contain `}`

### DIFF
--- a/libs/designer-ui/src/lib/arrayeditor/util/serializecollapsedarray.ts
+++ b/libs/designer-ui/src/lib/arrayeditor/util/serializecollapsedarray.ts
@@ -74,8 +74,8 @@ export const parseSimpleItems = (
     const stringValueCasted = prettifyJsonString(convertSegmentsToString(castedArraySegments, nodeMap));
     const stringValueUncasted = prettifyJsonString(convertSegmentsToString(uncastedArraySegments, nodeMap));
     return {
-      castedValue: convertStringToSegments(stringValueCasted, /*tokensEnabled*/ false, nodeMap),
-      uncastedValue: convertStringToSegments(stringValueUncasted, /*tokensEnabled*/ true, nodeMap),
+      castedValue: convertStringToSegments(stringValueCasted, nodeMap, { tokensEnabled: false }),
+      uncastedValue: convertStringToSegments(stringValueUncasted, nodeMap, { tokensEnabled: true }),
     };
   } catch (e) {
     return { uncastedValue: uncastedArraySegments, castedValue: castedArraySegments };
@@ -102,7 +102,7 @@ export const parseComplexItems = (
     uncastedArrayVal.push(convertComplexItemsToArray(itemSchema, items, nodeMap, /*suppress casting*/ true, castParameter));
   });
   return {
-    castedValue: convertStringToSegments(JSON.stringify(castedArrayVal, null, 4), /*tokensEnabled*/ false, nodeMap),
-    uncastedValue: convertStringToSegments(JSON.stringify(uncastedArrayVal, null, 4), /*tokensEnabled*/ true, nodeMap),
+    castedValue: convertStringToSegments(JSON.stringify(castedArrayVal, null, 4), nodeMap, { tokensEnabled: false }),
+    uncastedValue: convertStringToSegments(JSON.stringify(uncastedArrayVal, null, 4), nodeMap, { tokensEnabled: true }),
   };
 };

--- a/libs/designer-ui/src/lib/arrayeditor/util/util.ts
+++ b/libs/designer-ui/src/lib/arrayeditor/util/util.ts
@@ -159,8 +159,8 @@ export const validationAndSerializeSimpleArray = (
         returnItems.push({
           value: convertStringToSegments(
             valueType === constants.SWAGGER.TYPE.STRING ? (value as string) : JSON.stringify(value, null, 4),
-            /*tokensEnabled*/ true,
-            nodeMap
+            nodeMap,
+            { tokensEnabled: true }
           ),
           key: guid(),
         });
@@ -232,7 +232,7 @@ const convertObjectToComplexArrayItemArray = (
         key: itemSchema.key,
         title: handleTitle(itemSchema.key, itemSchema.title),
         description: itemSchema.description ?? '',
-        value: convertStringToSegments(obj, /*tokensEnabled*/ true, nodeMap),
+        value: convertStringToSegments(obj, nodeMap, { tokensEnabled: true }),
       },
     ];
   }
@@ -267,7 +267,7 @@ const convertObjectToComplexArrayItemArray = (
         key: itemSchemaProperty.key,
         title: handleTitle(itemSchema.key, itemSchemaProperty.title),
         description: itemSchemaProperty.description ?? '',
-        value: convertStringToSegments(value, true, nodeMap),
+        value: convertStringToSegments(value, nodeMap, { tokensEnabled: true }),
       });
     }
   });

--- a/libs/designer-ui/src/lib/authentication/util.ts
+++ b/libs/designer-ui/src/lib/authentication/util.ts
@@ -364,7 +364,7 @@ export const serializeAuthentication = (
   editorString: string,
   setCurrentProps: (items: AuthProps) => void,
   setOption: (s: AuthenticationType) => void,
-  nodeMap?: Map<string, ValueSegment>
+  nodeMap: Map<string, ValueSegment>
 ): boolean => {
   let jsonEditor = Object.create(null);
   try {
@@ -376,44 +376,44 @@ export const serializeAuthentication = (
   switch (jsonEditor.type) {
     case AuthenticationType.BASIC:
       returnItems.basic = {
-        basicUsername: convertStringToSegments(jsonEditor.username, true, nodeMap),
-        basicPassword: convertStringToSegments(jsonEditor.password, true, nodeMap),
+        basicUsername: convertStringToSegments(jsonEditor.username, nodeMap, { tokensEnabled: true }),
+        basicPassword: convertStringToSegments(jsonEditor.password, nodeMap, { tokensEnabled: true }),
       };
       break;
     case AuthenticationType.CERTIFICATE:
       returnItems.clientCertificate = {
-        clientCertificatePfx: convertStringToSegments(jsonEditor.pfx, true, nodeMap),
-        clientCertificatePassword: convertStringToSegments(jsonEditor.password, true, nodeMap),
+        clientCertificatePfx: convertStringToSegments(jsonEditor.pfx, nodeMap, { tokensEnabled: true }),
+        clientCertificatePassword: convertStringToSegments(jsonEditor.password, nodeMap, { tokensEnabled: true }),
       };
       break;
     case AuthenticationType.RAW:
       returnItems.raw = {
-        rawValue: convertStringToSegments(jsonEditor.value, true, nodeMap),
+        rawValue: convertStringToSegments(jsonEditor.value, nodeMap, { tokensEnabled: true }),
       };
       break;
     case AuthenticationType.MSI:
       returnItems.msi = {
         msiIdentity: jsonEditor.identity,
-        msiAudience: convertStringToSegments(jsonEditor.audience, true, nodeMap),
+        msiAudience: convertStringToSegments(jsonEditor.audience, nodeMap, { tokensEnabled: true }),
       };
       break;
     case AuthenticationType.OAUTH:
       returnItems.aadOAuth = {
-        oauthTenant: convertStringToSegments(jsonEditor.tenant, true, nodeMap),
-        oauthAudience: convertStringToSegments(jsonEditor.audience, true, nodeMap),
-        oauthClientId: convertStringToSegments(jsonEditor.clientId, true, nodeMap),
+        oauthTenant: convertStringToSegments(jsonEditor.tenant, nodeMap, { tokensEnabled: true }),
+        oauthAudience: convertStringToSegments(jsonEditor.audience, nodeMap, { tokensEnabled: true }),
+        oauthClientId: convertStringToSegments(jsonEditor.clientId, nodeMap, { tokensEnabled: true }),
       };
       if (jsonEditor.authority) {
-        returnItems.aadOAuth.oauthAuthority = convertStringToSegments(jsonEditor.authority, true, nodeMap);
+        returnItems.aadOAuth.oauthAuthority = convertStringToSegments(jsonEditor.authority, nodeMap, { tokensEnabled: true });
       }
       if (jsonEditor.secret) {
         returnItems.aadOAuth.oauthType = AuthenticationOAuthType.SECRET;
-        returnItems.aadOAuth.oauthTypeSecret = convertStringToSegments(jsonEditor.secret, true, nodeMap);
+        returnItems.aadOAuth.oauthTypeSecret = convertStringToSegments(jsonEditor.secret, nodeMap, { tokensEnabled: true });
       }
       if (jsonEditor.pfx && jsonEditor.password) {
         returnItems.aadOAuth.oauthType = AuthenticationOAuthType.CERTIFICATE;
-        returnItems.aadOAuth.oauthTypeCertificatePfx = convertStringToSegments(jsonEditor.pfx, true, nodeMap);
-        returnItems.aadOAuth.oauthTypeCertificatePassword = convertStringToSegments(jsonEditor.password, true, nodeMap);
+        returnItems.aadOAuth.oauthTypeCertificatePfx = convertStringToSegments(jsonEditor.pfx, nodeMap, { tokensEnabled: true });
+        returnItems.aadOAuth.oauthTypeCertificatePassword = convertStringToSegments(jsonEditor.password, nodeMap, { tokensEnabled: true });
       }
       break;
     default:

--- a/libs/designer-ui/src/lib/dictionary/util/serializecollapseddictionary.ts
+++ b/libs/designer-ui/src/lib/dictionary/util/serializecollapseddictionary.ts
@@ -27,8 +27,8 @@ export const serializeDictionary = (
         const newValue = valueType === constants.SWAGGER.TYPE.STRING ? (value as string) : removeQuotes(JSON.stringify(value));
         returnItems.push({
           id: guid(),
-          key: convertStringToSegments(newKey, true, nodeMap),
-          value: convertStringToSegments(newValue, true, nodeMap),
+          key: convertStringToSegments(newKey, nodeMap, { tokensEnabled: true }),
+          value: convertStringToSegments(newValue, nodeMap, { tokensEnabled: true }),
         });
       }
       setItems(returnItems);

--- a/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
@@ -57,12 +57,14 @@ describe('lib/editor/base/utils/editorToSegment', () => {
       const input = `Text before @{variables('abc'} text after`;
 
       const segments = convertStringToSegments(input, nodeMap);
-      const simplifiedSegments = segments.map((segment): SimplifiedValueSegment => ({
-        // Remove IDs for easier comparison.
-        token: segment.token,
-        type: segment.type,
-        value: segment.value,
-      }));
+      const simplifiedSegments = segments.map(
+        (segment): SimplifiedValueSegment => ({
+          // Remove IDs for easier comparison.
+          token: segment.token,
+          type: segment.type,
+          value: segment.value,
+        })
+      );
 
       expect(simplifiedSegments).toEqual([{ type: ValueSegmentType.LITERAL, value: input }]);
     });
@@ -70,40 +72,78 @@ describe('lib/editor/base/utils/editorToSegment', () => {
     it.each<[string, SimplifiedValueSegment[]]>([
       ['plain text', [{ type: ValueSegmentType.LITERAL, value: 'plain text' }]],
       ['@{no closing brace', [{ type: ValueSegmentType.LITERAL, value: '@{no closing brace' }]],
-      [`Text before @{variables('abc')} text after`, [{ type: ValueSegmentType.LITERAL, value: 'Text before ' }, initializeVariableToken, { type: ValueSegmentType.LITERAL, value: ' text after' }]],
-      [`Text before @{body('Create_new_folder')?['{Link}']} text after`, [{ type: ValueSegmentType.LITERAL, value: 'Text before ' }, createNewFolderToken, { type: ValueSegmentType.LITERAL, value: ' text after' }]],
-      [`t1 @{not a token t2 @{variables('abc')} t3`, [{ type: ValueSegmentType.LITERAL, value: 't1 @{not a token t2 ' }, initializeVariableToken, { type: ValueSegmentType.LITERAL, value: ' t3' }]],
-      [`t1 @{not a token} t2 @{variables('abc')} t3`, [{ type: ValueSegmentType.LITERAL, value: 't1 @{not a token} t2 ' }, initializeVariableToken, { type: ValueSegmentType.LITERAL, value: ' t3' }]],
+      [
+        `Text before @{variables('abc')} text after`,
+        [
+          { type: ValueSegmentType.LITERAL, value: 'Text before ' },
+          initializeVariableToken,
+          { type: ValueSegmentType.LITERAL, value: ' text after' },
+        ],
+      ],
+      [
+        `Text before @{body('Create_new_folder')?['{Link}']} text after`,
+        [
+          { type: ValueSegmentType.LITERAL, value: 'Text before ' },
+          createNewFolderToken,
+          { type: ValueSegmentType.LITERAL, value: ' text after' },
+        ],
+      ],
+      [
+        `t1 @{not a token t2 @{variables('abc')} t3`,
+        [
+          { type: ValueSegmentType.LITERAL, value: 't1 @{not a token t2 ' },
+          initializeVariableToken,
+          { type: ValueSegmentType.LITERAL, value: ' t3' },
+        ],
+      ],
+      [
+        `t1 @{not a token} t2 @{variables('abc')} t3`,
+        [
+          { type: ValueSegmentType.LITERAL, value: 't1 @{not a token} t2 ' },
+          initializeVariableToken,
+          { type: ValueSegmentType.LITERAL, value: ' t3' },
+        ],
+      ],
     ])('parses segments out of %p with appropriate node map', (input, expectedTokens) => {
       const nodeMap = new Map<string, ValueSegment>();
       nodeMap.set(`@{variables('abc')}`, { id: '', ...initializeVariableToken });
       nodeMap.set(`@{body('Create_new_folder')?['{Link}']}`, { id: '', ...createNewFolderToken });
 
       const segments = convertStringToSegments(input, nodeMap, { tokensEnabled: true });
-      const simplifiedSegments = segments.map((segment): SimplifiedValueSegment => ({
-        // Remove IDs for easier comparison.
-        token: segment.token,
-        type: segment.type,
-        value: segment.value,
-      }));
+      const simplifiedSegments = segments.map(
+        (segment): SimplifiedValueSegment => ({
+          // Remove IDs for easier comparison.
+          token: segment.token,
+          type: segment.type,
+          value: segment.value,
+        })
+      );
 
       expect(simplifiedSegments).toEqual(expectedTokens);
     });
 
     it.each<[string, SimplifiedValueSegment[]]>([
       ['plain text', [{ type: ValueSegmentType.LITERAL, value: 'plain text' }]],
-      [`Text before @{variables('abc')} text after`, [{ type: ValueSegmentType.LITERAL, value: `Text before @{variables('abc')} text after` }]],
-      [`Text before @{body('Create_new_folder')?['{Link}']} text after`, [{ type: ValueSegmentType.LITERAL, value: `Text before @{body('Create_new_folder')?['{Link}']} text after` }]],
+      [
+        `Text before @{variables('abc')} text after`,
+        [{ type: ValueSegmentType.LITERAL, value: `Text before @{variables('abc')} text after` }],
+      ],
+      [
+        `Text before @{body('Create_new_folder')?['{Link}']} text after`,
+        [{ type: ValueSegmentType.LITERAL, value: `Text before @{body('Create_new_folder')?['{Link}']} text after` }],
+      ],
     ])('parses segments out of %p with an empty node map', (input, expectedTokens) => {
       const nodeMap = new Map<string, ValueSegment>();
 
       const segments = convertStringToSegments(input, nodeMap, { tokensEnabled: true });
-      const simplifiedSegments = segments.map((segment): SimplifiedValueSegment => ({
-        // Remove IDs for easier comparison.
-        token: segment.token,
-        type: segment.type,
-        value: segment.value,
-      }));
+      const simplifiedSegments = segments.map(
+        (segment): SimplifiedValueSegment => ({
+          // Remove IDs for easier comparison.
+          token: segment.token,
+          type: segment.type,
+          value: segment.value,
+        })
+      );
 
       expect(simplifiedSegments).toEqual(expectedTokens);
     });

--- a/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
@@ -91,6 +91,14 @@ describe('lib/editor/base/utils/editorToSegment', () => {
         ],
       ],
       [
+        `Text quoted '@{variables('abc')}'`,
+        [
+          { type: ValueSegmentType.LITERAL, value: `Text quoted '` },
+          getInitializeVariableAbcToken(),
+          { type: ValueSegmentType.LITERAL, value: `'` },
+        ],
+      ],
+      [
         `Text before @{body('Create_new_folder')?['{Link}']} text after`,
         [
           { type: ValueSegmentType.LITERAL, value: 'Text before ' },

--- a/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
@@ -69,8 +69,11 @@ describe('lib/editor/base/utils/editorToSegment', () => {
 
     it.each<[string, SimplifiedValueSegment[]]>([
       ['plain text', [{ type: ValueSegmentType.LITERAL, value: 'plain text' }]],
+      ['@{no closing brace', [{ type: ValueSegmentType.LITERAL, value: '@{no closing brace' }]],
       [`Text before @{variables('abc')} text after`, [{ type: ValueSegmentType.LITERAL, value: 'Text before ' }, initializeVariableToken, { type: ValueSegmentType.LITERAL, value: ' text after' }]],
-      // [`Text before @{body('Create_new_folder')?['{Link}']} text after`, [{ type: ValueSegmentType.LITERAL, value: 'Text before ' }, createNewFolderToken, { type: ValueSegmentType.LITERAL, value: ' text after' }]],
+      [`Text before @{body('Create_new_folder')?['{Link}']} text after`, [{ type: ValueSegmentType.LITERAL, value: 'Text before ' }, createNewFolderToken, { type: ValueSegmentType.LITERAL, value: ' text after' }]],
+      [`t1 @{not a token t2 @{variables('abc')} t3`, [{ type: ValueSegmentType.LITERAL, value: 't1 @{not a token t2 ' }, initializeVariableToken, { type: ValueSegmentType.LITERAL, value: ' t3' }]],
+      [`t1 @{not a token} t2 @{variables('abc')} t3`, [{ type: ValueSegmentType.LITERAL, value: 't1 @{not a token} t2 ' }, initializeVariableToken, { type: ValueSegmentType.LITERAL, value: ' t3' }]],
     ])('parses segments out of %p with appropriate node map', (input, expectedTokens) => {
       const nodeMap = new Map<string, ValueSegment>();
       nodeMap.set(`@{variables('abc')}`, { id: '', ...initializeVariableToken });
@@ -89,8 +92,8 @@ describe('lib/editor/base/utils/editorToSegment', () => {
 
     it.each<[string, SimplifiedValueSegment[]]>([
       ['plain text', [{ type: ValueSegmentType.LITERAL, value: 'plain text' }]],
-      [`Text before @{variables('abc')} text after`, [{ type: ValueSegmentType.LITERAL, value: 'Text before ' }, { type: ValueSegmentType.LITERAL, value: ' text after' }]],
-      // [`Text before @{body('Create_new_folder')?['{Link}']} text after`, [{ type: ValueSegmentType.LITERAL, value: 'Text before ' }, createNewFolderToken, { type: ValueSegmentType.LITERAL, value: ' text after' }]],
+      [`Text before @{variables('abc')} text after`, [{ type: ValueSegmentType.LITERAL, value: `Text before @{variables('abc')} text after` }]],
+      [`Text before @{body('Create_new_folder')?['{Link}']} text after`, [{ type: ValueSegmentType.LITERAL, value: `Text before @{body('Create_new_folder')?['{Link}']} text after` }]],
     ])('parses segments out of %p with an empty node map', (input, expectedTokens) => {
       const nodeMap = new Map<string, ValueSegment>();
 

--- a/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
@@ -1,0 +1,90 @@
+import { ValueSegmentType } from '../../../models/parameter';
+import { convertStringToSegments } from '../editorToSegment';
+import type { ValueSegment } from '@microsoft/designer-client-services-logic-apps';
+
+type SimplifiedValueSegment = Omit<ValueSegment, 'id'>;
+
+describe('lib/editor/base/utils/editorToSegment', () => {
+  describe('convertStringToSegments', () => {
+    const initializeVariableToken: SimplifiedValueSegment = {
+      type: 'token',
+      token: {
+        key: 'variables:abc',
+        name: 'abc',
+        type: 'string',
+        title: 'abc',
+        brandColor: '#770BD6',
+        icon: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzJweCIgaGVpZ2h0PSIzMnB4IiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAzMiAzMiIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+DQogPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiBmaWxsPSIjNzcwQkQ2Ii8+DQogPGcgZmlsbD0iI2ZmZiI+DQogIDxwYXRoIGQ9Ik02Ljc2MywxMy42ODV2LTMuMjA4QzYuNzYzLDguNzQ4LDcuNzYyLDgsMTAsOHYxLjA3Yy0xLDAtMiwwLjMyNS0yLDEuNDA3djMuMTg4ICAgIEM4LDE0LjgzNiw2LjUxMiwxNiw1LjUxMiwxNkM2LjUxMiwxNiw4LDE3LjE2NCw4LDE4LjMzNVYyMS41YzAsMS4wODIsMSwxLjQyOSwyLDEuNDI5VjI0Yy0yLjIzOCwwLTMuMjM4LTAuNzcyLTMuMjM4LTIuNXYtMy4xNjUgICAgYzAtMS4xNDktMC44OTMtMS41MjktMS43NjMtMS41ODV2LTEuNUM1Ljg3LDE1LjE5NCw2Ljc2MywxNC44MzQsNi43NjMsMTMuNjg1eiIvPg0KICA8cGF0aCBkPSJtMjUuMjM4IDEzLjY4NXYtMy4yMDhjMC0xLjcyOS0xLTIuNDc3LTMuMjM4LTIuNDc3djEuMDdjMSAwIDIgMC4zMjUgMiAxLjQwN3YzLjE4OGMwIDEuMTcxIDEuNDg4IDIuMzM1IDIuNDg4IDIuMzM1LTEgMC0yLjQ4OCAxLjE2NC0yLjQ4OCAyLjMzNXYzLjE2NWMwIDEuMDgyLTEgMS40MjktMiAxLjQyOXYxLjA3MWMyLjIzOCAwIDMuMjM4LTAuNzcyIDMuMjM4LTIuNXYtMy4xNjVjMC0xLjE0OSAwLjg5My0xLjUyOSAxLjc2Mi0xLjU4NXYtMS41Yy0wLjg3LTAuMDU2LTEuNzYyLTAuNDE2LTEuNzYyLTEuNTY1eiIvPg0KICA8cGF0aCBkPSJtMTUuODE1IDE2LjUxMmwtMC4yNDItMC42NDFjLTAuMTc3LTAuNDUzLTAuMjczLTAuNjk4LTAuMjg5LTAuNzM0bC0wLjM3NS0wLjgzNmMtMC4yNjYtMC41OTktMC41MjEtMC44OTgtMC43NjYtMC44OTgtMC4zNyAwLTAuNjYyIDAuMzQ3LTAuODc1IDEuMDM5LTAuMTU2LTAuMDU3LTAuMjM0LTAuMTQxLTAuMjM0LTAuMjUgMC0wLjMyMyAwLjE4OC0wLjY5MiAwLjU2Mi0xLjEwOSAwLjM3NS0wLjQxNyAwLjcxLTAuNjI1IDEuMDA3LTAuNjI1IDAuNTgzIDAgMS4xODYgMC44MzkgMS44MTEgMi41MTZsMC4xNjEgMC40MTQgMC4xOC0wLjI4OWMxLjEwOC0xLjc2IDIuMDQ0LTIuNjQxIDIuODA0LTIuNjQxIDAuMTk4IDAgMC40MyAwLjA1OCAwLjY5NSAwLjE3MmwtMC45NDYgMC45OTJjLTAuMTI1LTAuMDM2LTAuMjE0LTAuMDU1LTAuMjY2LTAuMDU1LTAuNTczIDAtMS4yNTYgMC42NTktMi4wNDggMS45NzdsLTAuMjI3IDAuMzc5IDAuMTc5IDAuNDhjMC42ODQgMS44OTEgMS4yNDkgMi44MzYgMS42OTQgMi44MzYgMC40MDggMCAwLjcyLTAuMjkyIDAuOTM1LTAuODc1IDAuMTQ2IDAuMDk0IDAuMjE5IDAuMTkgMC4yMTkgMC4yODkgMCAwLjI2MS0wLjIwOCAwLjU3My0wLjYyNSAwLjkzOHMtMC43NzYgMC41NDctMS4wNzggMC41NDdjLTAuNjA0IDAtMS4yMjEtMC44NTItMS44NTEtMi41NTVsLTAuMjE5LTAuNTc4LTAuMjI3IDAuMzk4Yy0xLjA2MiAxLjgyMy0yLjA3OCAyLjczNC0zLjA0NyAyLjczNC0wLjM2NSAwLTAuNjc1LTAuMDkxLTAuOTMtMC4yNzFsMC45MDYtMC44ODVjMC4xNTYgMC4xNTYgMC4zMzggMC4yMzQgMC41NDcgMC4yMzQgMC41ODggMCAxLjI1LTAuNTk2IDEuOTg0LTEuNzg2bDAuNDA2LTAuNjU4IDAuMTU1LTAuMjU5eiIvPg0KICA8ZWxsaXBzZSB0cmFuc2Zvcm09Im1hdHJpeCguMDUzNiAtLjk5ODYgLjk5ODYgLjA1MzYgNS40OTI1IDMyLjI0NSkiIGN4PSIxOS43NTciIGN5PSIxMy4yMjUiIHJ4PSIuNzc4IiByeT0iLjc3OCIvPg0KICA8ZWxsaXBzZSB0cmFuc2Zvcm09Im1hdHJpeCguMDUzNiAtLjk5ODYgLjk5ODYgLjA1MzYgLTcuNTgzOSAzMC42MjkpIiBjeD0iMTIuMzY2IiBjeT0iMTkuMzE1IiByeD0iLjc3OCIgcnk9Ii43NzgiLz4NCiA8L2c+DQo8L3N2Zz4NCg==',
+        tokenType: 'variable',
+        value: "variables('abc')",
+      },
+      value: "variables('abc')",
+    };
+    const createNewFolderToken: SimplifiedValueSegment = {
+      type: 'token',
+      token: {
+        key: 'body.$.{Link}',
+        name: '{Link}',
+        type: 'string',
+        title: 'Link to item',
+        brandColor: '#036C70',
+        icon: 'https://connectoricons-prod.azureedge.net/releases/v1.0.1676/1.0.1676.3617/sharepointonline/icon.png',
+        description:
+          'Link that can be used to get to the file or list item. Only people with permissions to the item will be able to open the link.',
+        tokenType: 'outputs',
+        actionName: 'Create_new_folder',
+        required: false,
+        isSecure: false,
+        source: 'body',
+        schema: {
+          title: 'Link to item',
+          description:
+            'Link that can be used to get to the file or list item. Only people with permissions to the item will be able to open the link.',
+          type: 'string',
+          'x-ms-permission': 'read-only',
+          'x-ms-sort': 'none',
+        },
+        value: "body('Create_new_folder')?['{Link}']",
+      },
+      value: "body('Create_new_folder')?['{Link}']",
+    };
+
+    it('does not parse tokens if tokensEnabled=false', () => {
+      const nodeMap = new Map<string, ValueSegment>();
+      nodeMap.set(`@{variables('abc')}`, { id: '', ...initializeVariableToken });
+      nodeMap.set(`@{body('Create_new_folder')?['{Link}']}`, { id: '', ...createNewFolderToken });
+
+      const input = `Text before @{variables('abc'} text after`;
+
+      const segments = convertStringToSegments(input, false, nodeMap);
+      const simplifiedSegments = segments.map((segment): SimplifiedValueSegment => ({
+        // Remove IDs for easier comparison.
+        token: segment.token,
+        type: segment.type,
+        value: segment.value,
+      }));
+
+      expect(simplifiedSegments).toEqual([{ type: ValueSegmentType.LITERAL, value: input }]);
+    });
+
+    it.each<[string, SimplifiedValueSegment[]]>([
+      ['plain text', [{ type: ValueSegmentType.LITERAL, value: 'plain text' }]],
+      [`Text before @{variables('abc')} text after`, [{ type: ValueSegmentType.LITERAL, value: 'Text before ' }, initializeVariableToken, { type: ValueSegmentType.LITERAL, value: ' text after' }]],
+      // [`Text before @{body('Create_new_folder')?['{Link}']} text after`, [{ type: ValueSegmentType.LITERAL, value: 'Text before ' }, createNewFolderToken, { type: ValueSegmentType.LITERAL, value: ' text after' }]],
+    ])('parses tokens out of %p', (input, expectedTokens) => {
+      const nodeMap = new Map<string, ValueSegment>();
+      nodeMap.set(`@{variables('abc')}`, { id: '', ...initializeVariableToken });
+      nodeMap.set(`@{body('Create_new_folder')?['{Link}']}`, { id: '', ...createNewFolderToken });
+
+      const segments = convertStringToSegments(input, true, nodeMap);
+      const simplifiedSegments = segments.map((segment): SimplifiedValueSegment => ({
+        // Remove IDs for easier comparison.
+        token: segment.token,
+        type: segment.type,
+        value: segment.value,
+      }));
+
+      expect(simplifiedSegments).toEqual(expectedTokens);
+    });
+  });
+});

--- a/libs/designer-ui/src/lib/editor/base/utils/editorToSegment.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/editorToSegment.ts
@@ -34,11 +34,36 @@ const getChildrenNodesToSegments = (node: ElementNode, segments: ValueSegment[],
 
 export const convertStringToSegments = (value: string, tokensEnabled?: boolean, nodeMap?: Map<string, ValueSegment>): ValueSegment[] => {
   if (!value) return [];
-  if (typeof value !== 'string') return [{ id: guid(), type: ValueSegmentType.LITERAL, value }];
+  if (typeof value !== 'string' || !tokensEnabled) {
+    return [{ id: guid(), type: ValueSegmentType.LITERAL, value }];
+  }
+
+  const returnSegments: ValueSegment[] = [];
+
   let currIndex = 0;
   let prevIndex = 0;
-  const returnSegments: ValueSegment[] = [];
+  // let currSegmentType: ValueSegmentType = ValueSegmentType.LITERAL;
+  // let segmentSoFar = '';
+
   while (currIndex < value.length) {
+    /*
+    const currChar = value[currIndex];
+    const nextChar = value[currIndex + 1];
+
+    if (currChar === '@' && nextChar === '{') {
+      if (segmentSoFar) {
+        returnSegments.push({ id: guid(), type: ValueSegmentType.LITERAL, value: segmentSoFar });
+        segmentSoFar = '';
+      }
+      currSegmentType = ValueSegmentType.TOKEN;
+    } else if (currChar === '}' && currSegmentType === ValueSegmentType.TOKEN) {
+
+    }
+
+    segmentSoFar += currChar;
+    currIndex++;
+    */
+
     if (value.substring(currIndex - 2, currIndex) === '@{' && tokensEnabled) {
       if (value.substring(prevIndex, currIndex - 2)) {
         returnSegments.push({ id: guid(), type: ValueSegmentType.LITERAL, value: value.substring(prevIndex, currIndex - 2) });

--- a/libs/designer-ui/src/lib/editor/base/utils/editorToSegment.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/editorToSegment.ts
@@ -59,7 +59,8 @@ export const convertStringToSegments = (
     if (currChar === `'`) {
       if (isInQuotedString) {
         isInQuotedString = false;
-      } else {
+      } else if (currSegmentType === ValueSegmentType.TOKEN) {
+        // Quoted strings should only be handled inside `@{}` contexts.
         isInQuotedString = true;
       }
     }

--- a/libs/designer-ui/src/lib/editor/base/utils/editorToSegment.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/editorToSegment.ts
@@ -4,6 +4,7 @@ import { $isTokenNode } from '../nodes/tokenNode';
 import { guid } from '@microsoft/utils-logic-apps';
 import type { EditorState, ElementNode } from 'lexical';
 import { $getNodeByKey, $getRoot, $isElementNode, $isLineBreakNode, $isTextNode } from 'lexical';
+import type { SegmentParserOptions } from './parsesegments';
 
 export function serializeEditorState(editorState: EditorState, trimLiteral = false): ValueSegment[] {
   const segments: ValueSegment[] = [];
@@ -32,8 +33,11 @@ const getChildrenNodesToSegments = (node: ElementNode, segments: ValueSegment[],
   });
 };
 
-export const convertStringToSegments = (value: string, tokensEnabled?: boolean, nodeMap?: Map<string, ValueSegment>): ValueSegment[] => {
+export const convertStringToSegments = (value: string, nodeMap: Map<string, ValueSegment>, options?: SegmentParserOptions): ValueSegment[] => {
   if (!value) return [];
+
+  const { tokensEnabled } = options ?? {};
+
   if (typeof value !== 'string' || !tokensEnabled) {
     return [{ id: guid(), type: ValueSegmentType.LITERAL, value }];
   }

--- a/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/parsesegments.ts
@@ -171,33 +171,15 @@ const appendStringSegment = (
   options: SegmentParserOptions | undefined
 ) => {
   const { tokensEnabled } = options ?? {};
-  let currIndex = 0;
-  let prevIndex = 0;
-  while (currIndex < value.length) {
-    if (value.substring(currIndex - 2, currIndex) === '@{') {
-      const textSegment = value.substring(prevIndex, currIndex - 2);
-      if (textSegment) {
-        paragraph.append($createExtendedTextNode(textSegment, childNodeStyles, childNodeFormat));
-      }
-      const endIndex = value.indexOf('}', currIndex);
-      if (endIndex < 0) {
-        currIndex++;
-        continue;
-      }
-      const newIndex = endIndex + 2;
-      // token is found in the text
-      if (nodeMap && tokensEnabled) {
-        const tokenSegment = nodeMap.get(value.substring(currIndex - 2, newIndex));
-        const token = createTokenNodeFromSegment(tokenSegment, options, nodeMap);
-        token && paragraph.append(token);
-      }
-      prevIndex = currIndex = newIndex;
+  const segments = convertStringToSegments(value, tokensEnabled, nodeMap);
+
+  for (const segment of segments) {
+    if (segment.type === ValueSegmentType.LITERAL) {
+      paragraph.append($createExtendedTextNode(segment.value, childNodeStyles, childNodeFormat));
+    } else if (segment.type === ValueSegmentType.TOKEN) {
+      const token = createTokenNodeFromSegment(segment, options, nodeMap);
+      token && paragraph.append(token);
     }
-    currIndex++;
-  }
-  const textSegment = value.substring(prevIndex, currIndex);
-  if (textSegment) {
-    paragraph.append($createExtendedTextNode(textSegment, childNodeStyles, childNodeFormat));
   }
 };
 

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
@@ -114,7 +114,7 @@ export const convertEditorState = (
           return match;
         }
       });
-      const valueSegments: ValueSegment[] = convertStringToSegments(noTokenSpansString, true, nodeMap);
+      const valueSegments: ValueSegment[] = convertStringToSegments(noTokenSpansString, nodeMap, { tokensEnabled: true });
       resolve(valueSegments);
     });
   });


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

If a token containing `}` is added to the HTML editor, it will disappear: #4195

- **What is the new behavior (if this is a feature change)?**

Tokens are now properly retained even if they contain a `{`. Note: If a token contains `@{`, it may have issues with parsing.

Closes #4195.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

I don't think so, though a lot of internal signatures have changed to make `nodeMap` non-optional.

- **Please Include Screenshots or Videos of the intended change**:

![html-bracket-working](https://github.com/Azure/LogicAppsUX/assets/1350074/379cfda8-d2b0-4d86-b10c-28740f674691)