### PR TITLE
feat(vscode): Load run output data from monitoring view into unit test

### DIFF
--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -42,6 +42,7 @@ import { startLogicApp } from './startLogicApp';
 import { stopLogicApp } from './stopLogicApp';
 import { swapSlot } from './swapSlot';
 import { viewProperties } from './viewProperties';
+import { type IAzureConnectorsContext } from './workflows/azureConnectorWizard';
 import { configureWebhookRedirectEndpoint } from './workflows/configureWebhookRedirectEndpoint/configureWebhookRedirectEndpoint';
 import { enableAzureConnectors } from './workflows/enableAzureConnectors';
 import { exportLogicApp } from './workflows/exportLogicApp';
@@ -142,7 +143,9 @@ export function registerCommands(): void {
   registerCommand(extensionCommand.createNewDataMap, (context: IActionContext) => createNewDataMapCmd(context));
   registerCommand(extensionCommand.loadDataMapFile, (context: IActionContext, uri: Uri) => loadDataMapFileCmd(context, uri));
   // Unit Test Commands
-  registerCommandWithTreeNodeUnwrapping(extensionCommand.createUnitTest, createUnitTest);
+  registerCommandWithTreeNodeUnwrapping(extensionCommand.createUnitTest, async (context: IAzureConnectorsContext, node: Uri | undefined) =>
+    createUnitTest(context, node)
+  );
   registerCommandWithTreeNodeUnwrapping(extensionCommand.editUnitTest, editUnitTest);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.openUnitTestResults, openUnitTestResults);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.runUnitTest, runUnitTest);

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
@@ -27,6 +27,7 @@ export abstract class OpenDesignerBase {
   protected apiVersion: string;
   protected panelGroupKey: string;
   protected baseUrl: string;
+  protected workflowRuntimeBaseUrl: string;
   protected connectionData: ConnectionsData;
   protected panel: WebviewPanel;
   protected apiHubServiceDetails: Record<string, any>;
@@ -52,7 +53,8 @@ export abstract class OpenDesignerBase {
     panelGroupKey: string,
     readOnly: boolean,
     isLocal: boolean,
-    isMonitoringView: boolean
+    isMonitoringView: boolean,
+    runId: string
   ) {
     this.context = context;
     this.workflowName = workflowName;
@@ -62,6 +64,7 @@ export abstract class OpenDesignerBase {
     this.readOnly = readOnly;
     this.isLocal = isLocal;
     this.isMonitoringView = isMonitoringView;
+    this.runId = runId;
   }
 
   protected abstract createPanel(): Promise<void>;

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
@@ -42,6 +42,7 @@ export abstract class OpenDesignerBase {
   protected unitTestName: string;
   protected isUnitTest: boolean;
   protected unitTestDefinition: any;
+  protected runId?: string;
 
   protected constructor(
     context: IActionContext | IAzureConnectorsContext,

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
@@ -27,7 +27,7 @@ export class OpenDesignerForAzureResource extends OpenDesignerBase {
     const panelName = `${vscode.workspace.name}-${workflowName}`;
     const panelGroupKey = ext.webViewKey.designerAzure;
 
-    super(context, workflowName, panelName, workflowAppApiVersion, panelGroupKey, true, false, false);
+    super(context, workflowName, panelName, workflowAppApiVersion, panelGroupKey, true, false, false, '');
 
     this.node = node;
     this.workflow = node.workflowFileContent;

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -41,13 +41,16 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
   private projectPath: string | undefined;
   private panelMetadata: IDesignerPanelMetadata;
 
-  constructor(context: IActionContext, node: Uri, unitTestName?: string, unitTestDefinition?: any) {
+  constructor(context: IActionContext, node: Uri, unitTestName?: string, unitTestDefinition?: any, runId?: string) {
     const workflowName = path.basename(path.dirname(node.fsPath));
     const apiVersion = '2018-11-01';
     const panelName = `${workspace.name}-${workflowName}${unitTestName ? `-${unitTestName}` : ''}`;
     const panelGroupKey = ext.webViewKey.designerLocal;
+    const runWorflowId = runId && runId.endsWith('/') ? runId.substring(0, runId.length - 1) : runId;
 
     super(context, workflowName, panelName, apiVersion, panelGroupKey, !!unitTestName, true, false);
+
+    this.runId = runWorflowId;
     this.unitTestName = unitTestName;
     this.isUnitTest = !!unitTestName;
     this.unitTestDefinition = unitTestDefinition ?? null;
@@ -172,6 +175,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
             hostVersion: ext.extensionVersion,
             isUnitTest: this.isUnitTest,
             unitTestDefinition: this.unitTestDefinition,
+            runId: this.runId,
           },
         });
         await this.validateWorkflow(this.panelMetadata.workflowContent);

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -46,11 +46,10 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
     const apiVersion = '2018-11-01';
     const panelName = `${workspace.name}-${workflowName}${unitTestName ? `-${unitTestName}` : ''}`;
     const panelGroupKey = ext.webViewKey.designerLocal;
-    const runWorflowId = runId && runId.endsWith('/') ? runId.substring(0, runId.length - 1) : runId;
+    const runName = runId ? runId.split('/').slice(-1)[0] : '';
 
-    super(context, workflowName, panelName, apiVersion, panelGroupKey, !!unitTestName, true, false);
+    super(context, workflowName, panelName, apiVersion, panelGroupKey, !!unitTestName, true, false, runName);
 
-    this.runId = runWorflowId;
     this.unitTestName = unitTestName;
     this.isUnitTest = !!unitTestName;
     this.unitTestDefinition = unitTestDefinition ?? null;
@@ -97,6 +96,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
     await startDesignTimeApi(this.projectPath);
 
     this.baseUrl = `http://localhost:${ext.designTimePort}${managementApiPrefix}`;
+    this.workflowRuntimeBaseUrl = `http://localhost:${ext.workflowRuntimePort}${managementApiPrefix}`;
 
     this.panel = window.createWebviewPanel(
       this.panelGroupKey, // Key used to reference the panel
@@ -165,6 +165,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
             panelMetadata: this.panelMetadata,
             connectionData: this.connectionData,
             baseUrl: this.baseUrl,
+            workflowRuntimeBaseUrl: this.workflowRuntimeBaseUrl,
             apiVersion: this.apiVersion,
             apiHubServiceDetails: this.apiHubServiceDetails,
             readOnly: this.readOnly,

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewBase.ts
@@ -14,7 +14,6 @@ import * as vscode from 'vscode';
 export abstract class OpenMonitoringViewBase extends OpenDesignerBase {
   protected panel: WebviewPanel;
   protected panelGroupKey: ext.webViewKey;
-  protected runId: string;
   protected baseUrl: string;
   protected runName: string;
   protected workflowName: string;

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewBase.ts
@@ -15,7 +15,6 @@ export abstract class OpenMonitoringViewBase extends OpenDesignerBase {
   protected panel: WebviewPanel;
   protected panelGroupKey: ext.webViewKey;
   protected baseUrl: string;
-  protected runName: string;
   protected workflowName: string;
   protected workflowFilePath: string;
   protected localSettings: Record<string, string>;
@@ -27,17 +26,14 @@ export abstract class OpenMonitoringViewBase extends OpenDesignerBase {
     isLocal: boolean,
     apiVersion: string
   ) {
-    const runWorflowId = runId.endsWith('/') ? runId.substring(0, runId.length - 1) : runId;
-    const runName = runId.split('/').slice(-1)[0];
+    const runName = runId ? runId.split('/').slice(-1)[0] : '';
     const workflowName = runId.split('/').slice(-3)[0];
     const panelNamePrefix = isLocal ? `${vscode.workspace.name}-` : '';
     const panelName = `${panelNamePrefix}${workflowName}-${runName}`;
     const panelGroupKey = ext.webViewKey.monitoring;
 
-    super(context, workflowName, panelName, apiVersion, panelGroupKey, true, isLocal, true);
+    super(context, workflowName, panelName, apiVersion, panelGroupKey, true, isLocal, true, runName);
 
-    this.runId = runWorflowId;
-    this.runName = runName;
     this.workflowFilePath = workflowFilePath;
   }
 

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
@@ -120,7 +120,7 @@ export default class openMonitoringViewForAzureResource extends OpenMonitoringVi
             readOnly: this.readOnly,
             isLocal: this.isLocal,
             isMonitoringView: this.isMonitoringView,
-            runId: this.runName,
+            runId: this.runId,
             hostVersion: ext.extensionVersion,
           },
         });
@@ -147,7 +147,7 @@ export default class openMonitoringViewForAzureResource extends OpenMonitoringVi
 
     await vscode.window.withProgress(options, async () => {
       const triggerName = getTriggerName(this.node.workflowFileContent.definition);
-      const url = `${this.baseUrl}/workflows/${this.workflowName}/triggers/${triggerName}/histories/${this.runName}/resubmit?api-version=${this.apiVersion}`;
+      const url = `${this.baseUrl}/workflows/${this.workflowName}/triggers/${triggerName}/histories/${this.runId}/resubmit?api-version=${this.apiVersion}`;
 
       try {
         await sendAzureRequest(url, this.context, HTTP_METHODS.POST, this.node.subscription);

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
@@ -119,7 +119,7 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
             readOnly: this.readOnly,
             isLocal: this.isLocal,
             isMonitoringView: this.isMonitoringView,
-            runId: this.runName,
+            runId: this.runId,
             hostVersion: ext.extensionVersion,
           },
         });
@@ -153,7 +153,7 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
         const fileContent = await promises.readFile(this.workflowFilePath, 'utf8');
         const workflowContent: any = JSON.parse(fileContent);
         const triggerName = getTriggerName(workflowContent.definition);
-        const url = `${this.baseUrl}/workflows/${this.workflowName}/triggers/${triggerName}/histories/${this.runName}/resubmit?api-version=${this.apiVersion}`;
+        const url = `${this.baseUrl}/workflows/${this.workflowName}/triggers/${triggerName}/histories/${this.runId}/resubmit?api-version=${this.apiVersion}`;
 
         await sendRequest(this.context, { url, method: HTTP_METHODS.POST });
       } catch (error) {

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
@@ -134,7 +134,7 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
         break;
       }
       case ExtensionCommand.createUnitTest: {
-        await createUnitTest(this.context as IAzureConnectorsContext, vscode.Uri.file(this.workflowFilePath));
+        await createUnitTest(this.context as IAzureConnectorsContext, vscode.Uri.file(this.workflowFilePath), message.runId);
         break;
       }
       default:

--- a/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
@@ -151,7 +151,7 @@ export async function openOverview(context: IAzureConnectorsContext, node: vscod
         }, 5000);
         break;
       case ExtensionCommand.createUnitTest:
-        await createUnitTest(context, workflowNode as vscode.Uri);
+        await createUnitTest(context, workflowNode as vscode.Uri, message.runId);
         break;
       default:
         break;

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -18,9 +18,10 @@ import * as vscode from 'vscode';
  * Creates a unit test for a Logic App workflow.
  * @param {IAzureConnectorsContext} context - The context object for Azure Connectors.
  * @param {vscode.Uri | undefined} node - The URI of the workflow node, if available.
+ * @param {string | undefined} runId - The ID of the run, if available.
  * @returns A Promise that resolves when the unit test is created.
  */
-export async function createUnitTest(context: IAzureConnectorsContext, node: vscode.Uri | undefined): Promise<void> {
+export async function createUnitTest(context: IAzureConnectorsContext, node: vscode.Uri | undefined, runId?: string): Promise<void> {
   let workflowNode: vscode.Uri;
   const workspaceFolder = await getWorkspaceFolder(context);
   const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
@@ -39,7 +40,7 @@ export async function createUnitTest(context: IAzureConnectorsContext, node: vsc
     validateInput: async (name: string): Promise<string | undefined> => await validateUnitTestName(projectPath, workflowName, name),
   });
 
-  const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName);
+  const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName, null, runId);
   await openDesignerObj?.createPanel();
 }
 

--- a/apps/vs-code-react/src/app/designer/DesignerCommandBar/index.tsx
+++ b/apps/vs-code-react/src/app/designer/DesignerCommandBar/index.tsx
@@ -28,6 +28,7 @@ export interface DesignerCommandBarProps {
   isDarkMode: boolean;
   isUnitTest: boolean;
   isLocal: boolean;
+  runId: string;
 }
 
 export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({
@@ -37,6 +38,7 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({
   isDarkMode,
   isUnitTest,
   isLocal,
+  runId,
 }) => {
   const intl = useIntl();
   const vscode = useContext(VSCodeContext);
@@ -100,6 +102,7 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({
   const onCreateUnitTest = async () => {
     vscode.postMessage({
       command: ExtensionCommand.createUnitTest,
+      runId: runId,
     });
   };
 

--- a/apps/vs-code-react/src/app/designer/app.tsx
+++ b/apps/vs-code-react/src/app/designer/app.tsx
@@ -104,7 +104,7 @@ export const DesignerApp = () => {
   }, [connectionData]);
 
   const getRunInstance = () => {
-    if (isMonitoringView && !isEmptyString(runId) && panelMetaData !== null) {
+    if ((isMonitoringView || isUnitTest) && !isEmptyString(runId) && panelMetaData !== null) {
       return services.runService.getRun(runId);
     }
     return;
@@ -118,6 +118,18 @@ export const DesignerApp = () => {
       } as StandardApp;
       setRunInstance(runDefinition);
       setStandardApp(standardAppInstance);
+    } else if (isUnitTest) {
+      const actionOutputs = Object.keys(runDefinition.properties.actions).reduce((acc, actionName) => {
+        return {
+          ...acc,
+          [actionName]: {
+            status: runDefinition.properties.actions[actionName].status,
+            outputsLink: runDefinition.properties.actions[actionName].outputsLink,
+          },
+        };
+      }, {});
+
+      console.log('charlie', runDefinition, actionOutputs);
     }
   };
 
@@ -126,6 +138,7 @@ export const DesignerApp = () => {
     setStandardApp(undefined);
   };
 
+  /// NEED TO UPDATE THIS
   const { refetch, isError, isFetching, isLoading, isRefetching } = useQuery<any>(['runInstance', { runId }], getRunInstance, {
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -159,6 +172,7 @@ export const DesignerApp = () => {
         isDarkMode={theme === Theme.Dark}
         isUnitTest={isUnitTest}
         isLocal={isLocal}
+        runId={runId}
       />
     );
 

--- a/apps/vs-code-react/src/app/designer/app.tsx
+++ b/apps/vs-code-react/src/app/designer/app.tsx
@@ -36,6 +36,7 @@ export const DesignerApp = () => {
     hostVersion,
     isUnitTest,
     unitTestDefinition,
+    workflowRuntimeBaseUrl,
   } = vscodeState;
   const [standardApp, setStandardApp] = useState<StandardApp | undefined>(panelMetaData?.standardApp);
   const [runInstance, setRunInstance] = useState<LogicAppsV2.RunInstanceDefinition | null>(null);
@@ -74,6 +75,7 @@ export const DesignerApp = () => {
     };
     return getDesignerServices(
       baseUrl,
+      workflowRuntimeBaseUrl,
       apiVersion,
       apiHubServiceDetails ?? {},
       isLocal,
@@ -87,6 +89,7 @@ export const DesignerApp = () => {
     );
   }, [
     baseUrl,
+    workflowRuntimeBaseUrl,
     apiVersion,
     apiHubServiceDetails,
     isLocal,
@@ -123,7 +126,9 @@ export const DesignerApp = () => {
         return {
           ...acc,
           [actionName]: {
-            status: runDefinition.properties.actions[actionName].status,
+            properties: {
+              status: runDefinition.properties.actions[actionName].status,
+            },
             outputsLink: runDefinition.properties.actions[actionName].outputsLink,
           },
         };
@@ -138,7 +143,7 @@ export const DesignerApp = () => {
     setStandardApp(undefined);
   };
 
-  /// NEED TO UPDATE THIS
+  /// TODO(ccastrotrejo): NEED TO UPDATE THIS
   const { refetch, isError, isFetching, isLoading, isRefetching } = useQuery<any>(['runInstance', { runId }], getRunInstance, {
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/apps/vs-code-react/src/app/designer/app.tsx
+++ b/apps/vs-code-react/src/app/designer/app.tsx
@@ -1,4 +1,4 @@
-import { createFileSystemConnection } from '../../state/DesignerSlice';
+import { createFileSystemConnection, updateUnitTestDefinition } from '../../state/DesignerSlice';
 import type { AppDispatch, RootState } from '../../state/store';
 import { VSCodeContext } from '../../webviewCommunication';
 import { DesignerCommandBar } from './DesignerCommandBar';
@@ -127,11 +127,15 @@ export const DesignerApp = () => {
         outputsLink: runDefinition.properties.trigger.outputsLink as ContentLink,
       });
       const triggerMocks = {
-        properties: {
-          status: runDefinition.properties.trigger.status,
+        [runDefinition.properties.trigger.name]: {
+          properties: {
+            status: runDefinition.properties.trigger.status,
+          },
+          outputs: triggerOutputs.outputs,
         },
-        outputs: triggerOutputs.outputs,
       };
+
+      console.log('charlie', runDefinition);
 
       const actionMocks: Record<string, any> = {};
       await Promise.all(
@@ -147,13 +151,15 @@ export const DesignerApp = () => {
         })
       );
 
-      const unitTestDefinition2 = {
-        triggerMocks: triggerMocks,
-        actionMocks: actionMocks,
-        assertions: {},
-      };
-
-      console.log('charlie', runDefinition, unitTestDefinition2);
+      dispatch(
+        updateUnitTestDefinition({
+          unitTestDefinition: {
+            triggerMocks: triggerMocks,
+            actionMocks: actionMocks,
+            assertions: [],
+          },
+        })
+      );
     }
   };
 
@@ -199,6 +205,8 @@ export const DesignerApp = () => {
         runId={runId}
       />
     );
+
+  console.log('charlie', unitTestDefinition);
 
   const designerApp = standardApp ? (
     <BJSWorkflowProvider

--- a/apps/vs-code-react/src/app/designer/app.tsx
+++ b/apps/vs-code-react/src/app/designer/app.tsx
@@ -10,7 +10,7 @@ import type { ConnectionCreationInfo } from '@microsoft/designer-client-services
 import type { ConnectionReferences } from '@microsoft/logic-apps-designer';
 import { DesignerProvider, BJSWorkflowProvider, Designer, getTheme, useThemeObserver } from '@microsoft/logic-apps-designer';
 import type { ContentLink, LogicAppsV2 } from '@microsoft/utils-logic-apps';
-import { isEmptyString, Theme } from '@microsoft/utils-logic-apps';
+import { isEmptyString, isNullOrUndefined, Theme } from '@microsoft/utils-logic-apps';
 import type { FileSystemConnectionInfo, StandardApp } from '@microsoft/vscode-extension';
 import { ExtensionCommand } from '@microsoft/vscode-extension';
 import { useContext, useMemo, useState, useEffect } from 'react';
@@ -122,7 +122,7 @@ export const DesignerApp = () => {
       } as StandardApp;
       setRunInstance(runDefinition);
       setStandardApp(standardAppInstance);
-    } else if (isUnitTest) {
+    } else if (isUnitTest && isNullOrUndefined(unitTestDefinition)) {
       const triggerOutputs = await services.runService.getActionLinks({
         outputsLink: runDefinition.properties.trigger.outputsLink as ContentLink,
       });
@@ -134,8 +134,6 @@ export const DesignerApp = () => {
           outputs: triggerOutputs.outputs,
         },
       };
-
-      console.log('charlie', runDefinition);
 
       const actionMocks: Record<string, any> = {};
       await Promise.all(
@@ -205,8 +203,6 @@ export const DesignerApp = () => {
         runId={runId}
       />
     );
-
-  console.log('charlie', unitTestDefinition);
 
   const designerApp = standardApp ? (
     <BJSWorkflowProvider

--- a/apps/vs-code-react/src/app/designer/servicesHelper.ts
+++ b/apps/vs-code-react/src/app/designer/servicesHelper.ts
@@ -27,6 +27,20 @@ import { ExtensionCommand, HttpClient } from '@microsoft/vscode-extension';
 import type { QueryClient } from 'react-query';
 import type { WebviewApi } from 'vscode-webview';
 
+export interface DesignerServices {
+  connectionService: StandardConnectionService;
+  connectorService: StandardConnectorService;
+  operationManifestService: StandardOperationManifestService;
+  searchService: StandardSearchService;
+  oAuthService: BaseOAuthService;
+  gatewayService: BaseGatewayService;
+  workflowService: IWorkflowService;
+  hostService: IHostService;
+  runService: StandardRunService;
+  apimService: BaseApiManagementService;
+  functionService: BaseFunctionService;
+}
+
 export const getDesignerServices = (
   baseUrl: string,
   workflowRuntimeBaseUrl: string,
@@ -40,19 +54,7 @@ export const getDesignerServices = (
   oauthRedirectUrl: string,
   hostVersion: string,
   queryClient: QueryClient
-): {
-  connectionService: StandardConnectionService;
-  connectorService: StandardConnectorService;
-  operationManifestService: StandardOperationManifestService;
-  searchService: StandardSearchService;
-  oAuthService: BaseOAuthService;
-  gatewayService: BaseGatewayService;
-  workflowService: IWorkflowService;
-  hostService: IHostService;
-  runService: StandardRunService;
-  apimService: BaseApiManagementService;
-  functionService: BaseFunctionService;
-} => {
+): DesignerServices => {
   let authToken = '',
     panelId = '',
     workflowDetails: Record<string, any> = {},

--- a/apps/vs-code-react/src/app/designer/servicesHelper.ts
+++ b/apps/vs-code-react/src/app/designer/servicesHelper.ts
@@ -21,7 +21,7 @@ import type {
   IWorkflowService,
 } from '@microsoft/designer-client-services-logic-apps';
 import type { ManagedIdentity } from '@microsoft/utils-logic-apps';
-import { HTTP_METHODS, clone } from '@microsoft/utils-logic-apps';
+import { HTTP_METHODS, clone, isEmptyString } from '@microsoft/utils-logic-apps';
 import type { ConnectionAndAppSetting, ConnectionsData, IDesignerPanelMetadata } from '@microsoft/vscode-extension';
 import { ExtensionCommand, HttpClient } from '@microsoft/vscode-extension';
 import type { QueryClient } from 'react-query';
@@ -29,6 +29,7 @@ import type { WebviewApi } from 'vscode-webview';
 
 export const getDesignerServices = (
   baseUrl: string,
+  workflowRuntimeBaseUrl: string,
   apiVersion: string,
   apiHubDetails: ApiHubServiceDetails,
   isLocal: boolean,
@@ -278,7 +279,7 @@ export const getDesignerServices = (
 
   const runService = new StandardRunService({
     apiVersion,
-    baseUrl,
+    baseUrl: isEmptyString(workflowRuntimeBaseUrl) ? baseUrl : workflowRuntimeBaseUrl,
     workflowName: panelMetadata?.workflowName ?? '',
     httpClient,
   });

--- a/apps/vs-code-react/src/app/designer/utilities/runInstance.ts
+++ b/apps/vs-code-react/src/app/designer/utilities/runInstance.ts
@@ -1,0 +1,38 @@
+import { type DesignerServices } from '../servicesHelper';
+import { type LogicAppsV2, type ContentLink } from '@microsoft/utils-logic-apps';
+
+/**
+ * Retrieves the mock data for a run instance.
+ * @param {LogicAppsV2.RunInstanceDefinition} runDefinition - The run instance definition.
+ * @param {DesignerServices} services - The designer services.
+ * @returns An object containing the trigger mocks and action mocks.
+ */
+export const getRunInstanceMocks = async (runDefinition: LogicAppsV2.RunInstanceDefinition, services: DesignerServices) => {
+  const triggerOutputs = await services.runService.getActionLinks({
+    outputsLink: runDefinition.properties.trigger.outputsLink as ContentLink,
+  });
+  const triggerMocks = {
+    [runDefinition.properties.trigger.name]: {
+      properties: {
+        status: runDefinition.properties.trigger.status,
+      },
+      outputs: triggerOutputs.outputs,
+    },
+  };
+
+  const actionMocks: Record<string, any> = {};
+  await Promise.all(
+    Object.keys(runDefinition.properties.actions).map(async (actionName) => {
+      const outputsLink = runDefinition.properties.actions[actionName].outputsLink as ContentLink;
+      const actionOutputs = await services.runService.getActionLinks({ outputsLink });
+      actionMocks[actionName] = {
+        properties: {
+          status: runDefinition.properties.actions[actionName].status,
+        },
+        outputs: actionOutputs.outputs,
+      };
+    })
+  );
+
+  return { triggerMocks, actionMocks };
+};

--- a/apps/vs-code-react/src/app/overview/app.tsx
+++ b/apps/vs-code-react/src/app/overview/app.tsx
@@ -126,7 +126,7 @@ export const OverviewApp = () => {
       onCreateUnitTest={(run: RunDisplayItem) => {
         vscode.postMessage({
           command: ExtensionCommand.createUnitTest,
-          item: run,
+          runId: run.id,
         });
       }}
     />

--- a/apps/vs-code-react/src/state/DesignerSlice.ts
+++ b/apps/vs-code-react/src/state/DesignerSlice.ts
@@ -124,8 +124,18 @@ export const designerSlice = createSlice({
       }
       delete state.fileSystemConnections[connectionName];
     },
+    updateUnitTestDefinition: (state, action: PayloadAction<{ unitTestDefinition: UnitTestDefinition }>) => {
+      const { unitTestDefinition } = action.payload;
+      state.unitTestDefinition = unitTestDefinition;
+    },
   },
 });
 
-export const { initializeDesigner, updateCallbackUrl, createFileSystemConnection, updateFileSystemConnection, updatePanelMetadata } =
-  designerSlice.actions;
+export const {
+  initializeDesigner,
+  updateCallbackUrl,
+  createFileSystemConnection,
+  updateFileSystemConnection,
+  updatePanelMetadata,
+  updateUnitTestDefinition,
+} = designerSlice.actions;

--- a/apps/vs-code-react/src/state/DesignerSlice.ts
+++ b/apps/vs-code-react/src/state/DesignerSlice.ts
@@ -8,6 +8,7 @@ export interface DesignerState {
   panelMetaData: IDesignerPanelMetadata | null;
   connectionData: ConnectionsData;
   baseUrl: string;
+  workflowRuntimeBaseUrl: string;
   apiVersion: string;
   apiHubServiceDetails: ApiHubServiceDetails;
   readOnly: boolean;
@@ -26,6 +27,7 @@ export interface DesignerState {
 const initialState: DesignerState = {
   panelMetaData: null,
   baseUrl: '/url',
+  workflowRuntimeBaseUrl: '',
   apiVersion: '2018-11-01',
   connectionData: {},
   apiHubServiceDetails: {
@@ -57,6 +59,7 @@ export const designerSlice = createSlice({
   name: 'designer',
   initialState,
   reducers: {
+    /// TODO(ccastrotrejo): Update missing types
     initializeDesigner: (state, action: PayloadAction<any>) => {
       const {
         panelMetadata,
@@ -72,11 +75,13 @@ export const designerSlice = createSlice({
         hostVersion,
         isUnitTest,
         unitTestDefinition,
+        workflowRuntimeBaseUrl,
       } = action.payload;
 
       state.panelMetaData = panelMetadata;
       state.connectionData = connectionData;
       state.baseUrl = baseUrl;
+      state.workflowRuntimeBaseUrl = workflowRuntimeBaseUrl ?? '';
       state.apiVersion = apiVersion;
       state.apiHubServiceDetails = apiHubServiceDetails;
       state.readOnly = readOnly;

--- a/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
@@ -29,7 +29,7 @@ const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({ workflow, child
     dispatch(initRunInstance(runInstance ?? null));
     dispatch(initializeGraphState({ workflowDefinition: workflow, runInstance }));
     dispatch(initUnitTestDefinition(deserializeUnitTestDefinition(unitTestDefinition ?? null, workflow)));
-  }, [runInstance, workflow]);
+  }, [runInstance, workflow, unitTestDefinition]);
 
   return <>{children}</>;
 };

--- a/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer/src/lib/core/BJSWorkflowProvider.tsx
@@ -22,6 +22,7 @@ export interface BJSWorkflowProviderProps {
 
 const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({ workflow, children, runInstance, unitTestDefinition }) => {
   const dispatch = useDispatch<AppDispatch>();
+
   useDeepCompareEffect(() => {
     dispatch(initWorkflowSpec('BJS'));
     dispatch(initWorkflowKind(parseWorkflowKind(workflow?.kind)));

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -6,7 +6,7 @@ import { type OutputMock } from '../../state/unitTest/unitTestInterfaces';
 import type { Operations, NodesMetadata } from '../../state/workflow/workflowInterfaces';
 import { createWorkflowNode, createWorkflowEdge } from '../../utils/graph';
 import { toConditionViewModel } from '../../utils/parameters/helper';
-import { createLiteralValueSegment } from '../../utils/parameters/segment';
+import { createLiteralValueSegment, isValueSegment } from '../../utils/parameters/segment';
 import type { WorkflowNode, WorkflowEdge } from '../models/workflowNode';
 import { LoggerService, Status } from '@microsoft/designer-client-services-logic-apps';
 import { getDurationStringPanelMode, ActionResults } from '@microsoft/designer-ui';
@@ -23,6 +23,7 @@ import {
   getUniqueName,
   getRecordEntry,
   ConnectionType,
+  guid,
 } from '@microsoft/utils-logic-apps';
 
 const hasMultipleTriggers = (definition: LogicAppsV2.WorkflowDefinition): boolean => {
@@ -123,6 +124,10 @@ export const Deserialize = (
  */
 const parseOutputsToValueSegment = (mockOutputs: Record<string, any>) => {
   return Object.keys(mockOutputs).reduce((acc, key) => {
+    const id = guid();
+    if (isValueSegment({ id, ...mockOutputs[key][0] })) {
+      return { ...acc, [key]: [{ id, ...mockOutputs[key][0] }] };
+    }
     const value = typeof mockOutputs[key].value === 'object' ? JSON.stringify(mockOutputs[key].value) : mockOutputs[key].value;
     return { ...acc, [key]: [createLiteralValueSegment(value)] };
   }, {});

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/mockResultsTab/mockResultsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/mockResultsTab/mockResultsTab.tsx
@@ -59,11 +59,11 @@ export const MockResultsTab = () => {
   );
 
   const outputs: OutputsField[] = filteredOutputs.map((output: OutputInfo) => {
-    const { key: id, title: label, type } = output;
+    const { key: id, title: label, type, name } = output;
     const { editor, editorOptions, editorViewModel, schema } = getParameterEditorProps(output, [], true);
-    const value = mocks?.output[id] ?? [];
+    const value = mocks?.output[name] ?? [];
     const valueViewModel = { ...editorViewModel, uncastedValue: value };
-    const validationErrors = mocksValidationErrors[`${nodeName}-${id}`] ?? {};
+    const validationErrors = mocksValidationErrors[`${nodeName}-${name}`] ?? {};
 
     return {
       id,
@@ -81,7 +81,7 @@ export const MockResultsTab = () => {
       tokenMapping: {},
       validationErrors,
       suppressCastingForSerialize: false,
-      onValueChange: (newState: ChangeState) => onMockUpdate(id, newState, type),
+      onValueChange: (newState: ChangeState) => onMockUpdate(name, newState, type),
     };
   });
 

--- a/libs/services/designer-client-services/src/lib/standard/run.ts
+++ b/libs/services/designer-client-services/src/lib/standard/run.ts
@@ -217,7 +217,7 @@ export class StandardRunService implements IRunService {
    * @param {string} nodeId - Action ID.
    * @returns {Promise<any>} Action inputs and outputs.
    */
-  async getActionLinks(actionMetadata: { inputsLink?: ContentLink; outputsLink?: ContentLink }, nodeId: string): Promise<any> {
+  async getActionLinks(actionMetadata: { inputsLink?: ContentLink; outputsLink?: ContentLink }, nodeId?: string): Promise<any> {
     const { inputsLink, outputsLink } = actionMetadata ?? {};
     const { updateCors } = this.options;
     let inputs: Record<string, any> = {};


### PR DESCRIPTION
This pull request includes changes to the VS Code Designer application, specifically to the handling of unit tests and workflow monitoring. The changes introduce a new `runId` parameter to several functions and methods, modify the `OpenDesignerBase` class and its subclasses, and adjust how unit tests are created. 

Enhancements to Unit Test and Monitoring Workflow Handling:

* Send `runId` from Overview and Monitoring pages to designer pages. This allows to call the run instance API to get the outputs from the actions.

* Call the outputs API for all the actions within the workflow to populate the mock results when designer is loaded for unit test

* Added `workflowRuntimeBaseUrl` and `runId` as class properties and constructor parameters in `OpenDesignerBase` class and its subclasses.

* Modified `OpenMonitoringViewBase` class and its subclasses to handle `runId` properly.

* Added `runId` parameter to `createUnitTest` function. 

* Added `runId` to `DesignerCommandBarProps` and used it in `DesignerCommandBar` and `DesignerApp` components. 

#### Screenshots

https://github.com/Azure/LogicAppsUX/assets/102700317/1d2cf22f-8f0f-497b-aa5c-d47f6d9aa220

