### PR TITLE
feat(vscode): Implement results view webview

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -25,6 +25,14 @@ import {
   ProgressLocation,
 } from 'vscode';
 
+/**
+ * Opens the unit test results for a given context and node.
+ * If a specific node is provided, it opens the unit test results for that node.
+ * If no node is provided, it prompts the user to select a unit test and opens the results for that test.
+ * @param {IAzureConnectorsContext} context - The Azure Connectors context.
+ * @param {Uri | TestItem} node - The Uri or TestItem representing the node for which to open the unit test results.
+ * @returns A Promise that resolves when the unit test results are opened.
+ */
 export async function openUnitTestResults(context: IAzureConnectorsContext, node: Uri | TestItem): Promise<void> {
   let unitTestNode: Uri;
   const workspaceFolder = await getWorkspaceFolder(context);

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -23,6 +23,7 @@ import {
   type WebviewPanelOptions,
   type ProgressOptions,
   ProgressLocation,
+  workspace,
 } from 'vscode';
 
 /**
@@ -50,7 +51,7 @@ export async function openUnitTestResults(context: IAzureConnectorsContext, node
 
   if (ext.testRuns.has(unitTestNode.fsPath)) {
     const workflowName = path.basename(path.dirname(unitTestNode.fsPath));
-    await openResultsWebview(workflowName, unitTestName);
+    await openResultsWebview(workflowName, unitTestName, unitTestNode.fsPath);
   } else {
     window.showInformationMessage(
       localize('noRunForUnitTest', 'There is no run for the selected unit test. Make sure to run the unit test for "{0}"', unitTestName)
@@ -63,7 +64,7 @@ export async function openUnitTestResults(context: IAzureConnectorsContext, node
  * @param {string} workflowName - The name of the workflow.
  * @returns A promise that resolves when the unit test results are opened.
  */
-export async function openResultsWebview(workflowName: string, unitTestName: string): Promise<void> {
+export async function openResultsWebview(workflowName: string, unitTestName: string, unitTestFilePath: string): Promise<void> {
   const panelName = `${workflowName} - ${unitTestName} - ${localize('unitTestResult', 'unit test results')}`;
   const panelGroupKey = ext.webViewKey.unitTest;
   const existingPanel: WebviewPanel | undefined = tryGetWebviewPanel(panelGroupKey, panelName);
@@ -107,7 +108,7 @@ export async function openResultsWebview(workflowName: string, unitTestName: str
             break;
           }
           case ExtensionCommand.viewWorkflow: {
-            console.log('View workflow');
+            window.showTextDocument(await workspace.openTextDocument(unitTestFilePath));
             break;
           }
           default:

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -50,10 +50,7 @@ export async function openUnitTestResults(context: IAzureConnectorsContext, node
 
   if (ext.testRuns.has(unitTestNode.fsPath)) {
     const workflowName = path.basename(path.dirname(unitTestNode.fsPath));
-    // const workflowPath = path.join(projectPath, workflowName, workflowFileName);
-    // const workflowNode = Uri.file(workflowPath);
-    // const unitTestDefinition = JSON.parse(readFileSync(unitTestNode.fsPath, 'utf8'));
-    await openResultsWebview(workflowName);
+    await openResultsWebview(workflowName, unitTestName);
   } else {
     window.showInformationMessage(
       localize('noRunForUnitTest', 'There is no run for the selected unit test. Make sure to run the unit test for "{0}"', unitTestName)
@@ -66,8 +63,8 @@ export async function openUnitTestResults(context: IAzureConnectorsContext, node
  * @param {string} workflowName - The name of the workflow.
  * @returns A promise that resolves when the unit test results are opened.
  */
-export async function openResultsWebview(workflowName: string): Promise<void> {
-  const panelName = `${workflowName} - ${localize('unitTestResult', 'unit test results')}`;
+export async function openResultsWebview(workflowName: string, unitTestName: string): Promise<void> {
+  const panelName = `${workflowName} - ${unitTestName} - ${localize('unitTestResult', 'unit test results')}`;
   const panelGroupKey = ext.webViewKey.unitTest;
   const existingPanel: WebviewPanel | undefined = tryGetWebviewPanel(panelGroupKey, panelName);
 
@@ -103,8 +100,7 @@ export async function openResultsWebview(workflowName: string): Promise<void> {
               command: ExtensionCommand.initialize_frame,
               data: {
                 project: ProjectName.unitTest,
-                unitTestName: 'unitTestName',
-                unitTestDescription: 'unitTestDescription',
+                unitTestName,
                 hostVersion: ext.extensionVersion,
               },
             });

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -2,17 +2,28 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { developmentDirectoryName, testsDirectoryName, workflowFileName } from '../../../../constants';
+import { developmentDirectoryName, testsDirectoryName } from '../../../../constants';
 import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
+import { cacheWebviewPanel, removeWebviewPanelFromCache, tryGetWebviewPanel } from '../../../utils/codeless/common';
+import { getWebViewHTML } from '../../../utils/codeless/getWebViewHTML';
 import { getUnitTestName, pickUnitTest } from '../../../utils/unitTests';
 import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
 import { getWorkflowNode, getWorkspaceFolder } from '../../../utils/workspace';
 import { type IAzureConnectorsContext } from '../azureConnectorWizard';
-import OpenDesignerForLocalProject from '../openDesigner/openDesignerForLocalProject';
-import { readFileSync } from 'fs';
+import { ExtensionCommand, ProjectName } from '@microsoft/vscode-extension';
 import * as path from 'path';
-import { type TestItem, Uri, window } from 'vscode';
+import {
+  type TestItem,
+  Uri,
+  window,
+  type WebviewPanel,
+  ViewColumn,
+  type WebviewOptions,
+  type WebviewPanelOptions,
+  type ProgressOptions,
+  ProgressLocation,
+} from 'vscode';
 
 export async function openUnitTestResults(context: IAzureConnectorsContext, node: Uri | TestItem): Promise<void> {
   let unitTestNode: Uri;
@@ -31,15 +42,81 @@ export async function openUnitTestResults(context: IAzureConnectorsContext, node
 
   if (ext.testRuns.has(unitTestNode.fsPath)) {
     const workflowName = path.basename(path.dirname(unitTestNode.fsPath));
-    const workflowPath = path.join(projectPath, workflowName, workflowFileName);
-    const workflowNode = Uri.file(workflowPath);
-    const unitTestDefinition = JSON.parse(readFileSync(unitTestNode.fsPath, 'utf8'));
-
-    const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName, unitTestDefinition);
-    await openDesignerObj?.createPanel();
+    // const workflowPath = path.join(projectPath, workflowName, workflowFileName);
+    // const workflowNode = Uri.file(workflowPath);
+    // const unitTestDefinition = JSON.parse(readFileSync(unitTestNode.fsPath, 'utf8'));
+    await openResultsWebview(workflowName);
   } else {
     window.showInformationMessage(
       localize('noRunForUnitTest', 'There is no run for the selected unit test. Make sure to run the unit test for "{0}"', unitTestName)
     );
   }
+}
+
+/**
+ * Opens the unit test results in a webview panel.
+ * @param {string} workflowName - The name of the workflow.
+ * @returns A promise that resolves when the unit test results are opened.
+ */
+export async function openResultsWebview(workflowName: string): Promise<void> {
+  const panelName = `${workflowName} - ${localize('unitTestResult', 'unit test results')}`;
+  const panelGroupKey = ext.webViewKey.unitTest;
+  const existingPanel: WebviewPanel | undefined = tryGetWebviewPanel(panelGroupKey, panelName);
+
+  if (existingPanel) {
+    if (!existingPanel.active) {
+      existingPanel.reveal(ViewColumn.Active);
+    }
+
+    return;
+  }
+
+  const webviewOptions: WebviewOptions & WebviewPanelOptions = {
+    enableScripts: true,
+    retainContextWhenHidden: true,
+  };
+
+  const progressOptions: ProgressOptions = {
+    location: ProgressLocation.Notification,
+    title: localize('openingUnitTestResults', 'Opening unit test results...'),
+  };
+
+  const panel: WebviewPanel = window.createWebviewPanel('UnitTestsResults', panelName, ViewColumn.Active, webviewOptions);
+  panel.webview.html = await getWebViewHTML('vs-code-react', panel);
+
+  let interval;
+
+  await window.withProgress(progressOptions, async () => {
+    try {
+      panel.webview.onDidReceiveMessage(async (message) => {
+        switch (message.command) {
+          case ExtensionCommand.initialize: {
+            panel.webview.postMessage({
+              command: ExtensionCommand.initialize_frame,
+              data: {
+                project: ProjectName.unitTest,
+                hostVersion: ext.extensionVersion,
+              },
+            });
+            break;
+          }
+          default:
+            break;
+        }
+      }, ext.context.subscriptions);
+    } catch (error) {
+      window.showErrorMessage(`${localize('review failure', 'Error opening review')} ${error.message}`, localize('OK', 'OK'));
+      throw error;
+    }
+  });
+
+  panel.onDidDispose(
+    () => {
+      removeWebviewPanelFromCache(panelGroupKey, panelName);
+      clearInterval(interval);
+    },
+    null,
+    ext.context.subscriptions
+  );
+  cacheWebviewPanel(panelGroupKey, panelName, panel);
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -110,6 +110,10 @@ export async function openResultsWebview(workflowName: string): Promise<void> {
             });
             break;
           }
+          case ExtensionCommand.viewWorkflow: {
+            console.log('View workflow');
+            break;
+          }
           default:
             break;
         }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -103,6 +103,8 @@ export async function openResultsWebview(workflowName: string): Promise<void> {
               command: ExtensionCommand.initialize_frame,
               data: {
                 project: ProjectName.unitTest,
+                unitTestName: 'unitTestName',
+                unitTestDescription: 'unitTestDescription',
                 hostVersion: ext.extensionVersion,
               },
             });

--- a/apps/vs-code-designer/src/extensionVariables.ts
+++ b/apps/vs-code-designer/src/extensionVariables.ts
@@ -69,6 +69,7 @@ export namespace ext {
     monitoring: 'monitoring',
     export: 'export',
     overview: 'overview',
+    unitTest: 'unitTest',
   } as const;
   export type webViewKey = keyof typeof webViewKey;
 

--- a/apps/vs-code-react/src/app/unitTest/index.tsx
+++ b/apps/vs-code-react/src/app/unitTest/index.tsx
@@ -48,7 +48,9 @@ export const UnitTestResults: React.FC = () => {
         </Text>
       </div>
 
-      <Link onClick={handleViewWorkflow}>{intlText.VIEW_WORKFLOW}</Link>
+      <Link style={{ margin: '20px' }} onClick={handleViewWorkflow}>
+        {intlText.VIEW_WORKFLOW}
+      </Link>
     </div>
   );
 };

--- a/apps/vs-code-react/src/app/unitTest/index.tsx
+++ b/apps/vs-code-react/src/app/unitTest/index.tsx
@@ -28,6 +28,7 @@ export const UnitTestResults: React.FC = () => {
     }),
     TEST_ICON: intl.formatMessage({
       defaultMessage: 'Test icon',
+      id: 'qfmSaq',
       description: 'Test icon text',
     }),
   };

--- a/apps/vs-code-react/src/app/unitTest/index.tsx
+++ b/apps/vs-code-react/src/app/unitTest/index.tsx
@@ -1,3 +1,34 @@
+import type { RootState } from '../../state/store';
+import './unitTest.less';
+import { Text, Button } from '@fluentui/react-components';
+import { useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
+
 export const UnitTestResults: React.FC = () => {
-  return <h1>Unit Test Results</h1>;
+  const unitTestState = useSelector((state: RootState) => state.unitTest);
+
+  const { unitTestName, unitTestDescription } = unitTestState;
+
+  console.log(unitTestName, unitTestDescription);
+
+  const intl = useIntl();
+
+  const intlText = {
+    VIEW_WORKFLOW: intl.formatMessage({
+      defaultMessage: 'View workflow',
+      description: 'View workflow text',
+    }),
+  };
+
+  return (
+    <div className="msla-unit-test-results">
+      <Text size={800} block>
+        Title
+      </Text>
+      <Text size={300} block>
+        Description
+      </Text>
+      <Button appearance="transparent">{intlText.VIEW_WORKFLOW}</Button>
+    </div>
+  );
 };

--- a/apps/vs-code-react/src/app/unitTest/index.tsx
+++ b/apps/vs-code-react/src/app/unitTest/index.tsx
@@ -1,34 +1,42 @@
 import type { RootState } from '../../state/store';
+import { VSCodeContext } from '../../webviewCommunication';
 import './unitTest.less';
-import { Text, Button } from '@fluentui/react-components';
+import { Link, Text } from '@fluentui/react';
+import { ExtensionCommand } from '@microsoft/vscode-extension';
+import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
 export const UnitTestResults: React.FC = () => {
   const unitTestState = useSelector((state: RootState) => state.unitTest);
-
+  const vscode = useContext(VSCodeContext);
   const { unitTestName, unitTestDescription } = unitTestState;
-
-  console.log(unitTestName, unitTestDescription);
 
   const intl = useIntl();
 
   const intlText = {
     VIEW_WORKFLOW: intl.formatMessage({
       defaultMessage: 'View workflow',
+      id: 'v15Fiq',
       description: 'View workflow text',
     }),
   };
 
+  const handleViewWorkflow = () => {
+    vscode.postMessage({
+      command: ExtensionCommand.viewWorkflow,
+    });
+  };
+
   return (
     <div className="msla-unit-test-results">
-      <Text size={800} block>
-        Title
+      <Text variant="xxLarge" block>
+        {unitTestName}
       </Text>
-      <Text size={300} block>
-        Description
+      <Text variant="large" block>
+        {unitTestDescription}
       </Text>
-      <Button appearance="transparent">{intlText.VIEW_WORKFLOW}</Button>
+      <Link onClick={handleViewWorkflow}>{intlText.VIEW_WORKFLOW}</Link>
     </div>
   );
 };

--- a/apps/vs-code-react/src/app/unitTest/index.tsx
+++ b/apps/vs-code-react/src/app/unitTest/index.tsx
@@ -1,16 +1,22 @@
 import type { RootState } from '../../state/store';
 import { VSCodeContext } from '../../webviewCommunication';
 import './unitTest.less';
-import { Link, Text } from '@fluentui/react';
+import { FontIcon, Link, Text, mergeStyles } from '@fluentui/react';
 import { ExtensionCommand } from '@microsoft/vscode-extension';
 import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
+const iconClass = mergeStyles({
+  fontSize: 40,
+  height: 40,
+  width: 40,
+});
+
 export const UnitTestResults: React.FC = () => {
   const unitTestState = useSelector((state: RootState) => state.unitTest);
   const vscode = useContext(VSCodeContext);
-  const { unitTestName, unitTestDescription } = unitTestState;
+  const { unitTestName } = unitTestState;
 
   const intl = useIntl();
 
@@ -19,6 +25,10 @@ export const UnitTestResults: React.FC = () => {
       defaultMessage: 'View workflow',
       id: 'v15Fiq',
       description: 'View workflow text',
+    }),
+    TEST_ICON: intl.formatMessage({
+      defaultMessage: 'Test icon',
+      description: 'Test icon text',
     }),
   };
 
@@ -30,12 +40,13 @@ export const UnitTestResults: React.FC = () => {
 
   return (
     <div className="msla-unit-test-results">
-      <Text variant="xxLarge" block>
-        {unitTestName}
-      </Text>
-      <Text variant="large" block>
-        {unitTestDescription}
-      </Text>
+      <div className="msla-unit-test-results-header">
+        <FontIcon aria-label={intlText.TEST_ICON} iconName="TestPlan" className={iconClass} />
+        <Text variant="xxLarge" style={{ marginLeft: '10px' }}>
+          {unitTestName}
+        </Text>
+      </div>
+
       <Link onClick={handleViewWorkflow}>{intlText.VIEW_WORKFLOW}</Link>
     </div>
   );

--- a/apps/vs-code-react/src/app/unitTest/index.tsx
+++ b/apps/vs-code-react/src/app/unitTest/index.tsx
@@ -1,0 +1,3 @@
+export const UnitTestResults: React.FC = () => {
+  return <h1>Unit Test Results</h1>;
+};

--- a/apps/vs-code-react/src/app/unitTest/unitTest.less
+++ b/apps/vs-code-react/src/app/unitTest/unitTest.less
@@ -1,0 +1,4 @@
+.msla-unit-test-results {
+  height: 100vh;
+  padding: 0 20px;
+}

--- a/apps/vs-code-react/src/app/unitTest/unitTest.less
+++ b/apps/vs-code-react/src/app/unitTest/unitTest.less
@@ -1,4 +1,10 @@
 .msla-unit-test-results {
   height: 100vh;
-  padding: 0 20px;
+  padding: 40px;
+
+  &-header {
+    display: flex;
+    align-items: center;
+    margin: 20px;
+  }
 }

--- a/apps/vs-code-react/src/router/index.tsx
+++ b/apps/vs-code-react/src/router/index.tsx
@@ -8,6 +8,7 @@ import { Validation } from '../app/export/validation/validation';
 import { WorkflowsSelection } from '../app/export/workflowsSelection/workflowsSelection';
 import { OverviewApp } from '../app/overview/app';
 import { ReviewApp } from '../app/review';
+import { UnitTestResults } from '../app/unitTest';
 import { RouteName } from '../run-service';
 import { StateWrapper } from '../stateWrapper';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -28,6 +29,7 @@ export const Router: React.FC = () => {
         <Route path={`/${RouteName.overview}`} element={<OverviewApp />} />
         <Route path={`/${RouteName.dataMapper}`} element={<DataMapperApp />} />
         <Route path={`/${RouteName.designer}`} element={<DesignerApp />} />
+        <Route path={`/${RouteName.unitTest}`} element={<UnitTestResults />} />
       </Routes>
     </MemoryRouter>
   );

--- a/apps/vs-code-react/src/run-service/types.ts
+++ b/apps/vs-code-react/src/run-service/types.ts
@@ -1,7 +1,3 @@
-import type { InitializePayload, Status } from '../state/WorkflowSlice';
-import type { ApiHubServiceDetails, SchemaType } from '@microsoft/logic-apps-shared';
-import type { MapDefinitionData, ExtensionCommand, ConnectionsData, IDesignerPanelMetadata } from '@microsoft/vscode-extension';
-
 export interface IApiService {
   getWorkflows(subscriptionId: string, iseId?: string, location?: string): Promise<WorkflowsList[]>;
   getSubscriptions(): Promise<Array<ISubscription>>;
@@ -200,101 +196,6 @@ export const StyledWorkflowPart = {
   workflow: 'Workflow',
 };
 export type StyledWorkflowPart = (typeof StyledWorkflowPart)[keyof typeof StyledWorkflowPart];
-
-type FetchSchemaData = { fileName: string; type: SchemaType };
-export type XsltData = { filename: string; fileContents: string };
-
-// Data Mapper Message Interfaces
-export interface FetchSchemaMessage {
-  command: typeof ExtensionCommand.fetchSchema;
-  data: FetchSchemaData;
-}
-
-export interface LoadDataMapMessage {
-  command: typeof ExtensionCommand.loadDataMap;
-  data: MapDefinitionData;
-}
-
-export interface ShowAvailableSchemasMessage {
-  command: typeof ExtensionCommand.showAvailableSchemas;
-  data: string[];
-}
-
-export interface GetAvailableCustomXsltPathsMessage {
-  command: typeof ExtensionCommand.getAvailableCustomXsltPaths;
-  data: string[];
-}
-
-export interface SetXsltDataMessage {
-  command: typeof ExtensionCommand.setXsltData;
-  data: XsltData;
-}
-
-export interface SetRuntimePortMessage {
-  command: typeof ExtensionCommand.setRuntimePort;
-  data: string;
-}
-
-export interface GetConfigurationSettingMessage {
-  command: typeof ExtensionCommand.getConfigurationSetting;
-  data: boolean;
-}
-
-// Designer Message Interfaces
-export interface ReceiveCallbackMessage {
-  command: typeof ExtensionCommand.receiveCallback;
-  data: any;
-}
-
-export interface CompleteFileSystemConnectionMessage {
-  command: typeof ExtensionCommand.completeFileSystemConnection;
-  data: { connectionName: string; connection: any; error: string };
-}
-
-export interface UpdatePanelMetadataMessage {
-  command: typeof ExtensionCommand.update_panel_metadata;
-  data: {
-    panelMetadata: IDesignerPanelMetadata;
-    connectionData: ConnectionsData;
-    apiHubServiceDetails: ApiHubServiceDetails;
-  };
-}
-
-// Rest of Message Interfaces
-export interface InjectValuesMessage {
-  command: typeof ExtensionCommand.initialize_frame;
-  data: InitializePayload & {
-    project: string;
-  };
-}
-
-export interface UpdateAccessTokenMessage {
-  command: typeof ExtensionCommand.update_access_token;
-  data: {
-    accessToken?: string;
-  };
-}
-
-export interface UpdateExportPathMessage {
-  command: typeof ExtensionCommand.update_export_path;
-  data: {
-    targetDirectory: ITargetDirectory;
-  };
-}
-
-export interface AddStatusMessage {
-  command: typeof ExtensionCommand.add_status;
-  data: {
-    status: string;
-  };
-}
-
-export interface SetFinalStatusMessage {
-  command: typeof ExtensionCommand.set_final_status;
-  data: {
-    status: Status;
-  };
-}
 
 export interface IExportDetails {
   exportDetailCategory: string;

--- a/apps/vs-code-react/src/run-service/types.ts
+++ b/apps/vs-code-react/src/run-service/types.ts
@@ -145,6 +145,7 @@ export const RouteName = {
   review: 'review',
   designer: 'designer',
   dataMapper: 'dataMapper',
+  unitTest: 'unitTest',
 };
 
 export type RouteNameType = (typeof RouteName)[keyof typeof RouteName];

--- a/apps/vs-code-react/src/state/UnitTestSlice.ts
+++ b/apps/vs-code-react/src/state/UnitTestSlice.ts
@@ -1,0 +1,30 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+export interface UnitTestState {
+  hostVersion?: string;
+  unitTestName?: string;
+  unitTestDescription?: string;
+}
+
+const initialState: UnitTestState = {
+  hostVersion: '',
+  unitTestName: '',
+  unitTestDescription: '',
+};
+
+export const unitTestSlice = createSlice({
+  name: 'project',
+  initialState,
+  reducers: {
+    initialize: (state: UnitTestState, action: PayloadAction<any>) => {
+      state.hostVersion = action.payload.hostVersion;
+      state.unitTestName = action.payload.unitTestName;
+      state.unitTestDescription = action.payload.unitTestDescription;
+    },
+  },
+});
+
+export const { initialize } = unitTestSlice.actions;
+
+export default unitTestSlice.reducer;

--- a/apps/vs-code-react/src/state/UnitTestSlice.ts
+++ b/apps/vs-code-react/src/state/UnitTestSlice.ts
@@ -7,6 +7,13 @@ export interface UnitTestState {
   unitTestDescription?: string;
 }
 
+export interface InitializeUnitTestPayload {
+  hostVersion: string;
+  unitTestName: string;
+  unitTestDescription: string;
+  project: string;
+}
+
 const initialState: UnitTestState = {
   hostVersion: '',
   unitTestName: '',
@@ -17,7 +24,7 @@ export const unitTestSlice = createSlice({
   name: 'project',
   initialState,
   reducers: {
-    initialize: (state: UnitTestState, action: PayloadAction<any>) => {
+    initializeUnitTest: (state: UnitTestState, action: PayloadAction<InitializeUnitTestPayload>) => {
       state.hostVersion = action.payload.hostVersion;
       state.unitTestName = action.payload.unitTestName;
       state.unitTestDescription = action.payload.unitTestDescription;
@@ -25,6 +32,6 @@ export const unitTestSlice = createSlice({
   },
 });
 
-export const { initialize } = unitTestSlice.actions;
+export const { initializeUnitTest } = unitTestSlice.actions;
 
 export default unitTestSlice.reducer;

--- a/apps/vs-code-react/src/state/UnitTestSlice.ts
+++ b/apps/vs-code-react/src/state/UnitTestSlice.ts
@@ -4,7 +4,6 @@ import { createSlice } from '@reduxjs/toolkit';
 export interface UnitTestState {
   hostVersion?: string;
   unitTestName?: string;
-  unitTestDescription?: string;
 }
 
 export interface InitializeUnitTestPayload {
@@ -17,7 +16,6 @@ export interface InitializeUnitTestPayload {
 const initialState: UnitTestState = {
   hostVersion: '',
   unitTestName: '',
-  unitTestDescription: '',
 };
 
 export const unitTestSlice = createSlice({
@@ -27,7 +25,6 @@ export const unitTestSlice = createSlice({
     initializeUnitTest: (state: UnitTestState, action: PayloadAction<InitializeUnitTestPayload>) => {
       state.hostVersion = action.payload.hostVersion;
       state.unitTestName = action.payload.unitTestName;
-      state.unitTestDescription = action.payload.unitTestDescription;
     },
   },
 });

--- a/apps/vs-code-react/src/state/UnitTestSlice.ts
+++ b/apps/vs-code-react/src/state/UnitTestSlice.ts
@@ -19,7 +19,7 @@ const initialState: UnitTestState = {
 };
 
 export const unitTestSlice = createSlice({
-  name: 'project',
+  name: 'unitTest',
   initialState,
   reducers: {
     initializeUnitTest: (state: UnitTestState, action: PayloadAction<InitializeUnitTestPayload>) => {

--- a/apps/vs-code-react/src/state/store.ts
+++ b/apps/vs-code-react/src/state/store.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-named-as-default
 import { dataMapSlice } from './DataMapSlice';
 import { designerSlice } from './DesignerSlice';
+import { unitTestSlice } from './UnitTestSlice';
 import { workflowSlice } from './WorkflowSlice';
 import { projectSlice } from './projectSlice';
 import { configureStore } from '@reduxjs/toolkit';
@@ -11,6 +12,7 @@ export const store = configureStore({
     workflow: workflowSlice.reducer,
     designer: designerSlice.reducer,
     dataMapDataLoader: dataMapSlice.reducer,
+    unitTest: unitTestSlice.reducer,
   },
 });
 

--- a/apps/vs-code-react/src/stateWrapper.tsx
+++ b/apps/vs-code-react/src/stateWrapper.tsx
@@ -31,6 +31,10 @@ export const StateWrapper: React.FC = () => {
           navigate(`/${ProjectName.dataMapper}`, { replace: true });
           break;
         }
+        case ProjectName.unitTest: {
+          navigate(`/${ProjectName.unitTest}`, { replace: true });
+          break;
+        }
         default: {
           break;
         }

--- a/apps/vs-code-react/src/webviewCommunication.tsx
+++ b/apps/vs-code-react/src/webviewCommunication.tsx
@@ -66,7 +66,7 @@ export const WebViewCommunication: React.FC<{ children: ReactNode }> = ({ childr
     }
 
     switch (projectState?.project ?? message?.data?.project) {
-      case ProjectName.designer:
+      case ProjectName.designer: {
         switch (message.command) {
           case ExtensionCommand.initialize_frame:
             dispatch(initializeDesigner(message.data));
@@ -84,7 +84,8 @@ export const WebViewCommunication: React.FC<{ children: ReactNode }> = ({ childr
             throw new Error('Unknown post message received');
         }
         break;
-      case ProjectName.dataMapper:
+      }
+      case ProjectName.dataMapper: {
         switch (message.command) {
           case ExtensionCommand.setRuntimePort:
             dispatch(changeRuntimePort(message.data));
@@ -120,6 +121,17 @@ export const WebViewCommunication: React.FC<{ children: ReactNode }> = ({ childr
             throw new Error('Unknown post message received');
         }
         break;
+      }
+      case ProjectName.unitTest: {
+        switch (message.command) {
+          case ExtensionCommand.initialize_frame:
+            dispatch(initializeWorkflow(message.data as InitializePayload));
+            break;
+          default:
+            throw new Error('Unknown post message received');
+        }
+        break;
+      }
       default:
         switch (message.command) {
           case ExtensionCommand.initialize_frame:

--- a/apps/vs-code-react/src/webviewCommunication/index.tsx
+++ b/apps/vs-code-react/src/webviewCommunication/index.tsx
@@ -1,20 +1,4 @@
-import {
-  type UpdateAccessTokenMessage,
-  type UpdateExportPathMessage,
-  type AddStatusMessage,
-  type SetFinalStatusMessage,
-  type FetchSchemaMessage,
-  type LoadDataMapMessage,
-  type ShowAvailableSchemasMessage,
-  type GetAvailableCustomXsltPathsMessage,
-  type SetXsltDataMessage,
-  type SetRuntimePortMessage,
-  type GetConfigurationSettingMessage,
-  type InjectValuesMessage,
-  type UpdatePanelMetadataMessage,
-  type CompleteFileSystemConnectionMessage,
-  type ReceiveCallbackMessage,
-} from './run-service';
+import { SchemaType } from '@microsoft/logic-apps-shared';
 import {
   changeCustomXsltPathList,
   changeDataMapMetadata,
@@ -26,13 +10,20 @@ import {
   changeUseExpandedFunctionCards,
   changeXsltContent,
   changeXsltFilename,
-} from './state/DataMapSlice';
-import { initializeDesigner, updateCallbackUrl, updateFileSystemConnection, updatePanelMetadata } from './state/DesignerSlice';
-import type { InitializePayload } from './state/WorkflowSlice';
-import { initializeWorkflow, updateAccessToken, updateTargetDirectory, addStatus, setFinalStatus } from './state/WorkflowSlice';
-import { initialize } from './state/projectSlice';
-import type { AppDispatch, RootState } from './state/store';
-import { SchemaType } from '@microsoft/logic-apps-shared';
+} from '../state/DataMapSlice';
+import { initializeDesigner, updateCallbackUrl, updateFileSystemConnection, updatePanelMetadata } from '../state/DesignerSlice';
+import { initializeUnitTest, type InitializeUnitTestPayload } from '../state/UnitTestSlice';
+import {
+  initializeWorkflow,
+  type InitializePayload,
+  updateAccessToken,
+  updateTargetDirectory,
+  addStatus,
+  setFinalStatus,
+} from '../state/WorkflowSlice';
+import { initialize } from '../state/projectSlice';
+import type { AppDispatch, RootState } from '../state/store';
+import type { MessageType } from './messageTypes';
 import { ExtensionCommand, ProjectName } from '@microsoft/vscode-extension';
 import useEventListener from '@use-it/event-listener';
 import type { ReactNode } from 'react';
@@ -42,18 +33,6 @@ import type { WebviewApi } from 'vscode-webview';
 
 const vscode: WebviewApi<unknown> = acquireVsCodeApi();
 export const VSCodeContext = React.createContext(vscode);
-
-type DesignerMessageType = ReceiveCallbackMessage | CompleteFileSystemConnectionMessage | UpdatePanelMetadataMessage;
-type DataMapperMessageType =
-  | FetchSchemaMessage
-  | LoadDataMapMessage
-  | ShowAvailableSchemasMessage
-  | GetAvailableCustomXsltPathsMessage
-  | SetXsltDataMessage
-  | SetRuntimePortMessage
-  | GetConfigurationSettingMessage;
-type WorkflowMessageType = UpdateAccessTokenMessage | UpdateExportPathMessage | AddStatusMessage | SetFinalStatusMessage;
-type MessageType = InjectValuesMessage | DesignerMessageType | DataMapperMessageType | WorkflowMessageType;
 
 export const WebViewCommunication: React.FC<{ children: ReactNode }> = ({ children }) => {
   const dispatch: AppDispatch = useDispatch();
@@ -125,7 +104,7 @@ export const WebViewCommunication: React.FC<{ children: ReactNode }> = ({ childr
       case ProjectName.unitTest: {
         switch (message.command) {
           case ExtensionCommand.initialize_frame:
-            dispatch(initializeWorkflow(message.data as InitializePayload));
+            dispatch(initializeUnitTest(message.data as InitializeUnitTestPayload));
             break;
           default:
             throw new Error('Unknown post message received');

--- a/apps/vs-code-react/src/webviewCommunication/messageTypes.ts
+++ b/apps/vs-code-react/src/webviewCommunication/messageTypes.ts
@@ -1,0 +1,120 @@
+import type { ITargetDirectory } from '../run-service/types';
+import type { InitializeUnitTestPayload } from '../state/UnitTestSlice';
+import type { InitializePayload, Status } from '../state/WorkflowSlice';
+import type { ApiHubServiceDetails } from '@microsoft/designer-client-services-logic-apps';
+import type { SchemaType } from '@microsoft/utils-logic-apps';
+import type { MapDefinitionData, ExtensionCommand, ConnectionsData, IDesignerPanelMetadata } from '@microsoft/vscode-extension';
+
+type FetchSchemaData = { fileName: string; type: SchemaType };
+export type XsltData = { filename: string; fileContents: string };
+
+// Data Mapper Message Interfaces
+export interface FetchSchemaMessage {
+  command: typeof ExtensionCommand.fetchSchema;
+  data: FetchSchemaData;
+}
+
+export interface LoadDataMapMessage {
+  command: typeof ExtensionCommand.loadDataMap;
+  data: MapDefinitionData;
+}
+
+export interface ShowAvailableSchemasMessage {
+  command: typeof ExtensionCommand.showAvailableSchemas;
+  data: string[];
+}
+
+export interface GetAvailableCustomXsltPathsMessage {
+  command: typeof ExtensionCommand.getAvailableCustomXsltPaths;
+  data: string[];
+}
+
+export interface SetXsltDataMessage {
+  command: typeof ExtensionCommand.setXsltData;
+  data: XsltData;
+}
+
+export interface SetRuntimePortMessage {
+  command: typeof ExtensionCommand.setRuntimePort;
+  data: string;
+}
+
+export interface GetConfigurationSettingMessage {
+  command: typeof ExtensionCommand.getConfigurationSetting;
+  data: boolean;
+}
+
+// Designer Message Interfaces
+export interface ReceiveCallbackMessage {
+  command: typeof ExtensionCommand.receiveCallback;
+  data: any;
+}
+
+export interface CompleteFileSystemConnectionMessage {
+  command: typeof ExtensionCommand.completeFileSystemConnection;
+  data: { connectionName: string; connection: any; error: string };
+}
+
+export interface UpdatePanelMetadataMessage {
+  command: typeof ExtensionCommand.update_panel_metadata;
+  data: {
+    panelMetadata: IDesignerPanelMetadata;
+    connectionData: ConnectionsData;
+    apiHubServiceDetails: ApiHubServiceDetails;
+  };
+}
+
+// Rest of Message Interfaces
+export interface InjectValuesMessage {
+  command: typeof ExtensionCommand.initialize_frame;
+  data: InitializePayload & {
+    project: string;
+  };
+}
+
+export interface UpdateAccessTokenMessage {
+  command: typeof ExtensionCommand.update_access_token;
+  data: {
+    accessToken?: string;
+  };
+}
+
+export interface UpdateExportPathMessage {
+  command: typeof ExtensionCommand.update_export_path;
+  data: {
+    targetDirectory: ITargetDirectory;
+  };
+}
+
+export interface AddStatusMessage {
+  command: typeof ExtensionCommand.add_status;
+  data: {
+    status: string;
+  };
+}
+
+export interface SetFinalStatusMessage {
+  command: typeof ExtensionCommand.set_final_status;
+  data: {
+    status: Status;
+  };
+}
+
+// Unit test Message Interfaces
+export interface InitializeUnitTestMessage {
+  command: typeof ExtensionCommand.initialize_frame;
+  data: InitializeUnitTestPayload;
+}
+
+type DesignerMessageType = ReceiveCallbackMessage | CompleteFileSystemConnectionMessage | UpdatePanelMetadataMessage;
+type DataMapperMessageType =
+  | FetchSchemaMessage
+  | LoadDataMapMessage
+  | ShowAvailableSchemasMessage
+  | GetAvailableCustomXsltPathsMessage
+  | SetXsltDataMessage
+  | SetRuntimePortMessage
+  | GetConfigurationSettingMessage;
+type WorkflowMessageType = UpdateAccessTokenMessage | UpdateExportPathMessage | AddStatusMessage | SetFinalStatusMessage;
+type UnitTestMessageType = InitializeUnitTestMessage;
+export type MessageType = InjectValuesMessage | DesignerMessageType | DataMapperMessageType | WorkflowMessageType | UnitTestMessageType;

--- a/apps/vs-code-react/src/webviewCommunication/messageTypes.ts
+++ b/apps/vs-code-react/src/webviewCommunication/messageTypes.ts
@@ -1,8 +1,7 @@
+import type { ApiHubServiceDetails, SchemaType } from '@microsoft/logic-apps-shared';
 import type { ITargetDirectory } from '../run-service/types';
 import type { InitializeUnitTestPayload } from '../state/UnitTestSlice';
 import type { InitializePayload, Status } from '../state/WorkflowSlice';
-import type { ApiHubServiceDetails } from '@microsoft/designer-client-services-logic-apps';
-import type { SchemaType } from '@microsoft/utils-logic-apps';
 import type { MapDefinitionData, ExtensionCommand, ConnectionsData, IDesignerPanelMetadata } from '@microsoft/vscode-extension';
 
 type FetchSchemaData = { fileName: string; type: SchemaType };

--- a/libs/vscode-extension/src/lib/models/extensioncommand.ts
+++ b/libs/vscode-extension/src/lib/models/extensioncommand.ts
@@ -41,6 +41,7 @@ export const ExtensionCommand = {
   webviewRscLoadError: 'webviewRscLoadError',
   saveUnitTest: 'saveUnitTest',
   createUnitTest: 'createUnitTest',
+  viewWorkflow: 'viewWorkflow',
 } as const;
 export type ExtensionCommand = (typeof ExtensionCommand)[keyof typeof ExtensionCommand];
 

--- a/libs/vscode-extension/src/lib/models/project.ts
+++ b/libs/vscode-extension/src/lib/models/project.ts
@@ -12,6 +12,7 @@ export const ProjectName = {
   review: 'review',
   designer: 'designer',
   dataMapper: 'dataMapper',
+  unitTest: 'unitTest',
 } as const;
 export type ProjectNameType = (typeof ProjectName)[keyof typeof ProjectName];
 


### PR DESCRIPTION
This pull request primarily focuses on the implementation of unit test results display in the VS Code extension for Logic Apps. It introduces a new webview to display unit test results, and refactors the existing codebase to support this feature. 

* In `apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts`, several utility functions were added to manage webview panels and to get webview HTML. 

* The `openUnitTestResults` function in was refactored to open the unit test results in a webview panel instead of using the `OpenDesignerForLocalProject` class.

* A new Redux slice, `UnitTestSlice`, was added to manage the state of unit test results.

* A new React component, `UnitTestResults`, was introduced to display unit test results in a webview. 

* The `UnitTestResults` component was integrated into the application router allowing it to be navigated to via the `unitTest` route.

### What is missing:
- List of resolved or failed assertions: Will update this once BE provide executable and tests can return results

### Screenshots

<img width="1000" alt="Screenshot 2024-03-29 at 2 45 04 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/ccd7b539-3ea1-4a2e-816c-9402559be1cd">

https://github.com/Azure/LogicAppsUX/assets/102700317/2f1e610e-64ec-4c6a-ac84-d9cc2487da89

