### PR TITLE
fix(designer): Fix issue where next failure is disabled when there is only 1 failure

### DIFF
--- a/libs/designer-ui/src/lib/pager/index.tsx
+++ b/libs/designer-ui/src/lib/pager/index.tsx
@@ -76,8 +76,8 @@ export const Pager: React.FC<PagerProps> = ({
     setCurrent(initialCurrent);
   }, [initialCurrent]);
 
-  let failedMax = 0,
-    failedMin = 0;
+  let failedMax = 0;
+  let failedMin = 0;
   let onClickNext: PageChangeEventHandler | undefined, onClickPrevious: PageChangeEventHandler | undefined;
 
   if (failedIterationProps) {

--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -96,7 +96,7 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
   const failedIterationProps =
     failedRepetitions.length > 0
       ? {
-          max: failedRepetitions.length > 1 ? failedRepetitions[failedRepetitions.length - 1] + 1 : 0,
+          max: failedRepetitions.length >= 1 ? failedRepetitions[failedRepetitions.length - 1] + 1 : 0,
           min: failedRepetitions[0] + 1 >= 1 ? failedRepetitions[0] + 1 : 1,
           onClickNext: onClickNextFailed,
           onClickPrevious: onClickPreviousFailed,


### PR DESCRIPTION
This pull request includes changes to the `libs/designer-ui/src/lib/pager/index.tsx` and `libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx` files. The changes primarily focus on improving the readability and functionality of the code.

Improvements to readability:

* [`libs/designer-ui/src/lib/pager/index.tsx`](diffhunk://#diff-d1f4ef0b4caec1dd683763f7b7748b7cf23648a83b10ed08d864dd7c98a901aaL79-R80): The variables `failedMax` and `failedMin` have been declared separately to enhance code readability.

Improvements to functionality:

* [`libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx`](diffhunk://#diff-b8a3966d76571aa606548b1b1b08a6f8442a55647ccb04bbf3cc006f3adfb330L99-R99): The condition to set the `max` property of `failedIterationProps` has been updated to include the case when `failedRepetitions.length` is equal to 1. This ensures that the `max` property is set correctly even when there is only one failed repetition.