### PR TITLE
fix(vscode): Add app kind setting to local settings creation and update on design time

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppCreateStep.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import {
+  appKindSetting,
   azureWebJobsStorageKey,
   defaultVersionRange,
   extensionBundleId,
@@ -157,7 +158,7 @@ export class LogicAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWizar
     if (context.customLocation) {
       appSettings.push(
         {
-          name: 'APP_KIND',
+          name: appKindSetting,
           value: logicAppKindAppSetting,
         },
         {

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/workflowDesigner/DesignerConfig.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/workflowDesigner/DesignerConfig.ts
@@ -1,4 +1,4 @@
-import { designTimeDirectoryName } from '../../../../../../constants';
+import { designTimeDirectoryName, localSettingsFileName, logicAppKind } from '../../../../../../constants';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension';
 import * as fs from 'fs-extra';
@@ -57,13 +57,14 @@ export class DesignerConfig extends AzureWizardPromptStep<IProjectWizardContext>
    * @param folderPath The path to the folder where the local.settings.json file should be generated.
    */
   private async generateLocalSettingsJson(folderPath: string, context: IProjectWizardContext): Promise<void> {
-    const filePath = path.join(folderPath, 'local.settings.json');
+    const filePath = path.join(folderPath, localSettingsFileName);
     const designerProjPath: string = context.logicAppFolderPath;
     const content = {
       IsEncrypted: false,
       Values: {
         AzureWebJobsSecretStorageType: 'Files',
         FUNCTIONS_WORKER_RUNTIME: 'node',
+        APP_KIND: logicAppKind,
         ProjectDirectoryPath: designerProjPath,
       },
     };

--- a/apps/vs-code-designer/src/app/commands/dataMapper/DataMapperExt.ts
+++ b/apps/vs-code-designer/src/app/commands/dataMapper/DataMapperExt.ts
@@ -3,17 +3,18 @@ import DataMapperPanel from './DataMapperPanel';
 import { startBackendRuntime } from './FxWorkflowRuntime';
 import { webviewType } from './extensionConfig';
 import type { MapDefinitionEntry } from '@microsoft/logic-apps-shared';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { MapDefinitionData } from '@microsoft/vscode-extension';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
 import { Uri, ViewColumn, window } from 'vscode';
 
 export default class DataMapperExt {
-  public static async openDataMapperPanel(dataMapName: string, mapDefinitionData?: MapDefinitionData) {
+  public static async openDataMapperPanel(dataMapName: string, context: IActionContext, mapDefinitionData?: MapDefinitionData) {
     const workflowFolder = ext.logicAppWorkspace;
 
     if (workflowFolder) {
-      await startBackendRuntime(workflowFolder);
+      await startBackendRuntime(workflowFolder, context);
 
       DataMapperExt.createOrShow(dataMapName, mapDefinitionData);
     }

--- a/apps/vs-code-designer/src/app/commands/dataMapper/dataMapper.ts
+++ b/apps/vs-code-designer/src/app/commands/dataMapper/dataMapper.ts
@@ -20,7 +20,7 @@ export const createNewDataMapCmd = (context: IActionContext) => {
 
     context.telemetry.properties.result = 'Succeeded';
 
-    DataMapperExt.openDataMapperPanel(newDataMapName);
+    DataMapperExt.openDataMapperPanel(newDataMapName, context);
   });
 };
 
@@ -165,7 +165,7 @@ export const loadDataMapFileCmd = async (context: IActionContext, uri: Uri) => {
   const dataMapName = path.basename(mapDefinitionPath, path.extname(mapDefinitionPath)).replace(draftMapDefinitionSuffix, ''); // Gets filename w/o ext (and w/o draft suffix)
 
   // Set map definition data to be loaded once webview sends webviewLoaded msg
-  DataMapperExt.openDataMapperPanel(dataMapName, {
+  DataMapperExt.openDataMapperPanel(dataMapName, context, {
     mapDefinition,
     sourceSchemaFileName: path.basename(srcSchemaPath),
     targetSchemaFileName: path.basename(tgtSchemaPath),

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -202,6 +202,7 @@ export const targetBundleKey = 'FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI';
 
 // local.settings.json
 export const localEmulatorConnectionString = 'UseDevelopmentStorage=true';
+export const appKindSetting = 'APP_KIND';
 
 // Project
 export const defaultBundleId = 'Microsoft.Azure.Functions.ExtensionBundle';


### PR DESCRIPTION
This pull request mainly focuses on improving the codebase of the VS Code Designer app by refactoring constants and modifying function parameters to enhance maintainability. The changes are primarily related to the handling of settings and configuration in the application.


* The constant `APP_KIND` has been replaced with `appKindSetting` to enhance code readability and maintainability.
* Additional constants `localSettingsFileName` and `logicAppKind` have been imported to standardize the naming conventions and enhance code readability.
* A new constant `appKindSetting` has been added to standardize the naming conventions.
* The function `startDesignTimeApi` has been modified to replace the `updateProjectPath` function with the `addOrUpdateLocalAppSettings` function.
* The function `updateProjectPath` has been removed as it was replaced by the `addOrUpdateLocalAppSettings` function.