### PR TITLE
fix(designer-ui): Allow color picker sliders to be accessed by keyboard

### DIFF
--- a/libs/designer-ui/src/lib/html/plugins/toolbar/DropdownColorPicker.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/DropdownColorPicker.tsx
@@ -92,7 +92,6 @@ export const DropdownColorPicker = ({
   }, [exposedColor, selfColor, setExposedColor]);
 
   useEffect(() => {
-    console.log(exposedColor);
     onChange(exposedColor.hex);
   }, [exposedColor, onChange]);
 

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/DropdownColorPicker.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/DropdownColorPicker.tsx
@@ -9,6 +9,7 @@ import { transformColor } from '@microsoft/logic-apps-shared';
 import type { LexicalEditor } from 'lexical';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import constants from '../../../constants';
+import { useDebouncedState } from '@react-hookz/web';
 
 interface DropdownColorPickerProps {
   disabled?: boolean;
@@ -17,7 +18,7 @@ interface DropdownColorPickerProps {
   buttonIconSrc?: string;
   buttonLabel?: string;
   color: string;
-  onChange?: (color: string) => void;
+  onChange: (color: string) => void;
   title?: string;
   editor: LexicalEditor;
 }
@@ -34,6 +35,7 @@ export const DropdownColorPicker = ({
   const { isInverted } = useTheme();
   const [selfColor, setSelfColor] = useState(transformColor('hex', color));
   const [inputColor, setInputColor] = useState(color);
+  const [exposedColor, setExposedColor] = useDebouncedState(selfColor, 300);
   const innerDivRef = useRef(null);
 
   const arrowNavigationAttributes = useArrowNavigationGroup({ axis: 'horizontal', circular: true });
@@ -81,11 +83,18 @@ export const DropdownColorPicker = ({
 
   useEffect(() => {
     // Check if the dropdown is actually active
-    if (innerDivRef.current !== null && onChange) {
-      onChange(selfColor.hex);
+    if (innerDivRef.current !== null) {
+      if (exposedColor.hex !== selfColor.hex) {
+        setExposedColor(selfColor);
+      }
       setInputColor(selfColor.hex);
     }
-  }, [selfColor, onChange]);
+  }, [exposedColor, selfColor, setExposedColor]);
+
+  useEffect(() => {
+    console.log(exposedColor);
+    onChange(exposedColor.hex);
+  }, [exposedColor, onChange]);
 
   useEffect(() => {
     if (color === undefined) {
@@ -131,11 +140,7 @@ export const DropdownColorPicker = ({
             }}
           />
         </MoveWrapper>
-        <MoveWrapper
-          className="color-picker-hue"
-          onChange={onMoveHue}
-          value={{ ...huePosition, y: 0 }}
-        >
+        <MoveWrapper className="color-picker-hue" onChange={onMoveHue} value={{ ...huePosition, y: 0 }}>
           <div
             className="color-picker-hue_cursor"
             style={{

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/DropdownColorPicker.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/DropdownColorPicker.tsx
@@ -120,6 +120,7 @@ export const DropdownColorPicker = ({
           className="color-picker-saturation"
           style={{ backgroundColor: `hsl(${selfColor.hsv.hue}, 100%, 50%)` }}
           onChange={onMoveSaturation}
+          value={saturationPosition}
         >
           <div
             className="color-picker-saturation_cursor"
@@ -130,7 +131,11 @@ export const DropdownColorPicker = ({
             }}
           />
         </MoveWrapper>
-        <MoveWrapper className="color-picker-hue" onChange={onMoveHue}>
+        <MoveWrapper
+          className="color-picker-hue"
+          onChange={onMoveHue}
+          value={{ ...huePosition, y: 0 }}
+        >
           <div
             className="color-picker-hue_cursor"
             style={{


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix (a11y)

- **What is the current behavior?** (You can also link to an open issue here)

Color picker hex field and palette buttons can be accessed by keyboard, but the two sliders cannot.

- **What is the new behavior (if this is a feature change)?**

All fields of the color picker can now be accessed by keyboard, and controlled using arrow keys (and optionally +shift to move a larger distance at once).

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

![picker-all-fields](https://github.com/Azure/LogicAppsUX/assets/1350074/ec7d734f-9b58-4a5f-9f28-7776b9591c71)