### PR TITLE
fix(Designer): Fixed Consumption split on issue

### DIFF
--- a/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
@@ -3,11 +3,10 @@ import { ProviderWrappedContext } from './ProviderWrappedContext';
 import { initializeGraphState } from './parsers/ParseReduxAction';
 import { useAreDesignerOptionsInitialized, useAreServicesInitialized } from './state/designerOptions/designerOptionsSelectors';
 import { initializeServices } from './state/designerOptions/designerOptionsSlice';
-import { WorkflowKind } from './state/workflow/workflowInterfaces';
 import { initWorkflowKind, initRunInstance, initWorkflowSpec } from './state/workflow/workflowSlice';
 import type { AppDispatch } from './store';
+import { parseWorkflowKind } from './utils/workflow';
 import type { LogicAppsV2 } from '@microsoft/utils-logic-apps';
-import { equals } from '@microsoft/utils-logic-apps';
 import { useDeepCompareEffect } from '@react-hookz/web';
 import React, { useContext, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
@@ -22,7 +21,7 @@ const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({ workflow, child
   const dispatch = useDispatch<AppDispatch>();
   useDeepCompareEffect(() => {
     dispatch(initWorkflowSpec('BJS'));
-    dispatch(initWorkflowKind(equals(workflow?.kind, 'stateful') ? WorkflowKind.STATEFUL : WorkflowKind.STATELESS));
+    dispatch(initWorkflowKind(parseWorkflowKind(workflow?.kind)));
     dispatch(initRunInstance(runInstance ?? null));
     dispatch(initializeGraphState({ workflowDefinition: workflow, runInstance }));
   }, [runInstance, workflow]);

--- a/libs/designer/src/lib/core/state/workflow/workflowInterfaces.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowInterfaces.ts
@@ -22,7 +22,7 @@ export const WorkflowKind = {
   STATEFUL: 'stateful',
   STATELESS: 'stateless',
 } as const;
-export type WorkflowKind = (typeof WorkflowKind)[keyof typeof WorkflowKind];
+export type WorkflowKind = (typeof WorkflowKind)[keyof typeof WorkflowKind] | undefined;
 
 export type ErrorMessage = {
   nodeId: string;

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -20,8 +20,7 @@ import {
   updateStaticResults,
 } from '../operation/operationMetadataSlice';
 import type { RelationshipIds } from '../panel/panelInterfaces';
-import type { ErrorMessage, SpecTypes, WorkflowState } from './workflowInterfaces';
-import { WorkflowKind } from './workflowInterfaces';
+import type { ErrorMessage, SpecTypes, WorkflowState, WorkflowKind } from './workflowInterfaces';
 import { getWorkflowNodeFromGraphState } from './workflowSelectors';
 import { LogEntryLevel, LoggerService } from '@microsoft/designer-client-services-logic-apps';
 import type { MessageLevel } from '@microsoft/designer-ui';
@@ -40,7 +39,7 @@ export interface AddImplicitForeachPayload {
 
 export const initialWorkflowState: WorkflowState = {
   workflowSpec: 'BJS',
-  workflowKind: WorkflowKind.STATELESS,
+  workflowKind: undefined,
   graph: null,
   runInstance: null,
   operations: {},

--- a/libs/designer/src/lib/core/utils/workflow.ts
+++ b/libs/designer/src/lib/core/utils/workflow.ts
@@ -1,0 +1,8 @@
+import { WorkflowKind } from '../state/workflow/workflowInterfaces';
+import { equals } from '@microsoft/utils-logic-apps';
+
+export const parseWorkflowKind = (kind?: string): WorkflowKind => {
+  if (equals(kind, 'stateful')) return WorkflowKind.STATEFUL;
+  if (equals(kind, 'stateless')) return WorkflowKind.STATELESS;
+  return undefined;
+};


### PR DESCRIPTION
## Main Changes

Split on settings are now visible again in Consumption workflows
Fixes: https://github.com/Azure/LogicAppsUX/issues/4194

Workflow kind on Consumption workflows was being set to stateless, causing split on to be disabled.
Consumption passes in `undefined` as it's kind, and that value is now kept instead of being overwritten.