### PR TITLE
fix(vscode): Add keepNames to tsup config

### DIFF
--- a/apps/vs-code-designer/tsup.config.ts
+++ b/apps/vs-code-designer/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: ['vscode'],
+  keepNames: true,
 });


### PR DESCRIPTION
This pull request includes a minor change to the `tsup.config.ts` file in the `apps/vs-code-designer` directory. The `keepNames` property has been added to the configuration object passed to the `defineConfig` function. This property, when set to `true`, instructs the bundler to preserve the original names of the variables, functions, and classes in the output bundle.