### PR TITLE
fix(vscode): Update command titles

### DIFF
--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -33,7 +33,7 @@
       "commands": [
         {
           "command": "azureLogicAppsStandard.createLogicApp",
-          "title": "Create Logic App in Azure...",
+          "title": "Create logic app in Azure...",
           "type": "LogicApp",
           "detail": "To create and run automated workflows with little to no code."
         }
@@ -106,12 +106,12 @@
       },
       {
         "command": "azureLogicAppsStandard.createLogicApp",
-        "title": "Create Logic App in Azure...",
+        "title": "Create logic app in Azure...",
         "category": "Azure Logic Apps"
       },
       {
         "command": "azureLogicAppsStandard.createLogicAppAdvanced",
-        "title": "Create Logic App in Azure... (Advanced)",
+        "title": "Create logic app in Azure... (Advanced)",
         "category": "Azure Logic Apps"
       },
       {
@@ -131,7 +131,7 @@
       },
       {
         "command": "azureLogicAppsStandard.deleteLogicApp",
-        "title": "Delete Logic App...",
+        "title": "Delete logic app...",
         "category": "Azure Logic Apps"
       },
       {
@@ -155,7 +155,7 @@
       },
       {
         "command": "azureLogicAppsStandard.switchToDotnetProject",
-        "title": "Convert to NuGet-based Logic App project",
+        "title": "Convert to NuGet-based logic app project",
         "category": "Azure Logic Apps"
       },
       {
@@ -264,7 +264,7 @@
       },
       {
         "command": "azureLogicAppsStandard.useSQLStorage",
-        "title": "Use SQL storage for your Logic App project",
+        "title": "Use SQL storage for your logic app project",
         "category": "Azure Logic Apps"
       },
       {
@@ -737,7 +737,7 @@
               "~4",
               "~3"
             ],
-            "description": "The default version of the Azure Functions runtime to use when performing operations like \"Create New Logic App\".",
+            "description": "The default version of the Azure Functions runtime to use when performing operations like \"Create new logic app\".",
             "enumDescriptions": [
               "Azure Functions v4",
               "Azure Functions v3 (.NET Core)"


### PR DESCRIPTION
 The changes mainly involve the standardization of the naming convention for logic app-related commands and descriptions. The previously used title case has been replaced with sentence case.

* The title of the command "Create Logic App in Azure..." has been changed to "Create logic app in Azure...". Similar changes have been made to the titles of other commands related to logic apps, including "Create Logic App in Azure... (Advanced)", "Delete Logic App...", "Convert to NuGet-based Logic App project", and "Use SQL storage for your Logic App project". The description of the default version of the Azure Functions runtime has also been updated to use sentence case.