### PR TITLE
feat(vscode):  Improve status step indicator for export experience

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/exportLogicApp.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/exportLogicApp.ts
@@ -50,6 +50,22 @@ interface Deployment {
 }
 
 class ExportEngine {
+  private intlText = {
+    SUCESSFULL_EXPORTED_MESSAGE: localize('workflowsExportedSuccessfully', 'The selected workflows exported successfully.'),
+    DONE: localize('done', 'Done.'),
+    DEPLOYING_CONNECTIONS: localize('deployConnections', 'Deploying connections ...'),
+    DOWNLOADING_PACKAGE: localize('downloadingPackage', 'Downloading package ...'),
+    UNZIP_PACKAGE: localize('unzipPackage', 'Unzipping package ...'),
+    FETCH_CONNECTION: localize('fetchConnectionKeys', 'Retrieving connection keys ...'),
+    UPDATE_FILES: localize('updateFiles', 'Updating parameters and settings ...'),
+  };
+
+  private finalStatus = {
+    InProgress: 'InProgress',
+    Succeeded: 'Succeeded',
+    Failed: 'Failed',
+  };
+
   public constructor(
     private getAccessToken: () => string,
     private packageUrl: string,
@@ -64,32 +80,32 @@ class ExportEngine {
 
   public async export(): Promise<void> {
     try {
-      this.setFinalStatus('InProgress');
-      this.addStatus(localize('downloadPackage', 'Downloading package ...'));
+      this.setFinalStatus(this.finalStatus.InProgress);
+      this.addStatus(this.intlText.DOWNLOADING_PACKAGE);
       const flatFile = await axios.get(this.packageUrl, {
         responseType: 'arraybuffer',
         responseEncoding: 'binary',
       });
 
       const buffer = Buffer.from(flatFile.data);
-      this.addStatus(localize('done', 'Done.'));
-      this.addStatus(localize('unzipPackage', 'Unzipping package ...'));
+      this.addStatus(this.intlText.DONE);
+      this.addStatus(this.intlText.UNZIP_PACKAGE);
       const zip = new AdmZip(buffer);
       zip.extractAllTo(/*target path*/ this.targetDirectory, /*overwrite*/ true);
-      this.addStatus(localize('done', 'Done.'));
+      this.addStatus(this.intlText.DONE);
 
       const templatePath = `${this.targetDirectory}/.development/deployment/LogicAppStandardConnections.template.json`;
 
       const templateExists = await fse.pathExists(templatePath);
       if (!this.resourceGroupName || !templateExists) {
-        this.setFinalStatus('Succeeded');
-        this.addStatus(localize('workflowsExportedSuccessfully', 'The selected workflows exported successfully.'));
+        this.setFinalStatus(this.finalStatus.Succeeded);
+        this.addStatus(this.intlText.SUCESSFULL_EXPORTED_MESSAGE);
         const uri: vscode.Uri = vscode.Uri.file(this.targetDirectory);
         vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: true });
         return;
       }
 
-      this.addStatus(localize('deployConnections', 'Deploying connections ...'));
+      this.addStatus(this.intlText.DEPLOYING_CONNECTIONS);
 
       const connectionsTemplate = await fse.readJSON(templatePath);
       const parametersFile = await fse.readJSON(`${this.targetDirectory}/parameters.json`);
@@ -102,18 +118,18 @@ class ExportEngine {
       }
 
       const output = await this.deployConnectionsTemplate(connectionsTemplate);
-      this.addStatus(localize('done', 'Done.'));
+      this.addStatus(this.intlText.DONE);
 
       await this.fetchConnectionKeys(output);
       await this.updateParametersAndSettings(output, parametersFile, localSettingsFile);
 
-      this.setFinalStatus('Succeeded');
-      this.addStatus(localize('workflowsExportedSuccessfully', 'The selected workflows exported successfully.'));
+      this.setFinalStatus(this.finalStatus.Succeeded);
+      this.addStatus(this.intlText.SUCESSFULL_EXPORTED_MESSAGE);
       const uri: vscode.Uri = vscode.Uri.file(this.targetDirectory);
       vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: true });
     } catch (error) {
       this.addStatus(localize('exportFailed', 'Export failed. {0}', error?.message ?? ''));
-      this.setFinalStatus('Failed');
+      this.setFinalStatus(this.finalStatus.Failed);
     }
   }
 
@@ -207,12 +223,12 @@ class ExportEngine {
   }
 
   private async fetchConnectionKeys(output: ConnectionsDeploymentOutput): Promise<void> {
-    this.addStatus(localize('fetchConnectionKeys', 'Retrieving connection keys ...'));
+    this.addStatus(this.intlText.FETCH_CONNECTION);
     for (const connectionKey of Object.keys(output?.connections?.value || {})) {
       const connectionItem = output.connections.value[connectionKey];
       connectionItem.authKey = await this.getConnectionKey(connectionItem.connectionId);
     }
-    this.addStatus(localize('done', 'Done.'));
+    this.addStatus(this.intlText.DONE);
   }
 
   private async getConnectionKey(connectionId: string): Promise<string> {
@@ -262,7 +278,7 @@ class ExportEngine {
     parametersFile: any,
     localSettingsFile: any
   ): Promise<void> {
-    this.addStatus(localize('updateFiles', 'Updating parameters and settings ...'));
+    this.addStatus(this.intlText.UPDATE_FILES);
 
     const { value } = output.connections;
     for (const key of Object.keys(value)) {
@@ -280,7 +296,7 @@ class ExportEngine {
 
     writeFileSync(`${this.targetDirectory}/parameters.json`, JSON.stringify(parametersFile, null, 4));
     writeFileSync(`${this.targetDirectory}/local.settings.json`, JSON.stringify(localSettingsFile, null, 4));
-    this.addStatus(localize('done', 'Done.'));
+    this.addStatus(this.intlText.DONE);
   }
 }
 

--- a/apps/vs-code-designer/src/app/commands/workflows/exportLogicApp.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/exportLogicApp.ts
@@ -83,6 +83,7 @@ class ExportEngine {
       const templateExists = await fse.pathExists(templatePath);
       if (!this.resourceGroupName || !templateExists) {
         this.setFinalStatus('Succeeded');
+        this.addStatus(localize('workflowsExportedSuccessfully', 'The selected workflows exported successfully.'));
         const uri: vscode.Uri = vscode.Uri.file(this.targetDirectory);
         vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: true });
         return;
@@ -107,6 +108,7 @@ class ExportEngine {
       await this.updateParametersAndSettings(output, parametersFile, localSettingsFile);
 
       this.setFinalStatus('Succeeded');
+      this.addStatus(localize('workflowsExportedSuccessfully', 'The selected workflows exported successfully.'));
       const uri: vscode.Uri = vscode.Uri.file(this.targetDirectory);
       vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: true });
     } catch (error) {

--- a/apps/vs-code-react/src/app/export/export.less
+++ b/apps/vs-code-react/src/app/export/export.less
@@ -221,4 +221,12 @@
       }
     }
   }
+
+  &-status {
+    &--item {
+      display: inline-flex;
+      align-items: center;
+      margin: 10px 0;
+    }
+  }
 }

--- a/apps/vs-code-react/src/app/export/status/status.tsx
+++ b/apps/vs-code-react/src/app/export/status/status.tsx
@@ -53,19 +53,22 @@ const FinalStatusGadget: React.FC<FinalStatusGadgetProps> = ({ finalStatus }) =>
   const workflowState = useSelector((state: RootState) => state.workflow);
   const { targetDirectory } = workflowState.exportData;
 
-  const message = intl.formatMessage({
-    defaultMessage: 'For next steps, review the ',
-    description: 'The success message.',
-  });
+  const exportNextStepsPath = intl.formatMessage(
+    {
+      defaultMessage: 'For next steps, review the {path} file.',
+      description: 'The success message.',
+    },
+    {
+      path: `${targetDirectory.path}/.logs/export/README.md`,
+    }
+  );
 
   switch (finalStatus) {
     case FinalStatus.Succeeded:
       return (
         <div className="msla-export-status--item">
           <Icon iconName={'SkypeCheck'} />
-          <Text style={{ marginLeft: '5px' }}>
-            {message} {targetDirectory.path}/.logs/export/README.md
-          </Text>
+          <Text style={{ marginLeft: '5px' }}>{exportNextStepsPath}</Text>
         </div>
       );
     default:

--- a/apps/vs-code-react/src/app/export/status/status.tsx
+++ b/apps/vs-code-react/src/app/export/status/status.tsx
@@ -17,9 +17,9 @@ export const Status: React.FC = () => {
     }),
   };
 
-  const renderStatus = (status?: string, index?: number): JSX.Element => {
+  const renderStatus = (status?: string, index?: number, final?: string): JSX.Element => {
     const icon =
-      index === statuses.length - 1 && finalStatus !== FinalStatus.Succeeded ? (
+      index === statuses.length - 1 && final !== FinalStatus.Succeeded ? (
         <Spinner size={SpinnerSize.small} />
       ) : (
         <Icon iconName={'SkypeCheck'} />
@@ -38,7 +38,7 @@ export const Status: React.FC = () => {
       <Text variant="xLarge" block>
         {intlText.EXPORT_STATUS_TITLE}
       </Text>
-      <List items={statuses} onRenderCell={renderStatus} />
+      <List items={statuses} onRenderCell={(status, index) => renderStatus(status, index, finalStatus)} />
       <FinalStatusGadget finalStatus={finalStatus} />
     </div>
   );
@@ -63,7 +63,7 @@ const FinalStatusGadget: React.FC<FinalStatusGadgetProps> = ({ finalStatus }) =>
       return (
         <div className="msla-export-status--item">
           <Icon iconName={'SkypeCheck'} />
-          <Text block>
+          <Text style={{ marginLeft: '5px' }}>
             {message} {targetDirectory.path}/.logs/export/README.md
           </Text>
         </div>

--- a/apps/vs-code-react/src/app/export/status/status.tsx
+++ b/apps/vs-code-react/src/app/export/status/status.tsx
@@ -17,16 +17,16 @@ export const Status: React.FC = () => {
     }),
   };
 
-  const renderStatus = (status?: string, index?: number, final?: string): JSX.Element => {
+  const renderStatus = (status?: string, index?: number): JSX.Element => {
     const icon =
-      index === statuses.length - 1 && final !== FinalStatus.Succeeded ? (
+      index === statuses.length - 1 && finalStatus !== FinalStatus.Succeeded ? (
         <Spinner size={SpinnerSize.small} />
       ) : (
         <Icon iconName={'SkypeCheck'} />
       );
 
     return (
-      <div className="msla-export-status--item">
+      <div key={`index-${finalStatus}`} className="msla-export-status--item">
         {icon}
         <Text style={{ marginLeft: '5px' }}>{status}</Text>
       </div>
@@ -38,7 +38,7 @@ export const Status: React.FC = () => {
       <Text variant="xLarge" block>
         {intlText.EXPORT_STATUS_TITLE}
       </Text>
-      <List items={statuses} onRenderCell={(status, index) => renderStatus(status, index, finalStatus)} />
+      <List items={statuses} onRenderCell={renderStatus} />
       <FinalStatusGadget finalStatus={finalStatus} />
     </div>
   );
@@ -54,7 +54,7 @@ const FinalStatusGadget: React.FC<FinalStatusGadgetProps> = ({ finalStatus }) =>
   const { targetDirectory } = workflowState.exportData;
 
   const message = intl.formatMessage({
-    defaultMessage: 'The selected workflows exported successfully. For next steps, review the ',
+    defaultMessage: 'For next steps, review the ',
     description: 'The success message.',
   });
 

--- a/apps/vs-code-react/src/app/export/status/status.tsx
+++ b/apps/vs-code-react/src/app/export/status/status.tsx
@@ -56,7 +56,7 @@ const FinalStatusGadget: React.FC<FinalStatusGadgetProps> = ({ finalStatus }) =>
   const exportNextStepsPath = intl.formatMessage(
     {
       defaultMessage: 'For next steps, review the {path} file.',
-      description: 'The success message.',
+      description: 'Message for next steps after export',
     },
     {
       path: `${targetDirectory.path}/.logs/export/README.md`,

--- a/apps/vs-code-react/src/app/export/status/status.tsx
+++ b/apps/vs-code-react/src/app/export/status/status.tsx
@@ -1,6 +1,6 @@
 import { Status as FinalStatus } from '../../../state/WorkflowSlice';
 import type { RootState } from '../../../state/store';
-import { Text, List } from '@fluentui/react';
+import { Text, List, Icon, Spinner, SpinnerSize } from '@fluentui/react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
@@ -8,6 +8,7 @@ export const Status: React.FC = () => {
   const intl = useIntl();
   const workflowState = useSelector((state: RootState) => state.workflow);
   const statuses = workflowState.statuses ?? [];
+  const finalStatus = workflowState.finalStatus;
 
   const intlText = {
     EXPORT_STATUS_TITLE: intl.formatMessage({
@@ -16,8 +17,20 @@ export const Status: React.FC = () => {
     }),
   };
 
-  const renderStatus = (status?: string): JSX.Element => {
-    return <Text block>{status}</Text>;
+  const renderStatus = (status?: string, index?: number): JSX.Element => {
+    const icon =
+      index === statuses.length - 1 && finalStatus !== FinalStatus.Succeeded ? (
+        <Spinner size={SpinnerSize.small} />
+      ) : (
+        <Icon iconName={'SkypeCheck'} />
+      );
+
+    return (
+      <div className="msla-export-status--item">
+        {icon}
+        <Text style={{ marginLeft: '5px' }}>{status}</Text>
+      </div>
+    );
   };
 
   return (
@@ -26,15 +39,18 @@ export const Status: React.FC = () => {
         {intlText.EXPORT_STATUS_TITLE}
       </Text>
       <List items={statuses} onRenderCell={renderStatus} />
-      <FinalStatusGadget />
+      <FinalStatusGadget finalStatus={finalStatus} />
     </div>
   );
 };
 
-const FinalStatusGadget: React.FC = () => {
+interface FinalStatusGadgetProps {
+  finalStatus: string | undefined;
+}
+
+const FinalStatusGadget: React.FC<FinalStatusGadgetProps> = ({ finalStatus }) => {
   const intl = useIntl();
   const workflowState = useSelector((state: RootState) => state.workflow);
-  const status = workflowState.finalStatus;
   const { targetDirectory } = workflowState.exportData;
 
   const message = intl.formatMessage({
@@ -42,12 +58,15 @@ const FinalStatusGadget: React.FC = () => {
     description: 'The success message.',
   });
 
-  switch (status) {
+  switch (finalStatus) {
     case FinalStatus.Succeeded:
       return (
-        <Text block>
-          {message} {targetDirectory.path}/.logs/export/README.md
-        </Text>
+        <div className="msla-export-status--item">
+          <Icon iconName={'SkypeCheck'} />
+          <Text block>
+            {message} {targetDirectory.path}/.logs/export/README.md
+          </Text>
+        </div>
       );
     default:
       return null;


### PR DESCRIPTION
This pull request primarily focuses on improving the user feedback during the workflow export process in the VS Code Designer and React applications. The changes include adding success messages in the `ExportEngine` class, updating the status rendering in the React application, and adding new styles for the status items.

* Added success messages in the `ExportEngine` class to inform the user when the workflows are exported successfully. These messages are added in two places, once when the resource group name is not provided or the template does not exist, and once after the parameters and settings are updated.

* Updated the `renderStatus` function to include an icon and a spinner for the status items. The spinner is shown for the last item if the final status is not 'Succeeded'. Also, the `FinalStatusGadget` component now takes `finalStatus` as a prop and displays a check icon when the final status is 'Succeeded'. 

* Added new styles for the status items. Each status item is displayed as an inline-flex item with centered alignment.

### Screenshot

#### Before
<img width="1452" alt="Screenshot 2024-03-02 at 2 01 44 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/1cd4ec61-0b09-4e3e-bf2c-244afd94df0b">


#### After
<img width="1450" alt="Screenshot 2024-03-02 at 2 06 02 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/a7b61a33-2c0d-4ebe-a62a-798f7fb91200">


https://github.com/Azure/LogicAppsUX/assets/102700317/d541768b-9bf4-4ebd-8b01-87a7a6cc2de8


