### PR TITLE
fix(Designer): Secure string workflow parameters now pass validation

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -220,17 +220,19 @@ const getWorkflowParameters = (
     delete parameterDefinition['name'];
     delete parameterDefinition['isEditable'];
 
-    const valueIsString =
+    const isStringParameter =
       equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.STRING) ||
       equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.SECURE_STRING);
 
-    parameterDefinition.value = valueIsString ? value : value === '' ? undefined : typeof value !== 'string' ? value : JSON.parse(value);
+    parameterDefinition.value = isStringParameter
+      ? value
+      : value === ''
+      ? undefined
+      : typeof value !== 'string'
+      ? value
+      : JSON.parse(value);
 
-    const defaultValueIsString =
-      equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.STRING) ||
-      equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.SECURE_STRING);
-
-    parameterDefinition.defaultValue = defaultValueIsString
+    parameterDefinition.defaultValue = isStringParameter
       ? defaultValue
       : defaultValue === ''
       ? undefined

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -220,17 +220,17 @@ const getWorkflowParameters = (
     delete parameterDefinition['name'];
     delete parameterDefinition['isEditable'];
 
-    const isValueString =
+    const valueIsString =
       equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.STRING) ||
       equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.SECURE_STRING);
 
-    parameterDefinition.value = isValueString ? value : value === '' ? undefined : typeof value !== 'string' ? value : JSON.parse(value);
+    parameterDefinition.value = valueIsString ? value : value === '' ? undefined : typeof value !== 'string' ? value : JSON.parse(value);
 
-    const isDefaultValueString =
+    const defaultValueIsString =
       equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.STRING) ||
       equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.SECURE_STRING);
 
-    parameterDefinition.defaultValue = isDefaultValueString
+    parameterDefinition.defaultValue = defaultValueIsString
       ? defaultValue
       : defaultValue === ''
       ? undefined

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -220,15 +220,17 @@ const getWorkflowParameters = (
     delete parameterDefinition['name'];
     delete parameterDefinition['isEditable'];
 
-    parameterDefinition.value = equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.STRING)
-      ? value
-      : value === ''
-      ? undefined
-      : typeof value !== 'string'
-      ? value
-      : JSON.parse(value);
+    const isValueString =
+      equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.STRING) ||
+      equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.SECURE_STRING);
 
-    parameterDefinition.defaultValue = equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.STRING)
+    parameterDefinition.value = isValueString ? value : value === '' ? undefined : typeof value !== 'string' ? value : JSON.parse(value);
+
+    const isDefaultValueString =
+      equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.STRING) ||
+      equals(parameterDefinition.type, UIConstants.WORKFLOW_PARAMETER_TYPE.SECURE_STRING);
+
+    parameterDefinition.defaultValue = isDefaultValueString
       ? defaultValue
       : defaultValue === ''
       ? undefined


### PR DESCRIPTION
## Main Changes

Secure string workflow parameters now pass validation.
Previously our value / default value checking was verifying the values were objects, they are now evaluated just as-is like strings.
