### PR TITLE
fix(vscode): Add padding to overview page

### DIFF
--- a/apps/vs-code-react/src/app/overview/app.tsx
+++ b/apps/vs-code-react/src/app/overview/app.tsx
@@ -2,6 +2,7 @@ import { QueryKeys } from '../../run-service';
 import type { RunDisplayItem } from '../../run-service';
 import type { RootState } from '../../state/store';
 import { VSCodeContext } from '../../webviewCommunication';
+import './overview.less';
 import { StandardRunService } from '@microsoft/designer-client-services-logic-apps';
 import type { CallbackInfo } from '@microsoft/designer-client-services-logic-apps';
 import { Overview, isRunError, mapToRunItem } from '@microsoft/designer-ui';
@@ -104,24 +105,26 @@ export const OverviewApp = () => {
   }, [error, runTriggerError]);
 
   return (
-    <Overview
-      corsNotice={workflowState.corsNotice}
-      errorMessage={errorMessage}
-      hasMoreRuns={hasNextPage}
-      loading={isLoading || runTriggerLoading}
-      runItems={runItems ?? []}
-      workflowProperties={workflowState.workflowProperties}
-      isRefreshing={isRefetching}
-      onLoadMoreRuns={fetchNextPage}
-      onLoadRuns={refetch}
-      onOpenRun={(run: RunDisplayItem) => {
-        vscode.postMessage({
-          command: ExtensionCommand.loadRun,
-          item: run,
-        });
-      }}
-      onRunTrigger={runTriggerCall}
-      onVerifyRunId={onVerifyRunId}
-    />
+    <div className="msla-overview">
+      <Overview
+        corsNotice={workflowState.corsNotice}
+        errorMessage={errorMessage}
+        hasMoreRuns={hasNextPage}
+        loading={isLoading || runTriggerLoading}
+        runItems={runItems ?? []}
+        workflowProperties={workflowState.workflowProperties}
+        isRefreshing={isRefetching}
+        onLoadMoreRuns={fetchNextPage}
+        onLoadRuns={refetch}
+        onOpenRun={(run: RunDisplayItem) => {
+          vscode.postMessage({
+            command: ExtensionCommand.loadRun,
+            item: run,
+          });
+        }}
+        onRunTrigger={runTriggerCall}
+        onVerifyRunId={onVerifyRunId}
+      />
+    </div>
   );
 };

--- a/apps/vs-code-react/src/app/overview/overview.less
+++ b/apps/vs-code-react/src/app/overview/overview.less
@@ -1,0 +1,4 @@
+.msla-overview {
+  height: 100vh;
+  padding: 0 20px;
+}


### PR DESCRIPTION
This pull request primarily focuses on adding styling to the `OverviewApp` component in the `apps/vs-code-react/src/app/overview/app.tsx` file. 

* A new CSS class `msla-overview` was added to the `OverviewApp` component to apply specific styles. 
* The new `msla-overview` class was defined in this file with properties to set the height and padding of the component.


### Screenshots


#### Before
![Screenshot 2024-02-23 at 9 59 31 AM](https://github.com/Azure/LogicAppsUX/assets/102700317/6e9e99d4-0692-416b-bbf6-040b49bfdc8e)


#### After
![Screenshot 2024-02-23 at 9 58 53 AM](https://github.com/Azure/LogicAppsUX/assets/102700317/bb81ce3e-f705-4ec8-b43f-3254bf95a687)

