### PR TITLE
fix(designer): Adjust HTML editor toolbar color to fit contract requirements of 4.5:1

### DIFF
--- a/libs/designer-ui/src/lib/html/htmleditor.less
+++ b/libs/designer-ui/src/lib/html/htmleditor.less
@@ -142,7 +142,6 @@
     background-color: @ms-color-bodyText;
   }
   .item {
-    color: @ms-color-neutralTertiary;
     .active {
       display: flex;
       width: 20px;

--- a/libs/designer-ui/src/lib/html/htmleditor.less
+++ b/libs/designer-ui/src/lib/html/htmleditor.less
@@ -68,7 +68,7 @@
       line-height: 20px;
       vertical-align: middle;
       font-size: 14px;
-      color: #777;
+      color: #757575;
       text-overflow: ellipsis;
       overflow: hidden;
       height: 20px;
@@ -142,6 +142,7 @@
     background-color: @ms-color-bodyText;
   }
   .item {
+    color: @ms-color-neutralTertiary;
     .active {
       display: flex;
       width: 20px;


### PR DESCRIPTION
This pull request includes changes to the `htmleditor.less` file in the `libs/designer-ui` directory. The changes focus on modifying the color scheme of certain elements.

Here are the key changes:

* [`libs/designer-ui/src/lib/html/htmleditor.less`](diffhunk://#diff-ea81d5a7f1817f9d23b6f4092b5beb5edd248de1237601ad46cd0400d215c42fL71-R71): The color of the text has been updated from `#777` to `#757575` to provide a more consistent color scheme across the application and improve readability.