### PR TITLE
fix(deisgner): Fix a11y issue where info bubbles had no announcement to description in tooltip

### DIFF
--- a/libs/designer-ui/src/lib/infoDot/index.tsx
+++ b/libs/designer-ui/src/lib/infoDot/index.tsx
@@ -2,7 +2,7 @@ import InformationImage from './info.svg';
 import { Text, TooltipHost } from '@fluentui/react';
 
 export const InfoDot = (props: any) => {
-  const { alt = '', title, description, style, innerAriaHidden } = props;
+  const { title, description, style, innerAriaHidden } = props;
 
   const tooltipProps = {
     onRenderContent: () => (
@@ -19,7 +19,7 @@ export const InfoDot = (props: any) => {
 
   return (
     <TooltipHost tooltipProps={tooltipProps}>
-      <img className="msla-info-dot" alt={alt} src={InformationImage} style={style} tabIndex={0} />
+      <img className="msla-info-dot" alt={description} src={InformationImage} style={style} tabIndex={0} />
     </TooltipHost>
   );
 };


### PR DESCRIPTION
Fixes #4697

This pull request primarily focuses on changes in the `InfoDot` component in the `libs/designer-ui/src/lib/infoDot/index.tsx` file. The changes involve the removal of the `alt` prop and the subsequent use of the `description` prop as the `alt` attribute for the `img` element.

Here are the key changes:

* Removed the `alt` prop from the `InfoDot` component's props. This change simplifies the component's API by reducing the number of props it accepts.
* Updated the `alt` attribute of the `img` element within the `InfoDot` component to use the `description` prop instead of the removed `alt` prop. This ensures that the `img` element still has a meaningful `alt` attribute for accessibility purposes.