### PR TITLE
fix(vscode): Fix error handling and displaying and add input validations

### DIFF
--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/azureScriptWizard.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/azureScriptWizard.ts
@@ -44,10 +44,10 @@ export function createAzureWizard(wizardContext: IAzureScriptWizard): AzureWizar
 
   // Create the Azure Wizard with the modified steps
   return new AzureWizard(wizardContext, {
+    title: localize('generateDeploymentScripts', 'Generate deployment scripts'),
     promptSteps: [new ConfigureInitialLogicAppStep(), new setLogicappName(), new setStorageAccountName(), new setAppPlantName()],
     executeSteps: [new SourceControlPathListStep()],
     showLoadingPrompt: true,
-    title: localize('generateDeploymentScripts', 'Generate deployment scripts'),
   });
 }
 
@@ -119,8 +119,14 @@ export class setLogicappName extends AzureWizardPromptStep<IAzureScriptWizard> {
 
   public async prompt(context: IAzureScriptWizard): Promise<void> {
     context.logicAppName = await context.ui.showInputBox({
-      placeHolder: localize('setLogicappName', 'logicappName'),
-      prompt: localize('logicappNamePrompt', 'Provide a unique name for the logic app.'),
+      placeHolder: localize('setLogicAppName', 'Logic app name'),
+      prompt: localize('logicAppNamePrompt', 'Provide a unique name for the logic app.'),
+      validateInput: (value: string): string | undefined => {
+        if (!value || value.length === 0) {
+          return localize('logicAppNameEmpty', 'Logic app name cannot be empty');
+        }
+        return undefined;
+      },
     });
   }
 
@@ -135,8 +141,14 @@ export class setStorageAccountName extends AzureWizardPromptStep<IAzureScriptWiz
 
   public async prompt(context: IAzureScriptWizard): Promise<void> {
     context.storageAccountName = await context.ui.showInputBox({
-      placeHolder: localize('setStorageAccountName', 'storageAccountName'),
+      placeHolder: localize('setStorageAccountName', 'Storage account name'),
       prompt: localize('storageAccountNamePrompt', 'Provide a unique name for the storage account.'),
+      validateInput: (value: string): string | undefined => {
+        if (!value || value.length === 0) {
+          return localize('storageAccountNameEmpty', 'Storage account name cannot be empty');
+        }
+        return undefined;
+      },
     });
   }
 
@@ -151,8 +163,14 @@ export class setAppPlantName extends AzureWizardPromptStep<IAzureScriptWizard> {
 
   public async prompt(context: IAzureScriptWizard): Promise<void> {
     context.appServicePlan = await context.ui.showInputBox({
-      placeHolder: localize('setAppPlantName', 'appPlanName'),
+      placeHolder: localize('setAppPlanName', 'App Service plan name'),
       prompt: localize('appPlanNamePrompt', 'Provide a unique name for the App Service plan.'),
+      validateInput: (value: string): string | undefined => {
+        if (!value || value.length === 0) {
+          return localize('appPlanNameEmpty', 'App Service plan name cannot be empty');
+        }
+        return undefined;
+      },
     });
   }
 

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -9,7 +9,6 @@ import {
   workflowSubscriptionIdKey,
   localSettingsFileName,
   extensionCommand,
-  COMMON_ERRORS,
 } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
@@ -18,7 +17,7 @@ import { getConnectionsJson } from '../../utils/codeless/connection';
 import { getAuthorizationToken, getCloudHost } from '../../utils/codeless/getAuthorizationToken';
 import { getAccountCredentials } from '../../utils/credentials';
 import { addLocalFuncTelemetry } from '../../utils/funcCoreTools/funcVersion';
-import { handleError, showPreviewWarning, unzipLogicAppArtifacts } from '../../utils/taskUtils';
+import { showPreviewWarning, unzipLogicAppArtifacts } from '../../utils/taskUtils';
 import type { IAzureScriptWizard } from './azureScriptWizard';
 import { createAzureWizard } from './azureScriptWizard';
 import { FileManagement } from './iacGestureHelperFunctions';
@@ -60,15 +59,10 @@ export async function generateDeploymentScripts(context: IActionContext, project
       FileManagement.convertToValidWorkspace(sourceControlPath);
     }
   } catch (error) {
-    if (error?.message === COMMON_ERRORS.OPERATION_CANCELLED) {
-      const errorMessage = localize('errorScriptGen', 'Error during deployment script generation: {0}', error?.message);
-      throw new Error(errorMessage);
-    } else {
-      const localizedErrorMessage = localize('errorScriptGen', '[Error] generateDeploymentScripts failed: {0}', error);
-      ext.outputChannel.appendLog(localizedErrorMessage);
-      ext.outputChannel.appendLog(`[Error] generateDeploymentScripts failed: ${error}`);
-      await handleError(error, 'Error during deployment script generation');
-    }
+    const errorMessage = localize('errorScriptGen', 'Error during deployment script generation: {0}', error.message ?? error);
+    ext.outputChannel.appendLog(errorMessage);
+    context.telemetry.properties.error = errorMessage;
+    throw new Error(errorMessage);
   }
 }
 
@@ -87,8 +81,9 @@ async function setupWizardScriptContext(context: IActionContext, projectRoot: vs
     scriptContext.projectPath = parentDirPath;
     return scriptContext;
   } catch (error) {
-    await handleError(error, 'Error in setupWizardScriptContext');
-    throw error;
+    const errorMessage = localize('executeAzureWizardError', `Error in setupWizardScriptContext`, error.message ?? error);
+    ext.outputChannel.appendLog(errorMessage);
+    throw new Error(errorMessage);
   }
 }
 
@@ -102,7 +97,7 @@ async function callStandardApi(inputs: any): Promise<Buffer> {
     const { subscriptionId, resourceGroup, storageAccount, location, logicAppName, appServicePlan } = inputs;
     return await callStandardResourcesApi(subscriptionId, resourceGroup, storageAccount, location, logicAppName, appServicePlan);
   } catch (error) {
-    await handleError(error, 'Error calling Standard Resources API');
+    throw new Error(localize('Error calling Standard Resources API', error));
   }
 }
 
@@ -158,7 +153,7 @@ export async function callConsumptionApi(scriptContext: IAzureScriptWizard, inpu
         );
         await handleApiResponse(bufferData, unzipPath);
       } catch (error) {
-        const errorString = JSON.stringify(error, Object.getOwnPropertyNames(error));
+        const errorString = JSON.stringify(error.message);
         ext.outputChannel.appendLog(
           localize(
             'failedApiCallForConnectionWithError',
@@ -167,15 +162,18 @@ export async function callConsumptionApi(scriptContext: IAzureScriptWizard, inpu
             errorString
           )
         );
-        vscode.window.showErrorMessage(localize('apiCallFailedWithError', 'API call failed: {0}', errorString));
         throw new Error(localize('apiCallToConsumptionResourcesFailed', 'API call to Consumption Resources failed: {0}', errorString));
       }
     }
   } catch (error) {
     ext.outputChannel.appendLog(
-      localize('failedAllConsumptionCalls', 'Failed to complete Consumption API calls for all managed connections.')
+      localize(
+        'failedAllConsumptionCalls',
+        'Failed to complete Consumption API calls for all managed connections: {0}',
+        error.message ?? error
+      )
     );
-    await handleError(error, localize('errorConsumptionResources', 'Error calling Consumption Resources API Connections'));
+    throw new Error(localize('errorConsumptionResources', error));
   }
 }
 
@@ -196,8 +194,9 @@ async function handleApiResponse(zipContent: Buffer | Buffer[], targetDirectory:
     await unzipLogicAppArtifacts(zipContent, targetDirectory);
     ext.outputChannel.appendLog(localize('artifactsSuccessfullyUnzipped', 'Artifacts successfully unzipped.'));
   } catch (error) {
-    ext.outputChannel.appendLog(localize('errorHandlingApiResponse', 'Error occurred while handling API response.'));
-    await handleError(error, localize('errorInHandleApiResponse', 'Error in handleApiResponse'));
+    const errorMessage = localize('errorHandlingApiResponse', 'Error occurred while handling API response: {0}', error.message ?? error);
+    ext.outputChannel.appendLog(errorMessage);
+    throw new Error(errorMessage);
   }
 }
 
@@ -269,9 +268,6 @@ async function callStandardResourcesApi(
     const responseData = JSON.parse(new TextDecoder().decode(error.response.data));
     const { message = '', code = '' } = responseData?.error ?? {};
     ext.outputChannel.appendLog(localize('failedStandardResourcesApiCall', `Failed to call Standard Resources API: ${code} - ${message}`));
-    if (error.stack) {
-      ext.outputChannel.appendLog(localize('errorStack', `Error Stack: ${error.stack}`));
-    }
     throw new Error(localize('errorStandardResourcesApi', message));
   }
 }
@@ -340,13 +336,11 @@ async function gatherAndValidateInputs(scriptContext: IAzureScriptWizard, folder
   let localSettings;
 
   try {
-    ext.outputChannel.appendLog(localize('fetchLocalSettingsAttempt', 'Attempting to fetch local settings...'));
     localSettings = await getLocalSettings(scriptContext, folder);
-    ext.outputChannel.appendLog(localize('fetchLocalSettingsSuccess', `Successfully fetched local settings from ${localSettings}`));
   } catch (error) {
-    ext.outputChannel.appendLog(localize('fetchLocalSettingsError', `Error fetching local settings: ${error}`));
-    await handleError(error, localize('handleErrorFetchLocalSettings', 'Error fetching local settings'));
-    return;
+    const errorMessage = localize('errorFetchLocalSettings', 'Error fetching local settings: {0}', error.message ?? error);
+    ext.outputChannel.appendLog(errorMessage);
+    throw new Error(errorMessage);
   }
 
   const {
@@ -384,13 +378,9 @@ async function gatherAndValidateInputs(scriptContext: IAzureScriptWizard, folder
     await wizard.execute();
     ext.outputChannel.appendLog(localize('executeAzureWizardSuccess', 'Azure Wizard executed successfully.'));
   } catch (error) {
-    ext.outputChannel.appendLog(localize('executeAzureWizardError', `Error executing Azure Wizard: ${error}`));
-    if (error?.message === COMMON_ERRORS.OPERATION_CANCELLED) {
-      throw new Error(localize('handleError.error', error.message));
-    } else {
-      await handleError(error, localize('handleErrorExecuteAzureWizard', 'Error executing Azure Wizard'));
-    }
-    return;
+    const errorMessage = localize('executeAzureWizardError', `Error executing Azure Wizard: {0}`, error.message ?? error);
+    ext.outputChannel.appendLog(errorMessage);
+    throw new Error(errorMessage);
   }
 
   return {

--- a/apps/vs-code-designer/src/app/utils/taskUtils.ts
+++ b/apps/vs-code-designer/src/app/utils/taskUtils.ts
@@ -2,12 +2,9 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
 import * as packageJson from '../../package.json';
 import { isPathEqual } from './fs';
 import * as AdmZip from 'adm-zip';
-import * as vscode from 'vscode';
 import type { Task, WorkspaceFolder } from 'vscode';
 import { tasks as codeTasks, window } from 'vscode';
 
@@ -110,31 +107,4 @@ export function showPreviewWarning(commandIdentifier: string): void {
     const commandTitle = targetCommand.title;
     window.showInformationMessage(`The "${commandTitle}" command is a preview feature and might be subject to change.`);
   }
-}
-/**
- * Handles errors by showing a localized error message in the Visual Studio Code UI
- * @param error - The error object containing details about the error that occurred.
- * @param messagePrefix - A string prefix that will be prepended to the error message.
- * @throws {Error} - Throws a new Error with a localized message including the prefix and error details.
- */
-export async function handleError(error: Error, messagePrefix: string): Promise<void> {
-  const errorMessage: string = error.message || 'Unknown Error';
-  let errorDetails: string = error.message || 'Unknown Error';
-
-  if (error.stack) {
-    errorDetails += `\nStack Trace: ${error.stack}`;
-  }
-
-  // Serializing other potential properties on the error object
-  const additionalErrorInfo: string = JSON.stringify(error, Object.getOwnPropertyNames(error));
-  if (additionalErrorInfo && additionalErrorInfo !== '{}') {
-    errorDetails += `\nAdditional Info: ${additionalErrorInfo}`;
-  }
-
-  ext.outputChannel.appendLog(localize('Error details', `${messagePrefix}: ${errorDetails}`));
-  const fullErrorMessage = `${messagePrefix}: ${errorMessage}`;
-  vscode.window.showErrorMessage(fullErrorMessage);
-
-  // Throwing a new error with the composed message for consistency and clarity
-  throw new Error(localize('handleError.error', fullErrorMessage));
 }

--- a/apps/vs-code-designer/src/app/utils/taskUtils.ts
+++ b/apps/vs-code-designer/src/app/utils/taskUtils.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import * as packageJson from '../../package.json';
 import { isPathEqual } from './fs';
@@ -117,6 +118,7 @@ export function showPreviewWarning(commandIdentifier: string): void {
  * @throws {Error} - Throws a new Error with a localized message including the prefix and error details.
  */
 export async function handleError(error: Error, messagePrefix: string): Promise<void> {
+  const errorMessage: string = error.message || 'Unknown Error';
   let errorDetails: string = error.message || 'Unknown Error';
 
   if (error.stack) {
@@ -129,7 +131,8 @@ export async function handleError(error: Error, messagePrefix: string): Promise<
     errorDetails += `\nAdditional Info: ${additionalErrorInfo}`;
   }
 
-  const fullErrorMessage = `${messagePrefix}: ${errorDetails}`;
+  ext.outputChannel.appendLog(localize('Error details', `${messagePrefix}: ${errorDetails}`));
+  const fullErrorMessage = `${messagePrefix}: ${errorMessage}`;
   vscode.window.showErrorMessage(fullErrorMessage);
 
   // Throwing a new error with the composed message for consistency and clarity

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -291,8 +291,3 @@ export const logicAppFilter = {
   type: 'microsoft.web/sites',
   kind: 'functionapp,workflowapp',
 };
-
-export const COMMON_ERRORS = {
-  OPERATION_CANCELLED: 'Operation cancelled.',
-} as const;
-export type COMMON_ERRORS = (typeof COMMON_ERRORS)[keyof typeof COMMON_ERRORS];


### PR DESCRIPTION
This pull request includes changes to improve user input validation and error handling in the Azure Script Wizard and related components. The most important changes include adding input validation to the Azure Wizard prompts, reordering the title property in the Azure Wizard creation, and refactoring error handling across multiple methods. 

User input validation:

* Added input validation to ensure the logic app name, storage account name, and App Service plan name cannot be empty in the `setLogicappName`, `setStorageAccountName`, and `setAppPlantName` classes respectively. 

* Refactored error handling in multiple methods. The refactoring includes removing the usage of `handleError` method, logging the error messages directly to the output channel, and throwing new errors with the error messages. 

* Removed the `handleError` method which was used to handle errors by showing a localized error message in the Visual Studio Code UI.


#### Screenshots
![Screenshot 2024-03-01 at 11 22 25 AM](https://github.com/Azure/LogicAppsUX/assets/102700317/4ef05fa8-8588-42a7-a293-505d28d4769f)
<img width="1012" alt="Screenshot 2024-03-01 at 11 37 02 AM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/cb693f8a-9e5f-41b8-a65d-07634bed59c6">
