### PR TITLE
fix(vscode): fix turbo dependency for vscode build setup

### DIFF
--- a/apps/vs-code-designer/package.json
+++ b/apps/vs-code-designer/package.json
@@ -38,7 +38,7 @@
   },
   "private": true,
   "scripts": {
-    "build:extension": "tsup && pnpm run copyFiles && pnpm -w run build:vscode-react",
+    "build:extension": "tsup && pnpm run copyFiles",
     "copyFiles": "node extension-copy-svgs.js",
     "vscode:designer:pack": "pnpm run build:extension && pnpm run vscode:designer:pack:step1 && pnpm run vscode:designer:pack:step2",
     "vscode:designer:pack:step1": "cd ./dist && npm install",

--- a/apps/vs-code-react/package.json
+++ b/apps/vs-code-react/package.json
@@ -37,7 +37,6 @@
   "scripts": {
     "build": "vite build",
     "build:extension": "vite build --outDir ../../vs-code-designer/dist/vs-code-react",
-    "build:vscode-react": "vite build --outDir ../../vs-code-designer/dist/vs-code-react",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "type": "module"

--- a/apps/vs-code-react/package.json
+++ b/apps/vs-code-react/package.json
@@ -36,6 +36,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
+    "build:extension": "vite build --outDir ../../vs-code-designer/dist/vs-code-react",
     "build:vscode-react": "vite build --outDir ../../vs-code-designer/dist/vs-code-react",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "build:vscode-react": "turbo run build:vscode-react",
     "build:extension": "turbo run build:extension",
     "bump": "standard-version --no-verify",
     "check": "biome check --apply .",

--- a/turbo.json
+++ b/turbo.json
@@ -24,9 +24,6 @@
                 "build/**"
             ]
         },
-        "build:vscode-react": {
-            "cache": false
-        },
         "vscode-designer#build:extension": {
             "cache": false
         },

--- a/turbo.json
+++ b/turbo.json
@@ -27,8 +27,14 @@
         "build:vscode-react": {
             "cache": false
         },
-        "build:extension":{
+        "vscode-designer#build:extension": {
             "cache": false
+        },
+        "vscode-react#build:extension": {
+            "cache": false,
+            "dependsOn": [
+                "vscode-designer#build:extension"
+            ]
         },
         "dev": {
             "cache": false,
@@ -49,7 +55,7 @@
                 "coverage/**"
             ]
         },
-        "vscode:designer:pack":{
+        "vscode:designer:pack": {
             "cache": false,
             "dependsOn": [
                 "build"


### PR DESCRIPTION


https://github.com/Azure/LogicAppsUX/assets/13208452/4031203e-8668-4904-bbbe-b002257ba64d



This pull request primarily involves changes to the build scripts in the `package.json` files of the `vs-code-designer` and `vs-code-react` applications, as well as modifications to the `turbo.json` file. The main changes include the removal of the `build:vscode-react` script from the `vs-code-designer` application and its addition to the `vs-code-react` application, the removal of the `build:vscode-react` script from the root `package.json` file, and the addition of dependencies in the `turbo.json` file.

* [`apps/vs-code-designer/package.json`](diffhunk://#diff-910a12f0b9fcbead593b5611662c5a1685cafd5a50eafd7ee495a7ed628ed17cL41-R41): The `build:vscode-react` script was removed from the `build:extension` script, indicating that the `vs-code-react` build is no longer part of the `vs-code-designer` build process.
* [`apps/vs-code-react/package.json`](diffhunk://#diff-2c295c5ddc8f909d8e9a5828407bec205698d4296ffec5ea27c50d71ab6ff860L39-R39): The `build:vscode-react` script was renamed to `build:extension`, suggesting that the `vs-code-react` application now has its own build process separate from the `vs-code-designer` application.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L77): The `build:vscode-react` script was removed from the root `package.json` file, further indicating that the `vs-code-react` build is now separate from the main build process.
* [`turbo.json`](diffhunk://#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3L27-R34): The `build:vscode-react` pipeline was renamed to `vscode-designer#build:extension` and `vscode-react#build:extension`. The `vscode-react#build:extension` pipeline now depends on the `vscode-designer#build:extension` pipeline, meaning that the `vscode-designer` build must complete before the `vscode-react` build can start.