### PR TITLE
feat(designer): Add validation errors to output mocks

### DIFF
--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -215,6 +215,7 @@ export const TokenField = ({
           initialValue={editorViewModel.uncastedValue}
           tokenPickerButtonProps={tokenpickerButtonProps}
           getTokenPicker={getTokenPicker}
+          basePlugins={{ tokens: showTokens }}
           itemSchema={editorViewModel.itemSchema}
           castParameter={onCastParameter}
           onChange={onValueChange}

--- a/libs/designer-ui/src/lib/unitTesting/assertionsPanel/assertionField.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/assertionsPanel/assertionField.tsx
@@ -6,7 +6,7 @@ import type { TokenPickerMode } from '../../tokenpicker';
 import type { GetAssertionTokenPickerHandler } from './assertion';
 import type { ILabelStyles, IStyle, ITextFieldStyles } from '@fluentui/react';
 import { Label, Text, TextField } from '@fluentui/react';
-import { type Assertion, isEmptyString } from '@microsoft/utils-logic-apps';
+import { type Assertion, isEmptyString, isNullOrUndefined } from '@microsoft/utils-logic-apps';
 import { useIntl } from 'react-intl';
 
 export const labelStyles: Partial<ILabelStyles> = {
@@ -71,8 +71,6 @@ export const AssertionField = ({
   validationErrors,
 }: AssertionFieldProps): JSX.Element => {
   const intl = useIntl();
-
-  const errors = validationErrors ?? {};
 
   const parameterDetails: ParameterFieldDetails = {
     description: `${name}-${DESCRIPTION_KEY}`,
@@ -140,7 +138,7 @@ export const AssertionField = ({
             id={parameterDetails.name}
             ariaLabel={nameTitle}
             placeholder={namePlaceholder}
-            errorMessage={errors[NAME_KEY]}
+            errorMessage={validationErrors && validationErrors[NAME_KEY]}
             value={name}
             onChange={onNameChange}
             disabled={!isEditable}
@@ -211,9 +209,9 @@ export const AssertionField = ({
                 onCastParameter={() => ''}
                 onValueChange={onExpressionChange}
               />
-              {errors[EXPRESSION_KEY] && (
+              {!isNullOrUndefined(validationErrors) && validationErrors[EXPRESSION_KEY] && (
                 <span className="msla-input-parameter-error" role="alert">
-                  {errors[EXPRESSION_KEY]}
+                  {validationErrors[EXPRESSION_KEY]}
                 </span>
               )}
             </>

--- a/libs/designer-ui/src/lib/unitTesting/outputMocks/ouputsSettings.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/outputMocks/ouputsSettings.tsx
@@ -1,11 +1,11 @@
 import { SettingTokenField } from '../../settings/settingsection';
-import { ActionResults } from './outputMocks';
+import { ActionResults, type OutputsField } from './outputMocks';
 import { Text } from '@fluentui/react-components';
 import { isNullOrUndefined } from '@microsoft/utils-logic-apps';
 import { useIntl } from 'react-intl';
 
 export interface OutputsSettingsProps {
-  outputs: any[];
+  outputs: OutputsField[];
   nodeId: string;
   actionResult: string;
 }

--- a/libs/designer-ui/src/lib/unitTesting/outputMocks/ouputsSettings.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/outputMocks/ouputsSettings.tsx
@@ -1,6 +1,7 @@
 import { SettingTokenField } from '../../settings/settingsection';
 import { ActionResults } from './outputMocks';
 import { Text } from '@fluentui/react-components';
+import { isNullOrUndefined } from '@microsoft/utils-logic-apps';
 import { useIntl } from 'react-intl';
 
 export interface OutputsSettingsProps {
@@ -8,6 +9,8 @@ export interface OutputsSettingsProps {
   nodeId: string;
   actionResult: string;
 }
+
+const VALUE_KEY = 'value';
 
 export const OutputsSettings: React.FC<OutputsSettingsProps> = ({ nodeId, outputs, actionResult }): JSX.Element => {
   const intl = useIntl();
@@ -24,7 +27,14 @@ export const OutputsSettings: React.FC<OutputsSettingsProps> = ({ nodeId, output
   return hasMockOutputs ? (
     <>
       {outputs.map((output: any) => (
-        <SettingTokenField key={`${nodeId}-${output.id}`} {...output} />
+        <div key={`${nodeId}-${output.id}`}>
+          <SettingTokenField {...output} />
+          {!isNullOrUndefined(output.validationErrors) && output.validationErrors[VALUE_KEY] && (
+            <span className="msla-input-parameter-error" role="alert">
+              {output.validationErrors[VALUE_KEY]}
+            </span>
+          )}
+        </div>
       ))}
     </>
   ) : (

--- a/libs/designer-ui/src/lib/unitTesting/outputMocks/outputMocks.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/outputMocks/outputMocks.tsx
@@ -1,4 +1,6 @@
+import { type ChangeHandler } from '../../editor/base';
 import { type EventHandler } from '../../eventhandler';
+import { type SettingProps } from '../../settings/settingsection/settingtoggle';
 import { ActionResult } from './actionResult';
 import { OutputsSettings } from './ouputsSettings';
 import './outputMocks.less';
@@ -29,7 +31,7 @@ export interface OutputMocksProps {
   isMockSupported: boolean;
   nodeId: string;
   onActionResultUpdate: ActionResultUpdateHandler;
-  outputs: any[];
+  outputs: OutputsField[];
   mocks: OutputMock;
 }
 
@@ -39,6 +41,25 @@ export const ActionResults = {
   SKIPPED: 'skipped',
   FAILED: 'failed',
 };
+
+export interface OutputsField extends SettingProps {
+  id?: string;
+  label: string;
+  required?: boolean;
+  readOnly?: boolean;
+  value: ValueSegment[];
+  editor?: string;
+  editorOptions?: any;
+  schema: any;
+  tokenEditor: boolean;
+  isLoading?: boolean;
+  editorViewModel?: any;
+  showTokens?: boolean;
+  tokenMapping: Record<string, ValueSegment>;
+  validationErrors: Record<string, string | undefined>;
+  suppressCastingForSerialize?: boolean;
+  onValueChange?: ChangeHandler;
+}
 
 export const OutputMocks = ({ isMockSupported, nodeId, onActionResultUpdate, outputs, mocks }: OutputMocksProps) => {
   const intl = useIntl();

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -126,6 +126,7 @@ export const deserializeUnitTestDefinition = (
   const actionsKeys = Object.keys(definition.actions ?? {});
   const triggersKeys = Object.keys(definition.triggers ?? {});
 
+  // Build mock output for all actions and triggers
   const mockActions: Record<string, OutputMock> = actionsKeys.reduce((acc, key) => {
     const action = definition.actions && definition.actions[key];
     const type = action?.type?.toLowerCase();

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -115,6 +115,12 @@ export const Deserialize = (
   };
 };
 
+/**
+ * Deserializes a unit test definition and a workflow definition into assertions and mock results.
+ * @param {UnitTestDefinition | null} unitTestDefinition - The unit test definition to deserialize.
+ * @param {Workflow} workflowDefinition - The workflow definition to deserialize.
+ * @returns An object containing the assertions and mock results, or null if the unit test definition is null.
+ */
 export const deserializeUnitTestDefinition = (
   unitTestDefinition: UnitTestDefinition | null,
   workflowDefinition: Workflow
@@ -166,16 +172,20 @@ export const deserializeUnitTestDefinition = (
   const triggerName = triggersKeys[0]; // only 1 trigger
 
   if (triggerName) {
+    const mockOutputs = unitTestDefinition.triggerMocks[triggerName].outputs ?? {};
     mockResults[`&${triggerName}`] = {
       actionResult: unitTestDefinition.triggerMocks[triggerName].actionResult ?? ActionResults.SUCCESS,
-      output: unitTestDefinition.triggerMocks[triggerName].outputs ?? {},
+      output: mockOutputs,
+      isCompleted: !isNullOrEmpty(mockOutputs),
     };
   }
 
   Object.keys(unitTestDefinition.actionMocks).forEach((actionName) => {
+    const mockOutputs = unitTestDefinition.actionMocks[actionName].outputs ?? {};
     mockResults[actionName] = {
       actionResult: unitTestDefinition.actionMocks[actionName].actionResult ?? ActionResults.SUCCESS,
-      output: unitTestDefinition.actionMocks[actionName].outputs ?? {},
+      output: mockOutputs,
+      isCompleted: !isNullOrEmpty(mockOutputs),
     };
   });
 

--- a/libs/designer/src/lib/core/state/unitTest/unitTestInterfaces.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestInterfaces.ts
@@ -12,6 +12,7 @@ export interface updateOutputMockPayload {
   outputs: ValueSegment[];
   outputId: string;
   completed: boolean;
+  type: string;
 }
 
 export interface OutputMock {
@@ -36,5 +37,8 @@ export interface UpdateAssertionPayload {
 export interface UnitTestState {
   mockResults: Record<string, OutputMock>;
   assertions: Record<string, AssertionDefintion>;
-  validationErrors: Record<string, Record<string, string | undefined>>;
+  validationErrors: {
+    assertions: Record<string, Record<string, string | undefined>>;
+    mocks: Record<string, Record<string, string | undefined>>;
+  };
 }

--- a/libs/designer/src/lib/core/state/unitTest/unitTestInterfaces.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestInterfaces.ts
@@ -1,13 +1,13 @@
 import { type ValueSegment } from '@microsoft/designer-client-services-logic-apps';
 import type { Assertion, AssertionDefintion } from '@microsoft/utils-logic-apps';
 
-export interface updateOutputMockResultPayload {
+export interface updateMockResultPayload {
   operationName: string;
   actionResult: string;
   completed: boolean;
 }
 
-export interface updateOutputMockPayload {
+export interface updateMockPayload {
   operationName: string;
   outputs: ValueSegment[];
   outputId: string;

--- a/libs/designer/src/lib/core/state/unitTest/unitTestSelectors.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestSelectors.ts
@@ -25,7 +25,7 @@ export const useMockResults = (): Record<string, OutputMock> => {
  * @param {string} operationName - The name of the operation.
  * @returns The mock results for the specified operation, or undefined if not found.
  */
-export const useMockResultsByOperation = (operationName: string): OutputMock => {
+export const useMocksByOperation = (operationName: string): OutputMock => {
   return useSelector(
     createSelector(getUnitTestState, (state: UnitTestState) => {
       return state.mockResults[operationName];

--- a/libs/designer/src/lib/core/state/unitTest/unitTestSelectors.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestSelectors.ts
@@ -73,7 +73,19 @@ export const useAssertions = (): Record<string, AssertionDefintion> => {
 export const useAssertionsValidationErrors = (): Record<string, Record<string, string | undefined>> => {
   return useSelector(
     createSelector(getUnitTestState, (state: UnitTestState) => {
-      return state.validationErrors;
+      return state.validationErrors.assertions;
+    })
+  );
+};
+
+/**
+ * Custom hook that returns the mocks errors for mocks.
+ * @returns An object containing the validation errors for mocks.
+ */
+export const useMocksValidationErrors = (): Record<string, Record<string, string | undefined>> => {
+  return useSelector(
+    createSelector(getUnitTestState, (state: UnitTestState) => {
+      return state.validationErrors.mocks;
     })
   );
 };

--- a/libs/designer/src/lib/core/state/unitTest/unitTestSlice.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestSlice.ts
@@ -3,10 +3,10 @@ import { validateParameter } from '../workflowparameters/workflowparametersSlice
 import type {
   UpdateAssertionsPayload,
   UpdateAssertionPayload,
-  updateOutputMockPayload,
+  updateMockPayload,
   InitDefintionPayload,
   UnitTestState,
-  updateOutputMockResultPayload,
+  updateMockResultPayload,
 } from './unitTestInterfaces';
 import { ActionResults, type ParameterInfo } from '@microsoft/designer-ui';
 import { getIntl } from '@microsoft/intl-logic-apps';
@@ -118,12 +118,12 @@ export const unitTestSlice = createSlice({
         state.mockResults = mockResults;
       }
     },
-    updateOutputMock: (state: UnitTestState, action: PayloadAction<updateOutputMockPayload>) => {
+    updateMock: (state: UnitTestState, action: PayloadAction<updateMockPayload>) => {
       const { operationName, outputs, outputId, completed, type } = action.payload;
       const operationOutputs = state.mockResults[operationName].output;
       const operationOutputId = `${operationName}-${outputId}`;
       const validationErrors = {
-        value: validateParameter(outputId, { type: type, value: outputs[0].value }, 'value', {}),
+        value: validateParameter(outputId, { type: type, value: outputs[0]?.value ?? undefined }, 'value', {}, false),
       };
 
       const newErrorObj = {
@@ -144,7 +144,7 @@ export const unitTestSlice = createSlice({
       }
       state.mockResults[operationName].isCompleted = completed;
     },
-    updateActionResult: (state: UnitTestState, action: PayloadAction<updateOutputMockResultPayload>) => {
+    updateActionResult: (state: UnitTestState, action: PayloadAction<updateMockResultPayload>) => {
       const { operationName, actionResult, completed } = action.payload;
       state.mockResults[operationName].actionResult = actionResult;
       state.mockResults[operationName].isCompleted = completed;
@@ -184,6 +184,6 @@ export const unitTestSlice = createSlice({
   },
 });
 
-export const { updateAssertions, updateAssertion, initUnitTestDefinition, updateOutputMock, updateActionResult } = unitTestSlice.actions;
+export const { updateAssertions, updateAssertion, initUnitTestDefinition, updateMock, updateActionResult } = unitTestSlice.actions;
 
 export default unitTestSlice.reducer;

--- a/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -33,7 +33,7 @@ import {
   useOperationSummary,
 } from '../../core/state/selectors/actionMetadataSelector';
 import { useSettingValidationErrors } from '../../core/state/setting/settingSelector';
-import { useIsMockSupported, useMockResultsByOperation } from '../../core/state/unitTest/unitTestSelectors';
+import { useIsMockSupported, useMocksByOperation } from '../../core/state/unitTest/unitTestSelectors';
 import {
   useNodeDescription,
   useNodeDisplayName,
@@ -83,7 +83,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
   const parentRunIndex = useParentRunIndex(id);
   const runInstance = useRunInstance();
   const runData = useRunData(id);
-  const nodeMockResults = useMockResultsByOperation(isTrigger ? `&${id}` : id);
+  const nodeMockResults = useMocksByOperation(isTrigger ? `&${id}` : id);
   const isMockSupported = useIsMockSupported(id, isTrigger ?? false);
   const parentRunId = useParentRunId(id);
   const parenRunData = useRunData(parentRunId ?? '');

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/mockResultsTab/mockResultsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/mockResultsTab/mockResultsTab.tsx
@@ -2,17 +2,20 @@ import { Constants } from '../../../../../../../src/lib';
 import { convertVariableTypeToSwaggerType } from '../../../../../../lib/core/utils/variables';
 import constants from '../../../../../common/constants';
 import { useSelectedNodeId } from '../../../../../core/state/panel/panelSelectors';
-import {
-  useMocksValidationErrors,
-  useIsMockSupported,
-  useMockResultsByOperation,
-} from '../../../../../core/state/unitTest/unitTestSelectors';
-import { updateActionResult, updateOutputMock } from '../../../../../core/state/unitTest/unitTestSlice';
+import { useMocksValidationErrors, useIsMockSupported, useMocksByOperation } from '../../../../../core/state/unitTest/unitTestSelectors';
+import { updateActionResult, updateMock } from '../../../../../core/state/unitTest/unitTestSlice';
 import type { AppDispatch, RootState } from '../../../../../core/store';
 import { isRootNodeInGraph } from '../../../../../core/utils/graph';
 import { getParameterEditorProps } from '../../../../../core/utils/parameters/helper';
 import { type OutputInfo } from '@microsoft/designer-client-services-logic-apps';
-import { OutputMocks, type PanelTabFn, type ActionResultUpdateEvent, type ChangeState, ArrayType } from '@microsoft/designer-ui';
+import {
+  OutputMocks,
+  type PanelTabFn,
+  type ActionResultUpdateEvent,
+  type ChangeState,
+  ArrayType,
+  type OutputsField,
+} from '@microsoft/designer-ui';
 import { isNullOrUndefined } from '@microsoft/utils-logic-apps';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -24,7 +27,7 @@ export const MockResultsTab = () => {
   const nodeName = isTrigger ? `&${nodeId}` : nodeId;
   const rawOutputs = useSelector((state: RootState) => state.operations.outputParameters[nodeId]);
   const dispatch = useDispatch<AppDispatch>();
-  const mockResults = useMockResultsByOperation(nodeName);
+  const mocks = useMocksByOperation(nodeName);
   const mocksValidationErrors = useMocksValidationErrors();
 
   const filteredOutputs: OutputInfo[] = Object.values(rawOutputs.outputs)
@@ -43,9 +46,7 @@ export const MockResultsTab = () => {
       if (!isNullOrUndefined(viewModel) && viewModel.arrayType === ArrayType.COMPLEX) {
         propertiesToUpdate.value = viewModel.uncastedValue;
       }
-      dispatch(
-        updateOutputMock({ operationName: nodeName, outputs: propertiesToUpdate.value ?? [], outputId: id, completed: true, type: type })
-      );
+      dispatch(updateMock({ operationName: nodeName, outputs: propertiesToUpdate.value ?? [], outputId: id, completed: true, type: type }));
     },
     [nodeName, dispatch]
   );
@@ -57,10 +58,10 @@ export const MockResultsTab = () => {
     [nodeName, dispatch]
   );
 
-  const outputs = filteredOutputs.map((output: OutputInfo) => {
+  const outputs: OutputsField[] = filteredOutputs.map((output: OutputInfo) => {
     const { key: id, title: label, type } = output;
     const { editor, editorOptions, editorViewModel, schema } = getParameterEditorProps(output, [], true);
-    const value = mockResults?.output[id] ?? [];
+    const value = mocks?.output[id] ?? [];
     const valueViewModel = { ...editorViewModel, uncastedValue: value };
     const validationErrors = mocksValidationErrors[`${nodeName}-${id}`] ?? {};
 
@@ -77,7 +78,7 @@ export const MockResultsTab = () => {
       isLoading: false,
       editorViewModel: valueViewModel,
       showTokens: false,
-      tokenMapping: [],
+      tokenMapping: {},
       validationErrors,
       suppressCastingForSerialize: false,
       onValueChange: (newState: ChangeState) => onMockUpdate(id, newState, type),
@@ -90,7 +91,7 @@ export const MockResultsTab = () => {
       nodeId={nodeId}
       onActionResultUpdate={onActionResultUpdate}
       outputs={outputs}
-      mocks={mockResults}
+      mocks={mocks}
     />
   );
 };


### PR DESCRIPTION
This pull request primarily involves changes to improve the unit testing functionality of the application. The major changes include modifications to handle validation errors for both assertions and mocks, updates to the `UnitTestState` interface, and enhancements to the mock results handling in the unit test slice. Additionally, the outputs of workflows are parsed into a more structured format. 


* The `UnitTestState` interface has been updated to include validation errors for both assertions and mocks.
* Custom hooks have been created to return the validation errors for assertions and mocks.
* The `updateMock` action has been updated to validate the parameter and update the validation errors state.
* The `UnitTestState` interface has been updated to include validation errors for both assertions and mocks.
*  The `parseOutputMock` function has been added to parse the output of a workflow into a more structured format. This function is used in the `getTriggerActionMocks` function to parse the outputs of the trigger and action mocks. 



### Screenshots
<img width="1234" alt="Screenshot 2024-03-13 at 3 30 34 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/cba6691a-a91c-410f-a867-3b57312d4d5c">
