### PR TITLE
fix(vscode): Add error handle scenario for operation cancelled

### DIFF
--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -290,3 +290,8 @@ export const logicAppFilter = {
   type: 'microsoft.web/sites',
   kind: 'functionapp,workflowapp',
 };
+
+export const COMMON_ERRORS = {
+  OPERATION_CANCELLED: 'Operation cancelled.',
+} as const;
+export type COMMON_ERRORS = (typeof COMMON_ERRORS)[keyof typeof COMMON_ERRORS];

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -88,7 +88,7 @@
       },
       {
         "command": "azureLogicAppsStandard.deploy",
-        "title": "Deploy to Logic App...",
+        "title": "Deploy to logic app...",
         "category": "Azure Logic Apps",
         "icon": "$(cloud-upload)",
         "enablement": "!virtualWorkspace"
@@ -146,7 +146,7 @@
       },
       {
         "command": "azureLogicAppsStandard.exportLogicApp",
-        "title": "Export Logic App...",
+        "title": "Export logic app...",
         "category": "Azure Logic Apps",
         "icon": {
           "light": "assets/light/export.svg",

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -69,7 +69,7 @@
       },
       {
         "command": "azureLogicAppsStandard.createNewCodeProject",
-        "title": "Create new Logic App workspace...",
+        "title": "Create new logic app workspace...",
         "category": "Azure Logic Apps",
         "preview": true,
         "icon": {


### PR DESCRIPTION
This pull request primarily focuses on improving error handling in the `generateDeploymentScripts.ts` file and updating command titles in the `package.json` file of the `vs-code-designer` application. The most significant changes include the addition of a `COMMON_ERRORS` constant, modifications to error handling in `generateDeploymentScripts.ts`, and updates to the titles of several commands in `package.json`.

* Added a check for a specific error message (`COMMON_ERRORS.OPERATION_CANCELLED`) in the `generateDeploymentScripts` and `gatherAndValidateInputs` functions. If this error is encountered, a localized error message is thrown. 
* Added a `COMMON_ERRORS` constant to handle common error messages. This constant is used in the error handling logic in `generateDeploymentScripts.ts`.
* Updated the titles of three commands (`azureLogicAppsStandard.createNewCodeProject`, `azureLogicAppsStandard.deploy`, `azureLogicAppsStandard.exportLogicApp`) to use lower case for "logic app". 


#### Screenshot

<img width="1509" alt="Screenshot 2024-02-29 at 12 00 06 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/76175d98-fcfd-4264-9a1b-7a4e58f1e48d">
