### PR TITLE
chore(git): Rename templatesManifestFolder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "libs/designer/src/lib/core/templates/samples"]
-	path = libs/designer/src/lib/core/templates/samples
-	url = https://github.com/Azure/LogicAppsTemplates
+[submodule "libs/designer/src/lib/core/templates/templateFiles"]
+	path = libs/designer/src/lib/core/templates/templateFiles
+	url = https://github.com/Azure/LogicAppsTemplates.git

--- a/libs/designer/src/lib/core/state/templates/store.ts
+++ b/libs/designer/src/lib/core/state/templates/store.ts
@@ -18,7 +18,7 @@ export const setupStore = (preloadedState?: Partial<RootState>) => {
 };
 
 export const templateStore = setupStore();
-export const templatesPathFromState = '../../templates/samples';
+export const templatesPathFromState = '../../templates/templateFiles';
 export type RootState = ReturnType<typeof rootReducer>;
 export type AppStore = ReturnType<typeof setupStore>;
 export type AppDispatch = AppStore['dispatch'];


### PR DESCRIPTION
This pull request primarily focuses on refactoring the path and name of a submodule in the codebase. The submodule `libs/designer/src/lib/core/templates/samples` has been renamed to `libs/designer/src/lib/core/templates/templateFiles`. Additionally, the reference to this submodule in the `templatesPathFromState` constant has been updated to reflect this change.

Here are the key changes:

Submodule renaming and path update:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L1-R3): The submodule `libs/designer/src/lib/core/templates/samples` has been renamed to `libs/designer/src/lib/core/templates/templateFiles`, and the path has been updated accordingly.

Reference update in the codebase:

* [`libs/designer/src/lib/core/state/templates/store.ts`](diffhunk://#diff-2b69daed71b3177e6fe8b016978e67b52f77b1d0c570536bf7cf528c653746f4L21-R21): The `templatesPathFromState` constant has been updated to use the new submodule path `../../templates/templateFiles`.