### PR TITLE
fix(Designer): Only resolve app settings if they are used in resource ids

### DIFF
--- a/apps/designer-standalone/src/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
+++ b/apps/designer-standalone/src/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
@@ -76,8 +76,12 @@ export class WorkflowUtility {
     if (appsettings) {
       for (const settingName of Object.keys(appsettings)) {
         const settingValue = appsettings[settingName] !== undefined ? appsettings[settingName] : '';
-        result = replaceAllOccurrences(result, `@appsetting('${settingName}')`, settingValue);
-        result = replaceAllOccurrences(result, `@{appsetting('${settingName}')}`, settingValue);
+        // Only if an app setting comes after "/subscriptions/" should it be resolved
+        //     Leaving the subscription as an appsetting causes issues
+        //     Resolving other appsettings also causes issues
+        const subscriptionSearchValue = `/subscriptions/@appsetting('${settingName}')/`;
+        const subscriptionSettingValue = `/subscriptions/${settingValue}/`;
+        result = replaceAllOccurrences(result, subscriptionSearchValue, subscriptionSettingValue);
       }
     }
 

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -66,6 +66,7 @@ import {
   aggregate,
   equals,
   getRecordEntry,
+  parseErrorMessage,
 } from '@microsoft/logic-apps-shared';
 import type { InputParameter, OutputParameter, LogicAppsV2, OperationManifest } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
@@ -276,7 +277,8 @@ export const initializeOperationDetailsForManifest = async (
       ...childGraphInputs,
     ];
   } catch (error: any) {
-    const message = `Unable to initialize operation details for operation - ${nodeId}. Error details - ${error}`;
+    const errorMessage = parseErrorMessage(error);
+    const message = `Unable to initialize operation details for operation - ${nodeId}. Error details - ${errorMessage}`;
     LoggerService().log({
       level: LogEntryLevel.Error,
       area: 'operation deserializer',

--- a/libs/designer/src/lib/core/utils/swagger/operation.ts
+++ b/libs/designer/src/lib/core/utils/swagger/operation.ts
@@ -40,6 +40,7 @@ import {
   isDynamicSchemaExtension,
   isTemplateExpression,
   map,
+  parseErrorMessage,
   parsePathnameAndQueryKeyFromUri,
   removeConnectionPrefix,
   startsWith,
@@ -124,12 +125,7 @@ export const initializeOperationDetailsForSwagger = async (
 
     throw new Error('Operation info could not be found for a swagger operation');
   } catch (error: any) {
-    let errorString = '';
-    try {
-      errorString = error?.toString() ?? error;
-    } catch (_: any) {
-      errorString = 'Could not convert error to string';
-    }
+    const errorString = parseErrorMessage(error);
     const message = `Unable to initialize operation details for swagger based operation - ${nodeId}. Error details - ${errorString}`;
     LoggerService().log({
       level: LogEntryLevel.Error,

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/http.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/http.ts
@@ -8,13 +8,17 @@ export const HTTP_METHODS = {
 } as const;
 
 export const parseErrorMessage = (error: any, defaultErrorMessage?: string): string => {
-  let message = error?.message ?? error?.Message ?? error?.error?.message ?? error?.content?.message ?? undefined;
-  if (message) return message;
+  try {
+    let message = error?.message ?? error?.Message ?? error?.error?.message ?? error?.content?.message ?? undefined;
+    if (message) return message;
 
-  // Response text needs to be parsed to get internal error message
-  if (error?.responseText) {
-    message = parseErrorMessage(JSON.parse(error.responseText), defaultErrorMessage);
+    // Response text needs to be parsed to get internal error message
+    if (error?.responseText) {
+      message = parseErrorMessage(JSON.parse(error.responseText), defaultErrorMessage);
+    }
+
+    return message ?? defaultErrorMessage ?? error ?? 'Unknown error';
+  } catch (e) {
+    return 'Could not parse error message.';
   }
-
-  return message ?? defaultErrorMessage ?? 'Unknown error';
 };


### PR DESCRIPTION
## Main Changes

Only resolve app settings if they are used in resource ids.

This allows users to have key vault references in app settings / connections data without causing the initialization issues we were seeing when subscriptions had app settings values.
The only bad behavior with this change is when a user has a key vault reference as an app setting that is used in place of a subscription ID, I don't see a way around that one.

I've also updated a couple situations where we weren't parsing errors properly and returning generic errors on accident.