### PR TITLE
fix(Designer): Trigger deletion should also remove dependant tokens through the workflow

### DIFF
--- a/e2e/designer/tokenRemoval.spec.ts
+++ b/e2e/designer/tokenRemoval.spec.ts
@@ -45,6 +45,30 @@ test.describe(
       expect(JSON.stringify(serializedNew)).not.toContain("@variables('ArrayVariable')");
       expect(JSON.stringify(serializedNew)).not.toContain("@{variables('ArrayVariable')}");
     });
+
+    test('Tokens should be removed from parameters when trigger is deleted', async ({ page }) => {
+      await page.goto('/');
+
+      await GoToMockWorkflow(page, 'Panel');
+      const serializedOld: any = await getSerializedWorkflowFromState(page);
+      expect
+        .soft(serializedOld.definition.actions.Parse_JSON.inputs.content)
+        .toEqual(
+          "@{triggerBody()?['string']}@{variables('ArrayVariable')}@{parameters('EILCO Admin Nominations-OCSA List (cr773_EILCOAdminNominations_OCSA_L2)')}"
+        );
+      await page.getByTestId('card-manual').click({
+        button: 'right',
+      });
+      await page.getByText('Delete', { exact: true }).click();
+      await page.getByRole('button', { name: 'OK' }).click();
+      const serializedNew: any = await getSerializedWorkflowFromState(page);
+      expect(serializedNew.definition.actions.Parse_JSON.inputs.content).toEqual(
+        "@{variables('ArrayVariable')}@{parameters('EILCO Admin Nominations-OCSA List (cr773_EILCOAdminNominations_OCSA_L2)')}"
+      );
+      expect(JSON.stringify(serializedNew)).not.toContain("@triggerBody()?['string']");
+      expect(JSON.stringify(serializedNew)).not.toContain("@{triggerBody()?['string']}");
+    });
+
     test('Tokens should be removed from parameters when workflow parameter is deleted', async ({ page }) => {
       await page.goto('/');
 


### PR DESCRIPTION
This pull request primarily focuses on enhancing the token removal functionality in the workflow design process. The most significant changes include adding a new test case to verify token removal when a trigger is deleted, importing a new token type for deletion, and modifying the `deleteOperation` and `removeAllTokensFromNode` functions to handle trigger deletion.

Key changes include:

Token Removal Test:

* [`e2e/designer/tokenRemoval.spec.ts`](diffhunk://#diff-40403c79907f771d8e7b1e1e05be8490d591bde15b702d49732dbbea194bf2e0R48-R71): A new test case has been added to verify that tokens are correctly removed from parameters when a trigger is deleted. This ensures that any references to the deleted trigger are also removed, maintaining the integrity of the workflow.

Token Type Import:

* [`libs/designer/src/lib/core/actions/bjsworkflow/delete.ts`](diffhunk://#diff-8df26d60c06080c30206ea9b35fae88ca4b26cf36ca92febcd77f43804983803L20-R20): The `isOutputToken` function has been imported, which is used to identify output tokens that need to be removed when a trigger is deleted.

Function Modifications for Trigger Deletion:

* [`libs/designer/src/lib/core/actions/bjsworkflow/delete.ts`](diffhunk://#diff-8df26d60c06080c30206ea9b35fae88ca4b26cf36ca92febcd77f43804983803L40-R70): The `deleteOperation` function has been modified to include a new `isTrigger` parameter. This is used to determine if the operation being deleted is a trigger, which is necessary for the correct removal of associated tokens.
* [`libs/designer/src/lib/core/actions/bjsworkflow/delete.ts`](diffhunk://#diff-8df26d60c06080c30206ea9b35fae88ca4b26cf36ca92febcd77f43804983803L87-R96): The `removeAllTokensFromNode` function has been updated to handle trigger deletion. It now checks if the token being removed is an output token associated with a deleted trigger and removes it accordingly.