### PR TITLE
fix(designer): Have better validaiton for array values in parameters

### DIFF
--- a/libs/designer/src/lib/core/utils/validation.ts
+++ b/libs/designer/src/lib/core/utils/validation.ts
@@ -459,8 +459,12 @@ function isValidJSONObjectFormat(value: string): boolean {
 }
 
 function isValidArrayFormat(value: string): boolean {
-  const trimmedValue = (value || '').trim();
-  return startsWith(trimmedValue, '[') && endsWith(trimmedValue, ']');
+  try {
+    const v = JSON.parse(value);
+    return typeof v === 'object' && Array.isArray(v) && v.every((item) => item !== undefined && item !== null);
+  } catch (e) {
+    return false;
+  }
 }
 
 export const isISO8601 = (s: string) => {


### PR DESCRIPTION
Fixes #4123

This pull request includes a significant change to the `isValidArrayFormat` function in the `validation.ts` file. The function previously checked if a string value started with an opening bracket and ended with a closing bracket to validate if it was an array format. The updated function now uses `JSON.parse` to parse the string value and checks if the parsed value is an object, an array, and if all items in the array are not undefined or null. This change improves the accuracy of array format validation by ensuring the string value is a valid JSON array and not just any string enclosed in brackets.