### PR TITLE
fix(designer): Stringifying appsetting values during connection creation

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
@@ -731,7 +731,8 @@ function createLocalConnectionsData(
       const rawValue = parameterValue;
       if (connectionParameter?.parameterSource === ConnectionParameterSource.AppConfiguration) {
         const appSettingName = `${escapeSpecialChars(connectionKey)}_${escapeSpecialChars(parameterKey)}`;
-        result.settings[appSettingName] = parameterValues[parameterKey];
+        result.settings[appSettingName] =
+          typeof parameterValues[parameterKey] !== 'string' ? JSON.stringify(parameterValues[parameterKey]) : parameterValues[parameterKey];
 
         parameterValue = `@appsetting('${appSettingName}')`;
       }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
non string connection parameters were written in appsettings as non string values causing string operations to fail.

- **What is the new behavior (if this is a feature change)?**
Connection parameter values will be stringified before putting them as settings.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

- **Please Include Screenshots or Videos of the intended change**:
