### PR TITLE
chore(git): Mount templates folder to consume templates files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "libs/designer/src/lib/core/templates/samples"]
-	path = libs/designer/src/lib/core/templates/samples
-	url = https://github.com/Azure/LogicAppsTemplates
 [submodule "libs/designer/src/lib/ui/templates/templateFiles"]
 	path = libs/designer/src/lib/ui/templates/templateFiles
 	url = https://github.com/Azure/LogicAppsTemplates.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libs/designer/src/lib/core/templates/samples"]
 	path = libs/designer/src/lib/core/templates/samples
 	url = https://github.com/Azure/LogicAppsTemplates
+[submodule "libs/designer/src/lib/ui/templates/templateFiles"]
+	path = libs/designer/src/lib/ui/templates/templateFiles
+	url = https://github.com/Azure/LogicAppsTemplates.git


### PR DESCRIPTION
This pull request includes changes to the `.gitmodules` file and the `libs/designer/src/lib/ui/templates/templateFiles` file. The changes involve the addition of a new submodule and a subproject commit.

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R4-R6): A new submodule has been added to the project. The submodule, named `libs/designer/src/lib/ui/templates/templateFiles`, is linked to the repository at `https://github.com/Azure/LogicAppsTemplates.git`.
* [`libs/designer/src/lib/ui/templates/templateFiles`](diffhunk://#diff-1c473e2d91c0ae3e0341f5ea76ba653dd845913a9d0b34b86749cca3cbb18a8cR1): A subproject commit `7810d1f14d5d4e2c366f7e0ff463995efc077dd8` has been added to the `libs/designer/src/lib/ui/templates/templateFiles` submodule.