### PR TITLE
fix(designer): Fix issue in run history page where loops pager would only go to first error when clicking next failure

### DIFF
--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -6,8 +6,8 @@ import { getForeachItemsCount } from './helper';
 import { RunService } from '@microsoft/designer-client-services-logic-apps';
 import type { PageChangeEventArgs, PageChangeEventHandler } from '@microsoft/designer-ui';
 import { Pager } from '@microsoft/designer-ui';
-import { isNullOrUndefined, type LogicAppsV2 } from '@microsoft/utils-logic-apps';
-import { useEffect, useState } from 'react';
+import { FindPreviousAndNextPage, isNullOrUndefined, type LogicAppsV2 } from '@microsoft/utils-logic-apps';
+import { useCallback, useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import { useDispatch } from 'react-redux';
 
@@ -41,7 +41,7 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
       }, [])
       .sort();
 
-    setFailedRepetitions(sortedFailedRepetitions);
+    setFailedRepetitions(sortedFailedRepetitions.sort((a, b) => a - b));
   };
 
   const onRunRepetitionsError = async () => {
@@ -67,6 +67,8 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
     }
   }, [runInstance?.id, refetch, scopeId, normalizedType]);
 
+  const findPreviousAndNextFailed = useCallback((page: number) => FindPreviousAndNextPage(page, failedRepetitions), [failedRepetitions]);
+
   if (!forEachItemsCount || isError || collapsed) {
     return null;
   }
@@ -77,23 +79,13 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
   };
 
   const onClickNextFailed: PageChangeEventHandler = (page: PageChangeEventArgs) => {
-    let nextFailedRepetition = -1;
-    if (failedRepetitions.includes(page.value - 1)) {
-      nextFailedRepetition = page.value - 1;
-    } else if (page.value - 1 < failedRepetitions[0]) {
-      nextFailedRepetition = failedRepetitions[0];
-    }
+    const { nextFailedRepetition } = findPreviousAndNextFailed(page.value - 1);
     dispatch(setRunIndex({ page: nextFailedRepetition, nodeId: scopeId }));
     setCurrentPage(nextFailedRepetition + 1);
   };
 
   const onClickPreviousFailed: PageChangeEventHandler = (page: PageChangeEventArgs) => {
-    let prevFailedRepetition = -1;
-    if (failedRepetitions.includes(page.value - 1)) {
-      prevFailedRepetition = page.value - 1;
-    } else if (page.value - 1 > failedRepetitions[failedRepetitions.length - 1]) {
-      prevFailedRepetition = failedRepetitions[failedRepetitions.length - 1];
-    }
+    const { prevFailedRepetition } = findPreviousAndNextFailed(page.value - 1);
     dispatch(setRunIndex({ page: prevFailedRepetition, nodeId: scopeId }));
     setCurrentPage(prevFailedRepetition + 1);
   };
@@ -105,10 +97,7 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
   const failedIterationProps =
     failedRepetitions.length > 0
       ? {
-          max:
-            failedRepetitions[failedRepetitions.length - 1] + 1 <= forEachItemsCount
-              ? failedRepetitions[failedRepetitions.length - 1] + 1
-              : forEachItemsCount,
+          max: failedRepetitions.length > 1 ? failedRepetitions[failedRepetitions.length - 1] + 1 : 0,
           min: failedRepetitions[0] + 1 >= 1 ? failedRepetitions[0] + 1 : 1,
           onClickNext: onClickNextFailed,
           onClickPrevious: onClickPreviousFailed,

--- a/libs/services/intl/src/IntlProvider.tsx
+++ b/libs/services/intl/src/IntlProvider.tsx
@@ -72,7 +72,9 @@ const loadLocaleData = async (locale: string): Promise<Record<string, string> | 
       messages = await import('./compiled-lang/strings.json');
       break;
   }
-  return { ...messages };
+  //any strings with a key that has symbols gets compiled to be in the default object rather than exported individually as a module
+  const defaultMessages = messages.default ?? {};
+  return { ...messages, ...defaultMessages };
 };
 
 export const IntlProvider: React.FC<IntlProviderProps> = ({ locale, defaultLocale, children, onError }) => {

--- a/libs/utils/src/lib/helpers/__test__/functions.spec.ts
+++ b/libs/utils/src/lib/helpers/__test__/functions.spec.ts
@@ -44,6 +44,7 @@ import {
   trim,
   uniqueArray,
   unmap,
+  FindPreviousAndNextPage,
 } from './../functions';
 
 describe('lib/helpers/functions', () => {
@@ -1010,6 +1011,43 @@ describe('lib/helpers/functions', () => {
     it('returns true if a value is a valid icon or icon URL', () => {
       expect(isValidIcon('https://microsoft.com/icon.png')).toBe(true);
       expect(isValidIcon('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==')).toBe(true);
+    });
+  });
+
+  describe('FindPreviousAndNextPage', () => {
+    it('should return correct previous and next page', () => {
+      const bookmarks = [1, 2, 3, 4, 5];
+      const page = 3;
+      const result = FindPreviousAndNextPage(page, bookmarks);
+      expect(result).toEqual({ nextFailedRepetition: 3, prevFailedRepetition: 3 });
+    });
+
+    it('should return correct previous and next page when page is not in bookmarks', () => {
+      const bookmarks = [1, 2, 4, 5];
+      const page = 3;
+      const result = FindPreviousAndNextPage(page, bookmarks);
+      expect(result).toEqual({ nextFailedRepetition: 4, prevFailedRepetition: 2 });
+    });
+
+    it('should return -1 for both previous and next page when bookmarks is empty', () => {
+      const bookmarks: number[] = [];
+      const page = 3;
+      const result = FindPreviousAndNextPage(page, bookmarks);
+      expect(result).toEqual({ nextFailedRepetition: -1, prevFailedRepetition: -1 });
+    });
+
+    it('should return correct previous and next page when page is less than all bookmarks', () => {
+      const bookmarks = [2, 3, 4, 5];
+      const page = 1;
+      const result = FindPreviousAndNextPage(page, bookmarks);
+      expect(result).toEqual({ nextFailedRepetition: 2, prevFailedRepetition: -1 });
+    });
+
+    it('should return correct previous and next page when page is greater than all bookmarks', () => {
+      const bookmarks = [1, 2, 3, 4];
+      const page = 5;
+      const result = FindPreviousAndNextPage(page, bookmarks);
+      expect(result).toEqual({ nextFailedRepetition: -1, prevFailedRepetition: 4 });
     });
   });
 

--- a/libs/utils/src/lib/helpers/functions.ts
+++ b/libs/utils/src/lib/helpers/functions.ts
@@ -1046,3 +1046,25 @@ export const getRecordEntry = <T>(record: Record<string, T> | undefined, key: st
   if (!record || !key || !Object.hasOwn(record, key)) return undefined;
   return record[key];
 };
+
+export const FindPreviousAndNextPage = (page: number, bookmarks: number[]) => {
+  let left = 0;
+  let right = bookmarks.length - 1;
+  let nextFailedRepetition = -1;
+  let prevFailedRepetition = -1;
+  while (left <= right) {
+    const mid = Math.floor((left + right) / 2);
+    if (bookmarks[mid] < page) {
+      prevFailedRepetition = bookmarks[mid];
+      left = mid + 1;
+    } else if (bookmarks[mid] > page) {
+      nextFailedRepetition = bookmarks[mid];
+      right = mid - 1;
+    } else {
+      prevFailedRepetition = bookmarks[mid];
+      nextFailedRepetition = bookmarks[mid];
+      break;
+    }
+  }
+  return { nextFailedRepetition, prevFailedRepetition };
+};


### PR DESCRIPTION
This pull request primarily focuses on improving the functionality of the `LoopsPager` component in the `libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx` file. The changes include the introduction of a new function to find the previous and next failed pages, a modification to the sorting of failed repetitions, and adjustments to the handling of failed iteration properties. ALastly, the `FindPreviousAndNextPage` function was tested in `libs/utils/src/lib/helpers/__test__/functions.spec.ts` and implemented in `libs/utils/src/lib/helpers/functions.ts`.

Improvements to `LoopsPager`:

* [`libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx`](diffhunk://#diff-b8a3966d76571aa606548b1b1b08a6f8442a55647ccb04bbf3cc006f3adfb330L9-R10): Imported the `FindPreviousAndNextPage` function and `useCallback` hook.
* [`libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx`](diffhunk://#diff-b8a3966d76571aa606548b1b1b08a6f8442a55647ccb04bbf3cc006f3adfb330L44-R44): Sorted the `failedRepetitions` array in ascending order.
* [`libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx`](diffhunk://#diff-b8a3966d76571aa606548b1b1b08a6f8442a55647ccb04bbf3cc006f3adfb330R70-R71): Created a `findPreviousAndNextFailed` callback function to find the previous and next failed pages.
* [`libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx`](diffhunk://#diff-b8a3966d76571aa606548b1b1b08a6f8442a55647ccb04bbf3cc006f3adfb330L80-R88): Replaced the logic for finding the next and previous failed repetitions with calls to the `findPreviousAndNextFailed` function.
* [`libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx`](diffhunk://#diff-b8a3966d76571aa606548b1b1b08a6f8442a55647ccb04bbf3cc006f3adfb330L108-R100): Adjusted the `failedIterationProps` to handle the maximum value differently.

Testing and implementation of `FindPreviousAndNextPage`:

* [`libs/utils/src/lib/helpers/__test__/functions.spec.ts`](diffhunk://#diff-b62ecd2688b89898da363a9ca50d160b2d70c501b1ad9d80eb454ff145a9c946R47): Imported and tested the `FindPreviousAndNextPage` function. [[1]](diffhunk://#diff-b62ecd2688b89898da363a9ca50d160b2d70c501b1ad9d80eb454ff145a9c946R47) [[2]](diffhunk://#diff-b62ecd2688b89898da363a9ca50d160b2d70c501b1ad9d80eb454ff145a9c946R1017-R1053)
* [`libs/utils/src/lib/helpers/functions.ts`](diffhunk://#diff-df96833d7608d983b974a8c958ff1fb7576f67591b583bd1eaccebff66855ca8R1049-R1070): Implemented the `FindPreviousAndNextPage` function.

Before:

https://github.com/Azure/LogicAppsUX/assets/13208452/f87516a5-4379-4171-a6b8-f73897a1994c


After: 

https://github.com/Azure/LogicAppsUX/assets/13208452/048e09b1-fb23-4c7b-8d3f-2169842a94ea


Fixes #3983