### PR TITLE
feat(vscode): Add edit and view results for test files

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
@@ -20,13 +20,15 @@ import * as vscode from 'vscode';
  * @param {vscode.Uri} node - The URI of the unit test file to edit. If not provided, the user will be prompted to select a unit test file.
  * @returns A Promise that resolves when the unit test has been edited.
  */
-export async function editUnitTest(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
+export async function editUnitTest(context: IAzureConnectorsContext, node: vscode.Uri | vscode.TestItem): Promise<void> {
   let unitTestNode: vscode.Uri;
   const workspaceFolder = await getWorkspaceFolder(context);
   const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
 
-  if (node) {
+  if (node && node instanceof vscode.Uri) {
     unitTestNode = getWorkflowNode(node) as vscode.Uri;
+  } else if (node && !(node instanceof vscode.Uri) && node.uri instanceof vscode.Uri) {
+    unitTestNode = node.uri;
   } else {
     const unitTest = await pickUnitTest(context, path.join(projectPath, developmentDirectoryName, testsDirectoryName));
     unitTestNode = vscode.Uri.file(unitTest.data) as vscode.Uri;

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
@@ -3,13 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { developmentDirectoryName, testsDirectoryName, workflowFileName } from '../../../../constants';
-import { localize } from '../../../../localize';
-import { getUnitTestInLocalProject, getUnitTestName } from '../../../utils/unitTests';
+import { getUnitTestName, pickUnitTest } from '../../../utils/unitTests';
 import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
 import { getWorkflowNode, getWorkspaceFolder } from '../../../utils/workspace';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
 import OpenDesignerForLocalProject from '../openDesigner/openDesignerForLocalProject';
-import { type IAzureQuickPickItem, type IActionContext } from '@microsoft/vscode-azext-utils';
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -43,29 +41,3 @@ export async function editUnitTest(context: IAzureConnectorsContext, node: vscod
   const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName, unitTestDefinition);
   await openDesignerObj?.createPanel();
 }
-
-/**
- * Prompts the user to select a unit test to edit.
- * @param {IActionContext} context - The action context.
- * @param {string} projectPath - The path of the project.
- * @returns A promise that resolves to the selected unit test.
- */
-const pickUnitTest = async (context: IActionContext, projectPath: string) => {
-  const placeHolder: string = localize('selectUnitTest', 'Select unit test to edit');
-  return await context.ui.showQuickPick(getUnitTestPick(projectPath), { placeHolder });
-};
-
-/**
- * Retrieves a list of unit tests in the local project.
- * @param {string} projectPath - The path to the project.
- * @returns A promise that resolves to an array of unit test picks.
- */
-const getUnitTestPick = async (projectPath: string) => {
-  const listOfUnitTest = await getUnitTestInLocalProject(projectPath);
-  const picks: IAzureQuickPickItem<string>[] = Array.from(Object.keys(listOfUnitTest)).map((unitTestName) => {
-    return { label: unitTestName, data: listOfUnitTest[unitTestName] };
-  });
-
-  picks.sort((a, b) => a.label.localeCompare(b.label));
-  return picks;
-};

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -34,6 +34,4 @@ export async function openUnitTestResults(context: IAzureConnectorsContext, node
 
   const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName, unitTestDefinition);
   await openDesignerObj?.createPanel();
-
-  await openDesignerObj?.createPanel();
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -40,6 +40,6 @@ export async function openUnitTestResults(context: IAzureConnectorsContext, node
   }
 
   window.showInformationMessage(
-    localize('noRunForUnitTest', 'There is no run for the selected unit test. Please run the unit test for "{0}"', unitTestName)
+    localize('noRunForUnitTest', 'There is no run for the selected unit test. Make sure to run the unit test for "{0}"', unitTestName)
   );
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -2,15 +2,38 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { getUnitTestName } from '../../../utils/unitTests';
-import { getWorkflowNode } from '../../../utils/workspace';
+import { developmentDirectoryName, testsDirectoryName, workflowFileName } from '../../../../constants';
+import { getUnitTestName, pickUnitTest } from '../../../utils/unitTests';
+import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
+import { getWorkflowNode, getWorkspaceFolder } from '../../../utils/workspace';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
 import OpenDesignerForLocalProject from '../openDesigner/openDesignerForLocalProject';
-import type * as vscode from 'vscode';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { type TestItem, Uri } from 'vscode';
 
-export async function openUnitTestResults(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
-  const unitTestName = getUnitTestName(node.fsPath);
-  const workflowNode = getWorkflowNode(node) as vscode.Uri;
-  const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName);
+export async function openUnitTestResults(context: IAzureConnectorsContext, node: Uri | TestItem): Promise<void> {
+  let unitTestNode: Uri;
+  const workspaceFolder = await getWorkspaceFolder(context);
+  const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
+
+  if (node && node instanceof Uri) {
+    unitTestNode = getWorkflowNode(node) as Uri;
+  } else if (node && !(node instanceof Uri) && node.uri instanceof Uri) {
+    unitTestNode = node.uri;
+  } else {
+    const unitTest = await pickUnitTest(context, path.join(projectPath, developmentDirectoryName, testsDirectoryName));
+    unitTestNode = Uri.file(unitTest.data) as Uri;
+  }
+
+  const workflowName = path.basename(path.dirname(unitTestNode.fsPath));
+  const workflowPath = path.join(projectPath, workflowName, workflowFileName);
+  const workflowNode = Uri.file(workflowPath);
+  const unitTestDefinition = JSON.parse(readFileSync(unitTestNode.fsPath, 'utf8'));
+  const unitTestName = getUnitTestName(unitTestNode.fsPath);
+
+  const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName, unitTestDefinition);
+  await openDesignerObj?.createPanel();
+
   await openDesignerObj?.createPanel();
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/runUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/runUnitTest.ts
@@ -3,40 +3,69 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { runUnitTestEvent } from '../../../../constants';
+import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
-import { getLogicAppProjectRoot } from '../../../utils/codeless/connection';
-import { type IAzureConnectorsContext } from '../azureConnectorWizard';
-import { callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
-import * as child from 'child_process';
-import * as path from 'path';
+import { type IActionContext, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 
-export async function runUnitTest(context: IAzureConnectorsContext, node: vscode.Uri): Promise<void> {
-  await callWithTelemetryAndErrorHandling(runUnitTestEvent, async () => {
+export interface UnitTestResult {
+  isSuccessful: boolean;
+  assertions: any[];
+  duration?: number;
+}
+
+export async function runUnitTest(context: IActionContext, node: vscode.Uri | vscode.TestItem): Promise<UnitTestResult> {
+  return await callWithTelemetryAndErrorHandling(runUnitTestEvent, async () => {
     const options: vscode.ProgressOptions = {
       location: vscode.ProgressLocation.Notification,
       title: localize('azureFunctions.runUnitTest', 'Running Unit Test...'),
     };
 
-    await vscode.window.withProgress(options, async () => {
-      const pathToUnitTest = node.fsPath;
-      const projectPath: string | undefined = await getLogicAppProjectRoot(this.context, pathToUnitTest);
-      const workflowName = path.basename(path.dirname(pathToUnitTest));
-
-      const UNIT_TEST_EXE_NAME = 'LogicAppsTest.exe';
-      const pathToExe = path.join(projectPath, UNIT_TEST_EXE_NAME);
-
+    return await vscode.window.withProgress(options, async () => {
+      // This is where we are going to run the unit test from extension bundle
+      // Just put a random decision here in the meantime
       try {
-        const res = child.spawn(pathToExe, ['-PathToRoot', projectPath, '-workflowName', workflowName, '-pathToUnitTest', pathToUnitTest]);
+        const runId = node instanceof vscode.Uri ? node.fsPath : node.uri.fsPath;
+        const start = Date.now();
+        await new Promise((resolve) => setTimeout(resolve, 1000 + Math.random() * 1000));
+        const duration = Date.now() - start;
 
-        for await (const chunk of res.stdout) {
-          vscode.window.showInformationMessage(`${chunk}`);
-        }
+        const testResult = {
+          isSuccessful: start % 2 === 0,
+          assertions: [],
+          duration,
+        };
+
+        ext.testRuns.set(runId, {
+          runId,
+          results: testResult,
+        });
+
+        return testResult;
       } catch (error) {
         vscode.window.showErrorMessage(`${localize('runFailure', 'Error Running Unit Test.')} ${error.message}`, localize('OK', 'OK'));
         context.telemetry.properties.errorMessage = error.message;
         throw error;
       }
+
+      // const pathToUnitTest = node.fsPath;
+      // const projectPath: string | undefined = await getLogicAppProjectRoot(this.context, pathToUnitTest);
+      // const workflowName = path.basename(path.dirname(pathToUnitTest));
+
+      // const UNIT_TEST_EXE_NAME = 'LogicAppsTest.exe';
+      // const pathToExe = path.join(projectPath, UNIT_TEST_EXE_NAME);
+
+      // try {
+      //   const res = child.spawn(pathToExe, ['-PathToRoot', projectPath, '-workflowName', workflowName, '-pathToUnitTest', pathToUnitTest]);
+
+      //   for await (const chunk of res.stdout) {
+      //     vscode.window.showInformationMessage(`${chunk}`);
+      //   }
+      // } catch (error) {
+      //   vscode.window.showErrorMessage(`${localize('runFailure', 'Error Running Unit Test.')} ${error.message}`, localize('OK', 'OK'));
+      //   context.telemetry.properties.errorMessage = error.message;
+      //   throw error;
+      // }
     });
   });
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/runUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/runUnitTest.ts
@@ -5,15 +5,16 @@
 import { runUnitTestEvent } from '../../../../constants';
 import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
+import { type UnitTestResult } from '../../../utils/unitTests';
 import { type IActionContext, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 
-export interface UnitTestResult {
-  isSuccessful: boolean;
-  assertions: any[];
-  duration?: number;
-}
-
+/**
+ * Runs a unit test for a given node in the Logic Apps designer.
+ * @param {IActionContext} context -  The action context.
+ * @param {vscode.Uri | vscode.TestItem} node - The URI or TestItem representing the node to run the unit test for.
+ * @returns A Promise that resolves to the UnitTestResult object.
+ */
 export async function runUnitTest(context: IActionContext, node: vscode.Uri | vscode.TestItem): Promise<UnitTestResult> {
   return await callWithTelemetryAndErrorHandling(runUnitTestEvent, async () => {
     const options: vscode.ProgressOptions = {

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
@@ -10,6 +10,7 @@ import { TestWorkflow } from './testWorkflow';
 import { TestWorkspace } from './testWorkspace';
 import { isEmptyString } from '@microsoft/utils-logic-apps';
 import { type IActionContext, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
+import * as path from 'path';
 import {
   RelativePattern,
   type TestController,
@@ -210,8 +211,8 @@ const getOrCreateWorkspace = (controller: TestController, workspaceName: string,
  */
 const getOrCreateFile = async (controller: TestController, uri: Uri) => {
   const workspaceName = uri.fsPath.split('/').slice(-5)[0];
-  const testName = uri.fsPath.split('/').slice(-1)[0];
-  const workflowName = uri.fsPath.split('/').slice(-2)[0];
+  const testName = path.basename(uri.fsPath);
+  const workflowName = path.basename(path.dirname(uri.fsPath));
 
   const existingWorkspaceTest = controller.items.get(workspaceName);
 

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
@@ -141,10 +141,6 @@ const testsWorkspaceWatcher = (controller: TestController, fileChangedEmitter: E
       fileChangedEmitter.fire(uri);
     });
     watcher.onDidChange(async (uri) => {
-      const { data } = await getOrCreateFile(controller, uri);
-      if (data instanceof TestFile) {
-        await data.parseUnitTest();
-      }
       fileChangedEmitter.fire(uri);
     });
     watcher.onDidDelete((uri) => controller.items.delete(uri.toString()));

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
@@ -156,7 +156,7 @@ const findInitialFiles = async (controller: TestController, pattern: RelativePat
   const unitTestFiles = await workspace.findFiles(pattern);
 
   const workspacesTestFiles = unitTestFiles.reduce((acc, file: Uri) => {
-    const workspaceName = file.path.split('/').slice(-5)[0];
+    const workspaceName = file.fsPath.split('/').slice(-5)[0];
 
     if (!acc[workspaceName]) {
       acc[workspaceName] = [];
@@ -182,7 +182,7 @@ const getOrCreateWorkspace = (controller: TestController, workspaceName: string,
   if (existing) {
     return { file: existing, data: ext.testData.get(existing) as TestWorkspace };
   }
-  const filePath = files.length > 0 ? files[0].path : '';
+  const filePath = files.length > 0 ? files[0].fsPath : '';
   const workspaceUri = isEmptyString(filePath) ? undefined : Uri.file(filePath.split('/').slice(0, -4).join('/'));
 
   const workspaceTestItem = controller.createTestItem(workspaceName, workspaceName, workspaceUri);
@@ -202,9 +202,9 @@ const getOrCreateWorkspace = (controller: TestController, workspaceName: string,
  * @returns An object containing the file test and its associated data, if it exists.
  */
 const getOrCreateFile = async (controller: TestController, uri: Uri) => {
-  const workspaceName = uri.path.split('/').slice(-5)[0];
-  const testName = uri.path.split('/').slice(-1)[0];
-  const workflowName = uri.path.split('/').slice(-2)[0];
+  const workspaceName = uri.fsPath.split('/').slice(-5)[0];
+  const testName = uri.fsPath.split('/').slice(-1)[0];
+  const workflowName = uri.fsPath.split('/').slice(-2)[0];
 
   const existingWorkspaceTest = controller.items.get(workspaceName);
 
@@ -225,7 +225,7 @@ const getOrCreateFile = async (controller: TestController, uri: Uri) => {
       existingWorkspaceTest.children.add(workflowTestItem);
     }
   } else {
-    const workspaceUri = Uri.file(uri.path.split('/').slice(0, -4).join('/'));
+    const workspaceUri = Uri.file(uri.fsPath.split('/').slice(0, -4).join('/'));
     const workspaceTestItem = controller.createTestItem(workspaceName, workspaceName, workspaceUri);
     workspaceTestItem.canResolveChildren = true;
     controller.items.add(workspaceTestItem);

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
@@ -283,7 +283,7 @@ const startTestRun = (request: TestRunRequest, unitTestController: TestControlle
    */
   const runTestQueue = async () => {
     for (const { test, data } of queue) {
-      run.appendOutput(`Running ${test.id}\r\n`);
+      run.appendOutput(`Running ${test.label}\r\n`);
       if (run.token.isCancellationRequested) {
         run.skipped(test);
       } else {
@@ -291,7 +291,7 @@ const startTestRun = (request: TestRunRequest, unitTestController: TestControlle
         await data.run(test, run, activateContext);
       }
 
-      run.appendOutput(`Completed ${test.id}\r\n`);
+      run.appendOutput(`Completed ${test.label}\r\n`);
     }
 
     run.end();

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/testFile.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/testFile.ts
@@ -2,57 +2,14 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { localize } from '../../../localize';
 import { runUnitTest } from '../../commands/workflows/unitTest/runUnitTest';
-import { parseJson } from '../../utils/parseJson';
-import { type UnitTestDefinition } from '@microsoft/utils-logic-apps';
-import { type IActionContext, parseError } from '@microsoft/vscode-azext-utils';
-import * as fse from 'fs-extra';
-import { TestMessage, type TestItem, type Uri, type TestRun } from 'vscode';
+import { type IActionContext } from '@microsoft/vscode-azext-utils';
+import { TestMessage, type TestItem, type TestRun } from 'vscode';
 
 /**
  * Represents a test file.
  */
 export class TestFile {
-  private readonly name: string;
-  private file: Uri;
-  private fileTestItem: TestItem;
-  private unitTest: UnitTestDefinition;
-
-  /**
-   * Creates a new instance of the TestFile class.
-   * @param name - The name of the test file.
-   * @param file - The URI of the test file.
-   * @param fileTestItem - The test item associated with the test file.
-   */
-  constructor(name: string, file: Uri, fileTestItem: TestItem) {
-    this.name = name;
-    this.file = file;
-    this.fileTestItem = fileTestItem;
-  }
-
-  /**
-   * Parses the unit test data from the file.
-   * @returns A promise that resolves when the unit test data is parsed.
-   */
-  public async parseUnitTest(): Promise<void> {
-    const data: string = (await fse.readFile(this.file.fsPath)).toString();
-    if (/[^\s]/.test(data)) {
-      try {
-        this.unitTest = parseJson(data);
-      } catch (error) {
-        const message: string = localize('failedToParse', 'Failed to parse "{0}": {1}.', this.file.fsPath, parseError(error).message);
-        throw new Error(message);
-      }
-    } else {
-      this.unitTest = {
-        actionMocks: {},
-        triggerMocks: {},
-        assertions: [],
-      };
-    }
-  }
-
   /**
    * Runs a unit test for a specific test item.
    * @param {TestItem} item - The test item to run the unit test for.

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/testFile.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/testFile.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { localize } from '../../../localize';
+import { runUnitTest } from '../../commands/workflows/unitTest/runUnitTest';
 import { parseJson } from '../../utils/parseJson';
 import { type UnitTestDefinition } from '@microsoft/utils-logic-apps';
-import { parseError } from '@microsoft/vscode-azext-utils';
+import { type IActionContext, parseError } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import { TestMessage, type TestItem, type Uri, type TestRun } from 'vscode';
 
@@ -58,19 +59,13 @@ export class TestFile {
    * @param {TestRun} options - The options for running the unit test.
    * @returns A promise that resolves when the unit test is completed.
    */
-  async run(item: TestItem, options: TestRun): Promise<void> {
-    const start = Date.now();
-    await new Promise((resolve) => setTimeout(resolve, 1000 + Math.random() * 1000));
-    const duration = Date.now() - start;
-
-    // This is where we are going to run the unit test from extension bundle
-
-    // Just put a random decision here in the meantime
-    if (start % 2 === 0) {
-      options.passed(item, duration);
+  async run(item: TestItem, options: TestRun, activateContext: IActionContext): Promise<void> {
+    const unitTestResult = await runUnitTest(activateContext, item);
+    if (unitTestResult.isSuccessful) {
+      options.passed(item, unitTestResult.duration);
     } else {
       const message = TestMessage.diff(`Expected ${item.label}`, '1', '2');
-      options.failed(item, message, duration);
+      options.failed(item, message, unitTestResult.duration);
     }
   }
 }

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/testFile.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/testFile.ts
@@ -35,12 +35,12 @@ export class TestFile {
    * @returns A promise that resolves when the unit test data is parsed.
    */
   public async parseUnitTest(): Promise<void> {
-    const data: string = (await fse.readFile(this.file.path)).toString();
+    const data: string = (await fse.readFile(this.file.fsPath)).toString();
     if (/[^\s]/.test(data)) {
       try {
         this.unitTest = parseJson(data);
       } catch (error) {
-        const message: string = localize('failedToParse', 'Failed to parse "{0}": {1}.', this.file.path, parseError(error).message);
+        const message: string = localize('failedToParse', 'Failed to parse "{0}": {1}.', this.file.fsPath, parseError(error).message);
         throw new Error(message);
       }
     } else {

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkflow.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkflow.ts
@@ -43,8 +43,7 @@ export class TestWorkflow {
 
       const fileTestItem = controller.createTestItem(id, testName, testFile);
       controller.items.add(fileTestItem);
-      const data = new TestFile(testName, testFile, fileTestItem);
-      await data.parseUnitTest();
+      const data = new TestFile();
       ext.testData.set(fileTestItem, data);
       this.children.push(fileTestItem);
     }

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkflow.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkflow.ts
@@ -35,7 +35,7 @@ export class TestWorkflow {
    */
   public async createChild(controller: TestController): Promise<void> {
     for (const testFile of this.testFiles) {
-      const testName = testFile.path.split('/').slice(-1)[0];
+      const testName = testFile.fsPath.split('/').slice(-1)[0];
       const id = `${this.name}/${testName}`;
 
       const fileTestItem = controller.createTestItem(id, testName, testFile);

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkflow.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkflow.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { ext } from '../../../extensionVariables';
+import { getUnitTestName } from '../../utils/unitTests';
 import { TestFile } from './testFile';
+import * as path from 'path';
 import { type TestController, type TestItem, type Uri } from 'vscode';
 
 /**
@@ -35,8 +37,9 @@ export class TestWorkflow {
    */
   public async createChild(controller: TestController): Promise<void> {
     for (const testFile of this.testFiles) {
-      const testName = testFile.fsPath.split('/').slice(-1)[0];
-      const id = `${this.name}/${testName}`;
+      const testName = getUnitTestName(testFile.fsPath);
+      const unitTestFileName = path.basename(testFile.fsPath);
+      const id = `${this.name}/${unitTestFileName}`;
 
       const fileTestItem = controller.createTestItem(id, testName, testFile);
       controller.items.add(fileTestItem);

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkspace.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkspace.ts
@@ -35,7 +35,7 @@ export class TestWorkspace {
    */
   private parseTestWorkflows(workflows: Uri[]): Record<string, Uri[]> {
     return workflows.reduce((acc, workflow) => {
-      const workflowName = workflow.path.split('/').slice(-2)[0];
+      const workflowName = workflow.fsPath.split('/').slice(-2)[0];
       if (!acc[workflowName]) {
         acc[workflowName] = [];
       }
@@ -50,7 +50,7 @@ export class TestWorkspace {
    */
   public async createChild(controller: TestController) {
     Object.keys(this.workflows).forEach((workflow) => {
-      const filePath = this.workflows[workflow][0].path;
+      const filePath = this.workflows[workflow][0].fsPath;
       const workflowUri = Uri.file(filePath.substring(0, filePath.lastIndexOf('/')));
       const id = `${this.name}/${workflow}`;
       const workflowTestItem = controller.createTestItem(id, workflow, workflowUri);

--- a/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkspace.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/testWorkspace.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { ext } from '../../../extensionVariables';
 import { TestWorkflow } from './testWorkflow';
+import * as path from 'path';
 import { Uri, type TestController, type TestItem } from 'vscode';
 
 /**
@@ -35,7 +36,8 @@ export class TestWorkspace {
    */
   private parseTestWorkflows(workflows: Uri[]): Record<string, Uri[]> {
     return workflows.reduce((acc, workflow) => {
-      const workflowName = workflow.fsPath.split('/').slice(-2)[0];
+      const workflowName = path.basename(path.dirname(workflow.fsPath));
+
       if (!acc[workflowName]) {
         acc[workflowName] = [];
       }

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { developmentDirectoryName, saveUnitTestEvent, testsDirectoryName, unitTestsFileName } from '../../constants';
 import { localize } from '../../localize';
-import { callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
+import { type IAzureQuickPickItem, type IActionContext, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import * as fs from 'fs';
 import * as fse from 'fs-extra';
 import * as path from 'path';
@@ -150,3 +150,29 @@ export async function getUnitTestInLocalProject(projectPath: string): Promise<Re
 
   return unitTests;
 }
+
+/**
+ * Prompts the user to select a unit test to edit.
+ * @param {IActionContext} context - The action context.
+ * @param {string} projectPath - The path of the project.
+ * @returns A promise that resolves to the selected unit test.
+ */
+export const pickUnitTest = async (context: IActionContext, projectPath: string) => {
+  const placeHolder: string = localize('selectUnitTest', 'Select unit test to edit');
+  return await context.ui.showQuickPick(getUnitTestPick(projectPath), { placeHolder });
+};
+
+/**
+ * Retrieves a list of unit tests in the local project.
+ * @param {string} projectPath - The path to the project.
+ * @returns A promise that resolves to an array of unit test picks.
+ */
+const getUnitTestPick = async (projectPath: string) => {
+  const listOfUnitTest = await getUnitTestInLocalProject(projectPath);
+  const picks: IAzureQuickPickItem<string>[] = Array.from(Object.keys(listOfUnitTest)).map((unitTestName) => {
+    return { label: unitTestName, data: listOfUnitTest[unitTestName] };
+  });
+
+  picks.sort((a, b) => a.label.localeCompare(b.label));
+  return picks;
+};

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -10,6 +10,12 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+export interface UnitTestResult {
+  isSuccessful: boolean;
+  assertions: any[];
+  duration?: number;
+}
+
 export const saveUnitTestDefinition = async (
   projectPath: string,
   workflowName: string,

--- a/apps/vs-code-designer/src/extensionVariables.ts
+++ b/apps/vs-code-designer/src/extensionVariables.ts
@@ -100,6 +100,7 @@ export namespace ext {
   export const testFileChangedEmitter = new EventEmitter<Uri>();
   export const testData = new WeakMap<TestItem, TestData>();
   export let unitTestController: TestController;
+  export const testRuns = new Map<string, any>();
 }
 
 export const ExtensionCommand = {

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -65,7 +65,7 @@ export async function activate(context: vscode.ExtensionContext) {
     runPostWorkflowCreateStepsFromCache();
 
     await startOnboarding(activateContext);
-    await prepareTestExplorer(context);
+    await prepareTestExplorer(context, activateContext);
 
     ext.extensionVersion = getExtensionVersion();
     ext.rgApi = await getResourceGroupsApi();

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -338,12 +338,14 @@
       {
         "command": "azureLogicAppsStandard.openUnitTestResults",
         "title": "View Unit Test Results",
-        "category": "Azure Logic Apps"
+        "category": "Azure Logic Apps",
+        "icon": "$(tasklist)"
       },
       {
         "command": "azureLogicAppsStandard.editUnitTest",
         "title": "Edit Unit Test",
-        "category": "Azure Logic Apps"
+        "category": "Azure Logic Apps",
+        "icon": "$(edit)"
       },
       {
         "command": "azureLogicAppsStandard.runUnitTest",
@@ -695,7 +697,7 @@
         },
         {
           "command": "azureLogicAppsStandard.openUnitTestResults",
-          "when": "resourceFilename=~/.unit-test.[0-9]{14}/",
+          "when": "resourceFilename=~/.unit-test.json/",
           "group": "navigation@5"
         },
         {
@@ -741,6 +743,26 @@
         {
           "command": "azureLogicAppsStandard.viewProperties",
           "when": "never"
+        }
+      ],
+      "testing/item/context": [
+        {
+          "command": "azureLogicAppsStandard.editUnitTest",
+          "group": "inline@3",
+          "when": "testId=~/.unit-test.json/"
+        },
+        {
+          "command": "azureLogicAppsStandard.openUnitTestResults",
+          "group": "inline@4",
+          "when": "testId=~/.unit-test.json/"
+        },
+        {
+          "command": "azureLogicAppsStandard.editUnitTest",
+          "when": "testId=~/.unit-test.json/"
+        },
+        {
+          "command": "azureLogicAppsStandard.openUnitTestResults",
+          "when": "testId=~/.unit-test.json/"
         }
       ],
       "azureLogicAppsStandard.dataMapperMenu": [

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -332,24 +332,24 @@
       },
       {
         "command": "azureLogicAppsStandard.createUnitTest",
-        "title": "Create Unit Test",
+        "title": "Create unit test",
         "category": "Azure Logic Apps"
       },
       {
         "command": "azureLogicAppsStandard.openUnitTestResults",
-        "title": "View Unit Test Results",
+        "title": "View unit test results",
         "category": "Azure Logic Apps",
         "icon": "$(tasklist)"
       },
       {
         "command": "azureLogicAppsStandard.editUnitTest",
-        "title": "Edit Unit Test",
+        "title": "Edit unit test",
         "category": "Azure Logic Apps",
         "icon": "$(edit)"
       },
       {
         "command": "azureLogicAppsStandard.runUnitTest",
-        "title": "Run Unit Test",
+        "title": "Run unit test",
         "category": "Azure Logic Apps"
       }
     ],


### PR DESCRIPTION
This pull request primarily modifies the unit test handling in the `vs-code-designer` application. The changes include modifying the way unit tests are run, simplifying the `TestFile` class, and updating the handling of test files and workspaces in the unit test tree. 


* Refactored the `runUnitTest` function to simulate running a unit test and return a test result. The function now takes an additional `IActionContext` argument.

* Removed the `parseUnitTest` method and the `name`, `file`, `fileTestItem`, and `unitTest` properties from the `TestFile` class. The `run` method now calls the `runUnitTest` function and updates the test run based on the returned result.

* Updated several functions to use the file system path of URIs instead of the URI path, and to take an additional `IActionContext` argument. Removed the handling of file changes in the `testsWorkspaceWatcher` function.

* Updated imports and the `editUnitTest` function to handle a `vscode.Uri` or `vscode.TestItem` as the `node` argument. Removed the `pickUnitTest` and `getUnitTestPick` functions.
* Updated imports and the `openUnitTestResults` function to handle a `Uri` or `TestItem` as the `node` argument, and to show an information message if there is no run for the selected unit test.


### Screenshots


https://github.com/Azure/LogicAppsUX/assets/102700317/5f7630a5-82fe-4f21-9786-890462bc1c44

#### View unit test result button in test file

<img width="362" alt="Screenshot 2024-03-21 at 4 51 01 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/9eb2404e-1994-4cc3-95b7-c433699d50a9">

#### Edit unit test button in testfile
<img width="379" alt="Screenshot 2024-03-21 at 4 51 06 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/2d629461-3f6f-401b-9fd8-c5c6888e055e">

#### Information message when view unit test results without running the test
<img width="610" alt="Screenshot 2024-03-21 at 4 52 01 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/7157edcf-abf4-4c17-b5e8-4524b331f42b">
