### PR TITLE
fix(Consumption): Multiple minor changes to scope and subgraph nodes

### DIFF
--- a/libs/designer-ui/src/lib/card/scopeCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/scopeCard/index.tsx
@@ -51,9 +51,8 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
 
   const colorVars = { ['--brand-color' as any]: brandColor };
   const cardIcon = isLoading ? (
-    <Spinner className="msla-card-header-spinner" size={'tiny'} />
-  ) : // <Spinner className="msla-card-header-spinner" size={SpinnerSize.small} />
-  icon ? (
+    <Spinner className="msla-card-header-spinner" size={'tiny'} appearance="inverted" />
+  ) : icon ? (
     <img className="scope-icon" alt="" role="presentation" src={icon} />
   ) : null;
 
@@ -83,7 +82,7 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
             <button className="msla-scope-card-title-button" onClick={handleClick}>
               <div className="msla-scope-card-title-box">
                 <div className={css('gripper-section', draggable && 'draggable')}>{draggable ? <Gripper /> : null}</div>
-                {cardIcon}
+                <div className="panel-card-content-icon-section">{cardIcon}</div>
                 <div className="msla-scope-title">{title}</div>
               </div>
               {errorMessage ? <ErrorBanner errorLevel={errorLevel} errorMessage={errorMessage} /> : null}

--- a/libs/designer-ui/src/lib/card/scopeCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/scopeCard/index.tsx
@@ -5,8 +5,8 @@ import { ErrorBanner } from '../errorbanner';
 import { useCardContextMenu, useCardKeyboardInteraction } from '../hooks';
 import { Gripper } from '../images/dynamicsvgs/gripper';
 import type { CardProps } from '../index';
-import { css, Icon, TooltipHost } from '@fluentui/react';
-import { Spinner } from '@fluentui/react-components';
+import { css, Icon } from '@fluentui/react';
+import { Spinner, Tooltip } from '@fluentui/react-components';
 
 export interface ScopeCardProps extends CardProps {
   collapsed?: boolean;
@@ -93,14 +93,16 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
           <div>
             <div className="msla-badges">
               {badges.map(({ title, content, darkBackground, iconProps }) => (
-                <TooltipHost key={title} content={content}>
-                  <Icon
-                    className={css('panel-card-v2-badge', 'active', darkBackground && 'darkBackground')}
-                    {...iconProps}
-                    ariaLabel={`${title}: ${content}`}
-                    tabIndex={0}
-                  />
-                </TooltipHost>
+                <Tooltip key={title} relationship={'label'} withArrow={true} content={content}>
+                  <div>
+                    <Icon
+                      className={css('panel-card-v2-badge', 'active', darkBackground && 'darkBackground')}
+                      {...iconProps}
+                      ariaLabel={`${title}: ${content}`}
+                      tabIndex={0}
+                    />
+                  </div>
+                </Tooltip>
               ))}
             </div>
           </div>

--- a/libs/designer-ui/src/lib/card/scopeCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/scopeCard/index.tsx
@@ -89,7 +89,7 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
             </button>
             <NodeCollapseToggle collapsed={collapsed} handleCollapse={handleCollapse} />
           </div>
-          <div>
+          <div className="msla-card-v2-footer" onClick={handleClick}>
             <div className="msla-badges">
               {badges.map(({ title, content, darkBackground, iconProps }) => (
                 <Tooltip key={title} relationship={'label'} withArrow={true} content={content}>

--- a/libs/designer-ui/src/lib/card/scopeCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/scopeCard/index.tsx
@@ -5,7 +5,8 @@ import { ErrorBanner } from '../errorbanner';
 import { useCardContextMenu, useCardKeyboardInteraction } from '../hooks';
 import { Gripper } from '../images/dynamicsvgs/gripper';
 import type { CardProps } from '../index';
-import { css, Icon, Spinner, SpinnerSize, TooltipHost } from '@fluentui/react';
+import { css, Icon, TooltipHost } from '@fluentui/react';
+import { Spinner } from '@fluentui/react-components';
 
 export interface ScopeCardProps extends CardProps {
   collapsed?: boolean;
@@ -50,8 +51,9 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
 
   const colorVars = { ['--brand-color' as any]: brandColor };
   const cardIcon = isLoading ? (
-    <Spinner className="msla-card-header-spinner" size={SpinnerSize.small} />
-  ) : icon ? (
+    <Spinner className="msla-card-header-spinner" size={'tiny'} />
+  ) : // <Spinner className="msla-card-header-spinner" size={SpinnerSize.small} />
+  icon ? (
     <img className="scope-icon" alt="" role="presentation" src={icon} />
   ) : null;
 

--- a/libs/designer-ui/src/lib/card/scopeCard/scopeCard.less
+++ b/libs/designer-ui/src/lib/card/scopeCard/scopeCard.less
@@ -58,10 +58,22 @@
   }
 
   .msla-scope-card-title-box {
+    flex: 1 1 auto;
     display: flex;
     flex-direction: row;
     align-items: center;
     justify-content: flex-start;
+  }
+
+  .panel-card-content-icon-section {
+    display: flex;
+    margin: 8px 8px 8px 0px;
+
+    .panel-card-icon {
+      height: 24px;
+      width: 24px;
+      border-radius: 2px;
+    }
   }
 
   .gripper-section {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/move.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/move.ts
@@ -1,14 +1,10 @@
 import type { MoveNodePayload } from '../../parsers/moveNodeInWorkflow';
-import { clearPanel } from '../../state/panel/panelSlice';
-import { clearFocusNode, moveNode } from '../../state/workflow/workflowSlice';
+import { moveNode } from '../../state/workflow/workflowSlice';
 import type { RootState } from '../../store';
 import { updateAllUpstreamNodes } from './initialize';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 export const moveOperation = createAsyncThunk('moveOperation', async (movePayload: MoveNodePayload, { dispatch, getState }) => {
-  dispatch(clearFocusNode());
-  dispatch(clearPanel());
-
   dispatch(moveNode(movePayload));
   updateAllUpstreamNodes(getState() as RootState, dispatch);
 

--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -19,6 +19,7 @@ import {
   useParentRunIndex,
   useRunInstance,
   useParentRunId,
+  useNodeDescription,
 } from '../../core/state/workflow/workflowSelectors';
 import { setRepetitionRunData, toggleCollapsedGraphId } from '../../core/state/workflow/workflowSlice';
 import type { AppDispatch } from '../../core/store';
@@ -43,6 +44,7 @@ import type { NodeProps } from 'reactflow';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = Position.Bottom, id }: NodeProps) => {
   const scopeId = removeIdTag(id);
+  const nodeComment = useNodeDescription(scopeId);
 
   const node = useActionMetadata(scopeId);
   const operationsInfo = useAllOperations();
@@ -176,6 +178,19 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
     [brandColor, iconUri, opQuery.isLoading, isRepetitionLoading, isRepetitionRefetching]
   );
 
+  const comment = useMemo(
+    () =>
+      nodeComment
+        ? {
+            brandColor,
+            comment: nodeComment,
+            isDismissed: false,
+            isEditing: false,
+          }
+        : undefined,
+    [brandColor, nodeComment]
+  );
+
   const opManifestErrorText = intl.formatMessage({
     defaultMessage: 'Error fetching manifest',
     description: 'Error message when manifest fails to load',
@@ -279,6 +294,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
             selected={selected}
             contextMenuItems={contextMenuItems}
             runData={runData}
+            commentBox={comment}
           />
           {isMonitoringView && normalizedType === constants.NODE.TYPE.FOREACH ? (
             <LoopsPager metadata={metadata} scopeId={scopeId} collapsed={graphCollapsed} />

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -24,7 +24,8 @@ import { usePanelTabs } from './usePanelTabs';
 import { WorkflowService } from '@microsoft/designer-client-services-logic-apps';
 import type { CommonPanelProps, PageActionTelemetryData } from '@microsoft/designer-ui';
 import { PanelContainer, PanelLocation, PanelScope, PanelSize } from '@microsoft/designer-ui';
-import { isNullOrUndefined } from '@microsoft/logic-apps-shared';
+import { SUBGRAPH_TYPES, isNullOrUndefined } from '@microsoft/logic-apps-shared';
+import type { ReactElement } from 'react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -83,10 +84,13 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
     dispatch(setNodeDescription({ nodeId: selectedNode, ...(showCommentBox && { description: '' }) }));
   };
 
-  const headerMenuItems = [
-    <CommentMenuItem key={'comment'} onClick={handleCommentMenuClick} hasComment={showCommentBox} />,
-    <DeleteMenuItem key={'delete'} onClick={deleteClick} />,
-  ];
+  // Removing the 'add a note' button for subgraph nodes
+  const isSubgraphContainer = nodeMetaData?.subgraphType === SUBGRAPH_TYPES.SWITCH_CASE;
+  const headerMenuItems: ReactElement[] = [];
+  if (!isSubgraphContainer) {
+    headerMenuItems.push(<CommentMenuItem key={'comment'} onClick={handleCommentMenuClick} hasComment={showCommentBox} />);
+  }
+  headerMenuItems.push(<DeleteMenuItem key={'delete'} onClick={deleteClick} />);
 
   const onTitleChange = (newId: string): { valid: boolean; oldValue?: string } => {
     const isValid = isOperationNameValid(selectedNode, newId, isTriggerNode, nodesMetadata, idReplacements);


### PR DESCRIPTION
This PR includes many minor UI fixes to both scope nodes and subgraph nodes. Here is a list of all those changes:

1. We now show a note icon in the card footer when there is a note added to a scope node. For this we first needed to pass the note down through props and then adjust the display so it matched the current display on the operation nodes.
<img width="176" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/e1101450-5e73-4a74-9118-64d1dc2b6ae4">
<img width="184" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/fc74b59b-7863-4bc1-b6ec-1cc1f2b64b08">

2. We removed the 'Add a node' button option from subgraph nodes since users cant add notes to this type of node. For this we had to check if the node was a subgraph node and not include the 'Add a note' option for those cases. Now they only have the 'Delete' option
<img width="467" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/e62cd829-7bc6-49ef-a1b1-bf2d18135364">

3. Scope nodes had the old loading spinner but now it has been updated to match the current operation node spinner but in the 'inverted' style.
<img width="221" alt="image (10)" src="https://github.com/Azure/LogicAppsUX/assets/125534835/f022171e-74b5-4c50-aa5c-335503b236f3">
<img width="243" alt="image (11)" src="https://github.com/Azure/LogicAppsUX/assets/125534835/4025a447-6ee0-4401-a1e8-d9717eb5e3e8">

4. When you move a node and the panel was open, the panel would close, but now the panel will stay open if it was open and stay closed if it was closed.
<img width="700" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/8f3adf44-beb4-43c4-94db-24a0f26d6b4e">
<img width="700" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/125534835/591c6a75-5d1a-482e-9643-6c5958459a1d">


