### PR TITLE
fix(vscode): Add styles for dark mode for condition expression callout

### DIFF
--- a/libs/designer-ui/src/lib/styles.less
+++ b/libs/designer-ui/src/lib/styles.less
@@ -74,6 +74,7 @@
 @import "./dynamicallyaddedparameter/dynamicallyaddedparameter.less";
 @import "./editor/base/themes/editorTheme.less";
 @import "./unitTesting/assertionsPanel/assertions.less";
+@import "./unitTesting/conditionExpression/conditionExpression.less";
 
 .msla-clear-both {
   clear: both;

--- a/libs/designer-ui/src/lib/unitTesting/conditionExpression/conditionExpression.less
+++ b/libs/designer-ui/src/lib/unitTesting/conditionExpression/conditionExpression.less
@@ -1,0 +1,18 @@
+@import (reference) '../../variables.less';
+
+.msla-theme-dark {
+  .msla-condition-expression-callout {
+    background: @ms-color-primaryBackground;
+    border-bottom: 1px solid @ms-color-secondaryBackground;
+    .msla-panel-menu {
+      button[role='tab'] {
+        .ms-Pivot-text {
+          color: #fff;
+          &:hover {
+            color: #0078d4;
+          }
+        }
+      }
+    }
+  }
+}

--- a/libs/designer-ui/src/lib/unitTesting/conditionExpression/index.tsx
+++ b/libs/designer-ui/src/lib/unitTesting/conditionExpression/index.tsx
@@ -165,6 +165,7 @@ export function ConditionExpression({
       </div>
       {isCalloutVisible && !isReadOnly && (
         <Callout
+          className="msla-condition-expression-callout"
           role="dialog"
           ariaLabelledBy={labelId}
           target={`#condition-expression-${editorId}`}


### PR DESCRIPTION
This pull request primarily focuses on updating the UI styling for the Condition Expression component in the `libs/designer-ui` package. The changes include importing a new LESS file, adding new styles, and applying these styles to the Condition Expression component.

UI Styling Updates:

* Imported the new `conditionExpression.less` file which contains the styles for the Condition Expression component.

* Created a new LESS file where the styles for the Condition Expression component in dark theme are defined. It also imports a `variables.less` file for color definitions.

* Applied the new `msla-condition-expression-callout` class to the `Callout` component in the `ConditionExpression` function. This class is defined in the newly added `conditionExpression.less` file.