### PR TITLE
fix(designer): Null Literal are casted as String Literals

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -3457,7 +3457,10 @@ export function parameterValueToString(
           // Note: Token segment should be auto casted using interpolation if token type is
           // non string and referred in a string parameter.
           expressionValue =
-            !remappedParameterInfo.suppressCasting && parameterType === 'string' && segment.token?.type !== 'string'
+            !remappedParameterInfo.suppressCasting &&
+            parameterType === 'string' &&
+            segment.token?.type !== 'string' &&
+            !shouldUseLiteralValues(segment.token?.expression)
               ? `@{${expressionValue}}`
               : `@${expressionValue}`;
         }
@@ -3466,6 +3469,10 @@ export function parameterValueToString(
       return expressionValue;
     })
     .join('');
+}
+
+export function shouldUseLiteralValues(expression: Expression | undefined): boolean {
+  return (expression?.type as ExpressionType) === ExpressionType.NullLiteral;
 }
 
 export function parameterValueToJSONString(parameterValue: ValueSegment[], applyCasting = true, forValidation = false): string {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
   - Bug Fix

- **What is the current behavior?** (You can also link to an open issue here)
   - When using the expression editor to use the "null" value it correctly specifies the expression type is Null Literal, but when the value is formatted, its formatted as ${null} instead of @null which results in the null being treated as a String Literal instead of a Null Literal value. 
   - Link to Issue: https://github.com/Azure/LogicAppsUX/issues/3433
      - Note: This issue also mentions a similar issue occurs for True/False values and other keywords. This doesn't address all the keywords, just the null expression ones since that's the ones we're seeing on the PA side. If this seems to be more widespread then a follow up PR can be made to modify the function to check for other LiteralTypes as well. 

- **What is the new behavior (if this is a feature change)?**
   - This PR introduces a change to where if the expression type is "NullLiteral", then the value will be formatted as **"@null"** instead of **"@{null}"**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
   - N/A

- **Please Include Screenshots or Videos of the intended change**:
_**Flow Using Null Literal Value**_
![image](https://github.com/Azure/LogicAppsUX/assets/28818445/2589aedc-3129-4fde-94ed-f62c2a66f50d)

_**Value in Code View (without changes)**_
![image](https://github.com/Azure/LogicAppsUX/assets/28818445/a053c594-3e98-4aa5-9dba-b93ac176a7bb)

_**Value in Code View (with changes)**_
![image](https://github.com/Azure/LogicAppsUX/assets/28818445/b93c7aa0-c311-47b1-a7fd-aa3bc8798bc4)


