### PR TITLE
fix(designer): fix actions and triggers title not showing in dark theme

### DIFF
--- a/libs/designer-ui/src/lib/connectorsummarycard/connectorsummarycard.less
+++ b/libs/designer-ui/src/lib/connectorsummarycard/connectorsummarycard.less
@@ -89,4 +89,9 @@
       background: @ms-color-primaryBackgroundHover;
     }
   }
+
+  .msla-connector-summary-title {
+    color: @ms-color-black;
+  }
+  
 }

--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/operationSearchCard.less
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/operationSearchCard.less
@@ -73,5 +73,10 @@
     &:hover {
       background-color: @ms-color-primaryBackgroundHover;
     }
+    
+  }
+
+  .msla-op-search-card-name  {
+    color: @ms-color-black;
   }
 }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes/features)
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug
- **What is the current behavior?** (You can also link to an open issue here)
When designer is set to dark mode, triggers and actions title does not show
https://msazure.visualstudio.com/One/_workitems/edit/27320697
- **What is the new behavior (if this is a feature change)?**
Triggers and actions titles now shows when app is in dark mode
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
- **Please Include Screenshots or Videos of the intended change**:
<img width="462" alt="image" src="https://github.com/Azure/LogicAppsUX/assets/168464523/de6ad8e7-55f5-4e0e-9459-080f373c4353">
