### PR TITLE
fix(Consumption): Adding node name to props to account for change

### DIFF
--- a/libs/designer-ui/src/lib/modals/DeleteNodeModal.tsx
+++ b/libs/designer-ui/src/lib/modals/DeleteNodeModal.tsx
@@ -1,11 +1,12 @@
 import { Modal } from '@fluentui/react';
 import { Button, Spinner } from '@fluentui/react-components';
 import type { WorkflowNodeType } from '@microsoft/logic-apps-shared';
-import { idDisplayCase, WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
+import { WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
 import { useIntl } from 'react-intl';
 
 export interface DeleteNodeModalProps {
   nodeId: string;
+  nodeName: string;
   nodeType?: WorkflowNodeType;
   isOpen: boolean;
   isLoading?: boolean;
@@ -14,11 +15,9 @@ export interface DeleteNodeModalProps {
 }
 
 export const DeleteNodeModal = (props: DeleteNodeModalProps) => {
-  const { nodeId, nodeType, isOpen, onDismiss, onConfirm } = props;
+  const { nodeId, nodeName, nodeType, isOpen, onDismiss, onConfirm } = props;
 
   const intl = useIntl();
-
-  const nodeName = idDisplayCase(nodeId);
 
   const operationNodeTitle = intl.formatMessage({
     defaultMessage: 'Delete Workflow Action',

--- a/libs/designer/src/lib/ui/common/DeleteModal/DeleteModal.tsx
+++ b/libs/designer/src/lib/ui/common/DeleteModal/DeleteModal.tsx
@@ -1,5 +1,5 @@
 import type { AppDispatch } from '../../../core';
-import { useSelectedNodeId, useNodeMetadata } from '../../../core';
+import { useSelectedNodeId, useNodeMetadata, useNodeDisplayName } from '../../../core';
 import { deleteOperation, deleteGraphNode } from '../../../core/actions/bjsworkflow/delete';
 import { useShowDeleteModal } from '../../../core/state/designerView/designerViewSelectors';
 import { setShowDeleteModal } from '../../../core/state/designerView/designerViewSlice';
@@ -14,6 +14,7 @@ const DeleteModal = () => {
   const dispatch = useDispatch<AppDispatch>();
 
   const nodeId = removeIdTag(useSelectedNodeId()) ?? '';
+  const nodeName = useNodeDisplayName(nodeId);
   const nodeData = useWorkflowNode(nodeId);
   const metadata = useNodeMetadata(nodeId);
   const graphId = useMemo(() => metadata?.graphId ?? '', [metadata]);
@@ -55,7 +56,14 @@ const DeleteModal = () => {
   }, [nodeData, dispatch, nodeId, isTrigger, graphId, onDismiss]);
 
   return (
-    <DeleteNodeModal nodeId={nodeId} nodeType={nodeData?.type} isOpen={showDeleteModal} onDismiss={onDismiss} onConfirm={handleDelete} />
+    <DeleteNodeModal
+      nodeId={nodeId}
+      nodeName={nodeName}
+      nodeType={nodeData?.type}
+      isOpen={showDeleteModal}
+      onDismiss={onDismiss}
+      onConfirm={handleDelete}
+    />
   );
 };
 


### PR DESCRIPTION
This PR fixes the fact that the discard pop up message doesn't display the updated node name if the node name has been changed. Now, we define the node name in the DeleteModal.tsx file and pass it down through the props so that when the node name is updated, this is correctly displayed in the discard pop up.

Fixes #4277 
