### PR TITLE
fix(Designer): Fixed issue where some service provider operations would not appear in search / browse

### DIFF
--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -62,10 +62,17 @@ export const RecommendationPanelContext = (props: CommonPanelProps) => {
   const [activeSearchOperations, setActiveSearchOperations] = useState<DiscoveryOpArray>([]);
 
   // Remove duplicates from allOperations and activeSearchOperations
-  const allOperations: DiscoveryOpArray = useMemo(
-    () => joinAndDeduplicateById(preloadedOperations, activeSearchOperations),
-    [preloadedOperations, activeSearchOperations]
-  );
+  const allOperations: DiscoveryOpArray = useMemo(() => {
+    console.log(
+      '### aso:',
+      activeSearchOperations.filter((op) => op.properties.summary === 'Send message')
+    );
+    console.log(
+      '### po:',
+      preloadedOperations.filter((op) => op.properties.summary === 'Send message')
+    );
+    return joinAndDeduplicateById(preloadedOperations, activeSearchOperations);
+  }, [preloadedOperations, activeSearchOperations]);
 
   // Active search
   useDebouncedEffect(
@@ -263,5 +270,5 @@ export const RecommendationPanelContext = (props: CommonPanelProps) => {
 };
 
 const joinAndDeduplicateById = (arr1: DiscoveryOpArray, arr2: DiscoveryOpArray) => [
-  ...new Map([...arr1, ...arr2].map((v) => [v.id, v])).values(),
+  ...new Map([...arr1, ...arr2].map((v) => [`${v?.properties?.api?.id}/${v.id}`, v])).values(),
 ];

--- a/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -62,17 +62,10 @@ export const RecommendationPanelContext = (props: CommonPanelProps) => {
   const [activeSearchOperations, setActiveSearchOperations] = useState<DiscoveryOpArray>([]);
 
   // Remove duplicates from allOperations and activeSearchOperations
-  const allOperations: DiscoveryOpArray = useMemo(() => {
-    console.log(
-      '### aso:',
-      activeSearchOperations.filter((op) => op.properties.summary === 'Send message')
-    );
-    console.log(
-      '### po:',
-      preloadedOperations.filter((op) => op.properties.summary === 'Send message')
-    );
-    return joinAndDeduplicateById(preloadedOperations, activeSearchOperations);
-  }, [preloadedOperations, activeSearchOperations]);
+  const allOperations: DiscoveryOpArray = useMemo(
+    () => joinAndDeduplicateById(preloadedOperations, activeSearchOperations),
+    [preloadedOperations, activeSearchOperations]
+  );
 
   // Active search
   useDebouncedEffect(


### PR DESCRIPTION
## Main Changes

Fixed issue where some service provider operations would not appear in search / browse.
This was due to our deduplication of operations was solely dependent on operation ids, but service provider operation ids do not have their connector / api in the id to help differentiate. 
I've adjusted the uniqueness check to account for api ID as well as operation id.

Fixes https://github.com/Azure/LogicAppsUX/issues/4343