### PR TITLE
fix(vscode): Update path exist function

### DIFF
--- a/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
@@ -78,7 +78,7 @@ export async function getLocalSettingsJson(
   localSettingsPath: string,
   allowOverwrite = false
 ): Promise<ILocalSettingsJson> {
-  if (await fse.pathExists(localSettingsPath)) {
+  if (await fse.existsSync(localSettingsPath)) {
     const data: string = (await fse.readFile(localSettingsPath)).toString();
     const localSettingsUri: Uri = Uri.file(localSettingsPath);
 

--- a/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
@@ -78,7 +78,7 @@ export async function getLocalSettingsJson(
   localSettingsPath: string,
   allowOverwrite = false
 ): Promise<ILocalSettingsJson> {
-  if (await fse.existsSync(localSettingsPath)) {
+  if (fse.existsSync(localSettingsPath)) {
     const data: string = (await fse.readFile(localSettingsPath)).toString();
     const localSettingsUri: Uri = Uri.file(localSettingsPath);
 


### PR DESCRIPTION
This pull request includes a change in the `getLocalSettingsJson` function within the `apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts` file. The function has been updated to use the `existsSync` method instead of the `pathExists` method from the `fse` module. 