### PR TITLE
fix(designer): `updateExistingInputTokenTitles` is not invoked when dynamic outputs load

### DIFF
--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -284,6 +284,8 @@ export const operationMetadataSlice = createSlice({
       if (outputParameters) {
         outputParameters.outputs = { ...outputParameters.outputs, ...outputs };
       }
+
+      updateExistingInputTokenTitles(state, action.payload);
     },
     clearDynamicIO: (state, action: PayloadAction<ClearDynamicIOPayload>) => {
       const { nodeId, nodeIds: _nodeIds, inputs = true, outputs = true } = action.payload;
@@ -540,33 +542,33 @@ export const operationMetadataSlice = createSlice({
       state.loadStatus.nodesInitialized = false;
       state.loadStatus.nodesAndDynamicDataInitialized = false;
     });
-    // updateExistingInputTokenTitles
-    builder.addCase(addDynamicOutputs, (state, action) => {
-      const { outputs } = action.payload;
+  },
+});
 
-      const tokenTitles: Record<string, string> = {};
-      for (const outputValue of Object.values(outputs)) {
-        tokenTitles[outputValue.key] = getTokenTitle(outputValue);
-      }
+const updateExistingInputTokenTitles = (state: OperationMetadataState, actionPayload: AddDynamicOutputsPayload) => {
+  const { outputs } = actionPayload;
 
-      Object.entries(state.inputParameters).forEach(([nodeId, nodeInputs]) => {
-        Object.entries(nodeInputs.parameterGroups).forEach(([parameterId, parameterGroup]) => {
-          parameterGroup.parameters.forEach((parameter, parameterIndex) => {
-            parameter.value.forEach((segment, segmentIndex) => {
-              if (isTokenValueSegment(segment) && segment.token?.key) {
-                const normalizedKey = normalizeKey(segment.token.key);
-                if (normalizedKey in tokenTitles) {
-                  state.inputParameters[nodeId].parameterGroups[parameterId].parameters[parameterIndex].value[segmentIndex] =
-                    createTokenValueSegment({ ...segment.token, title: tokenTitles[normalizedKey] }, segment.value, segment.type);
-                }
-              }
-            });
-          });
+  const tokenTitles: Record<string, string> = {};
+  for (const outputValue of Object.values(outputs)) {
+    tokenTitles[outputValue.key] = getTokenTitle(outputValue);
+  }
+
+  Object.entries(state.inputParameters).forEach(([nodeId, nodeInputs]) => {
+    Object.entries(nodeInputs.parameterGroups).forEach(([parameterId, parameterGroup]) => {
+      parameterGroup.parameters.forEach((parameter, parameterIndex) => {
+        parameter.value.forEach((segment, segmentIndex) => {
+          if (isTokenValueSegment(segment) && segment.token?.key) {
+            const normalizedKey = normalizeKey(segment.token.key);
+            if (normalizedKey in tokenTitles) {
+              state.inputParameters[nodeId].parameterGroups[parameterId].parameters[parameterIndex].value[segmentIndex] =
+                createTokenValueSegment({ ...segment.token, title: tokenTitles[normalizedKey] }, segment.value, segment.type);
+            }
+          }
         });
       });
     });
-  },
-});
+  });
+};
 
 // Action creators are generated for each case reducer function
 export const {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

The fix in #4215 (for issue #4132) was updated with the change in #4377, which allowed token titles to be set with a `dispatch` call. However, in #4483, this behavior was changed to use `builder.addCase`. Unfortunately, `builder.addCase` does not work for actions created within the same class it is called.

This means token titles are not being set:

![gibberish-broken](https://github.com/Azure/LogicAppsUX/assets/1350074/83a3538d-82fa-4c23-ae53-4048ff99992e)

- **What is the new behavior (if this is a feature change)?**

This PR calls `updateExistingInputTokenTitles` directly from `addDynamicOutputs` instead of relying on `builder.addCase`.

This ensures that token titles are properly set:

![gibberish-fix](https://github.com/Azure/LogicAppsUX/assets/1350074/8ca65741-1135-4614-8ce7-63f96e87d881)

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No