### PR TITLE
fix(Designer): Connection TestLink / TestRequest both require failure to show error

### DIFF
--- a/libs/logic-apps-shared/src/utils/src/lib/models/connection.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/connection.ts
@@ -57,7 +57,7 @@ export interface ConnectionProperties {
 
 export type Connection = ArmResource<ConnectionProperties>;
 
-interface TestConnectionObject {
+export interface TestConnectionObject {
   body?: string;
   method: string;
   requestUri: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/logicappsux",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/logicappsux",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Main Changes

We now run a testLink request first, and if it fails we run a testRequest as well.
Only if both fail is the connection is shown as a failure.
This keeps priority on testLink which has been working in 99% of cases.
The testLink error is also the one shown over the testRequest error.