### PR TITLE
fix(vscode): Cast and uncast condition expression for unit test

### DIFF
--- a/libs/designer-ui/src/lib/expressioneditor/index.tsx
+++ b/libs/designer-ui/src/lib/expressioneditor/index.tsx
@@ -25,6 +25,7 @@ export interface ExpressionEditorProps {
   setExpressionEditorError: (error: string) => void;
   onFocus?: () => void;
   onContentChanged?(e: EditorContentChangedEventArgs): void;
+  isReadOnly?: boolean;
 }
 
 export function ExpressionEditor({
@@ -40,6 +41,7 @@ export function ExpressionEditor({
   setIsDragging,
   setExpressionEditorError,
   onContentChanged,
+  isReadOnly = false,
 }: ExpressionEditorProps): JSX.Element {
   const [mouseDownLocation, setMouseDownLocation] = useState(0);
   const [heightOnMouseDown, setHeightOnMouseDown] = useState(0);
@@ -89,6 +91,7 @@ export function ExpressionEditor({
         automaticLayout={true}
         data-automation-id="msla-expression-editor"
         height={`${currentHeight}px`}
+        readOnly={isReadOnly}
       />
       <div
         className="msla-expression-editor-expand"

--- a/libs/designer-ui/src/lib/unitTesting/assertionsPanel/assertion.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/assertionsPanel/assertion.tsx
@@ -36,7 +36,8 @@ export type GetConditionExpressionHandler = (
   labelId: string,
   initialValue: string,
   type: string,
-  onChange: (value: string) => void
+  onChange: (value: string) => void,
+  isReadOnly: boolean
 ) => JSX.Element;
 
 export interface AssertionProps {

--- a/libs/designer-ui/src/lib/unitTesting/assertionsPanel/assertionField.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/assertionsPanel/assertionField.tsx
@@ -131,7 +131,8 @@ export const AssertionField = ({
     parameterDetails.expression,
     expression,
     constants.SWAGGER.TYPE.ANY,
-    onExpressionChange
+    onExpressionChange,
+    !isEditable
   );
 
   return (

--- a/libs/designer-ui/src/lib/unitTesting/conditionExpression/index.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/conditionExpression/index.tsx
@@ -22,6 +22,7 @@ export interface ConditionExpressionProps {
   filteredTokenGroup?: TokenGroup[];
   expressionGroup?: TokenGroup[];
   onChange: (value: string) => void;
+  isReadOnly: boolean;
 }
 
 export function ConditionExpression({
@@ -33,6 +34,7 @@ export function ConditionExpression({
   expressionGroup,
   getValueSegmentFromToken,
   onChange,
+  isReadOnly,
 }: ConditionExpressionProps): JSX.Element {
   const intl = useIntl();
   const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
@@ -115,8 +117,6 @@ export function ConditionExpression({
     onChange(e.value ?? '');
   };
 
-  // Pending things to do
-  // 2.- z-index
   return (
     <>
       <div
@@ -138,9 +138,10 @@ export function ConditionExpression({
           hideUTFExpressions={false}
           onFocus={handleFocusExpression}
           onContentChanged={onContentChanged}
+          isReadOnly={isReadOnly}
         />
       </div>
-      {isCalloutVisible && (
+      {isCalloutVisible && !isReadOnly && (
         <Callout
           role="dialog"
           ariaLabelledBy={labelId}

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -11,6 +11,7 @@ import type { WorkflowParameterDefinition } from '../../state/workflowparameters
 import type { RootState } from '../../store';
 import { getNode, getTriggerNodeId, isRootNode, isRootNodeInGraph } from '../../utils/graph';
 import {
+  castValueSegments,
   encodePathValue,
   getAndEscapeSegment,
   getEncodeValue,
@@ -57,7 +58,7 @@ import {
   getRecordEntry,
 } from '@microsoft/logic-apps-shared';
 import type { ParameterInfo } from '@microsoft/designer-ui';
-import { UIConstants } from '@microsoft/designer-ui';
+import { TokenType, UIConstants } from '@microsoft/designer-ui';
 import type {
   Segment,
   LocationSwapMap,
@@ -71,6 +72,7 @@ import type {
   UnitTestDefinition,
 } from '@microsoft/logic-apps-shared';
 import merge from 'lodash.merge';
+import { createTokenValueSegment } from '../../../core';
 
 export interface SerializeOptions {
   skipValidation: boolean;
@@ -1098,8 +1100,14 @@ export const serializeUnitTestDefinition = async (rootState: RootState): Promise
 const getAssertions = (assertions: Record<string, AssertionDefintion>): Assertion[] => {
   return Object.values(assertions).map((assertion) => {
     const { name, description, assertionString } = assertion;
+    const assertionValueSegment = createTokenValueSegment(
+      { title: assertionString, key: assertionString, tokenType: TokenType.FX, type: Constants.SWAGGER.TYPE.STRING },
+      assertionString,
+      TokenType.FX
+    );
+    const castAsertionString = castValueSegments([assertionValueSegment], false, Constants.SWAGGER.TYPE.STRING, false);
 
-    return { name, description, assertionString: assertionString ?? '' };
+    return { name, description, assertionString: castAsertionString };
   });
 };
 

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -174,37 +174,6 @@ export const deserializeUnitTestDefinition = (
   assertions: Assertion[];
   mockResults: Record<string, OutputMock>;
 } | null => {
-  unitTestDefinition = {
-    triggerMocks: {
-      When_a_HTTP_request_is_received: {
-        properties: {
-          status: 'Succeeded',
-        },
-        outputs: {},
-      },
-    },
-    actionMocks: {
-      Create_or_update_a_resource_group: {
-        properties: {
-          status: 'Succeeded',
-        },
-        outputs: {},
-      },
-      HTTP: {
-        properties: {
-          status: 'Succeeded',
-        },
-        outputs: {},
-      },
-    },
-    assertions: [
-      {
-        name: 'New assertion',
-        description: '',
-        assertionString: "@equals('2','2')",
-      },
-    ],
-  };
   const { definition } = workflowDefinition;
   const actionsKeys = Object.keys(definition.actions ?? {});
   const triggersKeys = Object.keys(definition.triggers ?? {});

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -3445,8 +3445,25 @@ export function parameterValueToString(
 
     return encodePathValueWithFunction(fold(segmentValues, parameter.type) ?? '', parameter.info.encode);
   }
-
   const shouldInterpolate = value.length > 1;
+
+  return castValueSegments(segmentsAfterCasting, shouldInterpolate, parameterType, remappedParameterInfo.suppressCasting);
+}
+
+/**
+ * Casts the value segments after casting based on the provided parameters.
+ * @param {ValueSegment[]} segmentsAfterCasting - The value segments after casting.
+ * @param {boolean} shouldInterpolate - A boolean indicating whether interpolation should be performed.
+ * @param {string} parameterType - The type of the parameter.
+ * @param {boolean} suppressCasting - Optional. A boolean indicating whether casting should be suppressed.
+ * @returns The concatenated expression value.
+ */
+export const castValueSegments = (
+  segmentsAfterCasting: ValueSegment[],
+  shouldInterpolate: boolean,
+  parameterType: string,
+  suppressCasting?: boolean
+) => {
   return segmentsAfterCasting
     .map((segment) => {
       let expressionValue = segment.value;
@@ -3457,9 +3474,9 @@ export function parameterValueToString(
           // Note: Token segment should be auto casted using interpolation if token type is
           // non string and referred in a string parameter.
           expressionValue =
-            !remappedParameterInfo.suppressCasting &&
-            parameterType === 'string' &&
-            segment.token?.type !== 'string' &&
+            !suppressCasting &&
+            parameterType === constants.SWAGGER.TYPE.STRING &&
+            segment.token?.type !== constants.SWAGGER.TYPE.STRING &&
             !shouldUseLiteralValues(segment.token?.expression)
               ? `@{${expressionValue}}`
               : `@${expressionValue}`;
@@ -3469,7 +3486,7 @@ export function parameterValueToString(
       return expressionValue;
     })
     .join('');
-}
+};
 
 export function shouldUseLiteralValues(expression: Expression | undefined): boolean {
   return (expression?.type as ExpressionType) === ExpressionType.NullLiteral;

--- a/libs/designer/src/lib/ui/panel/assertionsPanel/assertionsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/assertionsPanel/assertionsPanel.tsx
@@ -157,7 +157,8 @@ const getConditionExpression = (
   type: string,
   tokenGroup: TokenGroup[],
   expressionGroup: TokenGroup[],
-  onChange: (value: string) => void
+  onChange: (value: string) => void,
+  isReadOnly: boolean
 ): JSX.Element => {
   const supportedTypes: string[] = getPropertyValue(Constants.TOKENS, type);
   const filteredTokens = tokenGroup.map((group) => ({
@@ -175,6 +176,7 @@ const getConditionExpression = (
       expressionGroup={expressionGroup}
       getValueSegmentFromToken={(token: OutputToken) => Promise.resolve(getValueSegmentFromToken(token))}
       onChange={onChange}
+      isReadOnly={isReadOnly}
     />
   );
 };
@@ -226,7 +228,7 @@ export const AssertionsPanel = (props: CommonPanelProps) => {
   };
 
   const getConditionExpressionHandler = useCallback(
-    (editorId: string, labelId: string, initialValue: string, type: string, onChange: (value: string) => void) => {
+    (editorId: string, labelId: string, initialValue: string, type: string, onChange: (value: string) => void, isReadOnly: boolean) => {
       return getConditionExpression(
         editorId,
         labelId,
@@ -234,7 +236,8 @@ export const AssertionsPanel = (props: CommonPanelProps) => {
         type,
         [...tokens.outputTokensWithValues, ...tokens.variableTokens],
         tokens.expressionTokens,
-        onChange
+        onChange,
+        isReadOnly
       );
     },
     [tokens]


### PR DESCRIPTION
This pull request primarily introduces read-only functionality to the ExpressionEditor and ConditionExpression components in the `libs/designer-ui` library. It also includes changes to the serialization and deserialization of unit test definitions, and to the parameter value conversion in the `libs/designer` library.

Read-only functionality:

* Added `isReadOnly` prop to `ExpressionEditorProps` and `ExpressionEditor` function. The `isReadOnly` prop is used to set the `readOnly` property of the editor component. 
* Added `isReadOnly` prop to `GetConditionExpressionHandler` and used it in `AssertionField`. 
* Added `isReadOnly` prop to `ConditionExpressionProps` and `ConditionExpression` function. The `isReadOnly` prop is used to control the visibility of the `Callout` component and the `readOnly` property of the editor component. 

* Modified `serializeUnitTestDefinition` to create a token value segment for the assertion string and cast it to the correct type. 
* Modified `deserializeUnitTestDefinition` to parse the assertion string as an expression function.
Parameter value conversion:

* Introduced `castValueSegments` function and used it in `parameterValueToString` to cast the value segments based on the provided parameters. 