### PR TITLE
fix(designer): fix issue where scope nodes didn't get focused when they were jumped to

### DIFF
--- a/libs/designer-ui/src/lib/card/scopeCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/scopeCard/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { StatusPill } from '../../monitoring';
 import NodeCollapseToggle from '../../nodeCollapseToggle';
 import { CardContextMenu } from '../cardcontextmenu';
@@ -33,14 +34,19 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
   handleCollapse,
   selected,
   contextMenuItems = [],
-  runData = {},
+  runData,
+  setFocus,
 }) => {
   const contextMenu = useCardContextMenu();
-
+  const focusRef = useRef<HTMLDivElement | null>(null);
   const handleClick: React.MouseEventHandler<HTMLElement> = () => {
     onClick?.();
   };
-
+  useEffect(() => {
+    if (setFocus) {
+      focusRef.current?.focus();
+    }
+  }, [setFocus]);
   const keyboardInteraction = useCardKeyboardInteraction(onClick, onDeleteClick);
 
   const badges = [
@@ -55,7 +61,6 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
   ) : icon ? (
     <img className="scope-icon" alt="" role="presentation" src={icon} />
   ) : null;
-
   return (
     <div ref={dragPreview} className="msla-content-fit" style={{ cursor: 'default' }}>
       <div aria-describedby={describedBy} className={'msla-content-fit'} aria-label={title}>
@@ -71,15 +76,15 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
           {isMonitoringView ? (
             <StatusPill
               id={`${title}-status`}
-              status={runData.status}
-              duration={runData.duration}
-              startTime={runData.startTime}
-              endTime={runData.endTime}
+              status={runData?.status}
+              duration={runData?.duration}
+              startTime={runData?.startTime}
+              endTime={runData?.endTime}
             />
           ) : null}
           <div className="msla-scope-card-content">
             <div className={css('msla-selection-box', 'white-outline', selected && 'selected')} />
-            <button className="msla-scope-card-title-button" onClick={handleClick}>
+            <button className="msla-scope-card-title-button" ref={focusRef as any} onClick={handleClick}>
               <div className="msla-scope-card-title-box">
                 <div className={css('gripper-section', draggable && 'draggable')}>{draggable ? <Gripper /> : null}</div>
                 <div className="panel-card-content-icon-section">{cardIcon}</div>

--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -25,6 +25,7 @@ import {
   useRunInstance,
   useParentRunId,
   useNodeDescription,
+  useShouldNodeFocus,
 } from '../../core/state/workflow/workflowSelectors';
 import { setRepetitionRunData, toggleCollapsedGraphId } from '../../core/state/workflow/workflowSlice';
 import type { AppDispatch } from '../../core/store';
@@ -53,7 +54,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = Position.Bottom, id }: NodeProps) => {
   const scopeId = removeIdTag(id);
   const nodeComment = useNodeDescription(scopeId);
-
+  const shouldFocus = useShouldNodeFocus(scopeId);
   const node = useActionMetadata(scopeId);
   const operationsInfo = useAllOperations();
 
@@ -335,6 +336,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
             contextMenuItems={contextMenuItems}
             runData={runData}
             commentBox={comment}
+            setFocus={shouldFocus}
           />
           <Tooltip
             positioning={{ target: rootRef.current, position: 'below', align: 'end' }}


### PR DESCRIPTION
This pull request primarily focuses on improving the user interaction with the `ScopeCard` component in the `libs/designer-ui` package. The changes introduced include the addition of a focus state for the `ScopeCard` and the use of optional chaining for `runData` properties.

Here are the most important changes:

User Interaction Improvement:

* [`libs/designer-ui/src/lib/card/scopeCard/index.tsx`](diffhunk://#diff-a89043898373470bd84f869c820776a801fe861cefd3f6d4bc02fc909f706b81L36-R49): Implemented a focus state for the `ScopeCard` by using `useRef` and `useEffect` hooks from React. This allows the card to be focused programmatically when the `setFocus` prop is true. [[1]](diffhunk://#diff-a89043898373470bd84f869c820776a801fe861cefd3f6d4bc02fc909f706b81L36-R49) [[2]](diffhunk://#diff-a89043898373470bd84f869c820776a801fe861cefd3f6d4bc02fc909f706b81L58) [[3]](diffhunk://#diff-a89043898373470bd84f869c820776a801fe861cefd3f6d4bc02fc909f706b81L74-R87)
* [`libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx`](diffhunk://#diff-3214690825743eaad95edb802e46b6e315b56a1b05018d5af76d43741adef851R28): Added the `useShouldNodeFocus` hook to determine whether the `ScopeCard` should be focused, and passed the result as the `setFocus` prop to the `ScopeCard` component. [[1]](diffhunk://#diff-3214690825743eaad95edb802e46b6e315b56a1b05018d5af76d43741adef851R28) [[2]](diffhunk://#diff-3214690825743eaad95edb802e46b6e315b56a1b05018d5af76d43741adef851L56-R57) [[3]](diffhunk://#diff-3214690825743eaad95edb802e46b6e315b56a1b05018d5af76d43741adef851R339)

Codebase Simplification:

* [`libs/designer-ui/src/lib/card/scopeCard/index.tsx`](diffhunk://#diff-a89043898373470bd84f869c820776a801fe861cefd3f6d4bc02fc909f706b81L74-R87): Used optional chaining for `runData` properties to simplify the code and prevent potential runtime errors.

The changes in this pull request will enhance the user experience by providing visual feedback when a `ScopeCard` is focused, and improve the codebase by preventing potential errors related to `runData` properties.