### PR TITLE
chore(Designer): Converted some commonly used reduce/spreads to for loops

### DIFF
--- a/apps/vs-code-react/src/app/designer/DesignerCommandBar/index.tsx
+++ b/apps/vs-code-react/src/app/designer/DesignerCommandBar/index.tsx
@@ -50,7 +50,9 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({ isRefres
       ignoreNonCriticalErrors: true,
     });
 
-    const validationErrorsList = Object.entries(designerState.operations.inputParameters).reduce((acc, [id, nodeInputs]) => {
+    let validationErrorsList: Record<string, boolean> = {};
+    const arr = Object.entries(designerState.operations.inputParameters);
+    for (const [id, nodeInputs] of arr) {
       const hasValidationErrors = Object.values(nodeInputs.parameterGroups).some((parameterGroup) => {
         return parameterGroup.parameters.some((parameter) => {
           const validationErrors = validateParameter(parameter, parameter.value);
@@ -60,8 +62,10 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({ isRefres
           return validationErrors.length;
         });
       });
-      return hasValidationErrors ? { ...acc, [id]: hasValidationErrors } : { ...acc };
-    }, {});
+      if (hasValidationErrors) {
+        validationErrorsList[id] = hasValidationErrors;
+      }
+    }
 
     const hasParametersErrors = !isNullOrEmpty(validationErrorsList);
 

--- a/libs/designer-ui/src/lib/utils/utils.ts
+++ b/libs/designer-ui/src/lib/utils/utils.ts
@@ -373,9 +373,10 @@ export function getStatusString(status: string, hasRetries: boolean): string {
 }
 
 export const filterRecord = <T>(data: Record<string, T>, filter: (_key: string, _val: any) => boolean): Record<string, T> => {
-  return Object.entries(data)
-    .filter(([key, value]) => filter(key, value))
-    .reduce((res: any, [key, value]: any) => ({ ...res, [key]: value }), {});
+  const keyValuePropArray = Object.entries(data).filter(([key, value]) => filter(key, value));
+  const output: Record<string, T> = {};
+  keyValuePropArray.forEach(([key, value]) => (output[key] = value));
+  return output;
 };
 
 export const getConnectorCategoryString = (connector: Connector | OperationApi | string): string => {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -334,9 +334,11 @@ export const addTokensAndVariables = (
     operationMetadata: { iconUri, brandColor },
     manifest,
   } = nodeData;
-  const nodeMap = Object.keys(operations).reduce((actionNodes: Record<string, string>, id: string) => ({ ...actionNodes, [id]: id }), {
-    [nodeId]: nodeId,
-  });
+  const nodeMap: Record<string, string> = { nodeId };
+  for (const key of Object.keys(operations)) {
+    nodeMap[key] = key;
+  }
+
   const upstreamNodeIds = getTokenNodeIds(
     nodeId,
     graph as WorkflowNode,

--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -88,17 +88,12 @@ export interface ServiceOptions {
 }
 
 export const updateWorkflowParameters = (parameters: Record<string, WorkflowParameter>, dispatch: Dispatch): void => {
-  dispatch(
-    initializeParameters(
-      Object.keys(parameters).reduce(
-        (result: Record<string, WorkflowParameterDefinition>, currentKey: string) => ({
-          ...result,
-          [currentKey]: { name: currentKey, isEditable: false, ...parameters[currentKey] },
-        }),
-        {}
-      )
-    )
-  );
+  let parametersObj: Record<string, WorkflowParameterDefinition> = {};
+  for (const [key, param] of Object.entries(parameters)) {
+    parametersObj[key] = { name: key, isEditable: false, ...param };
+  }
+
+  dispatch(initializeParameters(parametersObj));
 };
 
 export const getInputParametersFromManifest = (
@@ -210,12 +205,11 @@ export const getOutputParametersFromManifest = (
       undefined /* data */,
       true /* selectAllOneOfSchemas */
     );
-    originalOutputs = Object.values(originalOperationOutputs).reduce((result: Record<string, OutputInfo>, output: SchemaProperty) => {
-      return {
-        ...result,
-        [output.key]: toOutputInfo(output),
-      };
-    }, {});
+
+    originalOutputs = {};
+    for (const output of Object.values(originalOperationOutputs)) {
+      originalOutputs[output.key] = toOutputInfo(output);
+    }
 
     manifestToParse = getUpdatedManifestForSplitOn(manifestToParse, splitOnValue);
   }
@@ -485,10 +479,10 @@ export const updateCustomCodeInInputs = async (
 export const updateAllUpstreamNodes = (state: RootState, dispatch: Dispatch): void => {
   const allOperations = state.workflow.operations;
   const payload: UpdateUpstreamNodesPayload = {};
-  const nodeMap = Object.keys(allOperations).reduce(
-    (actionNodes: Record<string, string>, id: string) => ({ ...actionNodes, [id]: id }),
-    {}
-  );
+  const nodeMap: Record<string, string> = {};
+  for (const id of Object.keys(allOperations)) {
+    nodeMap[id] = id;
+  }
 
   for (const nodeId of Object.keys(allOperations)) {
     if (!isRootNodeInGraph(nodeId, 'root', state.workflow.nodesMetadata)) {

--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -527,9 +527,10 @@ export const operationMetadataSlice = createSlice({
     builder.addCase(addDynamicOutputs, (state, action) => {
       const { outputs } = action.payload;
 
-      const tokenTitles = Object.values(outputs).reduce((result: Record<string, string>, outputValue: OutputInfo) => {
-        return { ...result, [outputValue.key]: getTokenTitle(outputValue) };
-      }, {});
+      let tokenTitles: Record<string, string> = {};
+      for (const outputValue of Object.values(outputs)) {
+        tokenTitles[outputValue.key] = getTokenTitle(outputValue);
+      }
 
       Object.entries(state.inputParameters).forEach(([nodeId, nodeInputs]) => {
         Object.entries(nodeInputs.parameterGroups).forEach(([parameterId, parameterGroup]) => {

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -241,15 +241,13 @@ export const workflowSlice = createSlice({
         return;
       }
       const stack: WorkflowNode[] = [state.graph];
-      const dimensionChangesById = dimensionChanges.reduce<Record<string, NodeDimensionChange>>((acc, val) => {
-        if (val.type !== 'dimensions') {
-          return acc;
-        }
-        return {
-          ...acc,
-          [val.id]: val,
-        };
-      }, {});
+
+      let dimensionChangesById: Record<string, NodeDimensionChange> = {};
+      for (const val of dimensionChanges) {
+        if (val.type !== 'dimensions') continue;
+        dimensionChangesById[val.id] = val as NodeDimensionChange;
+      }
+
       while (stack.length) {
         const node = stack.shift();
         const change = getRecordEntry(dimensionChangesById, node?.id ?? '');

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/functions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/functions.ts
@@ -1029,12 +1029,10 @@ export function getResourceName(obj: any): string {
  */
 
 export const filterRecord = <T>(data: Record<string, T>, filter: (_key: string, _val: T) => boolean): Record<string, T> => {
-  return Object.entries(data)
-    .filter(([key, value]) => filter(key, value))
-    .reduce((res: any, [key, value]: any) => {
-      res[key] = value;
-      return res;
-    }, {});
+  const keyValuePropArray = Object.entries(data).filter(([key, value]) => filter(key, value));
+  const output: Record<string, T> = {};
+  keyValuePropArray.forEach(([key, value]) => (output[key] = value));
+  return output;
 };
 
 /**
@@ -1048,12 +1046,10 @@ export const sortRecord = <T>(
   data: Record<string, T>,
   sort: (_key1: string, _val1: T, _key2: string, _val2: T) => number
 ): Record<string, T> => {
-  return Object.entries(data)
-    .sort(([key1, val1], [key2, val2]) => sort(key1, val1, key2, val2))
-    .reduce((res: any, [key, value]: any) => {
-      res[key] = value;
-      return res;
-    }, {});
+  const keyValuePropArray = Object.entries(data).sort(([key1, val1], [key2, val2]) => sort(key1, val1, key2, val2));
+  const output: Record<string, T> = {};
+  keyValuePropArray.forEach(([key, value]) => (output[key] = value));
+  return output;
 };
 
 /**


### PR DESCRIPTION
## Main Changes

Refactored some of our commonly run reduce + spread calls to be for loops.
This was done with the intention of speeding things up but I'm seeing no noticeable difference between initialization times.
The test workflow I ran with 100+ actions of different connector / connections initialized both before and after this PR in ~16 seconds (runs slower than normal during performance diagnostics)
