### PR TITLE
fix(designer-ui): Prevent field placeholder from being used as title on HTML toolbar

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -173,12 +173,7 @@ export const BaseEditor = ({
 
   return (
     <>
-      <div
-        className={className ?? 'msla-editor-container'}
-        id={editorId}
-        ref={containerRef}
-        data-automation-id={dataAutomationId}
-      >
+      <div className={className ?? 'msla-editor-container'} id={editorId} ref={containerRef} data-automation-id={dataAutomationId}>
         {htmlEditor ? (
           <Toolbar
             isRawText={htmlEditor === 'raw-html'}
@@ -189,7 +184,12 @@ export const BaseEditor = ({
         ) : null}
         <TextPlugin
           contentEditable={
-            <ContentEditable className={css('editor-input', readonly && 'readonly')} ariaLabelledBy={labelId} ariaDescribedBy={id} title={placeholder} />
+            <ContentEditable
+              className={css('editor-input', readonly && 'readonly')}
+              ariaLabelledBy={labelId}
+              ariaDescribedBy={id}
+              title={placeholder}
+            />
           }
           placeholder={
             <span className="editor-placeholder" ref={placeholderRef}>

--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -178,7 +178,6 @@ export const BaseEditor = ({
         id={editorId}
         ref={containerRef}
         data-automation-id={dataAutomationId}
-        title={placeholder}
       >
         {htmlEditor ? (
           <Toolbar
@@ -190,7 +189,7 @@ export const BaseEditor = ({
         ) : null}
         <TextPlugin
           contentEditable={
-            <ContentEditable className={css('editor-input', readonly && 'readonly')} ariaLabelledBy={labelId} ariaDescribedBy={id} />
+            <ContentEditable className={css('editor-input', readonly && 'readonly')} ariaLabelledBy={labelId} ariaDescribedBy={id} title={placeholder} />
           }
           placeholder={
             <span className="editor-placeholder" ref={placeholderRef}>


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Hovering over a button which has no `title` attribute in the HTML toolbar causes the field's placeholder to appear as the `title`.

![toolbar-title-broken](https://github.com/Azure/LogicAppsUX/assets/1350074/fefa4090-fa91-4f83-9ed3-2c9e1e134883)

- **What is the new behavior (if this is a feature change)?**

Aforementioned placeholder title only appears when hovering over the editable content.

![toolbar-title-fixed](https://github.com/Azure/LogicAppsUX/assets/1350074/dc48a134-2388-4ca1-bcbb-b4acdbef04fa)

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No