### PR TITLE
fix(vscode): Implement function to determine if connections have been already parameterized

### DIFF
--- a/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
+++ b/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
@@ -8,7 +8,7 @@ import { localize } from '../../localize';
 import { getLocalSettingsJson } from '../utils/appSettings/localSettings';
 import { getConnectionsJson, saveConnectionReferences } from '../utils/codeless/connection';
 import { getParametersJson, saveWorkflowParameter } from '../utils/codeless/parameter';
-import { parameterizeConnection } from '../utils/codeless/parameterizer';
+import { isConnectionsParameterized, parameterizeConnection } from '../utils/codeless/parameterizer';
 import { tryGetLogicAppProjectRoot } from '../utils/verifyIsProject';
 import { getGlobalSetting, updateGlobalSetting } from '../utils/vsCodeConfig/settings';
 import { getWorkspaceFolder } from '../utils/workspace';
@@ -70,6 +70,11 @@ export async function parameterizeConnections(context: IActionContext): Promise<
           string,
           any
         >;
+
+        if (isConnectionsParameterized(connectionsData)) {
+          window.showInformationMessage(localize('connectionsAlreadyParameterized', 'Connections are already parameterized.'));
+          return;
+        }
 
         Object.keys(connectionsData).forEach((connectionType) => {
           if (connectionType !== 'serviceProviderConnections') {

--- a/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
@@ -6,6 +6,7 @@ import type {
   FunctionConnectionModel,
   APIManagementConnectionModel,
   Parameter,
+  ConnectionsData,
 } from '@microsoft/vscode-extension';
 
 const DELIMITER = '/';
@@ -56,6 +57,36 @@ export function parameterizeConnection(
   }
 
   return connection;
+}
+
+/**
+ * Checks if the connections data is parameterized.
+ * @param {ConnectionsData} connectionsData - The connections data object.
+ * @returns A boolean indicating whether the connections data is parameterized or not.
+ */
+export function isConnectionsParameterized(connectionsData: ConnectionsData): boolean {
+  for (const connectionType in connectionsData) {
+    if (connectionType !== 'serviceProviderConnections') {
+      const connectionTypeJson = connectionsData[connectionType];
+      for (const connectionKey in connectionTypeJson) {
+        const connection = connectionTypeJson[connectionKey];
+        if (isConnectionReferenceModel(connection)) {
+          if (connection.api.id.includes('@appsetting') || connection.connectionRuntimeUrl.includes('@parameters')) {
+            return true;
+          }
+        } else if (isFunctionConnectionModel(connection)) {
+          if (connection.function.id.includes('@parameters') || connection.triggerUrl.includes('@parameters')) {
+            return true;
+          }
+        } else if (isAPIManagementConnectionModel(connection)) {
+          if (connection.apiId.includes('@parameters') || connection.baseUrl.includes('@parameters')) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
This pull request primarily focuses on enhancing the parameterization of connections in the VS Code Designer application. The main changes include the addition of a function to check if connections are already parameterized, and the subsequent use of this function in the `parameterizeConnections` command. 

* A new function `isConnectionsParameterized` is added. This function checks if the connections data is already parameterized by examining various connection types and their properties. If any connection is found to be parameterized, the function returns `true`.

* Before parameterizing connections, the `parameterizeConnections` command now checks if the connections are already parameterized using the `isConnectionsParameterized` function. If they are, it shows an information message and returns without making any changes.


### Screenshots
<img width="1920" alt="Screenshot 2024-03-12 at 11 37 28 AM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/2a0e0f22-6a8f-4ca1-ab63-07b290c33194">
