### PR TITLE
fix(Designer): Fixed search locale not respecting portal language settings

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -170,11 +170,12 @@ const DesignerEditor = () => {
         tenantId,
         objectId,
         canonicalLocation,
+        language,
         queryClient,
         dispatch
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [workflow, workflowId, connectionsData, settingsData, workflowAppData, tenantId, designerID, runId]
+    [workflow, workflowId, connectionsData, settingsData, workflowAppData, tenantId, designerID, runId, language]
   );
 
   // Our iframe root element is given a strange padding (not in this repo), this removes it
@@ -370,6 +371,7 @@ const getDesignerServices = (
   tenantId: string | undefined,
   objectId: string | undefined,
   location: string,
+  locale: string | undefined,
   queryClient: QueryClient,
   dispatch: AppDispatch
 ): any => {
@@ -520,6 +522,7 @@ const getDesignerServices = (
     },
     showStatefulOperations: isStateful,
     isDev: false,
+    locale,
   });
 
   const oAuthService = new StandaloneOAuthService({

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
@@ -114,9 +114,9 @@ const DesignerEditorConsumption = () => {
   };
   const canonicalLocation = WorkflowUtility.convertToCanonicalFormat(workflowAndArtifactsData?.location ?? '');
   const services = React.useMemo(
-    () => getDesignerServices(workflowId, workflow as any, tenantId, objectId, canonicalLocation, undefined, queryClient),
+    () => getDesignerServices(workflowId, workflow as any, tenantId, objectId, canonicalLocation, language, undefined, queryClient),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [workflowId, workflow, tenantId, canonicalLocation, designerID]
+    [workflowId, workflow, tenantId, canonicalLocation, designerID, language]
   );
 
   const [parsedDefinition, setParsedDefinition] = React.useState<any>(undefined);
@@ -277,6 +277,7 @@ const getDesignerServices = (
   tenantId: string | undefined,
   objectId: string | undefined,
   location: string,
+  locale: string | undefined,
   loggerService?: any,
   queryClient?: any
 ): any => {
@@ -406,6 +407,7 @@ const getDesignerServices = (
       location,
     },
     isDev: false,
+    locale,
   });
 
   const oAuthService = new StandaloneOAuthService({

--- a/apps/Standalone/src/designer/components/LocalizationSettings.tsx
+++ b/apps/Standalone/src/designer/components/LocalizationSettings.tsx
@@ -18,7 +18,7 @@ export const LocalizationSettings = () => {
           text: 'English',
         },
         {
-          key: 'zh',
+          key: 'zh-hant',
           text: 'Chinese',
         },
         {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
@@ -29,6 +29,7 @@ export interface BaseSearchServiceOptions {
   };
   httpClient: IHttpClient;
   isDev?: boolean;
+  locale?: string;
 }
 
 const ISE_RESOURCE_ID = 'properties/integrationServiceEnvironmentResourceId';
@@ -64,7 +65,7 @@ export abstract class BaseSearchService implements ISearchService {
       return { value: [], hasMore: false };
     }
 
-    const { httpClient } = this.options;
+    const { httpClient, locale } = this.options;
 
     const queryParameters: QueryParameters = {
       $top: pageSize.toString(),
@@ -72,8 +73,10 @@ export abstract class BaseSearchService implements ISearchService {
       ...queryParams,
     };
 
+    const headers = locale ? { 'Accept-Language': locale } : undefined;
+
     try {
-      const { nextLink, value = [] } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri, queryParameters });
+      const { nextLink, value = [] } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri, queryParameters, headers });
       return { value, hasMore: !!nextLink };
     } catch (error) {
       return { value: [], hasMore: false };
@@ -81,11 +84,13 @@ export abstract class BaseSearchService implements ISearchService {
   }
 
   async getAzureResourceRecursive(uri: string, queryParams: any): Promise<any[]> {
-    const { httpClient } = this.options;
+    const { httpClient, locale } = this.options;
+
+    const headers = locale ? { 'Accept-Language': locale } : undefined;
 
     const requestPage = async (uri: string, value: any[], queryParameters?: any): Promise<any> => {
       try {
-        const { nextLink, value: newValue } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri, queryParameters });
+        const { nextLink, value: newValue } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri, queryParameters, headers });
         value.push(...newValue);
         if (nextLink) {
           return await requestPage(nextLink, value);
@@ -261,10 +266,12 @@ export abstract class BaseSearchService implements ISearchService {
     const {
       httpClient,
       apiHubServiceDetails: { apiVersion },
+      locale,
     } = this.options;
     const uri = `${workflowId}/triggers`;
     const queryParameters: QueryParameters = { 'api-version': apiVersion };
-    const response = await httpClient.get<any>({ uri, queryParameters });
+    const headers = locale ? { 'Accept-Language': locale } : undefined;
+    const response = await httpClient.get<any>({ uri, queryParameters, headers });
     return response?.value ?? [];
   }
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/search.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/search.ts
@@ -162,12 +162,14 @@ export class ConsumptionSearchService extends BaseSearchService {
       const {
         httpClient,
         apiHubServiceDetails: { apiVersion, subscriptionId, location },
+        locale,
       } = this.options;
       const filter = `$filter=${ISE_RESOURCE_ID} eq null`;
       const startUri = `/subscriptions/${subscriptionId}/providers/Microsoft.Web/customApis?api-version=${apiVersion}`;
       const uri = `${prevNextlink ?? startUri}&${filter}`;
+      const headers = locale ? { 'Accept-Language': locale } : undefined;
 
-      const { nextLink, value } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri });
+      const { nextLink, value } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri, headers });
       const filteredValue = value
         .filter((connector) => connector.properties?.supportedConnectionKinds?.includes('V1'))
         .filter((connector) => connector?.location === location);

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/search.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/search.ts
@@ -48,13 +48,14 @@ export class StandardSearchService extends BaseSearchService {
     if (this._isDev) {
       return Promise.resolve([...almostAllBuiltInOperations, ...getClientBuiltInOperations(filterOperation)]);
     }
-    const { apiVersion, baseUrl, httpClient, showStatefulOperations } = this.options;
+    const { apiVersion, baseUrl, httpClient, showStatefulOperations, locale } = this.options;
     const uri = `${baseUrl}/operations`;
     const queryParameters: QueryParameters = {
       'api-version': apiVersion,
       workflowKind: showStatefulOperations ? 'Stateful' : 'Stateless',
     };
-    const response = await httpClient.get<AzureOperationsFetchResponse>({ uri, queryParameters });
+    const headers = locale ? { 'Accept-Language': locale } : undefined;
+    const response = await httpClient.get<AzureOperationsFetchResponse>({ uri, queryParameters, headers });
     const isAzureConnectorsEnabled = this.options.apiHubServiceDetails.subscriptionId !== undefined;
     const filteredApiOperations = isAzureConnectorsEnabled ? response.value : filterAzureConnection(response.value);
 
@@ -104,12 +105,14 @@ export class StandardSearchService extends BaseSearchService {
       const {
         httpClient,
         apiHubServiceDetails: { apiVersion, subscriptionId, location },
+        locale,
       } = this.options;
       const filter = `$filter=${ISE_RESOURCE_ID} eq null`;
       const startUri = `/subscriptions/${subscriptionId}/providers/Microsoft.Web/customApis?api-version=${apiVersion}`;
       const uri = `${prevNextlink ?? startUri}&${filter}`;
+      const headers = locale ? { 'Accept-Language': locale } : undefined;
 
-      const { nextLink, value } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri });
+      const { nextLink, value } = await httpClient.get<ContinuationTokenResponse<any[]>>({ uri, headers });
       const filteredValue = value
         .filter((connector) => connector.properties?.supportedConnectionKinds?.includes('V2'))
         .filter((connector) => connector?.location === location);
@@ -125,12 +128,13 @@ export class StandardSearchService extends BaseSearchService {
     if (this._isDev) {
       return Promise.resolve([...connectorsSearchResultsMock, ...getClientBuiltInConnectors(filterConnector)]);
     }
-    const { apiVersion, baseUrl, httpClient } = this.options;
+    const { apiVersion, baseUrl, httpClient, locale } = this.options;
     const uri = `${baseUrl}/operationGroups`;
     const queryParameters: QueryParameters = {
       'api-version': apiVersion,
     };
-    const response = await httpClient.get<{ value: Connector[] }>({ uri, queryParameters });
+    const headers = locale ? { 'Accept-Language': locale } : undefined;
+    const response = await httpClient.get<{ value: Connector[] }>({ uri, queryParameters, headers });
     const isAzureConnectorsEnabled = this.options.apiHubServiceDetails.subscriptionId !== undefined;
     const filteredApiConnectors = isAzureConnectorsEnabled ? response.value : filterAzureConnection(response.value);
 


### PR DESCRIPTION
Fixed issue where our api calls were not respecting the selected language settings of portal.
If the user had their language set to chinese for example, their requests would not have the proper header and return results in english, when it should be requested with chinese headers.

I added the missing header to only our search requests.

Fixes https://github.com/Azure/LogicAppsUX/issues/4885 

![image](https://github.com/Azure/LogicAppsUX/assets/25409734/ab58d74f-7724-4364-815c-b09de72f12f8)

