### PR TITLE
fix(designer): Export the ValueSegmentConvertor class for use in PPUX

### DIFF
--- a/libs/designer/src/lib/core/index.ts
+++ b/libs/designer/src/lib/core/index.ts
@@ -61,7 +61,7 @@ export {
   createLiteralValueSegment,
   createTokenValueSegment,
   ValueSegmentConvertor,
-  ValueSegmentConvertorOptions
+  type ValueSegmentConvertorOptions
 } from './utils/parameters/segment';
 export {
   getOutputTokenSections,

--- a/libs/designer/src/lib/core/index.ts
+++ b/libs/designer/src/lib/core/index.ts
@@ -60,6 +60,8 @@ export {
 export {
   createLiteralValueSegment,
   createTokenValueSegment,
+  ValueSegmentConvertor,
+  ValueSegmentConvertorOptions
 } from './utils/parameters/segment';
 export {
   getOutputTokenSections,


### PR DESCRIPTION
Exporting the `ValueSegmentConvertor` class and it's option for generating tokens for `AdaptiveCardTriggerEditor`
V1 uses Parameter Service to generate tokens, but V3 has a ValueSegmentConvertor to do the same. Hence exporting this class.

