### PR TITLE
feat(designer): Add ability for host to send in overrides for internationalized strings

### DIFF
--- a/apps/Standalone/src/designer/app/SettingsSections/contextSettings.tsx
+++ b/apps/Standalone/src/designer/app/SettingsSections/contextSettings.tsx
@@ -8,6 +8,7 @@ import {
   useHostOptions,
   useShowPerformanceDebug,
   useSuppressDefaultNodeSelect,
+  useStringOverrides,
 } from '../../state/workflowLoadingSelectors';
 import {
   setDarkMode,
@@ -20,6 +21,7 @@ import {
   setHostOptions,
   setShowPerformanceDebug,
   setSuppressDefaultNodeSelect,
+  setStringOverrides,
 } from '../../state/workflowLoadingSlice';
 import { Checkbox } from '@fluentui/react';
 import { useCallback } from 'react';
@@ -34,6 +36,7 @@ const ContextSettings = () => {
   const suppressDefaultNodeSelect = useSuppressDefaultNodeSelect();
   const hostOptions = useHostOptions();
   const showPerformanceDebug = useShowPerformanceDebug();
+  const showTestStringOverride = useStringOverrides();
   const dispatch = useDispatch<AppDispatch>();
 
   const changeMonitoringView = useCallback(
@@ -86,6 +89,22 @@ const ContextSettings = () => {
         label="Show Performance Debug"
         checked={showPerformanceDebug}
         onChange={(_, checked) => dispatch(setShowPerformanceDebug(!!checked))}
+      />
+      <Checkbox
+        label="Test String Override"
+        checked={showTestStringOverride}
+        onChange={(_, checked) => {
+          dispatch(
+            setStringOverrides(
+              checked
+                ? {
+                    g5A6Bn: 'Connector Type',
+                    TRpSCQ: 'Action or Trigger',
+                  }
+                : undefined
+            )
+          );
+        }}
       />
     </div>
   );

--- a/apps/Standalone/src/designer/state/workflowLoadingSelectors.ts
+++ b/apps/Standalone/src/designer/state/workflowLoadingSelectors.ts
@@ -60,3 +60,7 @@ export const useSuppressDefaultNodeSelect = () => {
 export const useShowPerformanceDebug = () => {
   return useSelector((state: RootState) => state.workflowLoader.showPerformanceDebug);
 };
+
+export const useStringOverrides = () => {
+  return useSelector((state: RootState) => !!state.workflowLoader.hostOptions.stringOverrides);
+};

--- a/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
+++ b/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
@@ -29,6 +29,7 @@ export interface WorkflowLoadingState {
   hostOptions: {
     displayRuntimeInfo: boolean; // show info about where the action is run(i.e. InApp/Shared/Custom)
     forceEnableSplitOn?: boolean; // force enable split on for all actions
+    stringOverrides?: Record<string, string>; // string overrides for localization
   };
   showPerformanceDebug?: boolean;
 }
@@ -178,6 +179,9 @@ export const workflowLoadingSlice = createSlice({
     setShowPerformanceDebug: (state, action: PayloadAction<boolean>) => {
       state.showPerformanceDebug = action.payload;
     },
+    setStringOverrides: (state, action: PayloadAction<Record<string, string> | undefined>) => {
+      state.hostOptions.stringOverrides = action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(loadWorkflow.fulfilled, (state, action: PayloadAction<WorkflowPayload | null>) => {
@@ -223,6 +227,7 @@ export const {
   setSuppressDefaultNodeSelect,
   setHostOptions,
   setShowPerformanceDebug,
+  setStringOverrides,
 } = workflowLoadingSlice.actions;
 
 export default workflowLoadingSlice.reducer;

--- a/libs/designer/src/lib/core/DesignerProvider.tsx
+++ b/libs/designer/src/lib/core/DesignerProvider.tsx
@@ -52,7 +52,12 @@ export const DesignerProvider = ({ id, locale = 'en', options, children }: Desig
           <ThemeProvider theme={azTheme}>
             <FluentProvider theme={webTheme}>
               <div data-color-scheme={themeName} className={`msla-theme-${themeName}`} style={{ height: '100vh', overflow: 'hidden' }}>
-                <IntlProvider locale={locale} defaultLocale={locale} onError={onError}>
+                <IntlProvider
+                  locale={locale}
+                  defaultLocale={locale}
+                  stringOverrides={options.hostOptions.stringOverrides}
+                  onError={onError}
+                >
                   <ReduxReset id={id} />
                   {children}
                 </IntlProvider>

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -37,6 +37,7 @@ export interface DesignerOptionsState {
     recurrenceInterval?: LogicApps.Recurrence;
     forceEnableSplitOn?: boolean; // force enable split on (by default it is disabled on stateless workflows)
     hideUTFExpressions?: boolean; // hide UTF expressions in template functions
+    stringOverrides?: Record<string, string>; // string overrides for localization
   };
   nodeSelectAdditionalCallback?: (nodeId: string) => any;
   showConnectionsPanel?: boolean;

--- a/libs/logic-apps-shared/src/intl/src/IntlProvider.tsx
+++ b/libs/logic-apps-shared/src/intl/src/IntlProvider.tsx
@@ -10,9 +10,13 @@ export interface IntlProviderProps {
   defaultLocale: string;
   onError: OnErrorFn;
   children?: React.ReactNode;
+  stringOverrides?: Record<string, string>;
 }
 
-const loadLocaleData = async (locale: string): Promise<Record<string, string> | Record<string, MessageFormatElement[]>> => {
+export const loadLocaleData = async (
+  locale: string,
+  stringOverrides?: Record<string, string>
+): Promise<Record<string, string> | Record<string, MessageFormatElement[]>> => {
   let messages: any = {};
   switch (locale.split('-')[0].toLowerCase()) {
     case 'nl': {
@@ -102,12 +106,12 @@ const loadLocaleData = async (locale: string): Promise<Record<string, string> | 
   }
   //any strings with a key that has symbols gets compiled to be in the default object rather than exported individually as a module
   const defaultMessages = messages.default ?? {};
-  return { ...messages, ...defaultMessages };
+  return { ...messages, ...defaultMessages, ...(stringOverrides ?? {}) };
 };
 
-export const IntlProvider: React.FC<IntlProviderProps> = ({ locale, defaultLocale, children, onError }) => {
-  const { data } = useQuery(['localizationMessages', locale], async () => {
-    const messages = await loadLocaleData(locale);
+export const IntlProvider: React.FC<IntlProviderProps> = ({ locale, defaultLocale, children, stringOverrides, onError }) => {
+  const { data } = useQuery(['localizationMessages', locale, stringOverrides], async () => {
+    const messages = await loadLocaleData(locale, stringOverrides);
     return { ...messages };
   });
 

--- a/libs/logic-apps-shared/src/intl/src/__test__/IntlProvider.spec.tsx
+++ b/libs/logic-apps-shared/src/intl/src/__test__/IntlProvider.spec.tsx
@@ -2,42 +2,42 @@ import { describe, test, expect } from 'vitest';
 import { loadLocaleData } from '../IntlProvider';
 
 describe('loadLocaleData', () => {
-  test('returns correct messages for each non english locale', async () => {
-    const locales = ['nl', 'pl', 'pt', 'ru', 'sv', 'tr', 'zh', 'fr', 'cs', 'de', 'es', 'hu', 'id', 'it', 'ja', 'ko'];
-    const englishMessages = await loadLocaleData('en-US');
-    for (const locale of locales) {
-      const messages = await loadLocaleData(locale);
-      expect(messages).toBeDefined();
-      expect(messages).not.toEqual(englishMessages);
-      // Add more specific checks here based on the expected structure of your messages
-    }
-  });
-  test('returns correct messages for english locale, same as default messages', async () => {
-    const messages = await loadLocaleData('en-US');
-    const defaultMessages = await loadLocaleData('');
-    expect(messages).toBeDefined();
-    expect(messages).toEqual(defaultMessages);
-    // Add more specific checks here based on the expected structure of your messages
-  });
+    test('returns correct messages for each non english locale', async () => {
+        const locales = ['nl', 'pl', 'pt', 'pt-BR', 'zh-Hans', 'en-XA', 'ru', 'sv', 'tr', 'zh', 'fr', 'cs', 'de', 'es', 'hu', 'id', 'it', 'ja', 'ko'];
+        const englishMessages = await loadLocaleData('en-US');
+        for (const locale of locales) {
+            const messages = await loadLocaleData(locale);
+            expect(messages).toBeDefined();
+            expect(messages).not.toEqual(englishMessages);
+            // Add more specific checks here based on the expected structure of your messages
+        }
+    });
+    test('returns correct messages for english locale, same as default messages', async () => {
+        const messages = await loadLocaleData('en-US');
+        const defaultMessages = await loadLocaleData('');
+        expect(messages).toBeDefined();
+        expect(messages).toEqual(defaultMessages);
+        // Add more specific checks here based on the expected structure of your messages
+    });
 
-  test('returns english messages for unsupported locale', async () => {
-    const messages = await loadLocaleData('unsupported-locale');
-    const englishMessages = await loadLocaleData('en-US');
-    expect(messages).toBeDefined();
-    expect(messages).toEqual(englishMessages);
-    // Add more specific checks here based on the expected structure of your default messages
-  });
+    test('returns english messages for unsupported locale', async () => {
+        const messages = await loadLocaleData('unsupported-locale');
+        const englishMessages = await loadLocaleData('en-US');
+        expect(messages).toBeDefined();
+        expect(messages).toEqual(englishMessages);
+        // Add more specific checks here based on the expected structure of your default messages
+    });
 
-  test('merges string overrides into messages', async () => {
-    const stringOverrides = {
-      g5A6Bn: 'Connector Type',
-      TRpSCQ: 'Action or Trigger',
-      '/VcZ9g': 'Test String Override',
-    };
-    const messages = await loadLocaleData('en', stringOverrides);
-    expect(messages).toBeDefined();
-    expect(messages.g5A6Bn).toEqual('Connector Type');
-    expect(messages.TRpSCQ).toEqual('Action or Trigger');
-    expect(messages['/VcZ9g']).toEqual('Test String Override');
-  });
+    test('merges string overrides into messages', async () => {
+        const stringOverrides = {
+            g5A6Bn: 'Connector Type',
+            TRpSCQ: 'Action or Trigger',
+            '/VcZ9g': 'Test String Override',
+        };
+        const messages = await loadLocaleData('en', stringOverrides);
+        expect(messages).toBeDefined();
+        expect(messages.g5A6Bn).toEqual('Connector Type');
+        expect(messages.TRpSCQ).toEqual('Action or Trigger');
+        expect(messages['/VcZ9g']).toEqual('Test String Override');
+    });
 });

--- a/libs/logic-apps-shared/src/intl/src/__test__/IntlProvider.spec.tsx
+++ b/libs/logic-apps-shared/src/intl/src/__test__/IntlProvider.spec.tsx
@@ -1,0 +1,43 @@
+import { describe, test, expect } from 'vitest';
+import { loadLocaleData } from '../IntlProvider';
+
+describe('loadLocaleData', () => {
+  test('returns correct messages for each non english locale', async () => {
+    const locales = ['nl', 'pl', 'pt', 'ru', 'sv', 'tr', 'zh', 'fr', 'cs', 'de', 'es', 'hu', 'id', 'it', 'ja', 'ko'];
+    const englishMessages = await loadLocaleData('en-US');
+    for (const locale of locales) {
+      const messages = await loadLocaleData(locale);
+      expect(messages).toBeDefined();
+      expect(messages).not.toEqual(englishMessages);
+      // Add more specific checks here based on the expected structure of your messages
+    }
+  });
+  test('returns correct messages for english locale, same as default messages', async () => {
+    const messages = await loadLocaleData('en-US');
+    const defaultMessages = await loadLocaleData('');
+    expect(messages).toBeDefined();
+    expect(messages).toEqual(defaultMessages);
+    // Add more specific checks here based on the expected structure of your messages
+  });
+
+  test('returns english messages for unsupported locale', async () => {
+    const messages = await loadLocaleData('unsupported-locale');
+    const englishMessages = await loadLocaleData('en-US');
+    expect(messages).toBeDefined();
+    expect(messages).toEqual(englishMessages);
+    // Add more specific checks here based on the expected structure of your default messages
+  });
+
+  test('merges string overrides into messages', async () => {
+    const stringOverrides = {
+      g5A6Bn: 'Connector Type',
+      TRpSCQ: 'Action or Trigger',
+      '/VcZ9g': 'Test String Override',
+    };
+    const messages = await loadLocaleData('en', stringOverrides);
+    expect(messages).toBeDefined();
+    expect(messages.g5A6Bn).toEqual('Connector Type');
+    expect(messages.TRpSCQ).toEqual('Action or Trigger');
+    expect(messages['/VcZ9g']).toEqual('Test String Override');
+  });
+});

--- a/libs/logic-apps-shared/src/intl/src/__test__/intl.spec.tsx
+++ b/libs/logic-apps-shared/src/intl/src/__test__/intl.spec.tsx
@@ -1,83 +1,89 @@
 import { render, screen, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { getIntl } from '../intl';
-import { describe, test, expect } from 'vitest';
+import { getIntl, resetIntl } from '../intl';
+import { describe, test, expect, beforeEach } from 'vitest';
 import React from 'react';
 import { IntlProvider } from '../IntlProvider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 describe('IntlGlobalProvider', () => {
-  test('renders children correctly', () => {
-    render(
-      <QueryClientProvider
-        client={
-          new QueryClient({
-            defaultOptions: {
-              queries: {
-                refetchInterval: false,
-                refetchIntervalInBackground: false,
-                refetchOnWindowFocus: false,
-                refetchOnReconnect: false,
-                refetchOnMount: false,
-                staleTime: 1000 * 60 * 60 * 24, // 24 hours
-              },
-            },
-          })
-        }
-      >
-        <IntlProvider locale="fr" defaultLocale="en" onError={() => {}}>
-          <div>Test Child</div>
-        </IntlProvider>
-      </QueryClientProvider>
-    );
-    expect(screen.getByText('Test Child')).toBeInTheDocument();
-  });
+    beforeEach(() => {
+        resetIntl();
+    });
+    test('renders children correctly', () => {
+        render(
+            <QueryClientProvider
+                client={
+                    new QueryClient({
+                        defaultOptions: {
+                            queries: {
+                                refetchInterval: false,
+                                refetchIntervalInBackground: false,
+                                refetchOnWindowFocus: false,
+                                refetchOnReconnect: false,
+                                refetchOnMount: false,
+                                staleTime: 1000 * 60 * 60 * 24, // 24 hours
+                            },
+                        },
+                    })
+                }
+            >
+                <IntlProvider locale="fr" defaultLocale="en" onError={() => { }}>
+                    <div>Test Child</div>
+                </IntlProvider>
+            </QueryClientProvider>
+        );
+        expect(screen.getByText('Test Child')).toBeInTheDocument();
+    });
 });
 
 describe('getIntl', () => {
-  test('returns default IntlShape when INTL is undefined', () => {
-    const intl = getIntl();
-    expect(intl.locale).toBe('en');
-    expect(intl.messages).toEqual({});
-    expect(intl.defaultLocale).toBe('en');
-  });
-
-  test('returns defined INTL when INTL is defined', async () => {
-    render(
-      <QueryClientProvider
-        client={
-          new QueryClient({
-            defaultOptions: {
-              queries: {
-                refetchInterval: false,
-                refetchIntervalInBackground: false,
-                refetchOnWindowFocus: false,
-                refetchOnReconnect: false,
-                refetchOnMount: false,
-                staleTime: 1000 * 60 * 60 * 24, // 24 hours
-              },
-            },
-          })
-        }
-      >
-        <IntlProvider locale="fr" defaultLocale="en" onError={() => {}} />
-      </QueryClientProvider>
-    );
-
-    await waitFor(() => {
-      const intl = getIntl();
-      expect(intl.locale).toBe('fr');
-      expect(intl.defaultLocale).toBe('en');
-      expect(intl.messages).toEqual(
-        expect.objectContaining({
-          '00xlpa': [
-            {
-              type: 0,
-              value: 'Partagé',
-            },
-          ],
-        })
-      );
+    beforeEach(() => {
+        resetIntl();
     });
-  });
+    test('returns default IntlShape when INTL is undefined', () => {
+        const intl = getIntl();
+        expect(intl.locale).toBe('en');
+        expect(intl.messages).toEqual({});
+        expect(intl.defaultLocale).toBe('en');
+    });
+
+    test('returns defined INTL when INTL is defined', async () => {
+        render(
+            <QueryClientProvider
+                client={
+                    new QueryClient({
+                        defaultOptions: {
+                            queries: {
+                                refetchInterval: false,
+                                refetchIntervalInBackground: false,
+                                refetchOnWindowFocus: false,
+                                refetchOnReconnect: false,
+                                refetchOnMount: false,
+                                staleTime: 1000 * 60 * 60 * 24, // 24 hours
+                            },
+                        },
+                    })
+                }
+            >
+                <IntlProvider locale="fr" defaultLocale="en" onError={() => { }} />
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            const intl = getIntl();
+            expect(intl.locale).toBe('fr');
+            expect(intl.defaultLocale).toBe('en');
+            expect(intl.messages).toEqual(
+                expect.objectContaining({
+                    '00xlpa': [
+                        {
+                            type: 0,
+                            value: 'Partagé',
+                        },
+                    ],
+                })
+            );
+        });
+    });
 });

--- a/libs/logic-apps-shared/src/intl/src/__test__/intl.spec.tsx
+++ b/libs/logic-apps-shared/src/intl/src/__test__/intl.spec.tsx
@@ -1,0 +1,83 @@
+import { render, screen, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { getIntl } from '../intl';
+import { describe, test, expect } from 'vitest';
+import React from 'react';
+import { IntlProvider } from '../IntlProvider';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+describe('IntlGlobalProvider', () => {
+  test('renders children correctly', () => {
+    render(
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: {
+              queries: {
+                refetchInterval: false,
+                refetchIntervalInBackground: false,
+                refetchOnWindowFocus: false,
+                refetchOnReconnect: false,
+                refetchOnMount: false,
+                staleTime: 1000 * 60 * 60 * 24, // 24 hours
+              },
+            },
+          })
+        }
+      >
+        <IntlProvider locale="fr" defaultLocale="en" onError={() => {}}>
+          <div>Test Child</div>
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
+  });
+});
+
+describe('getIntl', () => {
+  test('returns default IntlShape when INTL is undefined', () => {
+    const intl = getIntl();
+    expect(intl.locale).toBe('en');
+    expect(intl.messages).toEqual({});
+    expect(intl.defaultLocale).toBe('en');
+  });
+
+  test('returns defined INTL when INTL is defined', async () => {
+    render(
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: {
+              queries: {
+                refetchInterval: false,
+                refetchIntervalInBackground: false,
+                refetchOnWindowFocus: false,
+                refetchOnReconnect: false,
+                refetchOnMount: false,
+                staleTime: 1000 * 60 * 60 * 24, // 24 hours
+              },
+            },
+          })
+        }
+      >
+        <IntlProvider locale="fr" defaultLocale="en" onError={() => {}} />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      const intl = getIntl();
+      expect(intl.locale).toBe('fr');
+      expect(intl.defaultLocale).toBe('en');
+      expect(intl.messages).toEqual(
+        expect.objectContaining({
+          '00xlpa': [
+            {
+              type: 0,
+              value: 'Partagé',
+            },
+          ],
+        })
+      );
+    });
+  });
+});

--- a/libs/logic-apps-shared/src/intl/src/index.ts
+++ b/libs/logic-apps-shared/src/intl/src/index.ts
@@ -1,2 +1,2 @@
 export * from './intl';
-export * from './IntlProvider';
+export { IntlProvider } from './IntlProvider';

--- a/libs/logic-apps-shared/src/intl/src/index.ts
+++ b/libs/logic-apps-shared/src/intl/src/index.ts
@@ -1,2 +1,2 @@
-export * from './intl';
+export { getIntl } from './intl';
 export { IntlProvider } from './IntlProvider';

--- a/libs/logic-apps-shared/src/intl/src/intl.tsx
+++ b/libs/logic-apps-shared/src/intl/src/intl.tsx
@@ -7,6 +7,7 @@ interface IntlGlobalProviderProps {
 }
 const cache = createIntlCache();
 let INTL: IntlShape | undefined;
+export const resetIntl = () => INTL = undefined;
 const IntlGlobalProvider = (props: IntlGlobalProviderProps) => {
   INTL = useIntl();
   return <>{props.children}</>;


### PR DESCRIPTION
This pull request primarily introduces the ability to override strings for localization in the application. This is achieved by adding a new `stringOverrides` property to several state and interface definitions, and modifying related functions and components to handle this new property. The changes also include the addition of a new checkbox in the `ContextSettings` component to allow users to toggle the test string override.

Here are the most important changes:

**State and Interface Updates:**

* [`apps/Standalone/src/designer/state/workflowLoadingSlice.ts`](diffhunk://#diff-e48356fbe118c8cea9880406f8cc5809a509614a466f83ddbcdf814c8dacdc6eR32): Added a `stringOverrides` property to the `WorkflowLoadingState` interface and the `hostOptions` object within it. This property is a record of string key-value pairs used for localization. Also added a `setStringOverrides` function to the `workflowLoadingSlice` to handle changes to this new property. [[1]](diffhunk://#diff-e48356fbe118c8cea9880406f8cc5809a509614a466f83ddbcdf814c8dacdc6eR32) [[2]](diffhunk://#diff-e48356fbe118c8cea9880406f8cc5809a509614a466f83ddbcdf814c8dacdc6eR182-R184) [[3]](diffhunk://#diff-e48356fbe118c8cea9880406f8cc5809a509614a466f83ddbcdf814c8dacdc6eR230)
* [`libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts`](diffhunk://#diff-7904559a193a9ef1a6a08a92759418fa2bcf6a2b16eaf7439f5505484989d4b0R40): Added a `stringOverrides` property to the `DesignerOptionsState` interface.
* [`libs/logic-apps-shared/src/intl/src/IntlProvider.tsx`](diffhunk://#diff-1bbe746044035b2e364e1107ec98cba3e469fa35b2e87a972b6b94993f4bb6bfR13-R19): Added a `stringOverrides` property to the `IntlProviderProps` interface. Modified the `loadLocaleData` function to include string overrides in the returned messages. [[1]](diffhunk://#diff-1bbe746044035b2e364e1107ec98cba3e469fa35b2e87a972b6b94993f4bb6bfR13-R19) [[2]](diffhunk://#diff-1bbe746044035b2e364e1107ec98cba3e469fa35b2e87a972b6b94993f4bb6bfL105-R114)

**Component Updates:**

* [`apps/Standalone/src/designer/app/SettingsSections/contextSettings.tsx`](diffhunk://#diff-271996368db3507a98e1a090ad3eb0e8a7f4e2b8de9143be8aae707459704537R11): Imported the `useStringOverrides` and `setStringOverrides` functions. Added a new checkbox to the `ContextSettings` component to allow users to toggle the test string override. [[1]](diffhunk://#diff-271996368db3507a98e1a090ad3eb0e8a7f4e2b8de9143be8aae707459704537R11) [[2]](diffhunk://#diff-271996368db3507a98e1a090ad3eb0e8a7f4e2b8de9143be8aae707459704537R24) [[3]](diffhunk://#diff-271996368db3507a98e1a090ad3eb0e8a7f4e2b8de9143be8aae707459704537R39) [[4]](diffhunk://#diff-271996368db3507a98e1a090ad3eb0e8a7f4e2b8de9143be8aae707459704537R93-R108)
* [`libs/designer/src/lib/core/DesignerProvider.tsx`](diffhunk://#diff-65099467d6a4c0fe8a5ead86de81b2276fa19baec1d887dac5dd0af7675b5273L55-R60): Passed the `stringOverrides` property to the `IntlProvider` component.

**Selector Updates:**

* [`apps/Standalone/src/designer/state/workflowLoadingSelectors.ts`](diffhunk://#diff-ccddee0d1c2b068cba8e9211d86a206fbede0fcf21f5eb519f1ef8b365d7ed0dR63-R66): Added a new `useStringOverrides` selector to get the `stringOverrides` property from the state.

**Test Updates:**

* [`libs/logic-apps-shared/src/intl/src/__test__/IntlProvider.spec.tsx`](diffhunk://#diff-51fa6280d72ffb410b795789a604d80444cd9bfedab70c206cc57cae50871663R1-R43): Added several new tests for the `loadLocaleData` function to ensure it correctly handles string overrides.

**Export Updates:**

* [`libs/logic-apps-shared/src/intl/src/index.ts`](diffhunk://#diff-d22bbcf95823408dc27630b75278dffdfc9864c4f3df50217d93155cff75dc4dL2-R2): Changed the export of `IntlProvider` to a named export.