### PR TITLE
feat(vscode): Add initial setup for unit testing with vitest in extension code

### DIFF
--- a/.github/workflows/base-coverage.yml
+++ b/.github/workflows/base-coverage.yml
@@ -30,14 +30,14 @@ jobs:
               - recursive: true
                 args: [--frozen-lockfile, --strict-peer-dependencies]   
 
-        - name: Run lib tests
+        - name: Run lib unit tests
           run: pnpm turbo run test:lib --cache-dir=.turbo
-        - name: Run extension tests
+        - name: Run extension unit tests
           run: pnpm turbo run test:extension-unit --cache-dir=.turbo
         - name: Create code coverage report
           run: |
             dotnet tool install -g dotnet-reportgenerator-globaltool
-            reportgenerator -reports:"libs/*/coverage/cobertura-coverage.xml" -targetdir:CodeCoverage -reporttypes:'Cobertura;MarkdownSummaryGithub'
+            reportgenerator -reports:"libs/*/coverage/cobertura-coverage.xml;apps/vs-code-designer/coverage/cobertura-coverage.xml" -targetdir:CodeCoverage -reporttypes:'Cobertura;MarkdownSummaryGithub'
 
         - uses: clearlyip/code-coverage-report-action@v4
           with:

--- a/.github/workflows/base-coverage.yml
+++ b/.github/workflows/base-coverage.yml
@@ -30,7 +30,10 @@ jobs:
               - recursive: true
                 args: [--frozen-lockfile, --strict-peer-dependencies]   
 
-        - run: pnpm turbo run test:lib --cache-dir=.turbo 
+        - name: Run lib tests
+          run: pnpm turbo run test:lib --cache-dir=.turbo
+        - name: Run extension tests
+          run: pnpm turbo run test:extension-unit --cache-dir=.turbo
         - name: Create code coverage report
           run: |
             dotnet tool install -g dotnet-reportgenerator-globaltool

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,4 @@ jobs:
       - run: turbo run build --cache-dir=.turbo
       - run: turbo run test:lib --cache-dir=.turbo
       - run: turbo run build:extension --cache-dir=.turbo
+      - run: turbo run test:extension-unit --cache-dir=.turbo

--- a/apps/vs-code-designer/package.json
+++ b/apps/vs-code-designer/package.json
@@ -43,6 +43,7 @@
     "vscode:designer:pack": "pnpm run build:extension && pnpm run vscode:designer:pack:step1 && pnpm run vscode:designer:pack:step2",
     "vscode:designer:pack:step1": "cd ./dist && npm install",
     "vscode:designer:pack:step2": "cd ./dist && vsce package",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test:extension-unit": "vitest --retry=3"
   }
 }

--- a/apps/vs-code-designer/src/app/utils/codeless/__test__/parameterizer.test.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/__test__/parameterizer.test.ts
@@ -27,7 +27,6 @@ describe('parameterizeConnection for ConnectionReferenceModel', () => {
         scheme: 'Key',
         parameter: "@appsetting('arm-connectionKey')",
       },
-      connectionProperties: null,
     };
 
     const parameters: any = {};

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -1,0 +1,6 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// https://testing-library.com/docs/react-testing-library/api#cleanup
+afterEach(() => cleanup());

--- a/apps/vs-code-designer/vitest.config.ts
+++ b/apps/vs-code-designer/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineProject } from 'vitest/config';
+import packageJson from './package.json';
+
+export default defineProject({
+  plugins: [],
+  test: {
+    name: packageJson.name,
+    dir: './src',
+    watch: false,
+    environment: 'jsdom',
+    setupFiles: ['test-setup.ts'],
+    coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'], reporter: ['html', 'cobertura'] },
+    restoreMocks: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "start:e2e": "turbo run e2e",
     "test:lib": "turbo run test:lib",
     "test:e2e": "playwright test",
+    "test:extension-unit": "turbo run test:extension-unit",
     "testgen": "playwright codegen https://localhost:4200",
     "vscode:designer:pack": "turbo run vscode:designer:pack"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -52,6 +52,11 @@
                 "coverage/**"
             ]
         },
+        "test:extension-unit": {
+            "outputs": [
+                "coverage/**"
+            ]
+        },
         "vscode:designer:pack": {
             "cache": false,
             "dependsOn": [


### PR DESCRIPTION
This pull request primarily focuses on extending the testing suite to include unit tests for the vscode extension. 



* Added a new script `test:extension-unit` to run the extension unit tests using vitest.
* Added setup for the extension unit tests, including importing the necessary libraries and defining the `afterEach` cleanup function.
* Defined the configuration for the extension unit tests, including the testing environment, coverage settings, and setup files.

* Added steps to run the extension unit tests in the GitHub actions workflows. 
* Added the `test:extension-unit` command to the root `package.json` and `turbo.json` files to enable running the extension unit tests from the root directory. 

* Removed the `connectionProperties` field from the test data, possibly to align with changes in the code under test.

####  Pasting the screenshot of the report for the extension. It is close to none, which means there is a lot of work to do :)
<img width="600" alt="Screenshot 2024-05-07 at 7 13 34 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/7ad088fe-1c23-465a-8b3f-ba88c7f306aa">
