### PR TITLE
fix(designer-ui): Prevent padding on HTML toolbar from creating scrollbar

### DIFF
--- a/libs/designer-ui/src/lib/html/htmleditor.less
+++ b/libs/designer-ui/src/lib/html/htmleditor.less
@@ -2,12 +2,11 @@ div.msla-html-editor-toolbar {
   justify-content: space-between;
   margin-bottom: 1px;
   background: #fff;
-  padding: 4px;
+  padding: 2px 4px;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   overflow: auto;
   align-items: center;
-  height: 36px;
 
   .msla-html-editor-toolbar-group {
     display: flex;
@@ -208,7 +207,7 @@ img.chevron-down {
 }
 
 div.msla-toolbar-divider {
-  padding: 4px 8px;
+  padding: 4px 6px;
 }
 .msla-colorpicker-input-wrapper {
   display: flex;


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Power Automate side-panel uses a custom width which leads to the following behavior:

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/6874f929-33d6-4a6e-87e7-d45cabda41e9)

This is a cosmetic issue introduced by #4823.

- **What is the new behavior (if this is a feature change)?**

Padding adjustments now display this correctly:

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/503fd161-4f20-4090-a275-e4d3af45cbb3)

Validated that LAUX standalone panel renders correctly after changes also:

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/639a777e-d6ad-441d-9ad5-03e6c3bbe284)

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No