### PR TITLE
fix(designer): Turn off spell check in editors

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -184,6 +184,7 @@ export const BaseEditor = ({
         <TextPlugin
           contentEditable={
             <ContentEditable
+              spellCheck={false}
               className={css('editor-input', readonly && 'readonly')}
               ariaLabelledBy={labelId}
               ariaDescribedBy={id}


### PR DESCRIPTION
This pull request includes a change to the `BaseEditor` component in the `libs/designer-ui/src/lib/editor/base/index.tsx` file. The `spellCheck` attribute has been added to the `ContentEditable` component and set to `false`. This change will prevent the browser from checking the spelling within the `ContentEditable` component.

fixes #4861