### PR TITLE
fix(vscode): Update Workflows Webjobs sdk version

### DIFF
--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -112,7 +112,7 @@ async function setupWizardScriptContext(context: IActionContext, projectRoot: vs
     scriptContext.projectPath = parentDirPath;
     return scriptContext;
   } catch (error) {
-    const errorMessage = localize('executeAzureWizardError', 'Error in setupWizardScriptContext', error.message ?? error);
+    const errorMessage = localize('setupWizardScriptContextError', 'Error in setupWizardScriptContext: {0}', error.message ?? error);
     ext.outputChannel.appendLog(errorMessage);
     throw new Error(errorMessage);
   }

--- a/apps/vs-code-designer/src/assets/FunctionProjectTemplate/FunctionsProjNet8
+++ b/apps/vs-code-designer/src/assets/FunctionProjectTemplate/FunctionsProjNet8
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" />
-    <PackageReference Include="Microsoft.Azure.Workflows.Webjobs.Sdk" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Azure.Workflows.Webjobs.Sdk" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>

--- a/apps/vs-code-designer/src/assets/FunctionProjectTemplate/FunctionsProjNetFx
+++ b/apps/vs-code-designer/src/assets/FunctionProjectTemplate/FunctionsProjNetFx
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.39" />
-    <PackageReference Include="Microsoft.Azure.Workflows.WebJobs.Sdk" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Azure.Workflows.WebJobs.Sdk" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />

--- a/apps/vs-code-designer/src/assets/RuleSetProjectTemplate/RulesFunctionsProj
+++ b/apps/vs-code-designer/src/assets/RuleSetProjectTemplate/RulesFunctionsProj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.39" />
-    <PackageReference Include="Microsoft.Azure.Workflows.WebJobs.Sdk" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Azure.Workflows.WebJobs.Sdk" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />


### PR DESCRIPTION
This pull request includes changes to three different project templates in the `apps/vs-code-designer` directory. The common change across all three templates is the update of the `Microsoft.Azure.Workflows.WebJobs.Sdk` package from version `1.0.1` to `1.1.0`.


* Updated the `Microsoft.Azure.Workflows.WebJobs.Sdk` package from version `1.0.1` to `1.1.0`.