### PR TITLE
feat(vscode): Add edit unit test from command palette

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -44,7 +44,7 @@ export async function createUnitTest(context: IAzureConnectorsContext, node: vsc
 }
 
 /**
- * Prompts the user to select a workflow and creates a unit test for it.
+ * Prompts the user to select a workflow and returns the selected workflow.
  * @param {IActionContext} context - The action context.
  * @param {string} projectPath - The path of the project.
  * @returns A promise that resolves to the selected workflow.
@@ -55,7 +55,7 @@ const pickWorkflow = async (context: IActionContext, projectPath: string) => {
 };
 
 /**
- * Retrieves the list of logic apps in a local project and returns an array of Azure Quick Pick items.
+ * Retrieves the list of workflows in the local project.
  * @param {string} projectPath - The path to the local project.
  * @returns An array of Azure Quick Pick items representing the logic apps in the project.
  */

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -51,7 +51,7 @@ export async function createUnitTest(context: IAzureConnectorsContext, node: vsc
  */
 const pickWorkflow = async (context: IActionContext, projectPath: string) => {
   const placeHolder: string = localize('selectLogicApp', 'Select workflow to create unit test');
-  return await context.ui.showQuickPick(getUnitTestPicks(projectPath), { placeHolder });
+  return await context.ui.showQuickPick(getWorkflowsPick(projectPath), { placeHolder });
 };
 
 /**
@@ -59,9 +59,9 @@ const pickWorkflow = async (context: IActionContext, projectPath: string) => {
  * @param {string} projectPath - The path to the local project.
  * @returns An array of Azure Quick Pick items representing the logic apps in the project.
  */
-const getUnitTestPicks = async (projectPath: string) => {
-  const listOfLogicApps = await getWorkflowsInLocalProject(projectPath);
-  const picks: IAzureQuickPickItem<string>[] = Array.from(Object.keys(listOfLogicApps)).map((workflowName) => {
+const getWorkflowsPick = async (projectPath: string) => {
+  const listOfWorkflows = await getWorkflowsInLocalProject(projectPath);
+  const picks: IAzureQuickPickItem<string>[] = Array.from(Object.keys(listOfWorkflows)).map((workflowName) => {
     return { label: workflowName, data: path.join(projectPath, workflowName, workflowFileName) };
   });
 

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -5,6 +5,7 @@
 import { workflowFileName } from '../../../../constants';
 import { localize } from '../../../../localize';
 import { getWorkflowsInLocalProject } from '../../../utils/codeless/common';
+import { validateUnitTestName } from '../../../utils/unitTests';
 import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
 import { getWorkflowNode, getWorkspaceFolder } from '../../../utils/workspace';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
@@ -20,41 +21,45 @@ import * as vscode from 'vscode';
  * @returns A Promise that resolves when the unit test is created.
  */
 export async function createUnitTest(context: IAzureConnectorsContext, node: vscode.Uri | undefined): Promise<void> {
-  const unitTestName = await context.ui.showInputBox({
-    prompt: localize('unitTestNamePrompt', 'Provide Unit Test name'),
-  });
-
-  let workflowNode;
+  let workflowNode: vscode.Uri;
+  const workspaceFolder = await getWorkspaceFolder(context);
+  const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
 
   if (node) {
     workflowNode = getWorkflowNode(node) as vscode.Uri;
   } else {
-    const workflow = await pickWorkflow(context);
-    workflowNode = vscode.Uri.file(workflow.data);
+    const workflow = await pickWorkflow(context, projectPath);
+    workflowNode = vscode.Uri.file(workflow.data) as vscode.Uri;
   }
+
+  const workflowName = path.basename(path.dirname(workflowNode.fsPath));
+  const unitTestName = await context.ui.showInputBox({
+    prompt: localize('unitTestNamePrompt', 'Provide a unit test name'),
+    placeHolder: localize('unitTestNamePlaceholder', 'Unit test name'),
+    validateInput: async (name: string): Promise<string | undefined> => await validateUnitTestName(projectPath, workflowName, name),
+  });
 
   const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName);
   await openDesignerObj?.createPanel();
 }
 
 /**
- * Prompts the user to select a workflow and returns the selected workflow.
+ * Prompts the user to select a workflow and creates a unit test for it.
  * @param {IActionContext} context - The action context.
- * @returns A Promise that resolves to the selected workflow.
+ * @param {string} projectPath - The path of the project.
+ * @returns A promise that resolves to the selected workflow.
  */
-const pickWorkflow = async (context: IActionContext) => {
+const pickWorkflow = async (context: IActionContext, projectPath: string) => {
   const placeHolder: string = localize('selectLogicApp', 'Select workflow to create unit test');
-  return await context.ui.showQuickPick(getWorkflowsPicks(context), { placeHolder });
+  return await context.ui.showQuickPick(getUnitTestPicks(projectPath), { placeHolder });
 };
 
 /**
- * Retrieves the list of workflows in the local project.
- * @param {IActionContext} context - The action context.
- * @returns A promise that resolves to an array of Azure Quick Pick items representing the workflows.
+ * Retrieves the list of logic apps in a local project and returns an array of Azure Quick Pick items.
+ * @param {string} projectPath - The path to the local project.
+ * @returns An array of Azure Quick Pick items representing the logic apps in the project.
  */
-const getWorkflowsPicks = async (context: IActionContext) => {
-  const workspaceFolder = await getWorkspaceFolder(context);
-  const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
+const getUnitTestPicks = async (projectPath: string) => {
   const listOfLogicApps = await getWorkflowsInLocalProject(projectPath);
   const picks: IAzureQuickPickItem<string>[] = Array.from(Object.keys(listOfLogicApps)).map((workflowName) => {
     return { label: workflowName, data: path.join(projectPath, workflowName, workflowFileName) };

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
@@ -2,25 +2,51 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { workflowFileName } from '../../../../constants';
-import { getLogicAppProjectRoot } from '../../../utils/codeless/connection';
-import { getUnitTestName } from '../../../utils/unitTests';
-import { getWorkflowNode } from '../../../utils/workspace';
+import { developmentDirectoryName, testsDirectoryName, workflowFileName } from '../../../../constants';
+import { localize } from '../../../../localize';
+import { getUnitTestInLocalProject, getUnitTestName } from '../../../utils/unitTests';
+import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
+import { getWorkflowNode, getWorkspaceFolder } from '../../../utils/workspace';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
 import OpenDesignerForLocalProject from '../openDesigner/openDesignerForLocalProject';
+import { type IAzureQuickPickItem, type IActionContext } from '@microsoft/vscode-azext-utils';
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
 export async function editUnitTest(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
-  const unitTestName = getUnitTestName(node.fsPath);
-  const unitTestNode = getWorkflowNode(node) as vscode.Uri;
+  let unitTestNode: vscode.Uri;
+  const workspaceFolder = await getWorkspaceFolder(context);
+  const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
 
-  const workflowName = path.basename(path.dirname(node.fsPath));
-  const workflowPath = path.join(await getLogicAppProjectRoot(context, unitTestNode.fsPath), workflowName, workflowFileName);
+  if (node) {
+    unitTestNode = getWorkflowNode(node) as vscode.Uri;
+  } else {
+    const unitTest = await pickUnitTest(context, path.join(projectPath, developmentDirectoryName, testsDirectoryName));
+    unitTestNode = vscode.Uri.file(unitTest.data) as vscode.Uri;
+  }
+
+  const workflowName = path.basename(path.dirname(unitTestNode.fsPath));
+  const workflowPath = path.join(projectPath, workflowName, workflowFileName);
   const workflowNode = vscode.Uri.file(workflowPath);
   const unitTestDefinition = JSON.parse(readFileSync(unitTestNode.fsPath, 'utf8'));
+  const unitTestName = getUnitTestName(unitTestNode.fsPath);
 
   const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName, unitTestDefinition);
   await openDesignerObj?.createPanel();
 }
+
+const pickUnitTest = async (context: IActionContext, projectPath: string) => {
+  const placeHolder: string = localize('selectLogicApp', 'Select unit test to edit');
+  return await context.ui.showQuickPick(getUnitTestPick(projectPath), { placeHolder });
+};
+
+const getUnitTestPick = async (projectPath: string) => {
+  const listOfUnitTest = await getUnitTestInLocalProject(projectPath);
+  const picks: IAzureQuickPickItem<string>[] = Array.from(Object.keys(listOfUnitTest)).map((unitTestName) => {
+    return { label: unitTestName, data: listOfUnitTest[unitTestName] };
+  });
+
+  picks.sort((a, b) => a.label.localeCompare(b.label));
+  return picks;
+};

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
@@ -14,6 +14,12 @@ import { readFileSync } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+/**
+ * Edits a unit test for a Logic App workflow.
+ * @param {IAzureConnectorsContext} context - The Azure Connectors context.
+ * @param {vscode.Uri} node - The URI of the unit test file to edit. If not provided, the user will be prompted to select a unit test file.
+ * @returns A Promise that resolves when the unit test has been edited.
+ */
 export async function editUnitTest(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
   let unitTestNode: vscode.Uri;
   const workspaceFolder = await getWorkspaceFolder(context);
@@ -36,11 +42,22 @@ export async function editUnitTest(context: IAzureConnectorsContext, node: vscod
   await openDesignerObj?.createPanel();
 }
 
+/**
+ * Prompts the user to select a unit test to edit.
+ * @param {IActionContext} context - The action context.
+ * @param {string} projectPath - The path of the project.
+ * @returns A promise that resolves to the selected unit test.
+ */
 const pickUnitTest = async (context: IActionContext, projectPath: string) => {
-  const placeHolder: string = localize('selectLogicApp', 'Select unit test to edit');
+  const placeHolder: string = localize('selectUnitTest', 'Select unit test to edit');
   return await context.ui.showQuickPick(getUnitTestPick(projectPath), { placeHolder });
 };
 
+/**
+ * Retrieves a list of unit tests in the local project.
+ * @param {string} projectPath - The path to the project.
+ * @returns A promise that resolves to an array of unit test picks.
+ */
 const getUnitTestPick = async (projectPath: string) => {
   const listOfUnitTest = await getUnitTestInLocalProject(projectPath);
   const picks: IAzureQuickPickItem<string>[] = Array.from(Object.keys(listOfUnitTest)).map((unitTestName) => {


### PR DESCRIPTION
This pull request introduces several changes to the `apps/vs-code-designer` package to improve the handling and creation of unit tests. The changes include the addition of a unit test name validation function, the modification of the `createUnitTest` and `editUnitTest` functions to improve user prompts and workflow selection, and the addition of a function to retrieve a list of unit tests in a local project.

*  Modified the `createUnitTest` function to validate the unit test name and to use the `projectPath` in the `pickWorkflow` and `getWorkflowsPick` functions. 
* Modified the `editUnitTest` function to prompt the user to select a unit test file if one is not provided and to use the `projectPath` in the `pickUnitTest` and `getUnitTestPick` functions.

* Added the `validateUnitTestName` function to validate the unit test name and the `validateUnitTestNameCore` function to check if a unit test with the same name already exists.

*  Added the `getUnitTestInLocalProject` function to retrieve a list of unit tests in a local project.