### PR TITLE
fix(vscode): Add conditional clause for already initialized projects

### DIFF
--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -52,7 +52,7 @@ export async function verifyVSCodeConfigOnActivate(
               break;
             default:
           }
-        } else {
+        } else if (version === undefined) {
           await promptToInitializeProject(workspacePath, context);
         }
       }


### PR DESCRIPTION
This pull request includes a modification to the `verifyVSCodeConfigOnActivate` function in the `apps/vs-code-designer/src/app/utils/vsCodeConfig/verifyVSCodeConfigOnActivate.ts` file. The change introduces a condition to check if the `version` is `undefined` before calling the `promptToInitializeProject` function. This ensures that the prompt to initialize the project only appears when the `version` is not defined.