### PR TITLE
fix(designer): Seperate values of degree of parallelism for triggers and actions

### DIFF
--- a/libs/designer/src/lib/ui/settings/sections/general.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/general.tsx
@@ -1,7 +1,7 @@
 import type { SectionProps, ToggleHandler, TextChangeHandler, NumberChangeHandler } from '..';
 import { SettingSectionName } from '..';
 import constants from '../../../common/constants';
-import { useOperationInfo } from '../../../core';
+import { useNodeMetadata, useOperationInfo } from '../../../core';
 import { useSelectedNodeId } from '../../../core/state/panel/panelSelectors';
 import { useOutputParameters } from '../../../core/state/selectors/actionMetadataSelector';
 import { getSplitOnOptions } from '../../../core/utils/outputs';
@@ -44,9 +44,10 @@ export const General = ({
 }: GeneralSectionProps): JSX.Element => {
   const intl = useIntl();
   const nodeId = useSelectedNodeId();
+  const nodesMetadata = useNodeMetadata(nodeId);
   const operationInfo = useOperationInfo(nodeId);
   const nodeOutputs = useOutputParameters(nodeId);
-
+  const isTrigger = nodesMetadata?.isRoot ?? false;
   const generalTitle = intl.formatMessage({
     defaultMessage: 'General',
     description: 'title for general setting section',
@@ -207,9 +208,11 @@ export const General = ({
       {
         settingType: 'CustomValueSlider',
         settingProp: {
-          maxVal: constants.CONCURRENCY_ACTION_SLIDER_LIMITS.MAX,
-          minVal: constants.CONCURRENCY_ACTION_SLIDER_LIMITS.MIN,
-          value: concurrency?.value?.value ?? constants.CONCURRENCY_ACTION_SLIDER_LIMITS.DEFAULT,
+          maxVal: isTrigger ? constants.CONCURRENCY_TRIGGER_SLIDER_LIMITS.MAX : constants.CONCURRENCY_ACTION_SLIDER_LIMITS.MAX,
+          minVal: isTrigger ? constants.CONCURRENCY_TRIGGER_SLIDER_LIMITS.MIN : constants.CONCURRENCY_ACTION_SLIDER_LIMITS.MIN,
+          value:
+            concurrency?.value?.value ??
+            (isTrigger ? constants.CONCURRENCY_TRIGGER_SLIDER_LIMITS.DEFAULT : constants.CONCURRENCY_ACTION_SLIDER_LIMITS.DEFAULT),
           onValueChange: onConcurrencyValueChange,
           sliderLabel: degreeOfParallelism,
           readOnly,


### PR DESCRIPTION
This pull request primarily focuses on updating the `General` component in the `libs/designer/src/lib/ui/settings/sections/general.tsx` file. The changes revolve around the introduction of a new `useNodeMetadata` hook and the use of a new `isTrigger` variable to modify the behavior of the `CustomValueSlider` setting.

Here are the key changes:

* [`libs/designer/src/lib/ui/settings/sections/general.tsx`](diffhunk://#diff-a97ce766b7f4a0ed6117256aa57522a701295e9f8a30bec0686207a5060ddd7fL4-R4): Imported the `useNodeMetadata` hook from the `../../../core` module. This new hook is used to fetch metadata for a specific node.
* [`libs/designer/src/lib/ui/settings/sections/general.tsx`](diffhunk://#diff-a97ce766b7f4a0ed6117256aa57522a701295e9f8a30bec0686207a5060ddd7fR47-R50): Introduced a new `isTrigger` variable within the `General` component. This variable is derived from the `nodesMetadata` object, which is fetched using the `useNodeMetadata` hook. The `isTrigger` variable is used to determine if the current node is a root node.
* [`libs/designer/src/lib/ui/settings/sections/general.tsx`](diffhunk://#diff-a97ce766b7f4a0ed6117256aa57522a701295e9f8a30bec0686207a5060ddd7fL210-R215): Modified the `CustomValueSlider` setting within the `General` component. The `maxVal`, `minVal`, and `value` properties of the `settingProp` object now depend on the `isTrigger` variable. This change allows the slider limits and default value to differ based on whether the current node is a root node or not.
* 
https://github.com/Azure/LogicAppsUX/assets/13208452/f36278bf-d28f-4308-b06c-eb9ba5dbbaf3

fixes #4186