### PR TITLE
feat(vscode): Update path in workspace to save unit tests

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/editUnitTest.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { developmentDirectoryName, testsDirectoryName, workflowFileName } from '../../../../constants';
+import { testsDirectoryName, workflowFileName } from '../../../../constants';
 import { getUnitTestName, pickUnitTest } from '../../../utils/unitTests';
 import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
 import { getWorkflowNode, getWorkspaceFolder } from '../../../utils/workspace';
@@ -28,7 +28,7 @@ export async function editUnitTest(context: IAzureConnectorsContext, node: vscod
   } else if (node && !(node instanceof vscode.Uri) && node.uri instanceof vscode.Uri) {
     unitTestNode = node.uri;
   } else {
-    const unitTest = await pickUnitTest(context, path.join(projectPath, developmentDirectoryName, testsDirectoryName));
+    const unitTest = await pickUnitTest(context, path.join(projectPath, testsDirectoryName));
     unitTestNode = vscode.Uri.file(unitTest.data) as vscode.Uri;
   }
 

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/openUnitTestResults.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { developmentDirectoryName, testsDirectoryName, workflowFileName } from '../../../../constants';
+import { testsDirectoryName, workflowFileName } from '../../../../constants';
 import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
 import { cacheWebviewPanel, removeWebviewPanelFromCache, tryGetWebviewPanel } from '../../../utils/codeless/common';
@@ -44,7 +44,7 @@ export async function openUnitTestResults(context: IAzureConnectorsContext, node
   } else if (node && !(node instanceof Uri) && node.uri instanceof Uri) {
     unitTestNode = node.uri;
   } else {
-    const unitTest = await pickUnitTest(context, path.join(projectPath, developmentDirectoryName, testsDirectoryName));
+    const unitTest = await pickUnitTest(context, path.join(projectPath, testsDirectoryName));
     unitTestNode = Uri.file(unitTest.data) as Uri;
   }
   const unitTestName = getUnitTestName(unitTestNode.fsPath);

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { developmentDirectoryName, saveUnitTestEvent, testsDirectoryName, unitTestsFileName } from '../../constants';
+import { saveUnitTestEvent, testsDirectoryName, unitTestsFileName } from '../../constants';
 import { localize } from '../../localize';
 import { type IAzureQuickPickItem, type IActionContext, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import * as fs from 'fs';
@@ -67,7 +67,7 @@ export const getUnitTestName = (filePath: string) => {
  * @returns The path of the unit test file.
  */
 const getUnitTestsPath = (projectPath: string, workflowName: string, unitTestName: string) => {
-  return path.join(projectPath, developmentDirectoryName, testsDirectoryName, workflowName, `${unitTestName}${unitTestsFileName}`);
+  return path.join(projectPath, testsDirectoryName, workflowName, `${unitTestName}${unitTestsFileName}`);
 };
 
 /**
@@ -77,7 +77,7 @@ const getUnitTestsPath = (projectPath: string, workflowName: string, unitTestNam
  * @returns The path to the workflow tests directory.
  */
 const getWorkflowTestsPath = (projectPath: string, workflowName: string) => {
-  return path.join(projectPath, developmentDirectoryName, testsDirectoryName, workflowName);
+  return path.join(projectPath, testsDirectoryName, workflowName);
 };
 
 /**

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -22,8 +22,7 @@ export const unitTestsFileName = '.unit-test.json';
 
 // Folder names
 export const designTimeDirectoryName = 'workflow-designtime';
-export const developmentDirectoryName = '.development';
-export const testsDirectoryName = 'tests';
+export const testsDirectoryName = 'Tests';
 export const vscodeFolderName = '.vscode';
 
 export const logicAppsStandardExtensionId = 'ms-azuretools.vscode-azurelogicapps';


### PR DESCRIPTION
This pull request primarily focuses on changing the directory structure of the unit tests in the VS Code Designer App. The `developmentDirectoryName` constant has been removed, and the `testsDirectoryName` constant has been capitalized. As a result, the unit tests are no longer nested under the `.development` directory and are now directly under the project path in a `Tests` directory.


* The import of `developmentDirectoryName` has been removed and the `testsDirectoryName` is now used directly under the `projectPath` in the `pickUnitTest` function. 

* Similar to the previous file, the `developmentDirectoryName` is no longer imported and the `testsDirectoryName` is used directly under the `projectPath` in the `pickUnitTest` function.

* The `developmentDirectoryName` is no longer imported and the `testsDirectoryName` is used directly under the `projectPath` in the `getUnitTestsPath` and `getWorkflowTestsPath` functions.

* The `developmentDirectoryName` constant has been removed and the `testsDirectoryName` constant has been capitalized.