### PR TITLE
fix(designer): Fix required screen announcement for required recurrence fields

### DIFF
--- a/libs/designer-ui/src/lib/recurrence/dropdownControl.tsx
+++ b/libs/designer-ui/src/lib/recurrence/dropdownControl.tsx
@@ -101,6 +101,7 @@ export const DropdownControl = ({
         disabled={readOnly}
         ariaLabel={label}
         options={options}
+        required={required}
         className={css('msla-authentication-dropdown')}
         multiSelect={isMultiSelect}
         onChange={handleOptionSelect}

--- a/libs/designer-ui/src/lib/recurrence/textInput.tsx
+++ b/libs/designer-ui/src/lib/recurrence/textInput.tsx
@@ -62,6 +62,7 @@ export const TextInput = ({
       <TextField
         ariaLabel={label}
         value={value}
+        required={required}
         placeholder={placeholder}
         styles={textFieldStyles}
         readOnly={readOnly}


### PR DESCRIPTION
This pull request includes changes to two components in the `libs/designer-ui/src/lib/recurrence` directory. Both changes add a `required` attribute to form elements, which will enforce that these fields must be filled out by the user.

* [`libs/designer-ui/src/lib/recurrence/dropdownControl.tsx`](diffhunk://#diff-e602cf4d4fa3a779d805c8d92b4729d39d17c4c1fd2c52e3528a5b582ec34753R104): Added a `required` attribute to the `DropdownControl` component, which will enforce that a selection must be made from the dropdown by the user.
* [`libs/designer-ui/src/lib/recurrence/textInput.tsx`](diffhunk://#diff-cc846eed09fbf24dae089e99041c7bfb55986627f14c64cfc79b5854924ccf0bR65): Added a `required` attribute to the `TextInput` component, which will enforce that the text input field must be filled out by the user.