### PR TITLE
chore(docs): Update vscode vsix path and add nvm installation guide

### DIFF
--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -14,6 +14,12 @@ Ensure you have the following installed on your system:
 - Node.js v18 or higher
 - PNPM 
 
+### Node Version Manager (NVM) Installation (Recommended)
+
+Check here for Windows setup and installation guide: [NVM for Windows installation](https://github.com/coreybutler/nvm-windows)
+
+Check here for MacOS and Linux setup and installation guide: [NVM for MacOS and Linux installation](https://github.com/nvm-sh/nvm)
+
 ### Pnpm CLI Installation (Recommended)
 
 Check here for system specific ways to install: [Pnpm installation](https://pnpm.io/installation)

--- a/apps/docs/docs/vscode.md
+++ b/apps/docs/docs/vscode.md
@@ -46,7 +46,7 @@ To build a private vsix from the compiled project, follow these steps:
 
 1.  Follow steps 1-3 from Run (Dev/Debug) section. This will compile the project and will update the latest changes for the vsix creation.
 2.  Run the following command: `npm run vscode:designer:pack` in the root folder. This will create a vsix file in `dist` root folder.
-3.  After running the command, you will see the following message: `Packaged: /<repo-path>/LogicAppsUX/dist/apps/vs-code-designer/vscode-azurelogicapps-<extension-version>.vsix` with the exact path where the vsix file is located.
+3.  After running the command, you will see the following message: `Packaged: /<repo-path>/LogicAppsUX/apps/vs-code-designer/dist/vscode-azurelogicapps-<extension-version>.vsix` with the exact path where the vsix file is located.
 
 ## App architecture
 


### PR DESCRIPTION
This pull request includes changes to the documentation files `intro.md` and `vscode.md` in the `apps/docs/docs` directory. The changes provide additional information on Node Version Manager (NVM) installation and correct the path for the vsix file location in the build instructions.

* Added a new section on Node Version Manager (NVM) installation, including links to setup and installation guides for Windows, MacOS, and Linux.
* Corrected the path for the vsix file location in the build instructions.