### PR TITLE
fix(designer): Update action result properties of mock actions

### DIFF
--- a/libs/designer-ui/src/lib/unitTesting/outputMocks/outputMocks.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/outputMocks/outputMocks.tsx
@@ -36,10 +36,10 @@ export interface OutputMocksProps {
 }
 
 export const ActionResults = {
-  SUCCESS: 'success',
-  TIMEDOUT: 'timedOut',
-  SKIPPED: 'skipped',
-  FAILED: 'failed',
+  SUCCESS: 'Succeeded',
+  TIMEDOUT: 'TimedOut',
+  SKIPPED: 'Skipped',
+  FAILED: 'Failed',
 };
 
 export interface OutputsField extends SettingProps {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -1138,9 +1138,9 @@ const getTriggerActionMocks = (
       const outputsValue = parseOutputMock(outputMock.output);
       if (key.charAt(0) === '&') {
         const triggerName = key.substring(1);
-        triggerMocks[triggerName] = { actionResult: outputMock.actionResult, outputs: outputsValue };
+        triggerMocks[triggerName] = { properties: { status: outputMock.actionResult }, outputs: outputsValue };
       } else {
-        actionMocks[key] = { actionResult: outputMock.actionResult, outputs: outputsValue };
+        actionMocks[key] = { properties: { status: outputMock.actionResult }, outputs: outputsValue };
       }
     }
   });

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -174,7 +174,7 @@ export const deserializeUnitTestDefinition = (
   if (triggerName) {
     const mockOutputs = unitTestDefinition.triggerMocks[triggerName].outputs ?? {};
     mockResults[`&${triggerName}`] = {
-      actionResult: unitTestDefinition.triggerMocks[triggerName].actionResult ?? ActionResults.SUCCESS,
+      actionResult: unitTestDefinition.triggerMocks[triggerName].properties?.status ?? ActionResults.SUCCESS,
       output: mockOutputs,
       isCompleted: !isNullOrEmpty(mockOutputs),
     };
@@ -183,7 +183,7 @@ export const deserializeUnitTestDefinition = (
   Object.keys(unitTestDefinition.actionMocks).forEach((actionName) => {
     const mockOutputs = unitTestDefinition.actionMocks[actionName].outputs ?? {};
     mockResults[actionName] = {
-      actionResult: unitTestDefinition.actionMocks[actionName].actionResult ?? ActionResults.SUCCESS,
+      actionResult: unitTestDefinition.actionMocks[actionName].properties?.status ?? ActionResults.SUCCESS,
       output: mockOutputs,
       isCompleted: !isNullOrEmpty(mockOutputs),
     };

--- a/libs/utils/src/lib/models/unitTest.ts
+++ b/libs/utils/src/lib/models/unitTest.ts
@@ -1,6 +1,8 @@
 export interface OperationMock {
   outputs?: Record<string, any>;
-  actionResult?: string;
+  properties?: {
+    status: string;
+  };
 }
 
 export interface Assertion {


### PR DESCRIPTION
This pull request primarily focuses on refactoring the structure of action results and the way they are handled in the codebase. The changes involve updating the `ActionResults` object, modifying how action results are assigned in `getTriggerActionMocks`, and adjusting how action results are deserialized in `deserializeUnitTestDefinition`. Additionally, the `OperationMock` interface has been updated to include a `properties` object.



* The `getTriggerActionMocks` function now assigns action results within a `properties` object with a `status` key.
* The `deserializeUnitTestDefinition` function now retrieves the action result from the `properties` object's `status` key in both the `triggerMocks` and `actionMocks` objects. 
* The `OperationMock` interface has been updated to replace the `actionResult` key with a `properties` object that includes a `status` key.