### PR TITLE
fix(designer): Deleting a scope node brings panel to wrong id

### DIFF
--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -177,9 +177,9 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
   }, [dispatch, scopeId]);
 
   const deleteClick = useCallback(() => {
-    dispatch(setSelectedNodeId(id));
+    dispatch(setSelectedNodeId(scopeId));
     dispatch(setShowDeleteModal(true));
-  }, [dispatch, id]);
+  }, [dispatch, scopeId]);
 
   const copyClick = useCallback(() => {
     setShowCopyCallout(true);


### PR DESCRIPTION
very small change to use scopeId instead as the id has an idTag and isn't one of the nodeIds