### PR TITLE
meta(vscode): Add new vsix build to artifacts production build

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -84,8 +84,7 @@ jobs:
       - name: 'Set Designer Extension VSIX aiKey in package.json'
         run: echo "`jq '.aiKey="${{ env.AI_KEY }}"' apps/vs-code-designer/src/package.json`" > apps/vs-code-designer/src/package.json
 
-      # - run: npm run build:vscode-designer
-      # - run: npm run vscode:designer:pack
+      - run: pnpm run vscode:designer:pack
 
       - name: 'Get Previous tag'
         id: previoustag
@@ -93,16 +92,15 @@ jobs:
         with:
           fallback: 0.0.0
 
-      # - name: Archive VSIX
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     path: |
-      #       dist/apps/vs-code-designer/*.vsix
+      - name: Archive VSIX
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            apps/vscode-designer/dist/*.vsix
 
       - uses: ncipollo/release-action@v1
         with:
-          # artifacts: 'LICENSE.md,dist/apps/vs-code-designer/*.vsix'
-          artifacts: 'LICENSE.md'
+          artifacts: 'LICENSE.md,apps/vscode-designer/dist/*.vsix'
           generateReleaseNotes: true
           tag: '${{ steps.previoustag.outputs.tag }}'
           token: ${{ secrets.AUTOMATION_PAT }}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start:e2e": "turbo run e2e",
     "build": "turbo run build",
     "build:vscode": "turbo run build:vscode",
+    "vscode:designer:pack": "turbo run vscode:designer:pack",
     "test": "turbo run test:unit",
     "test:e2e": "playwright test",
     "check": "biome check --apply .",

--- a/turbo.json
+++ b/turbo.json
@@ -44,6 +44,12 @@
             "outputs": [
                 "coverage/**"
             ]
+        },
+        "vscode:designer:pack":{
+            "cache": false,
+            "dependsOn": [
+                "build"
+            ]
         }
     }
 }


### PR DESCRIPTION
This pull request primarily focuses on modifying the build process for the VS Code Designer extension. The changes include updating the GitHub Actions workflow for production builds, adding a new npm script for packing the extension, and updating the Turbo configuration file.

GitHub Actions workflow:

* [`.github/workflows/production-build.yml`](diffhunk://#diff-20fbc76be4bae1652559385109766d3a3a185d70ae392c77fab423e41f5b6b16L87-R103): Un-commented and updated the command to pack the VS Code Designer extension. Also un-commented and updated the step to archive the packed extension as an artifact. Finally, the artifacts for the release action were updated to include the packed extension.

Npm scripts:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R14): Added a new npm script `vscode:designer:pack` to pack the VS Code Designer extension.

Turbo configuration:

* [`turbo.json`](diffhunk://#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3R47-R52): Added a new task `vscode:designer:pack` to the Turbo configuration. This task does not use the cache and it depends on the `build` task.