### PR TITLE
feat(vscode): Download extension bundle in extension activation instead of project initialization

### DIFF
--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -20,7 +20,6 @@ import {
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { type settingsFileContent } from '../../commands/dataMapper/extensionConfig';
-import { downloadExtensionBundle } from '../bundleFeed';
 import { updateFuncIgnore } from '../codeless/common';
 import { writeFormattedJson } from '../fs';
 import { getFunctionsCommand } from '../funcCoreTools/funcVersion';
@@ -213,7 +212,6 @@ export async function promptStartDesignTimeOption(context: IActionContext) {
     const showStartDesignTimeMessage = !!getWorkspaceSetting<boolean>(showStartDesignTimeMessageSetting);
 
     if (projectPath) {
-      await downloadExtensionBundle(context);
       if (autoStartDesignTime) {
         startDesignTimeApi(projectPath);
       } else if (showStartDesignTimeMessage) {

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -4,6 +4,7 @@ import { supportedDataMapDefinitionFileExts, supportedSchemaFileExts } from './a
 import { registerCommands } from './app/commands/registerCommands';
 import { getResourceGroupsApi } from './app/resourcesExtension/getExtensionApi';
 import type { AzureAccountTreeItemWithProjects } from './app/tree/AzureAccountTreeItemWithProjects';
+import { downloadExtensionBundle } from './app/utils/bundleFeed';
 import { stopDesignTimeApi } from './app/utils/codeless/startDesignTimeApi';
 import { UriHandler } from './app/utils/codeless/urihandler';
 import { getExtensionVersion } from './app/utils/extension';
@@ -54,6 +55,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     runPostWorkflowCreateStepsFromCache();
 
+    await downloadExtensionBundle(activateContext);
     await startOnboarding(activateContext);
 
     ext.extensionVersion = getExtensionVersion();


### PR DESCRIPTION
The changes revolve around the `downloadExtensionBundle` function. The function was removed from `startDesignTimeApi.ts` and added to `main.ts`, changing the location and timing of when the extension bundle is downloaded.

These changes suggest a shift in the strategy for handling extension bundles, moving the download operation from a later stage (`promptStartDesignTimeOption`) to an earlier stage (`activate`) in the application lifecycle.