### PR TITLE
fix(designer-ui): [A11Y] Auto-focus color picker in HTML toolbar

### DIFF
--- a/libs/designer-ui/src/lib/html/plugins/toolbar/ColorPickerTextInput.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/ColorPickerTextInput.tsx
@@ -1,4 +1,6 @@
 import { css, useTheme } from '@fluentui/react';
+import { useContext, useEffect, useRef } from 'react';
+import { DropDownContext } from './helper/DropdownItems';
 
 type Props = Readonly<{
   'data-test-id'?: string;
@@ -9,7 +11,19 @@ type Props = Readonly<{
 }>;
 
 export function TextInput({ label, value, onChange, placeholder = '', 'data-test-id': dataTestId }: Props): JSX.Element {
+  const ref = useRef<HTMLInputElement>(null);
   const { isInverted } = useTheme();
+
+  const dropDownContext = useContext(DropDownContext);
+
+  const { registerItem } = dropDownContext ?? {};
+
+  useEffect(() => {
+    if (registerItem && ref?.current) {
+      registerItem(ref);
+    }
+  }, [ref, registerItem]);
+
   return (
     <div className="msla-colorpicker-input-wrapper">
       <label className="msla-colorpicker-input-label">{label}</label>
@@ -21,6 +35,7 @@ export function TextInput({ label, value, onChange, placeholder = '', 'data-test
         onChange={(e) => {
           onChange(e.target.value);
         }}
+        ref={ref}
         data-test-id={dataTestId}
       />
     </div>

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/DropdownItemElement.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/DropdownItemElement.ts
@@ -1,0 +1,1 @@
+export type DropdownItemHTMLElement = HTMLButtonElement | HTMLInputElement;

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/DropdownItemElement.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/DropdownItemElement.ts
@@ -1,1 +1,0 @@
-export type DropdownItemHTMLElement = HTMLButtonElement | HTMLInputElement;

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/DropdownItems.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/DropdownItems.tsx
@@ -1,7 +1,8 @@
 import { css, useTheme } from '@fluentui/react';
 import type { MutableRefObject, RefObject } from 'react';
 import { createContext, useEffect, useMemo, useCallback, useState } from 'react';
-import type { DropdownItemHTMLElement } from './DropdownItemElement';
+
+type DropdownItemHTMLElement = HTMLButtonElement | HTMLInputElement;
 
 interface DropdownItemsProps {
   children: React.ReactNode;

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/DropdownItems.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/DropdownItems.tsx
@@ -1,6 +1,7 @@
 import { css, useTheme } from '@fluentui/react';
 import type { MutableRefObject, RefObject } from 'react';
 import { createContext, useEffect, useMemo, useCallback, useState } from 'react';
+import type { DropdownItemHTMLElement } from './DropdownItemElement';
 
 interface DropdownItemsProps {
   children: React.ReactNode;
@@ -10,19 +11,19 @@ interface DropdownItemsProps {
 }
 
 export type DropDownContextType = {
-  registerItem: (ref: RefObject<HTMLButtonElement>) => void;
+  registerItem: (ref: RefObject<DropdownItemHTMLElement>) => void;
 };
 
 export const DropDownContext = createContext<DropDownContextType | null>(null);
 
 export const DropDownItems = ({ children, dropDownRef, stopCloseOnClickSelf, onClose }: DropdownItemsProps) => {
   const { isInverted } = useTheme();
-  const [items, setItems] = useState<RefObject<HTMLButtonElement>[]>();
-  const [highlightedItem, setHighlightedItem] = useState<RefObject<HTMLButtonElement>>();
+  const [items, setItems] = useState<RefObject<DropdownItemHTMLElement>[]>();
+  const [highlightedItem, setHighlightedItem] = useState<RefObject<DropdownItemHTMLElement>>();
 
   // register item to end of list
   const registerItem = useCallback(
-    (itemRef: RefObject<HTMLButtonElement>) => {
+    (itemRef: RefObject<DropdownItemHTMLElement>) => {
       setItems((prev) => (prev ? [...prev, itemRef] : [itemRef]));
     },
     [setItems]
@@ -94,6 +95,7 @@ export const DropDownItems = ({ children, dropDownRef, stopCloseOnClickSelf, onC
             e.relatedTarget?.classList.contains('fontsize-item') ||
             e.relatedTarget?.classList.contains('fontfamily-item') ||
             e.relatedTarget?.classList.contains('fontcolor-item') ||
+            e.relatedTarget?.classList.contains('default-color-buttons') ||
             e.target.classList.contains('blockcontrol-item') ||
             e.target.classList.contains('default-color-buttons')
           ) {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix (accessibility)

- **What is the current behavior?** (You can also link to an open issue here)

HTML toolbar color picker popover cannot be focused by keyboard. Fixes #4457.

![popover-unfocused](https://github.com/Azure/LogicAppsUX/assets/1350074/463bbd8b-46b5-4c82-92c2-72fc7d90bbea)

- **What is the new behavior (if this is a feature change)?**

HTML toolbar color picker auto-focuses when selected.

![popover-focus](https://github.com/Azure/LogicAppsUX/assets/1350074/b4bd1669-3b02-4bb4-a1b9-393843734905)

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No