### PR TITLE
fix(Designer): Only show dropdown for array editor when there are options

### DIFF
--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -128,10 +128,14 @@ export const TokenField = ({
           onChange={onValueChange}
           dataAutomationId={`msla-setting-token-editor-arrayeditor-${labelForAutomationId}`}
           // Props for dynamic options
-          options={dropdownOptions?.map((option: any, index: number) => ({
-            key: index.toString(),
-            ...option,
-          }))}
+          options={
+            dropdownOptions.length > 0
+              ? dropdownOptions.map((option: any, index: number) => ({
+                  key: index.toString(),
+                  ...option,
+                }))
+              : undefined
+          }
           isLoading={isLoading}
           errorDetails={errorDetails}
           onMenuOpen={onComboboxMenuOpen}

--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -148,14 +148,7 @@ export function TokenPicker({
     description: 'Placeholder text to search token picker',
   });
 
-  const topCalloutStyle = windowDimensions.height / 5.25;
-
   const calloutStyles: Partial<ICalloutContentStyles> = {
-    root: {
-      position: 'fixed',
-      top: `${topCalloutStyle}px !important`,
-      maxHeight: '470px !important',
-    },
     calloutMain: {
       overflow: 'visible',
     },

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickersection.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickersection.tsx
@@ -66,7 +66,7 @@ export const TokenPickerSection = ({
       style={{
         maxHeight: fullScreen
           ? windowDimensions.height - (expressionEditorCurrentHeight + 287)
-          : Math.min(windowDimensions.height - (expressionEditorCurrentHeight + 197), 180),
+          : Math.min(windowDimensions.height - (expressionEditorCurrentHeight + 197), 540),
       }}
     >
       {searchQuery && noItems ? <TokenPickerNoMatches /> : null}


### PR DESCRIPTION
Fixes https://github.com/Azure/LogicAppsUX/issues/4781
![fixArrayEditor](https://github.com/Azure/LogicAppsUX/assets/95886809/b246c74e-a89e-48c9-90a7-90f9e3519896)
Also reverting: 
https://github.com/Azure/LogicAppsUX/pull/4744
because it was causing
<img width="1123" alt="Screenshot 2024-05-06 135647" src="https://github.com/Azure/LogicAppsUX/assets/95886809/91eecbd7-52c2-43e0-b736-403f2768cd2c">
