### PR TITLE
fix(dataMapper): Fix issue loading schemas in stand alone

### DIFF
--- a/apps/Standalone/src/dataMapperV1/state/SchemaDataLoader.ts
+++ b/apps/Standalone/src/dataMapperV1/state/SchemaDataLoader.ts
@@ -95,7 +95,7 @@ export const schemaDataLoaderSlice = createSlice({
 const loadSchemaFromMock = async (resourcePath: string): Promise<DataMapSchema | undefined> => {
   try {
     const schema: DataMapSchema = await import(`../schemas/${resourcePath.split('.')[0]}.json`);
-    return schema;
+    return (schema as any)?.default ?? schema;
   } catch (ex) {
     console.error(ex);
     return undefined;


### PR DESCRIPTION
This pull request includes a change to the `loadSchemaFromMock` function in the `SchemaDataLoader.ts` file. The change modifies the return statement to handle both ES6 module imports and CommonJS module imports. This is done by checking for a `default` property on the imported `schema` object, which would exist in the case of an ES6 module import. If the `default` property exists, it is returned; otherwise, the original `schema` object is returned. This change ensures the function works correctly regardless of the module system used in the imported schema file.