### PR TITLE
fix(Designer): "Internal" swagger operation parameters are now initialized properly

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -339,9 +339,9 @@ const serializeSwaggerBasedOperation = async (rootState: RootState, operationId:
       ? constructInputValues('recurrence.$.recurrence', inputsToSerialize, false /* encodePathComponents */)
       : undefined;
   const retryPolicy = getRetryPolicy(nodeSettings);
-  const inputPathValue = await serializeParametersFromSwagger(inputsToSerialize, operationInfo);
+  const inputValues = await serializeParametersFromSwagger(inputsToSerialize, operationInfo);
   const hostInfo = { host: { connection: { referenceName: getRecordEntry(rootState.connections.connectionsMapping, operationId) } } };
-  const inputs = { ...hostInfo, ...inputPathValue, retryPolicy };
+  const inputs = { ...hostInfo, ...inputValues, retryPolicy };
   const serializedType = equals(type, Constants.NODE.TYPE.API_CONNECTION)
     ? Constants.SERIALIZED_TYPE.API_CONNECTION
     : equals(type, Constants.NODE.TYPE.API_CONNECTION_NOTIFICATION)

--- a/libs/logic-apps-shared/src/parsers/lib/common/schemaprocessor.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/common/schemaprocessor.ts
@@ -258,7 +258,9 @@ export class SchemaProcessor {
     titlePrefix = this._concatenateString(titlePrefix, schema.title);
     summaryPrefix = this._concatenateString(summaryPrefix, summary);
 
-    if (keys.length && !this._isInternalParameter(schema) && !isReadOnlyInputParameter) {
+    const skipInternal = this.options.excludeInternal && this._isInternalParameter(schema);
+
+    if (keys.length && !skipInternal && !isReadOnlyInputParameter) {
       const outputs = keys.map((key) => {
         const childOutput = properties[key] as SchemaObject;
 


### PR DESCRIPTION
## Main Changes

We had a bug where swagger parameters labeled as "internal" were not getting initialized.
In our schema / parameter processors we have some flags to exclude "internal" properties, and in one place we were not respecting this flag.
This has now been fixed and I'm seeing "internal" swagger parameters get serialized properly.

The below "body" parameters were marked as internal in this operation.

![image](https://github.com/Azure/LogicAppsUX/assets/25409734/4fbd3fbf-7b10-4d3b-981e-45b3d6e65bd7)
