### PR TITLE
feat(vscode): Create unit test via command palette

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/switchDebugMode/StatelessWorkflowsListStep.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/switchDebugMode/StatelessWorkflowsListStep.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { workflowFileName } from '../../.../../../../constants';
 import { localize } from '../../../../localize';
 import type { IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
@@ -43,7 +44,7 @@ export class StatelessWorkflowsListStep extends AzureWizardPromptStep<IDebugMode
 
       if (fileStats.isDirectory()) {
         try {
-          const workflowFilePath = path.join(fullPath, 'workflow.json');
+          const workflowFilePath = path.join(fullPath, workflowFileName);
 
           if (await pathExists(workflowFilePath)) {
             const workflowContent = JSON.parse(readFileSync(workflowFilePath, 'utf8'));

--- a/apps/vs-code-designer/src/app/commands/workflows/switchToDotnetProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/switchToDotnetProject.ts
@@ -2,7 +2,14 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { connectionsFileName, funcIgnoreFileName, funcVersionSetting, hostFileName, localSettingsFileName } from '../../../constants';
+import {
+  connectionsFileName,
+  funcIgnoreFileName,
+  funcVersionSetting,
+  hostFileName,
+  localSettingsFileName,
+  workflowFileName,
+} from '../../../constants';
 import { localize } from '../../../localize';
 import { initProjectForVSCode } from '../../commands/initProjectForVSCode/initProjectForVSCode';
 import { DotnetTemplateProvider } from '../../templates/dotnet/DotnetTemplateProvider';
@@ -256,7 +263,7 @@ async function getArtifactNamesFromProject(target: vscode.Uri): Promise<{ [key: 
     const filePath: string = path.join(target.fsPath, file);
     if (await (await fse.stat(filePath)).isDirectory()) {
       const workflowFiles: string[] = await fse.readdir(filePath);
-      if (workflowFiles.length == 1 && workflowFiles[0] == 'workflow.json') {
+      if (workflowFiles.length == 1 && workflowFiles[0] == workflowFileName) {
         artifactDict['workflows'].push(file);
       }
     }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -3,17 +3,63 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { localize } from '../../../../localize';
-import { getWorkflowNode } from '../../../utils/workspace';
+import { getWorkflowsInLocalProject } from '../../../utils/codeless/common';
+import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
+import { getWorkflowNode, getWorkspaceFolder } from '../../../utils/workspace';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
 import OpenDesignerForLocalProject from '../openDesigner/openDesignerForLocalProject';
-import type * as vscode from 'vscode';
+import { type IAzureQuickPickItem, type IActionContext } from '@microsoft/vscode-azext-utils';
+import * as path from 'path';
+import * as vscode from 'vscode';
 
-export async function createUnitTest(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
+/**
+ * Creates a unit test for a Logic App workflow.
+ * @param {IAzureConnectorsContext} context - The context object for Azure Connectors.
+ * @param {vscode.Uri | undefined} node - The URI of the workflow node, if available.
+ * @returns A Promise that resolves when the unit test is created.
+ */
+export async function createUnitTest(context: IAzureConnectorsContext, node: vscode.Uri | undefined): Promise<void> {
   const unitTestName = await context.ui.showInputBox({
     prompt: localize('unitTestNamePrompt', 'Provide Unit Test name'),
   });
-  const workflowNode = getWorkflowNode(node) as vscode.Uri;
+
+  let workflowNode;
+
+  if (node) {
+    workflowNode = getWorkflowNode(node) as vscode.Uri;
+  } else {
+    const workflow = await pickWorkflow(context);
+    workflowNode = vscode.Uri.file(workflow.data);
+  }
+  console.log('charlie', workflowNode);
 
   const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName);
   await openDesignerObj?.createPanel();
 }
+
+/**
+ * Prompts the user to select a workflow and returns the selected workflow.
+ * @param {IActionContext} context - The action context.
+ * @returns A Promise that resolves to the selected workflow.
+ */
+const pickWorkflow = async (context: IActionContext) => {
+  const placeHolder: string = localize('selectLogicApp', 'Select workflow to create unit test');
+  return await context.ui.showQuickPick(getWorkflowsPicks(context), { placeHolder });
+};
+
+/**
+ * Retrieves the list of workflows in the local project.
+ * @param {IActionContext} context - The action context.
+ * @returns A promise that resolves to an array of Azure Quick Pick items representing the workflows.
+ */
+const getWorkflowsPicks = async (context: IActionContext) => {
+  const workspaceFolder = await getWorkspaceFolder(context);
+  const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
+  const listOfLogicApps = await getWorkflowsInLocalProject(projectPath);
+  const picks: IAzureQuickPickItem<string>[] = Array.from(Object.keys(listOfLogicApps)).map((workflowName) => {
+    return { label: workflowName, data: path.join(projectPath, workflowName) };
+  });
+
+  picks.sort((a, b) => a.label.localeCompare(b.label));
+  return picks;
+};

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { workflowFileName } from '../../../../constants';
 import { localize } from '../../../../localize';
 import { getWorkflowsInLocalProject } from '../../../utils/codeless/common';
 import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
@@ -31,7 +32,6 @@ export async function createUnitTest(context: IAzureConnectorsContext, node: vsc
     const workflow = await pickWorkflow(context);
     workflowNode = vscode.Uri.file(workflow.data);
   }
-  console.log('charlie', workflowNode);
 
   const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName);
   await openDesignerObj?.createPanel();
@@ -57,7 +57,7 @@ const getWorkflowsPicks = async (context: IActionContext) => {
   const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
   const listOfLogicApps = await getWorkflowsInLocalProject(projectPath);
   const picks: IAzureQuickPickItem<string>[] = Array.from(Object.keys(listOfLogicApps)).map((workflowName) => {
-    return { label: workflowName, data: path.join(projectPath, workflowName) };
+    return { label: workflowName, data: path.join(projectPath, workflowName, workflowFileName) };
   });
 
   picks.sort((a, b) => a.label.localeCompare(b.label));

--- a/apps/vs-code-designer/src/app/utils/codeless/common.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/common.ts
@@ -6,6 +6,7 @@ import {
   workflowLocationKey,
   workflowManagementBaseURIKey,
   managementApiPrefix,
+  workflowFileName,
 } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
@@ -187,7 +188,7 @@ export async function getManualWorkflowsInLocalProject(projectPath: string, work
 
     if (fileStats.isDirectory() && subPath !== workflowToExclude) {
       try {
-        const workflowFilePath = path.join(fullPath, 'workflow.json');
+        const workflowFilePath = path.join(fullPath, workflowFileName);
 
         if (await fse.pathExists(workflowFilePath)) {
           const schema = getRequestTriggerSchema(JSON.parse(readFileSync(workflowFilePath, 'utf8')));
@@ -199,6 +200,36 @@ export async function getManualWorkflowsInLocalProject(projectPath: string, work
       } catch {
         // If unable to load the workflow or read the definition we skip the workflow
         // in child workflow list.
+      }
+    }
+  }
+
+  return workflowDetails;
+}
+
+export async function getWorkflowsInLocalProject(projectPath: string): Promise<Record<string, any>> {
+  if (!(await fse.pathExists(projectPath))) {
+    return {};
+  }
+
+  const workflowDetails: Record<string, any> = {};
+  const subPaths: string[] = await fse.readdir(projectPath);
+  for (const subPath of subPaths) {
+    const fullPath: string = path.join(projectPath, subPath);
+    const fileStats = await fse.lstat(fullPath);
+
+    if (fileStats.isDirectory()) {
+      try {
+        const workflowFilePath = path.join(fullPath, workflowFileName);
+
+        if (await fse.pathExists(workflowFilePath)) {
+          const schema = JSON.parse(readFileSync(workflowFilePath, 'utf8'));
+          if (schema) {
+            workflowDetails[subPath] = schema;
+          }
+        }
+      } catch {
+        // If unable to load the workflow or read the definition we skip the workflow
       }
     }
   }

--- a/apps/vs-code-designer/src/app/utils/codeless/common.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/common.ts
@@ -207,7 +207,12 @@ export async function getManualWorkflowsInLocalProject(projectPath: string, work
   return workflowDetails;
 }
 
-export async function getWorkflowsInLocalProject(projectPath: string): Promise<Record<string, any>> {
+/**
+ * Retrieves the workflows in a local project.
+ * @param {string} projectPath - The path to the project.
+ * @returns A promise that resolves to a record of workflow names and their corresponding schemas.
+ */
+export async function getWorkflowsInLocalProject(projectPath: string): Promise<Record<string, StandardApp>> {
   if (!(await fse.pathExists(projectPath))) {
     return {};
   }

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { workflowFileName } from '../../constants';
 import { localize } from '../../localize';
 import type { RemoteWorkflowTreeItem } from '../tree/remoteWorkflowsTree/RemoteWorkflowTreeItem';
 import { NoWorkspaceError } from './errors';
@@ -90,7 +91,7 @@ export async function getWorkspaceFolder(context: IActionContext): Promise<vscod
 export const getWorkflowNode = (node: vscode.Uri | RemoteWorkflowTreeItem | undefined): vscode.Uri | RemoteWorkflowTreeItem | undefined => {
   if (isNullOrUndefined(node)) {
     const activeFile = vscode?.window?.activeTextEditor?.document;
-    if (activeFile?.fileName.endsWith('workflow.json')) {
+    if (activeFile?.fileName.endsWith(workflowFileName)) {
       return activeFile.uri;
     }
   }

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -715,10 +715,6 @@
           "when": "resourceFilename==workflow.json"
         },
         {
-          "command": "azureLogicAppsStandard.createUnitTest",
-          "when": "always"
-        },
-        {
           "command": "azureLogicAppsStandard.createNewCodeProject",
           "when": "isWindows"
         },

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -715,6 +715,10 @@
           "when": "resourceFilename==workflow.json"
         },
         {
+          "command": "azureLogicAppsStandard.createUnitTest",
+          "when": "always"
+        },
+        {
           "command": "azureLogicAppsStandard.createNewCodeProject",
           "when": "isWindows"
         },


### PR DESCRIPTION
This pull request primarily focuses on refactoring the hard-coded 'workflow.json' filename to use a constant, `workflowFileName`, across various files in the `apps/vs-code-designer` directory. This change improves code maintainability and consistency. Additionally, there are changes in the `createUnitTest.ts` file to enhance the unit test creation process by prompting the user to select a workflow if one is not provided. 

* Replaced the hard-coded 'workflow.json' filename with the `workflowFileName` constant.
* Several changes were made to enhance the unit test creation process. If a workflow node is not provided, the user is now prompted to select a workflow. Additional utility functions were also added to support this feature.


#### Screenshot

https://github.com/Azure/LogicAppsUX/assets/102700317/45e94048-2d4d-46b7-9610-5cbce52e33a2

