### PR TITLE
fix(designer): Fixes an issue where titles were sometimes not updating input tokens from dynamic data

### DIFF
--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -3,11 +3,11 @@ import type { Settings } from '../../actions/bjsworkflow/settings';
 import type { NodeStaticResults } from '../../actions/bjsworkflow/staticresults';
 import { StaticResultOption } from '../../actions/bjsworkflow/staticresults';
 import type { RepetitionContext } from '../../utils/parameters/helper';
-import { isTokenValueSegment } from '../../utils/parameters/segment';
+import { createTokenValueSegment, isTokenValueSegment } from '../../utils/parameters/segment';
 import { normalizeKey } from '../../utils/tokens';
 import { resetNodesLoadStatus, resetWorkflowState } from '../global';
 import { LogEntryLevel, LoggerService } from '@microsoft/designer-client-services-logic-apps';
-import type { ParameterInfo, Token } from '@microsoft/designer-ui';
+import type { ParameterInfo } from '@microsoft/designer-ui';
 import type { FilePickerInfo, InputParameter, OutputParameter, SwaggerParser } from '@microsoft/logic-apps-shared';
 import { getRecordEntry, type OpenAPIV2, type OperationInfo } from '@microsoft/logic-apps-shared';
 import { createSlice } from '@reduxjs/toolkit';
@@ -173,7 +173,7 @@ interface AddDynamicOutputsPayload {
   outputs: Record<string, OutputInfo>;
 }
 
-interface updateExisitingInputTokenTitlesPayload {
+interface updateExistingInputTokenTitlesPayload {
   tokenTitles: Record<string, string>;
 }
 
@@ -304,7 +304,7 @@ export const operationMetadataSlice = createSlice({
       const nodeErrors = getRecordEntry(state.errors, nodeId);
       delete nodeErrors?.[ErrorLevel.DynamicOutputs];
     },
-    updateExisitingInputTokenTitles: (state, action: PayloadAction<updateExisitingInputTokenTitlesPayload>) => {
+    updateExistingInputTokenTitles: (state, action: PayloadAction<updateExistingInputTokenTitlesPayload>) => {
       const { tokenTitles } = action.payload;
 
       Object.entries(state.inputParameters).forEach(([nodeId, nodeInputs]) => {
@@ -314,9 +314,8 @@ export const operationMetadataSlice = createSlice({
               if (isTokenValueSegment(segment) && segment.token?.key) {
                 const normalizedKey = normalizeKey(segment.token.key);
                 if (normalizedKey in tokenTitles) {
-                  (
-                    state.inputParameters[nodeId].parameterGroups[parameterId].parameters[parameterIndex].value[segmentIndex].token as Token
-                  ).title = tokenTitles[normalizedKey];
+                  state.inputParameters[nodeId].parameterGroups[parameterId].parameters[parameterIndex].value[segmentIndex] =
+                    createTokenValueSegment({ ...segment.token, title: tokenTitles[normalizedKey] }, segment.value, segment.type);
                 }
               }
             });
@@ -499,7 +498,7 @@ export const {
   updateStaticResults,
   updateParameterConditionalVisibility,
   updateParameterValidation,
-  updateExisitingInputTokenTitles,
+  updateExistingInputTokenTitles,
   removeParameterValidationError,
   updateOutputs,
   updateActionMetadata,

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -10,7 +10,7 @@ import {
   addDynamicOutputs,
   clearDynamicOutputs,
   updateErrorDetails,
-  updateExisitingInputTokenTitles,
+  updateExistingInputTokenTitles,
 } from '../state/operation/operationMetadataSlice';
 import { addDynamicTokens } from '../state/tokens/tokensSlice';
 import type { WorkflowKind } from '../state/workflow/workflowInterfaces';
@@ -500,7 +500,7 @@ export const loadDynamicOutputsInNode = async (
 
           dispatch(addDynamicOutputs({ nodeId, outputs: dynamicOutputs }));
 
-          dispatch(updateExisitingInputTokenTitles({ tokenTitles: dynamicOutputTitles }));
+          dispatch(updateExistingInputTokenTitles({ tokenTitles: dynamicOutputTitles }));
 
           let iconUri: string, brandColor: string;
           if (OperationManifestService().isSupported(operationInfo.type, operationInfo.kind)) {


### PR DESCRIPTION
For the most part [this PR](https://github.com/Azure/LogicAppsUX/pull/4215) seems to behave as intended where we follow the steps

1. Initialize graph and all the input parameters
2. At this point, the workflow is already visible, and if input parameters contain dynamic data, it begins to start fetching them
3. Once dynamic data is fetched to populate the downstream tokens (added in the last PR)
4. Once a user clicks on a downstream action with that updated token, it should be populated with the new title

The case I see that doesn't fully work currently is if a user clicks on the downstream action in between steps 1 and 3. This is because the dynamic data is not yet loaded, and thus the updated title name is not actually fetched yet.