### PR TITLE
fix(vscode): Check connections parameterization during generate deployment scripts command

### DIFF
--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -57,7 +57,7 @@ export async function activate(context: vscode.ExtensionContext) {
     runPostWorkflowCreateStepsFromCache();
 
     await downloadExtensionBundle(activateContext);
-    await promptParameterizeConnections(activateContext);
+    promptParameterizeConnections(activateContext);
     await startOnboarding(activateContext);
 
     ext.extensionVersion = getExtensionVersion();


### PR DESCRIPTION
This pull request primarily focuses on the refactoring of the `generateDeploymentScripts` function The changes aim to improve how connections are parameterized in the function. 


* Removed the `parameterizeConnectionsInProjectLoadSetting` from the import statement and replaced it with the `isConnectionsParameterized` function. This change indicates a shift in how connections are parameterized. Checks if the connections are parameterized using the `isConnectionsParameterized` function.

* In the `activate` function in `apps/vs-code-designer/src/main.ts`, the `promptParameterizeConnections` function call is no longer awaited. This change suggests that the function does not return a promise that needs to be resolved or that the function's completion is not critical to the flow of the `activate` function.