### PR TITLE
fix(desinger): Remove Outputs if includeRootOutputs is not set

### DIFF
--- a/libs/logic-apps-shared/src/parsers/lib/manifest/parser.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/manifest/parser.ts
@@ -131,7 +131,11 @@ export class ManifestParser {
       OutputsProcessor.convertSchemaPropertyToOutputParameter(item, SwaggerConstants.OutputSource.Outputs, 'outputs')
     );
 
-    return map(outputParameters, SwaggerConstants.OutputMapKey);
+    const filteredOutputParameters = !this._operationManifest.properties.includeRootOutputs
+      ? outputParameters.filter((parameter) => parameter.key !== 'outputs.$')
+      : outputParameters;
+
+    return map(filteredOutputParameters, SwaggerConstants.OutputMapKey);
   }
 
   /**


### PR DESCRIPTION
only include root outputs if explicitly set in the manifest.

Fixes https://github.com/Azure/LogicAppsUX/issues/3967