### PR TITLE
fix(vscode): Update asssertions redux actions

### DIFF
--- a/libs/designer/src/lib/core/state/unitTest/unitTestInterfaces.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestInterfaces.ts
@@ -37,6 +37,11 @@ export interface UpdateAssertionPayload {
   assertionToUpdate: AssertionDefintion;
 }
 
+export interface UpdateAssertioExpressionPayload {
+  id: string;
+  assertionString: string;
+}
+
 export interface UnitTestState {
   mockResults: Record<string, OutputMock>;
   assertions: Record<string, AssertionDefintion>;

--- a/libs/designer/src/lib/core/state/unitTest/unitTestInterfaces.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestInterfaces.ts
@@ -25,8 +25,8 @@ export interface InitDefintionPayload {
   mockResults: Record<string, OutputMock>;
 }
 
-export interface UpdateAssertionsPayload {
-  assertions: Record<string, AssertionDefintion>;
+export interface AddAssertionPayload {
+  assertion: AssertionDefintion;
 }
 
 export interface DeleteAssertionsPayload {

--- a/libs/designer/src/lib/core/state/unitTest/unitTestSlice.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestSlice.ts
@@ -7,6 +7,7 @@ import type {
   UnitTestState,
   updateMockResultPayload,
   DeleteAssertionsPayload,
+  UpdateAssertioExpressionPayload,
 } from './unitTestInterfaces';
 import { ActionResults } from '@microsoft/designer-ui';
 import {
@@ -161,6 +162,29 @@ export const unitTestSlice = createSlice({
         delete state.validationErrors.assertions[assertionId];
       }
     },
+    updateAssertionExpression: (state: UnitTestState, action: PayloadAction<UpdateAssertioExpressionPayload>) => {
+      const { id, assertionString } = action.payload;
+      const validationErrors = {
+        expression: validateAssertion(id, { expression: assertionString }, 'expression', state.assertions),
+      };
+      state.assertions[id] = {
+        ...state.assertions[id],
+        assertionString,
+      };
+
+      const newErrorObj = {
+        ...(getRecordEntry(state.validationErrors.assertions, id) ?? {}),
+        ...validationErrors,
+      };
+      if (!newErrorObj.expression) {
+        delete newErrorObj.expression;
+      }
+      if (Object.keys(newErrorObj).length === 0) {
+        delete state.validationErrors.assertions[id];
+      } else {
+        state.validationErrors.assertions[id] = newErrorObj;
+      }
+    },
     updateAssertion: (state: UnitTestState, action: PayloadAction<UpdateAssertionPayload>) => {
       const { assertionToUpdate } = action.payload;
       const { name, id, description, assertionString } = assertionToUpdate;
@@ -193,7 +217,14 @@ export const unitTestSlice = createSlice({
   },
 });
 
-export const { updateAssertions, deleteAssertion, updateAssertion, initUnitTestDefinition, updateMock, updateActionResult } =
-  unitTestSlice.actions;
+export const {
+  updateAssertions,
+  deleteAssertion,
+  updateAssertion,
+  updateAssertionExpression,
+  initUnitTestDefinition,
+  updateMock,
+  updateActionResult,
+} = unitTestSlice.actions;
 
 export default unitTestSlice.reducer;

--- a/libs/designer/src/lib/ui/panel/assertionsPanel/assertionsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/assertionsPanel/assertionsPanel.tsx
@@ -4,7 +4,7 @@ import { Constants } from '../../..';
 import { getTriggerNodeId } from '../../../core';
 import type { VariableDeclaration } from '../../../core/state/tokens/tokensSlice';
 import { useAssertions, useAssertionsValidationErrors } from '../../../core/state/unitTest/unitTestSelectors';
-import { updateAssertions, updateAssertion, deleteAssertion } from '../../../core/state/unitTest/unitTestSlice';
+import { updateAssertions, updateAssertion, deleteAssertion, updateAssertionExpression } from '../../../core/state/unitTest/unitTestSlice';
 import type { AppDispatch, RootState } from '../../../core/store';
 import {
   VariableBrandColor,
@@ -229,14 +229,6 @@ export const AssertionsPanel = (props: CommonPanelProps) => {
 
   const getConditionExpressionHandler = useCallback(
     (editorId: string, labelId: string, assertionId: string, initialValue: string, type: string, isReadOnly: boolean) => {
-      const onExpressionAssertionUpdate = (assertionId: string, assertionString: string) => {
-        const newAssertions = { ...assertions };
-        const assertionToUpdate = { ...newAssertions[assertionId], assertionString };
-        dispatch(updateAssertion({ assertionToUpdate }));
-        newAssertions[assertionId] = assertionToUpdate;
-        setAssertions(newAssertions);
-      };
-
       return getConditionExpression(
         editorId,
         labelId,
@@ -245,12 +237,12 @@ export const AssertionsPanel = (props: CommonPanelProps) => {
         [...tokens.outputTokensWithValues, ...tokens.variableTokens],
         tokens.expressionTokens,
         (value) => {
-          onExpressionAssertionUpdate(assertionId, value);
+          dispatch(updateAssertionExpression({ id: assertionId, assertionString: value }));
         },
         isReadOnly
       );
     },
-    [assertions, dispatch, tokens.expressionTokens, tokens.outputTokensWithValues, tokens.variableTokens]
+    [dispatch, tokens.expressionTokens, tokens.outputTokensWithValues, tokens.variableTokens]
   );
 
   return (

--- a/libs/designer/src/lib/ui/panel/assertionsPanel/assertionsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/assertionsPanel/assertionsPanel.tsx
@@ -1,10 +1,9 @@
-import type { AssertionDefintion } from '@microsoft/logic-apps-shared';
 import { aggregate, getIntl, getPropertyValue, guid, labelCase } from '@microsoft/logic-apps-shared';
 import { Constants } from '../../..';
 import { getTriggerNodeId } from '../../../core';
 import type { VariableDeclaration } from '../../../core/state/tokens/tokensSlice';
 import { useAssertions, useAssertionsValidationErrors } from '../../../core/state/unitTest/unitTestSelectors';
-import { updateAssertions, updateAssertion, deleteAssertion, updateAssertionExpression } from '../../../core/state/unitTest/unitTestSlice';
+import { addAssertion, updateAssertion, deleteAssertion, updateAssertionExpression } from '../../../core/state/unitTest/unitTestSlice';
 import type { AppDispatch, RootState } from '../../../core/store';
 import {
   VariableBrandColor,
@@ -27,7 +26,7 @@ import {
   ValueSegmentType,
   ConditionExpression,
 } from '@microsoft/designer-ui';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 const getVariableTokens = (variables: Record<string, VariableDeclaration[]>): OutputToken[] => {
@@ -182,8 +181,7 @@ const getConditionExpression = (
 };
 
 export const AssertionsPanel = (props: CommonPanelProps) => {
-  const workflowAssertions = useAssertions();
-  const [assertions, setAssertions] = useState<Record<string, AssertionDefintion>>(workflowAssertions);
+  const assertions = useAssertions();
   const assertionsValidationErrors = useAssertionsValidationErrors();
 
   const dispatch = useDispatch<AppDispatch>();
@@ -195,9 +193,6 @@ export const AssertionsPanel = (props: CommonPanelProps) => {
 
   const onAssertionDelete = (event: AssertionDeleteEvent) => {
     const { id } = event;
-    const newAssertions = { ...assertions };
-    delete newAssertions[id];
-    setAssertions(newAssertions);
     dispatch(deleteAssertion({ assertionId: id }));
   };
 
@@ -205,26 +200,18 @@ export const AssertionsPanel = (props: CommonPanelProps) => {
     const { name, description, id, assertionString, isEditable } = event;
     const assertionToUpdate = { name, description, id, assertionString, isEditable };
     dispatch(updateAssertion({ assertionToUpdate }));
-
-    const newAssertions = { ...assertions };
-    newAssertions[id] = assertionToUpdate;
-    setAssertions(newAssertions);
   };
 
   const onAssertionAdd = (event: AssertionAddEvent) => {
     const id = guid();
-    const newAssertions = {
-      ...assertions,
-      [id]: {
-        id: id,
-        name: event.name,
-        isEditable: true,
-        description: event.description,
-        assertionString: event.assertionString,
-      },
+    const newAssertion = {
+      id: id,
+      name: event.name,
+      isEditable: true,
+      description: event.description,
+      assertionString: event.assertionString,
     };
-    setAssertions(newAssertions);
-    dispatch(updateAssertions({ assertions: newAssertions }));
+    dispatch(addAssertion({ assertion: newAssertion }));
   };
 
   const getConditionExpressionHandler = useCallback(


### PR DESCRIPTION
This pull request introduces several changes to the unit testing logic and the assertions panel in the designer library of the application. The most significant changes include the modification of the `UpdateAssertionsPayload` interface to `AddAssertionPayload`, the addition of a new interface `UpdateAssertioExpressionPayload`, and the introduction of a new function `checkAssertionsErrors` in the unit test slice. Moreover, the `unitTestSlice` itself has undergone several changes, including the replacement of `updateAssertions` with `addAssertion` and `updateAssertionExpression`. Lastly, the assertions panel has been updated to use the new actions from the unit test slice.


* The `UpdateAssertionsPayload` interface has been replaced with `AddAssertionPayload` which takes in a single `AssertionDefintion` instead of a record of assertions. A new interface `UpdateAssertioExpressionPayload` has been added to handle updates to assertion expressions. 

* The `updateAssertions` action in the `unitTestSlice` has been replaced with `addAssertion` which adds a single assertion to the state and checks for assertion errors. A new action `updateAssertionExpression` has been added to update the expression of an assertion and check for errors. The `validateAssertion` function has been made private and a new function `checkAssertionsErrors` has been introduced to check for assertion errors in the state.


* The assertions panel now uses the new `addAssertion` and `updateAssertionExpression` actions from the unit test slice. The local state management of assertions has been removed as the state is now directly updated using the actions. 