### PR TITLE
fix(desiger): Fix issue where next failure is disabled when there is only 1 failure

### DIFF
--- a/libs/designer-ui/src/lib/pager/index.tsx
+++ b/libs/designer-ui/src/lib/pager/index.tsx
@@ -76,8 +76,8 @@ export const Pager: React.FC<PagerProps> = ({
     setCurrent(initialCurrent);
   }, [initialCurrent]);
 
-  let failedMax = 0,
-    failedMin = 0;
+  let failedMax = 0;
+  let failedMin = 0;
   let onClickNext: PageChangeEventHandler | undefined, onClickPrevious: PageChangeEventHandler | undefined;
 
   if (failedIterationProps) {

--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -97,7 +97,7 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
   const failedIterationProps =
     failedRepetitions.length > 0
       ? {
-          max: failedRepetitions.length > 1 ? failedRepetitions[failedRepetitions.length - 1] + 1 : 0,
+          max: failedRepetitions.length >= 1 ? failedRepetitions[failedRepetitions.length - 1] + 1 : 0,
           min: failedRepetitions[0] + 1 >= 1 ? failedRepetitions[0] + 1 : 1,
           onClickNext: onClickNextFailed,
           onClickPrevious: onClickPreviousFailed,


### PR DESCRIPTION
Hotfix of https://github.com/Azure/LogicAppsUX/pull/4468
