### PR TITLE
fix(designer): Fix attachment wording

### DIFF
--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -665,7 +665,7 @@ export const getTokenExpressionValueForManifestBasedOperation = (
 /**
  * generate the full path for the specifiecd expression segments, e.g, for @body('action')?[test] => body.$.test
  * if the splitOn is not empty, and the expression is triggerBody(), then it would also append the splitOn path,
- * e.g, @triggerBody()?[attachements] with splitOn: @triggerBody()['value'], the result would be: body.$.value.attachments
+ * e.g, @triggerBody()?[attachments] with splitOn: @triggerBody()['value'], the result would be: body.$.value.attachments
  */
 const getFullPath = (expressionSegment: ExpressionFunction, splitOn?: Expression): string => {
   const segments = [equals(expressionSegment.name, 'outputs') ? 'outputs' : 'body', '$'];

--- a/libs/logic-apps-shared/src/parsers/lib/common/helpers/__test__/keysutility.spec.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/common/helpers/__test__/keysutility.spec.ts
@@ -3,23 +3,23 @@ import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, exp
 describe('Parameter Key Utility Tests', () => {
   describe('isAncestorKey', () => {
     it('should return correct result different cases', () => {
-      expect(ParameterKeyUtility.isAncestorKey('body.$.attachements.[*].test', 'body.$.attachements')).toBeTruthy();
-      expect(ParameterKeyUtility.isAncestorKey('body.$.attachements.[*].any.[*].test', 'body.$.attachements')).toBeTruthy();
-      expect(ParameterKeyUtility.isAncestorKey('body.$.attachements123', 'body.$.attachements')).toBeFalsy();
-      expect(ParameterKeyUtility.isAncestorKey('body.$.attachement.[*].test', 'body.$.attachements')).toBeFalsy();
-      expect(ParameterKeyUtility.isAncestorKey('body.$.attachement.[*].test', undefined)).toBeFalsy();
+      expect(ParameterKeyUtility.isAncestorKey('body.$.attachments.[*].test', 'body.$.attachments')).toBeTruthy();
+      expect(ParameterKeyUtility.isAncestorKey('body.$.attachments.[*].any.[*].test', 'body.$.attachments')).toBeTruthy();
+      expect(ParameterKeyUtility.isAncestorKey('body.$.attachments123', 'body.$.attachments')).toBeFalsy();
+      expect(ParameterKeyUtility.isAncestorKey('body.$.attachment.[*].test', 'body.$.attachments')).toBeFalsy();
+      expect(ParameterKeyUtility.isAncestorKey('body.$.attachment.[*].test', undefined)).toBeFalsy();
     });
   });
 
   describe('isChildKey', () => {
     it('should return correct result different cases', () => {
-      expect(ParameterKeyUtility.isChildKey('body.$.attachements', 'body.$.attachements.[*]')).toBeTruthy();
-      expect(ParameterKeyUtility.isChildKey('body.$.attachements.[*]', 'body.$.attachements.[*].test')).toBeTruthy();
+      expect(ParameterKeyUtility.isChildKey('body.$.attachments', 'body.$.attachments.[*]')).toBeTruthy();
+      expect(ParameterKeyUtility.isChildKey('body.$.attachments.[*]', 'body.$.attachments.[*].test')).toBeTruthy();
       expect(ParameterKeyUtility.isChildKey('body.$.[*].test.[*]', 'body.$.[*].test.[*].id')).toBeTruthy();
-      expect(ParameterKeyUtility.isChildKey('body.$', 'body.$.attachements')).toBeTruthy();
-      expect(ParameterKeyUtility.isChildKey('body.$.attachements123', 'body.$.attachements')).toBeFalsy();
-      expect(ParameterKeyUtility.isChildKey('body.$.attachement2222', 'body.$.attachements.test')).toBeFalsy();
-      expect(ParameterKeyUtility.isChildKey('body.$.attachement.[*].test', undefined)).toBeFalsy();
+      expect(ParameterKeyUtility.isChildKey('body.$', 'body.$.attachments')).toBeTruthy();
+      expect(ParameterKeyUtility.isChildKey('body.$.attachments123', 'body.$.attachments')).toBeFalsy();
+      expect(ParameterKeyUtility.isChildKey('body.$.attachment2222', 'body.$.attachments.test')).toBeFalsy();
+      expect(ParameterKeyUtility.isChildKey('body.$.attachment.[*].test', undefined)).toBeFalsy();
     });
   });
 

--- a/libs/logic-apps-shared/src/parsers/lib/swagger/__test__/fixtures/outlook.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/swagger/__test__/fixtures/outlook.ts
@@ -10492,7 +10492,7 @@ export const Outlook = {
             in: 'path',
             description: 'Id of the attachment to download.',
             required: true,
-            'x-ms-summary': 'Attachement Id',
+            'x-ms-summary': 'Attachment Id',
             type: 'string',
           },
           {


### PR DESCRIPTION
This pull request primarily focuses on correcting spelling mistakes across different files in the codebase. The term 'attachements' has been corrected to 'attachments' in multiple places. 

* Corrected the spelling of 'attachments' in the comment section of the function `getTokenExpressionValueForManifestBasedOperation`.
* Fixed the spelling of 'attachments' in multiple test cases under the 'Parameter Key Utility Tests'.
* Updated the 'x-ms-summary' property value from 'Attachement Id' to 'Attachment Id' in the `Outlook` export object.

Fixes #4948