### PR TITLE
fix(Designer): Fixed issue where dynamic data call would fail when value is non-string

### DIFF
--- a/libs/logic-apps-shared/src/parsers/lib/common/helpers/expression.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/common/helpers/expression.ts
@@ -53,10 +53,9 @@ export function isWhitespace(ch: string) {
 }
 
 export function isTemplateExpression(value: string): boolean {
-  if (isNullOrEmpty(value) || value.length < 2) {
+  if (isNullOrEmpty(value) || typeof value !== 'string' || value.length < 2) {
     return false;
   }
-
   return value.charAt(0) === '@' || value.indexOf('@{') > 0;
 }
 


### PR DESCRIPTION
## Main Changes

Dynamic data call would be interrupted by checking the value for a template expression.
This template fix has now been improve to catch non-string values.

Fixes: https://github.com/Azure/LogicAppsUX/issues/4578
Fixes: https://github.com/Azure/LogicAppsUX/issues/3450
Possibly fixes: https://github.com/Azure/LogicAppsUX/issues/4358
