### PR TITLE
chore(meta):  Add vscode extension build to test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,4 @@ jobs:
       # - run: npx nx affected --target=lint --parallel
       - run: turbo run build --cache-dir=.turbo
       - run: turbo run test:lib --cache-dir=.turbo
+      - run: turbo run build:extension --cache-dir=.turbo


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/test.yml` file. It adds a new job step to the workflow which builds the vscode extension using Turbo.