### PR TITLE
meta(vscode): Fix typo in yaml

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -85,7 +85,7 @@ jobs:
         run: echo "`jq '.aiKey="${{ env.AI_KEY }}"' apps/vs-code-designer/src/package.json`" > apps/vs-code-designer/src/package.json
 
       - name: 'Pack VSCode Designer Extension'
-        - run: pnpm run vscode:designer:pack
+        run: pnpm run vscode:designer:pack
 
       - name: 'Get Previous tag'
         id: previoustag


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/production-build.yml` file. The change simplifies the 'Pack VSCode Designer Extension' job by removing an unnecessary dash before the `run` command.