### PR TITLE
fix(Designer): Fixed issue where we weren't handling null connection references fully

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -394,8 +394,8 @@ export function needsSimpleConnection(connector: Connector): boolean {
 }
 
 export function needsConfigConnection(connector: Connector): boolean {
-  if (connector?.properties?.connectionParameters) {
-    const connectionParameters = connector.properties.connectionParameters;
+  const connectionParameters = connector?.properties?.connectionParameters;
+  if (connectionParameters) {
     return Object.keys(connectionParameters)
       .filter((connectionParameterKey) => !isHiddenConnectionParameter(connectionParameters, connectionParameterKey))
       .some((connectionParameterKey) => {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -131,7 +131,7 @@ export const serializeWorkflow = async (rootState: RootState, options?: Serializ
   }
 
   const { connectionsMapping, connectionReferences: referencesObject } = rootState.connections;
-  const connectionReferences = Object.keys(connectionsMapping).reduce((references: ConnectionReferences, nodeId: string) => {
+  const connectionReferences = Object.keys(connectionsMapping ?? {}).reduce((references: ConnectionReferences, nodeId: string) => {
     const referenceKey = getRecordEntry(connectionsMapping, nodeId);
     if (!referenceKey || !referencesObject[referenceKey]) {
       return references;
@@ -151,7 +151,7 @@ export const serializeWorkflow = async (rootState: RootState, options?: Serializ
       $schema:
         WorkflowService().getDefinitionSchema?.(unmap(rootState.operations.operationInfo)) ?? rootState.workflow.originalDefinition.$schema,
       actions: await getActions(rootState, options),
-      ...(Object.keys(rootState?.staticResults?.properties).length > 0 ? { staticResults: rootState.staticResults.properties } : {}),
+      ...(Object.keys(rootState?.staticResults?.properties ?? {}).length > 0 ? { staticResults: rootState.staticResults.properties } : {}),
       triggers: await getTrigger(rootState, options),
     },
     connectionReferences,

--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -11,7 +11,7 @@ import {
   isServiceProviderOperation,
   getRecordEntry,
   type Connector,
-  Gateway
+  Gateway,
 } from '@microsoft/logic-apps-shared';
 import { useMemo } from 'react';
 import { UseQueryResult, useQuery } from 'react-query';
@@ -117,7 +117,7 @@ export const useConnectionRefsByConnectorId = (connectorId?: string) => {
 
 export const useIsOperationMissingConnection = (nodeId: string) => {
   const connectionsMapping = useSelector((state: RootState) => state.connections.connectionsMapping);
-  return Object.keys(connectionsMapping).includes(nodeId) && getRecordEntry(connectionsMapping, nodeId) === null;
+  return Object.keys(connectionsMapping ?? {}).includes(nodeId) && getRecordEntry(connectionsMapping, nodeId) === null;
 };
 
 export const useShowIdentitySelectorQuery = (nodeId: string) => {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
@@ -615,7 +615,7 @@ function convertToServiceProviderConnectionsData(
     ? connectionParameterMetadata.connectionParameterSet?.parameters
     : (connectionParameterMetadata.connectionParameters as Record<string, ConnectionParameter>);
   const parameterValues = connectionParametersSetValues
-    ? Object.keys(connectionParametersSetValues.values).reduce(
+    ? Object.keys(connectionParametersSetValues?.values ?? {}).reduce(
         (result: Record<string, any>, currentKey: string) => ({
           ...result,
           [currentKey]: connectionParametersSetValues.values[currentKey].value,


### PR DESCRIPTION
## Main Changes

There were a couple spots we were potentially passing null data to `Object.keys` function calls which errors.
I've just added some `?? {}` catches to avoid these errors.