### PR TITLE
fix(designer): Fixed request locale not respecting portal language settings

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/HttpClient.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/HttpClient.ts
@@ -6,8 +6,8 @@ import axiosRetry from 'axios-retry';
 export class HttpClient implements IHttpClient {
   private _extraHeaders: Record<string, any>;
 
-  constructor() {
-    this._extraHeaders = getExtraHeaders();
+  constructor(language?: string) {
+    this._extraHeaders = getExtraHeaders(language);
     axiosRetry(axios, { retries: 3 });
   }
 
@@ -109,9 +109,10 @@ export function isSuccessResponse(statusCode: number): boolean {
   return statusCode >= 200 && statusCode <= 299;
 }
 
-export function getExtraHeaders(): Record<string, string> {
+export function getExtraHeaders(language?: string): Record<string, string> {
   return {
     'x-ms-user-agent': 'LogicAppsDesigner/(host localdesigner)',
+    ...(language ? { 'Accept-Language': language } : {}),
   };
 }
 

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -61,7 +61,6 @@ import type { QueryClient } from '@tanstack/react-query';
 import { useDispatch, useSelector } from 'react-redux';
 
 const apiVersion = '2020-06-01';
-const httpClient = new HttpClient();
 
 const DesignerEditor = () => {
   const { id: workflowId } = useSelector((state: RootState) => ({
@@ -171,10 +170,11 @@ const DesignerEditor = () => {
         objectId,
         canonicalLocation,
         queryClient,
-        dispatch
+        dispatch,
+        language
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [workflow, workflowId, connectionsData, settingsData, workflowAppData, tenantId, designerID, runId]
+    [workflow, workflowId, connectionsData, settingsData, workflowAppData, tenantId, designerID, runId, language]
   );
 
   // Our iframe root element is given a strange padding (not in this repo), this removes it
@@ -371,7 +371,8 @@ const getDesignerServices = (
   objectId: string | undefined,
   location: string,
   queryClient: QueryClient,
-  dispatch: AppDispatch
+  dispatch: AppDispatch,
+  language?: string
 ): any => {
   const siteResourceId = new ArmParser(workflowId).topmostResourceId;
   const armUrl = 'https://management.azure.com';
@@ -380,6 +381,8 @@ const getDesignerServices = (
   const workflowIdWithHostRuntime = `${siteResourceId}/hostruntime/runtime/webhooks/workflow/api/management/workflows/${workflowName}`;
   const appName = siteResourceId.split('/').splice(-1)[0];
   const { subscriptionId, resourceGroup } = new ArmParser(workflowId);
+
+  const httpClient = new HttpClient(language);
 
   const defaultServiceParams = { baseUrl, httpClient, apiVersion };
   const armServiceParams = {

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
@@ -49,7 +49,6 @@ import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 const apiVersion = '2020-06-01';
-const httpClient = new HttpClient();
 
 const DesignerEditorConsumption = () => {
   const dispatch = useDispatch<AppDispatch>();
@@ -114,9 +113,9 @@ const DesignerEditorConsumption = () => {
   };
   const canonicalLocation = WorkflowUtility.convertToCanonicalFormat(workflowAndArtifactsData?.location ?? '');
   const services = React.useMemo(
-    () => getDesignerServices(workflowId, workflow as any, tenantId, objectId, canonicalLocation, undefined, queryClient),
+    () => getDesignerServices(workflowId, workflow as any, tenantId, objectId, canonicalLocation, undefined, queryClient, language),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [workflowId, workflow, tenantId, canonicalLocation, designerID]
+    [workflowId, workflow, tenantId, canonicalLocation, designerID, language]
   );
 
   const [parsedDefinition, setParsedDefinition] = React.useState<any>(undefined);
@@ -278,11 +277,14 @@ const getDesignerServices = (
   objectId: string | undefined,
   location: string,
   loggerService?: any,
-  queryClient?: any
+  queryClient?: any,
+  language = 'en'
 ): any => {
   const baseUrl = 'https://management.azure.com';
   const workflowName = workflowId.split('/').splice(-1)[0];
   const { subscriptionId, resourceGroup } = new ArmParser(workflowId);
+
+  const httpClient = new HttpClient(language);
 
   const defaultServiceParams = { baseUrl, httpClient, apiVersion };
 

--- a/apps/Standalone/src/designer/components/LocalizationSettings.tsx
+++ b/apps/Standalone/src/designer/components/LocalizationSettings.tsx
@@ -18,7 +18,7 @@ export const LocalizationSettings = () => {
           text: 'English',
         },
         {
-          key: 'zh',
+          key: 'zh-hant',
           text: 'Chinese',
         },
         {


### PR DESCRIPTION
Fixed issue where our api calls were not respecting the selected language settings of portal.
If the user had their language set to chinese for example, their requests would not have the proper header and return results in english, when it should be requested with chinese headers.

Fixes: https://github.com/Azure/LogicAppsUX/issues/4885 