### PR TITLE
fix(Designer): Resolve all app settings except key vault reference values

### DIFF
--- a/apps/designer-standalone/src/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
+++ b/apps/designer-standalone/src/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
@@ -76,8 +76,10 @@ export class WorkflowUtility {
     if (appsettings) {
       for (const settingName of Object.keys(appsettings)) {
         const settingValue = appsettings[settingName] !== undefined ? appsettings[settingName] : '';
-        result = replaceOccurrenceInResourceIds(result, `@appsetting('${settingName}')`, settingValue);
-        result = replaceOccurrenceInResourceIds(result, `@{appsetting('${settingName}')}`, settingValue);
+        // Don't replace if the setting value is a KeyVault reference
+        if (settingValue.startsWith('@Microsoft.KeyVault(')) continue;
+        result = replaceAllOccurrences(result, `@appsetting('${settingName}')`, settingValue);
+        result = replaceAllOccurrences(result, `@{appsetting('${settingName}')}`, settingValue);
       }
     }
 
@@ -115,22 +117,4 @@ function replaceIfFoundAndVerifyJson(stringifiedJson: string, searchValue: strin
   } catch {
     return undefined;
   }
-}
-
-function replaceOccurrenceInResourceIds(_inputString: string, settingName: string, settingValue: string): string {
-  let inputString = _inputString;
-  const resourceIdRegex = /\/subscriptions\/[^"]+"/g;
-  const resourceIds = inputString.match(resourceIdRegex);
-
-  // If no resource ids are found, return the original string
-  if (!resourceIds) return inputString;
-
-  for (const resourceId of resourceIds) {
-    if (resourceId.includes(settingName)) {
-      const replacedString = resourceId.replace(settingName, settingValue);
-      // Replace the original resource id in the input string with the replaced string
-      inputString = inputString.replace(resourceId, replacedString);
-    }
-  }
-  return inputString;
 }


### PR DESCRIPTION
## Main Changes

We now resolve any app settings in connections data that does not contain a keyvault reference.
Our last fix of only resolving app settings in resource ids did not apply to enough situations, we saw customers use app settings other ways we didn't know about so we're going back to resolving nearly everything.

This is just for standalone, nothing here needs to be merged into portal through packages.