### PR TITLE
fix(designer): Fix react-flow CSS path and a couple exports

### DIFF
--- a/libs/designer/src/lib/common/models/workflow.ts
+++ b/libs/designer/src/lib/common/models/workflow.ts
@@ -32,8 +32,11 @@ export const ImpersonationSource = {
 } as const;
 export type ImpersonationSource = (typeof ImpersonationSource)[keyof typeof ImpersonationSource];
 
-type ReferenceKey = string;
+export type ReferenceKey = string;
 export type ConnectionReferences = Record<ReferenceKey, ConnectionReference>;
+
+export type NodeId = string;
+export type ConnectionMapping = Record<NodeId, ReferenceKey | null>;
 
 export interface WorkflowParameter {
   name?: string;

--- a/libs/designer/src/lib/core/actions/bjsworkflow/copypaste.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/copypaste.ts
@@ -1,4 +1,4 @@
-import { ReferenceKey } from 'lib/common/models/workflow';
+import type { ReferenceKey } from '../../../common/models/workflow';
 import { setFocusNode, type RootState } from '../..';
 import { initCopiedConnectionMap } from '../../state/connection/connectionSlice';
 import type { NodeData, NodeOperation } from '../../state/operation/operationMetadataSlice';

--- a/libs/designer/src/lib/core/actions/bjsworkflow/copypaste.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/copypaste.ts
@@ -1,5 +1,5 @@
+import { ReferenceKey } from 'lib/common/models/workflow';
 import { setFocusNode, type RootState } from '../..';
-import type { ReferenceKey } from '../../state/connection/connectionSlice';
 import { initCopiedConnectionMap } from '../../state/connection/connectionSlice';
 import type { NodeData, NodeOperation } from '../../state/operation/operationMetadataSlice';
 import { initializeNodes, initializeOperationInfo } from '../../state/operation/operationMetadataSlice';

--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -1,10 +1,9 @@
-import type { ConnectionReference, ConnectionReferences } from '../../../common/models/workflow';
+import type { ConnectionMapping, ConnectionReference, ConnectionReferences } from '../../../common/models/workflow';
 import { getConnection } from '../../queries/connections';
 import type { RootState } from '../../store';
 import { getConnectionReference, isConnectionMultiAuthManagedIdentityType } from '../../utils/connectors/connections';
 import { useNodeConnectorId } from '../operation/operationSelector';
 import { useOperationManifest, useOperationInfo } from '../selectors/actionMetadataSelector';
-import type { ConnectionMapping } from './connectionSlice';
 import {
   ConnectionService,
   GatewayService,

--- a/libs/designer/src/lib/core/state/connection/connectionSlice.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSlice.ts
@@ -1,4 +1,4 @@
-import type { ConnectionReferences } from '../../../common/models/workflow';
+import type { ConnectionMapping, ConnectionReferences, NodeId, ReferenceKey } from '../../../common/models/workflow';
 import type { UpdateConnectionPayload } from '../../actions/bjsworkflow/connections';
 import { resetWorkflowState } from '../global';
 import { LogEntryLevel, LoggerService, deepCompareObjects, equals, getUniqueName } from '@microsoft/logic-apps-shared';
@@ -9,10 +9,6 @@ export interface ConnectionsStoreState {
   connectionsMapping: ConnectionMapping;
   connectionReferences: ConnectionReferences;
 }
-
-type NodeId = string;
-export type ReferenceKey = string | null;
-export type ConnectionMapping = Record<NodeId, ReferenceKey>;
 
 export const initialConnectionsState: ConnectionsStoreState = {
   connectionsMapping: {},

--- a/libs/designer/src/lib/ui/styles.less
+++ b/libs/designer/src/lib/ui/styles.less
@@ -2,7 +2,7 @@
 @import './settings/sections/runafterconfiguration/runafterconfiguration.less';
 @import './connections/runAfterIndicator/styles.less';
 @import './panel/connectionsPanel/connectionsPanel.less';
-@import (css) 'reactflow/dist/style.css';
+@import (css) '~/reactflow/dist/style.css';
 
 .react-flow__edge {
   cursor: grab;

--- a/libs/designer/src/lib/ui/styles.less
+++ b/libs/designer/src/lib/ui/styles.less
@@ -2,7 +2,7 @@
 @import './settings/sections/runafterconfiguration/runafterconfiguration.less';
 @import './connections/runAfterIndicator/styles.less';
 @import './panel/connectionsPanel/connectionsPanel.less';
-@import (css) '~/reactflow/dist/style.css';
+@import (css) '~reactflow/dist/style.css';
 
 .react-flow__edge {
   cursor: grab;

--- a/libs/designer/tsup.config.ts
+++ b/libs/designer/tsup.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     splitting: false,
     tsconfig: 'tsconfig.json',
     format: ['cjs', 'esm'],
-    external: ['react'],
+    external: ['react', '~/reactflow/dist/style.css'],
     injectStyle: false,
     loader: {
         '.svg': 'dataurl',

--- a/libs/designer/tsup.config.ts
+++ b/libs/designer/tsup.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     splitting: false,
     tsconfig: 'tsconfig.json',
     format: ['cjs', 'esm'],
-    external: ['react', '~/reactflow/dist/style.css'],
+    external: ['react', '~reactflow/dist/style.css'],
     injectStyle: false,
     loader: {
         '.svg': 'dataurl',


### PR DESCRIPTION
After transition of LAUX v3 to v4, some exports were lost (primarily, `ConnectionMapping`), and react-flow CSS stopped working. This PR updates the react-flow CSS path and updates the `ConnectionMapping` export.

This should not have any breaking changes, but does touch the react-flow CSS import/export, so might have an effect there depending on consumer.