### PR TITLE
chore(meta): Update build dependency in turbo for vscode

### DIFF
--- a/apps/vs-code-designer/package.json
+++ b/apps/vs-code-designer/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build:extension": "tsup && pnpm run copyFiles",
     "copyFiles": "node extension-copy-svgs.js",
-    "vscode:designer:pack": "pnpm -w run build:extension && pnpm run vscode:designer:pack:step1 && pnpm run vscode:designer:pack:step2",
+    "vscode:designer:pack": "pnpm run vscode:designer:pack:step1 && pnpm run vscode:designer:pack:step2",
     "vscode:designer:pack:step1": "cd ./dist && npm install",
     "vscode:designer:pack:step2": "cd ./dist && vsce package",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,10 @@
             ]
         },
         "vscode-designer#build:extension": {
-            "cache": false
+            "cache": false,
+            "dependsOn": [
+                "build"
+            ]
         },
         "vscode-react#build:extension": {
             "cache": false,
@@ -60,7 +63,7 @@
         "vscode:designer:pack": {
             "cache": false,
             "dependsOn": [
-                "build"
+                "vscode-react#build:extension"
             ]
         }
     }


### PR DESCRIPTION
This pull request primarily focuses on improving the build process in the `vs-code-designer` and `turbo.json` files. The most important changes include modifying the `vscode:designer:pack` script in `package.json` and adding dependencies in `turbo.json`.


* The `vscode:designer:pack` script was modified. The `pnpm -w run build:extension` command was removed from the script, which now only runs `vscode:designer:pack:step1` and `vscode:designer:pack:step2`.


* The `vscode-designer#build:extension` task now depends on the `build` task.
* The `vscode:designer:pack` task now depends on the `vscode-react#build:extension` task instead of the `build` task.