### PR TITLE
fix(Designer): Fixed connection reference bug for MI connections

### DIFF
--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/functions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/functions.ts
@@ -856,7 +856,7 @@ export function deepCompareObjects(object1: Record<string, any> | undefined, obj
     const val2 = object2[key];
     const areObjects = isObject(val1) && isObject(val2);
 
-    if ((areObjects && !deepCompareObjects(val1, val2)) || (!areObjects && val1 !== val2)) {
+    if (areObjects ? !deepCompareObjects(val1, val2) : JSON.stringify(val1) !== JSON.stringify(val2)) {
       return false;
     }
   }


### PR DESCRIPTION
## Main Changes

Adjusted the comparison in our deep compare util method to account for arrays, was previously comparing by reference on non-objects which was causing failures.
This led to arrays that had the same information returning as not equal, which made us skip over existing connection references and making a new one for each action with a MI connection.
Stringifying then comparing will give us a proper comparison for any data type in this util function.
(This is the only instance we use this function as well, so I'm not worried about any other side effects)

Will be hotfixing this into our staging release we started earlier today.
Should be live by March 8th.
