### PR TITLE
fix(vscode): Remove double onboarding binaries validation

### DIFF
--- a/apps/vs-code-designer/src/onboarding.ts
+++ b/apps/vs-code-designer/src/onboarding.ts
@@ -46,8 +46,6 @@ export const startOnboarding = async (activateContext: IActionContext) => {
     });
   });
 
-  await onboardBinaries(activateContext);
-
   await callWithTelemetryAndErrorHandling(autoStartDesignTimeSetting, async (actionContext: IActionContext) => {
     await runWithDurationTelemetry(actionContext, showStartDesignTimeMessageSetting, async () => {
       await promptStartDesignTimeOption(activateContext);


### PR DESCRIPTION
This pull request includes a change to the `startOnboarding` function in the `onboarding.ts` file of the `vs-code-designer` app. The change removes the call to `onboardBinaries` within this function. This function is already called in the installBinaries function.