### PR TITLE
feat(designer): Adding Option to Open Token Picker by Default

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -78,6 +78,7 @@ export interface BasePlugins {
   autoFocus?: boolean;
   autoLink?: boolean;
   clearEditor?: boolean;
+  focusOpensTokenPicker?: boolean;
   history?: boolean;
   tokens?: boolean;
   treeView?: boolean;
@@ -110,7 +111,7 @@ export const BaseEditor = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const placeholderRef = useRef<HTMLDivElement>(null);
   const [isEditorFocused, setIsEditorFocused] = useState(false);
-  const [isTokenPickerOpened, setIsTokenPickerOpened] = useState(false);
+  const [isTokenPickerOpened, setIsTokenPickerOpened] = useState(basePlugins.focusOpensTokenPicker === true);
   const [tokenPickerMode, setTokenPickerMode] = useState<TokenPickerMode | undefined>();
   const [floatingAnchorElem, setFloatingAnchorElem] = useState<HTMLDivElement | null>(null);
 

--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -1,5 +1,5 @@
 import { Toolbar } from '../../html/plugins/toolbar/Toolbar';
-import type { TokenPickerMode } from '../../tokenpicker';
+import { TokenPickerMode } from '../../tokenpicker';
 import { useId } from '../../useId';
 import type { ValueSegment } from '../models/parameter';
 import { ArrowNavigation } from './plugins/ArrowNavigation';
@@ -111,7 +111,9 @@ export const BaseEditor = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const placeholderRef = useRef<HTMLDivElement>(null);
   const [isEditorFocused, setIsEditorFocused] = useState(false);
-  const [isTokenPickerOpened, setIsTokenPickerOpened] = useState(basePlugins.focusOpensTokenPicker === true);
+  const [isTokenPickerOpened, setIsTokenPickerOpened] = useState(false);
+  const [focusOpensTokenPicker, setFocusOpensTokenPicker] = useState(false);
+  const [userClosedTokenPicker, setUserClosedTokenPicker] = useState(false);
   const [tokenPickerMode, setTokenPickerMode] = useState<TokenPickerMode | undefined>();
   const [floatingAnchorElem, setFloatingAnchorElem] = useState<HTMLDivElement | null>(null);
 
@@ -149,6 +151,11 @@ export const BaseEditor = ({
   const handleFocus = () => {
     onFocus?.();
     setIsEditorFocused(true);
+    if (basePlugins.focusOpensTokenPicker && !userClosedTokenPicker) {
+      openTokenPicker(TokenPickerMode.TOKEN);
+      setFocusOpensTokenPicker(true);
+    }
+    setUserClosedTokenPicker(false);
   };
 
   const handleBlur = () => {
@@ -156,10 +163,11 @@ export const BaseEditor = ({
       onBlur?.();
     }
     setIsEditorFocused(false);
+    setFocusOpensTokenPicker(false);
   };
 
   const handleClick = () => {
-    if (isTokenPickerOpened) {
+    if (isTokenPickerOpened && focusOpensTokenPicker) {
       setIsTokenPickerOpened(false);
     }
   };
@@ -167,6 +175,12 @@ export const BaseEditor = ({
   const openTokenPicker = (mode: TokenPickerMode) => {
     setIsTokenPickerOpened(true);
     setTokenPickerMode(mode);
+    setFocusOpensTokenPicker(false);
+  };
+
+  const closeTokenPicker = () => {
+    setIsTokenPickerOpened(false);
+    setUserClosedTokenPicker(true);
   };
 
   const id = useId('msla-described-by-message');
@@ -219,7 +233,7 @@ export const BaseEditor = ({
             <InsertTokenNode />
             <DeleteTokenNode />
             <OpenTokenPicker openTokenPicker={openTokenPicker} />
-            <CloseTokenPicker closeTokenPicker={() => setIsTokenPickerOpened(false)} />
+            <CloseTokenPicker closeTokenPicker={closeTokenPicker} />
             <TokenTypeAheadPlugin
               openTokenPicker={openTokenPicker}
               isEditorFocused={isEditorFocused}

--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -59,6 +59,7 @@ export interface SettingTokenFieldProps extends SettingProps {
   validationErrors?: string[];
   hideValidationErrors?: ChangeHandler;
   suppressCastingForSerialize?: boolean;
+  focusOpensTokenPicker?: boolean;
 }
 
 export const SettingTokenField = ({ ...props }: SettingTokenFieldProps) => {
@@ -107,6 +108,7 @@ export const TokenField = ({
   onCastParameter,
   getTokenPicker,
   suppressCastingForSerialize,
+  focusOpensTokenPicker,
 }: TokenFieldProps) => {
   const dropdownOptions = getDropdownOptionsFromOptions(editorOptions);
   const labelForAutomationId = replaceWhiteSpaceWithUnderscore(label);
@@ -380,7 +382,7 @@ export const TokenField = ({
           labelId={labelId}
           className="msla-setting-token-editor-container"
           placeholder={placeholder}
-          basePlugins={{ tokens: showTokens }}
+          basePlugins={{ tokens: showTokens, focusOpensTokenPicker: focusOpensTokenPicker }}
           readonly={readOnly}
           initialValue={value}
           tokenPickerButtonProps={tokenpickerButtonProps}

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -33,10 +33,11 @@ export interface DesignerOptionsState {
   suppressDefaultNodeSelectFunctionality?: boolean;
   hostOptions: {
     displayRuntimeInfo: boolean; // show info about where the action is run(i.e. InApp/Shared/Custom)
-    suppressCastingForSerialize?: boolean; // suppress casting for serialize
-    recurrenceInterval?: LogicApps.Recurrence;
+    focusOpensTokenPicker?: boolean; // token picker auto opens on focus
     forceEnableSplitOn?: boolean; // force enable split on (by default it is disabled on stateless workflows)
     hideUTFExpressions?: boolean; // hide UTF expressions in template functions
+    recurrenceInterval?: LogicApps.Recurrence;
+    suppressCastingForSerialize?: boolean; // suppress casting for serialize
   };
   nodeSelectAdditionalCallback?: (nodeId: string) => any;
   showConnectionsPanel?: boolean;

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -35,8 +35,9 @@ const initialState: DesignerOptionsState = {
   panelTabHideKeys: [],
   hostOptions: {
     displayRuntimeInfo: true,
-    suppressCastingForSerialize: false,
+    focusOpensTokenPicker: false,
     recurrenceInterval: undefined,
+    suppressCastingForSerialize: false,
   },
 };
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -216,7 +216,7 @@ const ParameterSection = ({
   const panelLocation = usePanelLocation();
   const nodeTitle = replaceWhiteSpaceWithUnderscore(useNodeDisplayName(nodeId));
 
-  const { suppressCastingForSerialize, hideUTFExpressions } = useHostOptions();
+  const { focusOpensTokenPicker, hideUTFExpressions, suppressCastingForSerialize } = useHostOptions();
 
   const [tokenMapping, setTokenMapping] = useState<Record<string, ValueSegment>>({});
 
@@ -430,6 +430,7 @@ const ParameterSection = ({
         placeholder,
         editorViewModel: remappedEditorViewModel,
         conditionalVisibility,
+        focusOpensTokenPicker,
       };
       const { editor, editorOptions } = getEditorAndOptions(operationInfo, param, upstreamNodeIds ?? [], variables);
 


### PR DESCRIPTION
Adding a flag focusOpensTokenPicker to designerOptions so that we can make the token editor open by default when the associated editor is selected. The behavior will align with the v1 designer experience.