### PR TITLE
fix(designer): Revert - Adding hidden parameter field in ConnectionCreationInfo to pass selected credential id (#4193)

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/_test__/createConnection.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/_test__/createConnection.spec.tsx
@@ -1,5 +1,5 @@
 import { MockHttpClient } from '../../../../../__test__/mock-http-client';
-import { CreateConnection, parseParameterValues, type CreateConnectionProps } from '../createConnection';
+import { CreateConnection, type CreateConnectionProps } from '../createConnection';
 import { UniversalConnectionParameter } from '../formInputs/universalConnectionParameter';
 import {
   InitConnectionParameterEditorService,
@@ -577,35 +577,6 @@ describe('ui/createConnection', () => {
 
       const mappingEditors = findParameterComponents(createConnection, CustomCredentialMappingEditor);
       expect(mappingEditors).toHaveLength(0);
-    });
-
-    test('parseParameterValues', () => {
-      const parameterValues: Record<string, any> = {
-        a: 'foobar',
-        b: 42,
-        c: null,
-        d: undefined,
-        e: { foo: 'bar' },
-        f: ['id', 66],
-      };
-      const capabilityEnabledParameters: Record<string, ConnectionParameter> = {
-        a: { type: 'connection' },
-        z: { type: 'other' },
-      };
-
-      const { visibleParameterValues, additionalParameterValues } = parseParameterValues(parameterValues, capabilityEnabledParameters);
-      expect(visibleParameterValues).toStrictEqual({ a: 'foobar' });
-      expect(additionalParameterValues).toStrictEqual({
-        b: 42,
-        c: null,
-        d: undefined,
-        e: { foo: 'bar' },
-        f: ['id', 66],
-      });
-
-      const emptyParameters = parseParameterValues({}, capabilityEnabledParameters);
-      expect(emptyParameters.visibleParameterValues).toStrictEqual({});
-      expect(emptyParameters.additionalParameterValues).toStrictEqual({});
     });
   });
 

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -60,8 +60,7 @@ export interface CreateConnectionProps {
     parameterValues?: Record<string, any>,
     isOAuthConnection?: boolean,
     alternativeParameterValues?: Record<string, any>,
-    identitySelected?: string,
-    additionalParameterValues?: Record<string, any>
+    identitySelected?: string
   ) => void;
   cancelCallback?: () => void;
   hideCancelButton?: boolean;
@@ -302,7 +301,9 @@ export const CreateConnection = (props: CreateConnectionProps) => {
   const canSubmit = useMemo(() => !isLoading && validParams, [isLoading, validParams]);
 
   const submitCallback = useCallback(() => {
-    const { visibleParameterValues, additionalParameterValues } = parseParameterValues(parameterValues, capabilityEnabledParameters);
+    const visibleParameterValues = Object.fromEntries(
+      Object.entries(parameterValues).filter(([key]) => Object.keys(capabilityEnabledParameters).includes(key)) ?? []
+    );
 
     // This value needs to be passed conditionally but the parameter is hidden, so we're manually inputting it here
     if (
@@ -325,8 +326,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
       visibleParameterValues,
       isUsingOAuth,
       alternativeParameterValues,
-      identitySelected,
-      additionalParameterValues
+      identitySelected
     );
   }, [
     parameterValues,
@@ -654,17 +654,3 @@ const isServicePrincipalParameterVisible = (key: string, parameter: any): boolea
   if (constraints?.hidden === 'true' || constraints?.hideInUI === 'true') return false;
   return true;
 };
-
-export function parseParameterValues(
-  parameterValues: Record<string, any>,
-  capabilityEnabledParameters: Record<string, ConnectionParameter | ConnectionParameterSetParameter>
-) {
-  const visibleParameterValues = Object.fromEntries(
-    Object.entries(parameterValues).filter(([key]) => Object.keys(capabilityEnabledParameters).includes(key)) ?? []
-  );
-  const additionalParameterValues = Object.fromEntries(
-    Object.entries(parameterValues).filter(([key]) => !Object.keys(capabilityEnabledParameters).includes(key)) ?? []
-  );
-
-  return { visibleParameterValues, additionalParameterValues };
-}

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
@@ -129,8 +129,7 @@ export const CreateConnectionWrapper = () => {
       parameterValues: Record<string, any> = {},
       isOAuthConnection?: boolean,
       alternativeParameterValues?: Record<string, any>,
-      identitySelected?: string,
-      additionalParameterValues?: Record<string, any>
+      identitySelected?: string
     ) => {
       if (!connector?.id) return;
 
@@ -189,7 +188,6 @@ export const CreateConnectionWrapper = () => {
             : undefined,
           connectionParameters: outputParameterValues,
           alternativeParameterValues,
-          additionalParameterValues,
         };
 
         const parametersMetadata: ConnectionParametersMetadata = {

--- a/libs/services/designer-client-services/src/lib/connection.ts
+++ b/libs/services/designer-client-services/src/lib/connection.ts
@@ -21,7 +21,6 @@ export interface ConnectionCreationInfo {
   displayName?: string;
   parameterName?: string;
   appSettings?: Record<string, string>;
-  additionalParameterValues?: Record<string, string>;
 }
 
 export interface ConnectionParametersMetadata {

--- a/libs/services/designer-client-services/src/lib/standard/connection.ts
+++ b/libs/services/designer-client-services/src/lib/standard/connection.ts
@@ -48,7 +48,6 @@ interface ServiceProviderConnectionModel {
   };
   parameterSetName?: string;
   displayName?: string;
-  additionalParameterValues?: Record<string, string>;
 }
 
 interface FunctionsConnectionModel {
@@ -606,7 +605,6 @@ function convertToServiceProviderConnectionsData(
     displayName,
     connectionParameters: connectionParameterValues,
     connectionParametersSet: connectionParametersSetValues,
-    additionalParameterValues,
   } = connectionInfo;
   const connectionParameters = connectionParametersSetValues
     ? connectionParameterMetadata.connectionParameterSet?.parameters
@@ -628,7 +626,6 @@ function convertToServiceProviderConnectionsData(
       ...optional('parameterSetName', connectionParametersSetValues?.name),
       serviceProvider: { id: connectorId },
       displayName,
-      ...optional('additionalParameterValues', additionalParameterValues),
     },
     settings: connectionInfo.appSettings ?? {},
     pathLocation: [serviceProviderLocation],


### PR DESCRIPTION
This reverts commit 2d43902c95b9eeb9ec9536939309c3224431e8e9.

@adboillo We are reverting this https://github.com/Azure/LogicAppsUX/pull/4193 as the change causes issue when creating connections for service provider.

I think mainly the main issue is here libs/services/designer-client-services/src/lib/standard/connection.ts with the `...optional('additionalParameterValues', additionalParameterValues),`

Fixes #4264 

### Screenshots

#### Isssue
<img width="1000" alt="Screenshot 2024-02-27 at 9 35 54 AM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/a2dbf20f-17b0-4798-a136-366a55e32c22">


#### Fix with revert
<img width="1407" alt="Screenshot 2024-02-27 at 9 39 00 AM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/88f2ce98-9e9f-4426-825e-2e8e0e738a33">


