### PR TITLE
fix(designer): Fix issue where scopes could drag/drop into themselves

### DIFF
--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -3,7 +3,12 @@ import { getMonitoringError } from '../../common/utilities/error';
 import { moveOperation } from '../../core/actions/bjsworkflow/move';
 import { useMonitoringView, useReadOnly } from '../../core/state/designerOptions/designerOptionsSelectors';
 import { setShowDeleteModal } from '../../core/state/designerView/designerViewSlice';
-import { useBrandColor, useIconUri, useParameterValidationErrors } from '../../core/state/operation/operationSelector';
+import {
+  useBrandColor,
+  useIconUri,
+  useParameterValidationErrors,
+  useTokenDependencies,
+} from '../../core/state/operation/operationSelector';
 import { useIsNodeSelected } from '../../core/state/panel/panelSelectors';
 import { changePanelNode, setSelectedNodeId } from '../../core/state/panel/panelSlice';
 import { useAllOperations, useOperationQuery } from '../../core/state/selectors/actionMetadataSelector';
@@ -106,7 +111,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
       refetch();
     }
   }, [dispatch, parentRunIndex, isMonitoringView, refetch, repetitionName, parenRunData?.status]);
-
+  const dependencies = useTokenDependencies(scopeId);
   const [{ isDragging }, drag, dragPreview] = useDrag(
     () => ({
       type: 'BOX',
@@ -128,7 +133,9 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
         }
       },
       item: {
-        id: scopeId,
+        id: id,
+        dependencies,
+        isScope: true,
       },
       canDrag: !readOnly,
       collect: (monitor) => ({


### PR DESCRIPTION
Fixes #4666 

This pull request primarily involves changes to two files: `ScopeCardNode.tsx` and `dropzone.tsx` located in `libs/designer/src/lib/ui/`. The changes mainly revolve around adding dependency and scope-related features to the `ScopeCardNode` and `DropZone` components.

Key changes include:

Dependency and Scope-related Changes:

* [`libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx`](diffhunk://#diff-3214690825743eaad95edb802e46b6e315b56a1b05018d5af76d43741adef851L6-R11): Imported the `useTokenDependencies` hook, used it to fetch dependencies for a given scope, and included these dependencies in the draggable item's data. [[1]](diffhunk://#diff-3214690825743eaad95edb802e46b6e315b56a1b05018d5af76d43741adef851L6-R11) [[2]](diffhunk://#diff-3214690825743eaad95edb802e46b6e315b56a1b05018d5af76d43741adef851L109-R114) [[3]](diffhunk://#diff-3214690825743eaad95edb802e46b6e315b56a1b05018d5af76d43741adef851L131-R138)
* [`libs/designer/src/lib/ui/connections/dropzone.tsx`](diffhunk://#diff-1cc68771ba543817b757dcf4a348bcd4177a9d2aaf3797b9158baaaa75fcace9L5-R10): Imported the `useAllGraphParents` hook, used it to fetch all parent scopes for a given graph, and included a check to prevent a scope from being moved above its parent scopes. [[1]](diffhunk://#diff-1cc68771ba543817b757dcf4a348bcd4177a9d2aaf3797b9158baaaa75fcace9L5-R10) [[2]](diffhunk://#diff-1cc68771ba543817b757dcf4a348bcd4177a9d2aaf3797b9158baaaa75fcace9L143-R149) [[3]](diffhunk://#diff-1cc68771ba543817b757dcf4a348bcd4177a9d2aaf3797b9158baaaa75fcace9R158-R171)

These changes aim to enhance the functionality of the `ScopeCardNode` and `DropZone` components by considering dependencies and scope hierarchy, which can help prevent invalid operations and improve the overall user experience.