### PR TITLE
fix(vscode): Update imports to shared library

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createNewCodeProject.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createNewCodeProject.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { isString } from '@microsoft/logic-apps-shared';
 import {
   extensionCommand,
   funcVersionSetting,
@@ -20,7 +21,6 @@ import { OpenFolderStepCodeProject } from './CodeProjectBase/OpenFolderStepCodeP
 import { SetLogicAppName } from './CodeProjectBase/SetLogicAppNameStep';
 import { setWorkspaceName } from './CodeProjectBase/SetWorkspaceName';
 import { SetLogicAppType } from './CodeProjectBase/setLogicAppType';
-import { isString } from '@microsoft/utils-logic-apps';
 import { AzureWizard } from '@microsoft/vscode-azext-utils';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { latestGAVersion, OpenBehavior } from '@microsoft/vscode-extension';

--- a/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
+++ b/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { isEmptyString } from '@microsoft/logic-apps-shared';
 import { localSettingsFileName, parameterizeConnectionsInProjectLoadSetting } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
@@ -12,7 +13,6 @@ import { isConnectionsParameterized, parameterizeConnection } from '../utils/cod
 import { tryGetLogicAppProjectRoot } from '../utils/verifyIsProject';
 import { getGlobalSetting, updateGlobalSetting } from '../utils/vsCodeConfig/settings';
 import { getWorkspaceFolder } from '../utils/workspace';
-import { isEmptyString } from '@microsoft/utils-logic-apps';
 import { DialogResponses, type IActionContext } from '@microsoft/vscode-azext-utils';
 import { type ConnectionsData } from '@microsoft/vscode-extension';
 import * as path from 'path';

--- a/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
@@ -1,5 +1,5 @@
+import { isEmptyString } from '@microsoft/logic-apps-shared';
 import { workflowLocationKey, workflowSubscriptionIdKey, workflowResourceGroupNameKey } from '../../../constants';
-import { isEmptyString } from '@microsoft/utils-logic-apps';
 import type {
   ConnectionReferenceModel,
   ServiceProviderConnectionModel,


### PR DESCRIPTION
This pull request mainly involves updates to import statements in several files under `apps/vs-code-designer/src/app/`. The changes are focused on replacing the usage of certain utility functions from the `@microsoft/utils-logic-apps` package with their counterparts from the `@microsoft/logic-apps-shared` package. 


*The `isString` function is now imported from `@microsoft/logic-apps-shared` instead of `@microsoft/utils-logic-apps`. 

* The `isEmptyString` function is now imported from `@microsoft/logic-apps-shared` instead of `@microsoft/utils-logic-apps`. 

* The `isEmptyString` function is now imported from `@microsoft/logic-apps-shared` instead of `@microsoft/utils-logic-apps`.