### PR TITLE
fix(designer): Add id's to format message

### DIFF
--- a/libs/designer-ui/src/lib/unitTesting/assertionsPanel/assertionButtons.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/assertionsPanel/assertionButtons.tsx
@@ -16,11 +16,13 @@ export const AssertionButtons = ({ onDelete, isEditable, onEdit }: assertionButt
 
   const deleteAssertionText = intl.formatMessage({
     defaultMessage: 'Delete assertion',
+    id: '+nCfrr',
     description: 'Create Assertion Text',
   });
 
   const editAssertionText = intl.formatMessage({
     defaultMessage: 'Edit assertion',
+    id: 'dzPAxq',
     description: 'Edit Assertion Text',
   });
 

--- a/libs/designer-ui/src/lib/unitTesting/outputMocks/actionResult.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/outputMocks/actionResult.tsx
@@ -14,22 +14,27 @@ export const ActionResult: React.FC<ActionResultProps> = ({ nodeId, onActionResu
   const intlText = {
     ACTION_RESULT: intl.formatMessage({
       defaultMessage: 'Action Result',
+      id: '5U6Dee',
       description: 'The label for the action result dropdown in the unit test panel.',
     }),
     SUCCEEDED_STATUS: intl.formatMessage({
       defaultMessage: 'Is successful',
+      id: 'HF2SNx',
       description: 'Successful action result',
     }),
     TIMEDOUT_STATUS: intl.formatMessage({
       defaultMessage: 'Timed out',
+      id: '2M+Kcv',
       description: 'Timed action result',
     }),
     SKIPPED_STATUS: intl.formatMessage({
       defaultMessage: 'Is skipped',
+      id: 'gX4ect',
       description: 'Skipped action result',
     }),
     FAILED_STATUS: intl.formatMessage({
       defaultMessage: 'Has failed',
+      id: 'cySYfO',
       description: 'Failed action result',
     }),
   };


### PR DESCRIPTION
This pull request primarily focuses on the enhancement of internationalization (i18n) in the `libs/designer-ui` package. The changes include the addition of unique identifiers to the internationalization function `intl.formatMessage()` in both `assertionButtons.tsx` and `actionResult.tsx` files. 


* Added unique identifiers to the `intl.formatMessage()` function for 'Delete assertion' and 'Edit assertion' text. This will help in providing translations for these texts in different languages.

* Added unique identifiers to the `intl.formatMessage()` function for 'Action Result', 'Is successful', 'Timed out', 'Is skipped', and 'Has failed' text. This will help in providing translations for these texts in different languages.