### PR TITLE
fix(designer): Only use default value when the parameter is required

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -871,7 +871,10 @@ export function loadParameterValue(parameter: InputParameter): ValueSegment[] {
   if (parameter.isNotificationUrl) {
     valueObject = `@${constants.HTTP_WEBHOOK_LIST_CALLBACK_URL_NAME}`;
   } else {
-    valueObject = parameter?.value ?? parameter?.default;
+    valueObject = parameter?.value;
+    if (parameter?.required && valueObject === undefined) {
+      valueObject = parameter?.default;
+    }
   }
 
   let valueSegments = convertToValueSegments(valueObject, !parameter.suppressCasting /* shouldUncast */);


### PR DESCRIPTION
On optional parameters, we should not use the default value, as there are times where the customer wants to keep the value unset.

Fixes https://github.com/Azure/LogicAppsUX/issues/4481