### PR TITLE
fix(Consumption): Adding check for valid 'false' value

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -137,6 +137,7 @@ import {
   nthLastIndexOf,
   parseErrorMessage,
   getRecordEntry,
+  isBoolean,
 } from '@microsoft/logic-apps-shared';
 import type {
   DependentParameterInfo,
@@ -861,7 +862,7 @@ export function loadParameterValue(parameter: InputParameter): ValueSegment[] {
 
   if (parameter.isNotificationUrl) {
     valueObject = `@${constants.HTTP_WEBHOOK_LIST_CALLBACK_URL_NAME}`;
-  } else if (parameter.value || (parameter.type === 'boolean' && parameter.value === false)) {
+  } else if (parameter.value || isBoolean(parameter.value)) {
     valueObject = parameter.value;
   } else if (parameter.default) {
     valueObject = parameter.default;

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -861,7 +861,7 @@ export function loadParameterValue(parameter: InputParameter): ValueSegment[] {
 
   if (parameter.isNotificationUrl) {
     valueObject = `@${constants.HTTP_WEBHOOK_LIST_CALLBACK_URL_NAME}`;
-  } else if (parameter.value) {
+  } else if (parameter.value || (parameter.type === 'boolean' && parameter.value === false)) {
     valueObject = parameter.value;
   } else if (parameter.default) {
     valueObject = parameter.default;


### PR DESCRIPTION
This PR addresses the issue that when initializing or setting a variable to false, when reopening designer, it won't populate this value correctly, leaving it as an empty string, even though it would show up correctly in the code view. This is because when we were checking to see if there was a value and the value was false, it would take this to mean there was no value. Now we add an extra check such that if the type is a boolean and the value is false, it will accept this as a valid value. 

fixes #4342 