### PR TITLE
fix(consumption): Deleting idReplamenent when deleting node

### DIFF
--- a/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
@@ -60,6 +60,7 @@ export const deleteNodeFromWorkflow = (
   delete nodesMetadata[nodeId];
   delete state.operations[nodeId];
   delete state.newlyAddedOperations[nodeId];
+  delete state.idReplacements[nodeId];
   state.isDirty = true;
 
   // Decrease action count of graph


### PR DESCRIPTION
In this PR we are removing the nodeId from idReplacements when the node is deleted. This fixes the issue that if you add a node, change the name, then delete it, if you add the node again it will use the name you changed it to rather than the default name. 

Fixes #4366