### PR TITLE
test(designer): shard e2e tests for better performance

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,11 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -23,10 +28,46 @@ jobs:
     - name: Install Playwright Browsers
       run: pnpm run e2e:setup
     - name: Run Playwright tests
-      run: pnpm run test:e2e --grep @mock
-    - uses: actions/upload-artifact@v4
-      if: always()
+      run: pnpm run test:e2e --grep @mock --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+    - name: Upload blob report to GitHub Actions Artifacts
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
       with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+        name: blob-report-${{ matrix.shardIndex }}
+        path: blob-report
+        retention-days: 1
+
+  merge-reports:
+    # Merge reports after playwright-tests, even if some shards have failed
+    if: ${{ !cancelled() }}
+    needs: [test]
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18
+    - uses: pnpm/action-setup@v3
+      with:
+        version: 8
+        run_install: |
+          - recursive: true
+            args: [--frozen-lockfile, --strict-peer-dependencies]
+
+    - name: Download blob reports from GitHub Actions Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: all-blob-reports
+        pattern: blob-report-*
+        merge-multiple: true
+
+    - name: Merge into HTML Report
+      run: npx playwright merge-reports --reporter html ./all-blob-reports 
+
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-report--attempt-${{ github.run_attempt }}
+        path: playwright-report
+        retention-days: 14


### PR DESCRIPTION
This pull request includes significant modifications to the `.github/workflows/playwright.yml` file to improve the testing process. The changes mainly involve implementing a sharding strategy for running Playwright tests, modifying the artifact upload process, and adding a new job to merge test reports.

Sharding strategy:

* A new `strategy` block was added under the `test` job, implementing a matrix strategy with a `shardIndex` and `shardTotal`. This allows the Playwright tests to be divided and run across multiple shards, improving the efficiency and speed of the testing process.

Artifact upload modifications:

* The `Run Playwright tests` step was modified to include the shard index and total in the command, aligning with the new sharding strategy.
* The `actions/upload-artifact` step was renamed to `Upload blob report to GitHub Actions Artifacts`, and the conditions for running this step were changed to only execute if the job was not cancelled. The artifact's name and path were also updated to include the shard index, and the retention period was reduced from 30 to 1 day.

New job for merging reports:

* A new job named `merge-reports` was added. This job is responsible for downloading all blob reports, merging them into a single HTML report, and uploading this report as a new artifact. This job runs even if some shards have failed and only if the workflow was not cancelled.