### PR TITLE
fix(vscode): Update command to build all projects for extension

### DIFF
--- a/apps/vs-code-designer/package.json
+++ b/apps/vs-code-designer/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build:extension": "tsup && pnpm run copyFiles",
     "copyFiles": "node extension-copy-svgs.js",
-    "vscode:designer:pack": "pnpm run build:extension && pnpm run vscode:designer:pack:step1 && pnpm run vscode:designer:pack:step2",
+    "vscode:designer:pack": "pnpm -w run build:extension && pnpm run vscode:designer:pack:step1 && pnpm run vscode:designer:pack:step2",
     "vscode:designer:pack:step1": "cd ./dist && npm install",
     "vscode:designer:pack:step2": "cd ./dist && vsce package",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
This pull request includes a modification to the `vscode:designer:pack` script in the `apps/vs-code-designer/package.json` file. The change adds the `-w` option to the `pnpm` command in the script, which allows the command to run in the current workspace. This change ensures that the `build:extension` script is run in the correct context.