### PR TITLE
Fix(Data Mapper): Disabling context menu as it causes app to crash

### DIFF
--- a/libs/data-mapper/src/lib/components/edge/ConnectionEdge.tsx
+++ b/libs/data-mapper/src/lib/components/edge/ConnectionEdge.tsx
@@ -1,9 +1,4 @@
-import {
-  deleteCurrentlySelectedItem,
-  setCanvasToolboxTabToDisplay,
-  setInlineFunctionInputOutputKeys,
-  setSelectedItem,
-} from '../../core/state/DataMapSlice';
+import { setCanvasToolboxTabToDisplay, setInlineFunctionInputOutputKeys } from '../../core/state/DataMapSlice';
 import type { AppDispatch, RootState } from '../../core/state/Store';
 import { getSmoothStepEdge } from '../../utils/Edge.Utils';
 import {
@@ -16,8 +11,7 @@ import {
 import { ToolboxPanelTabs } from '../canvasToolbox/CanvasToolbox';
 import { Button, Tooltip, makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import { Add20Filled } from '@fluentui/react-icons';
-import { CardContextMenu, useCardContextMenu } from '@microsoft/designer-ui';
-import { DeleteMenuItem } from '@microsoft/logic-apps-designer';
+import { useCardContextMenu } from '@microsoft/designer-ui';
 import type React from 'react';
 import { useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -157,11 +151,6 @@ export const ConnectionEdge = (props: EdgeProps) => {
 
   const contextMenu = useCardContextMenu();
 
-  const handleDeleteClick = () => {
-    dispatch(setSelectedItem(id));
-    dispatch(deleteCurrentlySelectedItem());
-  };
-
   return (
     <svg onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)} onContextMenu={contextMenu.handle}>
       <BaseEdge
@@ -206,13 +195,6 @@ export const ConnectionEdge = (props: EdgeProps) => {
           </Tooltip>
         ) : null}
       </foreignObject>
-      <CardContextMenu
-        title={'Delete'}
-        contextMenuLocation={contextMenu.location}
-        menuItems={[<DeleteMenuItem key="delete" onClick={handleDeleteClick} />]}
-        open={contextMenu.isShowing}
-        setOpen={contextMenu.setIsShowing}
-      />
     </svg>
   );
 };

--- a/libs/data-mapper/src/lib/components/nodeCard/functionCard/ExpandedFunctionCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/functionCard/ExpandedFunctionCard.tsx
@@ -1,6 +1,6 @@
 import { expandedFunctionCardMaxWidth } from '../../../constants/NodeConstants';
 import { customTokens } from '../../../core';
-import { deleteCurrentlySelectedItem, setSelectedItem } from '../../../core/state/DataMapSlice';
+// import { deleteCurrentlySelectedItem, setSelectedItem } from '../../../core/state/DataMapSlice';
 import type { RootState } from '../../../core/state/Store';
 import { generateInputHandleId } from '../../../utils/Connection.Utils';
 import { hasOnlyCustomInputType } from '../../../utils/Function.Utils';
@@ -13,10 +13,10 @@ import { inputsValid, useFunctionCardStyles } from './FunctionCard';
 import { Stack, StackItem } from '@fluentui/react';
 import { Button, Divider, PresenceBadge, Text, Tooltip, mergeClasses, tokens } from '@fluentui/react-components';
 import { useBoolean } from '@fluentui/react-hooks';
-import { CardContextMenu, useCardContextMenu } from '@microsoft/designer-ui';
-import { DeleteMenuItem } from '@microsoft/logic-apps-designer';
+import { useCardContextMenu } from '@microsoft/designer-ui';
+//import { DeleteMenuItem } from '@microsoft/logic-apps-designer';
 import { useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import type { NodeProps } from 'reactflow';
 import { Handle, Position } from 'reactflow';
 
@@ -24,7 +24,6 @@ export const ExpandedFunctionCard = (props: NodeProps<FunctionCardProps>) => {
   const { functionData, functionBranding, dataTestId } = props.data;
   const reactFlowId = props.id;
 
-  const dispatch = useDispatch();
   const classes = useFunctionCardStyles();
 
   const selectedItemKey = useSelector((state: RootState) => state.dataMap.present.curDataMapOperation.selectedItemKey);
@@ -45,10 +44,10 @@ export const ExpandedFunctionCard = (props: NodeProps<FunctionCardProps>) => {
 
   const contextMenu = useCardContextMenu();
 
-  const handleDeleteClick = () => {
-    dispatch(setSelectedItem(reactFlowId));
-    dispatch(deleteCurrentlySelectedItem());
-  };
+  // const handleDeleteClick = () => {
+  //   dispatch(setSelectedItem(reactFlowId));
+  //   dispatch(deleteCurrentlySelectedItem());
+  // };
 
   const handleHeaderOnClick = () => {
     // Require a function to already be selected to be able to collapse
@@ -226,13 +225,13 @@ export const ExpandedFunctionCard = (props: NodeProps<FunctionCardProps>) => {
         ) : null}
       </div>
 
-      <CardContextMenu
+      {/* <CardContextMenu
         title={'Delete'}
         contextMenuLocation={contextMenu.location}
         menuItems={[<DeleteMenuItem key="delete" onClick={handleDeleteClick} />]}
         open={contextMenu.isShowing}
         setOpen={contextMenu.setIsShowing}
-      />
+      /> */}
     </div>
   );
 };

--- a/libs/data-mapper/src/lib/components/nodeCard/functionCard/SimpleFunctionCard.tsx
+++ b/libs/data-mapper/src/lib/components/nodeCard/functionCard/SimpleFunctionCard.tsx
@@ -1,6 +1,5 @@
 import { ReactFlowNodeType } from '../../../constants/ReactFlowConstants';
 import { customTokens } from '../../../core';
-import { deleteCurrentlySelectedItem, setSelectedItem } from '../../../core/state/DataMapSlice';
 import type { RootState } from '../../../core/state/Store';
 import { isNodeHighlighted } from '../../../utils/ReactFlow.Util';
 import { FunctionIcon } from '../../functionIcon/FunctionIcon';
@@ -9,10 +8,9 @@ import { errorCardStyles, getStylesForSharedState, highlightedCardStyles, select
 import type { FunctionCardProps } from './FunctionCard';
 import { inputsValid, shouldDisplaySourceHandle, shouldDisplayTargetHandle, useFunctionCardStyles } from './FunctionCard';
 import { Button, PresenceBadge, Text, Tooltip, mergeClasses, tokens } from '@fluentui/react-components';
-import { CardContextMenu, useCardContextMenu } from '@microsoft/designer-ui';
-import { DeleteMenuItem } from '@microsoft/logic-apps-designer';
+import { useCardContextMenu } from '@microsoft/designer-ui';
 import { useMemo, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import type { NodeProps } from 'reactflow';
 import { Position } from 'reactflow';
 
@@ -20,7 +18,6 @@ export const SimpleFunctionCard = (props: NodeProps<FunctionCardProps>) => {
   const { functionData, disabled, functionBranding, displayHandle, onClick, dataTestId } = props.data;
   const reactFlowId = props.id;
 
-  const dispatch = useDispatch();
   const classes = useFunctionCardStyles();
   const mergedClasses = mergeClasses(getStylesForSharedState().root, classes.root);
 
@@ -41,11 +38,6 @@ export const SimpleFunctionCard = (props: NodeProps<FunctionCardProps>) => {
   }, [isCurrentNodeSelected, reactFlowId, selectedItemConnectedNodes]);
 
   const contextMenu = useCardContextMenu();
-
-  const handleDeleteClick = () => {
-    dispatch(setSelectedItem(reactFlowId));
-    dispatch(deleteCurrentlySelectedItem());
-  };
 
   const displayTargetHandle = shouldDisplayTargetHandle(displayHandle, sourceNodeConnectionBeingDrawnFromId, reactFlowId, functionData);
   const displaySourceHandle = shouldDisplaySourceHandle(
@@ -122,13 +114,6 @@ export const SimpleFunctionCard = (props: NodeProps<FunctionCardProps>) => {
         shouldDisplay={displaySourceHandle}
         nodeReactFlowType={ReactFlowNodeType.FunctionNode}
         nodeReactFlowId={reactFlowId}
-      />
-      <CardContextMenu
-        title={'Delete'}
-        contextMenuLocation={contextMenu.location}
-        menuItems={[<DeleteMenuItem key="delete" onClick={handleDeleteClick} />]}
-        open={contextMenu.isShowing}
-        setOpen={contextMenu.setIsShowing}
       />
     </div>
   );


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
removing right click menu 
- **What is the current behavior?** (You can also link to an open issue here)
 Data Mapper crashes because it is using a shared component that references Designer state
- **What is the new behavior (if this is a feature change)?**
removing instead of fixing as DMV2 will not use the same context menu
does not block users, they can still delete using the delete key or from the function menu
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**:
