### PR TITLE
fix(designer): Fix issue where some strings wouldn't be localized in azure portal and power automate

### DIFF
--- a/libs/services/intl/src/IntlProvider.tsx
+++ b/libs/services/intl/src/IntlProvider.tsx
@@ -72,7 +72,9 @@ const loadLocaleData = async (locale: string): Promise<Record<string, string> | 
       messages = await import('./compiled-lang/strings.json');
       break;
   }
-  return { ...messages };
+  //any strings with a key that has symbols gets compiled to be in the default object rather than exported individually as a module
+  const defaultMessages = messages.default ?? {};
+  return { ...messages, ...defaultMessages };
 };
 
 export const IntlProvider: React.FC<IntlProviderProps> = ({ locale, defaultLocale, children, onError }) => {


### PR DESCRIPTION
This pull request includes a significant change to the `loadLocaleData` function in the `IntlProvider.tsx` file. The modification ensures that any strings with a key that has symbols get compiled to be in the default object rather than exported individually as a module.

* [`libs/services/intl/src/IntlProvider.tsx`](diffhunk://#diff-24a037dcc98b8383728091c7c66ee17595ceba2c85fd61594bd3145f6b4d0006L75-R77): Modified the `loadLocaleData` function to compile any strings with a key that has symbols into the default object. This change prevents these strings from being exported individually as a module, thus improving the organization and accessibility of the strings.


Before:
![CleanShot 2024-02-16 at 17 15 40@2x](https://github.com/Azure/LogicAppsUX/assets/13208452/55065ee4-e406-4e07-ba81-1ef80fa32bda)

After:
![CleanShot 2024-02-16 at 17 14 57@2x](https://github.com/Azure/LogicAppsUX/assets/13208452/28efcabd-6049-4da2-aabf-16d43f9f44af)
