### PR TITLE
feat(Designer): Add data-automation-id for connector summary card

### DIFF
--- a/libs/designer-ui/src/lib/connectorsummarycard/index.tsx
+++ b/libs/designer-ui/src/lib/connectorsummarycard/index.tsx
@@ -49,13 +49,18 @@ export const ConnectorSummaryCard = (props: ConnectorSummaryCardProps) => {
 
   if (isCard)
     return (
-      <button className="msla-connector-summary-card" onClick={handleClick} aria-label={`${connectorName} ${description}`}>
+      <button
+        className="msla-connector-summary-card"
+        onClick={handleClick}
+        aria-label={`${connectorName} ${description}`}
+        data-automation-id={id}
+      >
         <Content />
       </button>
     );
 
   return (
-    <div className="msla-connector-summary-display">
+    <div className="msla-connector-summary-display" data-automation-id={id}>
       <ConnectorImage />
       <div style={{ flexGrow: 1 }}>
         <Content />


### PR DESCRIPTION
Add data-automation-id for connector summary card

# Checklist

* [x] The commit message follows our guidelines
* [x] N/A. Tests for the changes have been added (for bug fixes/features)
* [x] N/A Docs have been added / updated (for bug fixes / features)

# Changes

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature: add automation id to improve automated UI test stability and robustness with respect to UI/styling or locale changes.

**What is the current behavior?** (You can also link to an open issue here)

Two connector summary cards cannot be distinguished from each other, except by their content - which is a localized text.

**What is the new behavior (if this is a feature change)?**

Adding `data-automation-id` prop to the component, where the value is the connector `id`, in order to guarantee a consistent way to distinguish and select the right element when using automated tests.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

**No.**
- No behavior change
- No visual change

# Screenshots

![Screenshot 2024-03-25 171009](https://github.com/Azure/LogicAppsUX/assets/92312794/f794d4fc-7e5b-4ad0-be7b-d356baf3273b)


