### PR TITLE
fix(designer-ui): [a11y] Prevent sticky search header from hiding action buttons in side panel

### DIFF
--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/operationSearchHeader.less
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/operationSearchHeader.less
@@ -31,6 +31,10 @@
     overflow: hidden;
     white-space: nowrap;
   }
+
+  @media only screen and (max-height: 420px) {
+    position: initial;
+  }
 }
 
 .msla-theme-dark {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix (styling, accessibility)

- **What is the current behavior?** (You can also link to an open issue here)

For screens which are vertically narrow, buttons in the actions side panel are not visible when searching, due to the sticky header covering them.

![invisible-actions](https://github.com/Azure/LogicAppsUX/assets/1350074/9f1f8a50-180e-406c-a27e-a15b10d7955d)

- **What is the new behavior (if this is a feature change)?**

For screens <420px tall, the search header is no longer sticky, allowing all actions to be seen if scrolled.

![invisible-actions-fixed](https://github.com/Azure/LogicAppsUX/assets/1350074/37c4b5cf-936d-41ef-b65a-2d07322692bc)

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No