### PR TITLE
fix(designer): Update to make connections name case-insensitive

### DIFF
--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/connections.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/connections.ts
@@ -202,10 +202,10 @@ function _isConnectionParameterHidden(connectionParameter: ConnectionParameter):
 }
 
 export const getUniqueName = (keys: string[], prefix: string): { name: string; index: number } => {
-  const set = new Set(keys.map((name) => name.split('::')[0]));
+  const set = new Set(keys.map((name) => name.split('::')[0].toLowerCase()));
 
   let index = 0;
-  let name = prefix;
+  let name = prefix.toLowerCase();
   while (set.has(name)) {
     name = `${prefix}-${++index}`;
   }


### PR DESCRIPTION
This pull request contains a change to the `getUniqueName` function in the `connections.ts` file. The modification ensures that the uniqueness of names is determined in a case-insensitive manner. This is achieved by converting the `name` and `prefix` variables to lower case before checking for uniqueness.

* The `getUniqueName` function now converts the `name` and `prefix` variables to lower case before checking for uniqueness in the set. This ensures that the uniqueness check is case-insensitive.

#### Screenshot

<img width="259" alt="Screenshot 2024-02-28 at 2 09 35 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/f8ef1b41-08d9-4182-bf24-407eb54ad730">
