### PR TITLE
fix(meta): Update pnpm version in coverage-report

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -32,7 +32,7 @@ jobs:
 
         - uses: pnpm/action-setup@v3
           with:
-            version: 9
+            version: 9.1.3
             run_install: |
               - recursive: true
                 args: [--frozen-lockfile, --strict-peer-dependencies]   


### PR DESCRIPTION
This pull request includes a minor update to the `coverage-report.yml` workflow file. Specifically, the version of `pnpm/action-setup` has been updated from `9` to `9.1.3` to ensure we are using the latest stable version of the package. This change will help maintain the stability and reliability of our CI/CD pipeline.