### PR TITLE
fix(designer): Fix Infinite Loop on resolving app settings

### DIFF
--- a/apps/designer-standalone/src/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
+++ b/apps/designer-standalone/src/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
@@ -98,7 +98,6 @@ function replaceAllOccurrences(content: string, searchValue: string, value: any)
       replaceIfFoundAndVerifyJson(content, searchValue, `${value}`) ??
       content.replace(searchValue, '');
 
-    // eslint-disable-next-line no-param-reassign
     content = tempResult;
   }
 
@@ -110,7 +109,10 @@ function replaceIfFoundAndVerifyJson(stringifiedJson: string, searchValue: strin
     return undefined;
   }
 
-  const result = stringifiedJson.replace(searchValue, value);
+  const result = stringifiedJson.replace(searchValue, function () {
+    return value;
+  });
+
   try {
     JSON.parse(result);
     return result;


### PR DESCRIPTION
When a user has a connection string containing "$&" we end up in an infinite loop when trying to resolve the connection references, unable to load designer, unable to load connections tab, etc. This fixes it in designer standalone - will need to also make this change in portal

Happening due to:  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter