### PR TITLE
meta(vscode): Fix typo in vsix path in production build

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -84,7 +84,8 @@ jobs:
       - name: 'Set Designer Extension VSIX aiKey in package.json'
         run: echo "`jq '.aiKey="${{ env.AI_KEY }}"' apps/vs-code-designer/src/package.json`" > apps/vs-code-designer/src/package.json
 
-      - run: pnpm run vscode:designer:pack
+      - name: 'Pack VSCode Designer Extension'
+        - run: pnpm run vscode:designer:pack
 
       - name: 'Get Previous tag'
         id: previoustag
@@ -96,11 +97,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: |
-            apps/vscode-designer/dist/*.vsix
+            apps/vs-code-designer/dist/*.vsix
 
       - uses: ncipollo/release-action@v1
         with:
-          artifacts: 'LICENSE.md,apps/vscode-designer/dist/*.vsix'
+          artifacts: 'LICENSE.md,apps/vs-code-designer/dist/*.vsix'
           generateReleaseNotes: true
           tag: '${{ steps.previoustag.outputs.tag }}'
           token: ${{ secrets.AUTOMATION_PAT }}


### PR DESCRIPTION
This pull request primarily focuses on changes in the `.github/workflows/production-build.yml` file. The changes pertain to the packaging and path of the VSCode Designer Extension in the GitHub actions workflow. 

* [`.github/workflows/production-build.yml`](diffhunk://#diff-20fbc76be4bae1652559385109766d3a3a185d70ae392c77fab423e41f5b6b16R87): Added a new step to pack the VSCode Designer Extension in the GitHub actions workflow. The path of the VSCode Designer Extension was updated in the artifact upload and release actions. [[1]](diffhunk://#diff-20fbc76be4bae1652559385109766d3a3a185d70ae392c77fab423e41f5b6b16R87) [[2]](diffhunk://#diff-20fbc76be4bae1652559385109766d3a3a185d70ae392c77fab423e41f5b6b16L99-R104)