### PR TITLE
meta(repo): Fix script to be able to run test:lib locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "turbo run build",
     "build:vscode": "turbo run build:vscode",
     "vscode:designer:pack": "turbo run vscode:designer:pack",
-    "test": "turbo run test:unit",
+    "test:lib": "turbo run test:lib",
     "test:e2e": "playwright test",
     "check": "biome check --apply .",
     "extract": "formatjs extract \"libs/**/*.{ts,tsx}\" --ignore \"libs/**/*.{d,test,spec}.{ts,tsx}\" --out-file Localize/lang/strings.json --format ./format.js",


### PR DESCRIPTION
This pull request includes a minor change to the `package.json` file. The change modifies the `test` script to specifically run the library tests by renaming it to `test:lib`. This adjustment helps to distinguish it from other types of tests, such as end-to-end tests, that may be present in the project.