### PR TITLE
fix(vscode): Add base path for svgs and remove duplicated code

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewBase.ts
@@ -46,11 +46,4 @@ export abstract class OpenMonitoringViewBase extends OpenDesignerBase {
   protected getExistingPanel(): WebviewPanel | undefined {
     return tryGetWebviewPanel(this.panelGroupKey, this.panelName);
   }
-
-  protected getPanelOptions(): vscode.WebviewOptions & vscode.WebviewPanelOptions {
-    return {
-      enableScripts: true,
-      retainContextWhenHidden: true,
-    };
-  }
 }

--- a/apps/vs-code-react/vite.config.ts
+++ b/apps/vs-code-react/vite.config.ts
@@ -8,6 +8,7 @@ import mkcert from 'vite-plugin-mkcert';
 // https://vitejs.dev/config/
 export default defineConfig({
   root: './src',
+  base: './',
   resolve: {
     alias: [
       {


### PR DESCRIPTION
This pull request primarily focuses on streamlining the codebase in two files: `openMonitoringViewBase.ts` and `vite.config.ts`. The most significant changes include the removal of a method in the `OpenMonitoringViewBase` class and an adjustment to the configuration in `vite.config.ts`.

* The `getPanelOptions` method was removed from the `OpenMonitoringViewBase` class. This method previously returned webview options for the panel. Its removal suggests that the default options are now being used or they're being defined elsewhere.
* The configuration for Vite, a build tool used in the project, was modified. The `base` option was added and set to `'./'`, which changes the base public path when serving or building the project.


#### Before
![image](https://github.com/Azure/LogicAppsUX/assets/102700317/3f2b78f4-4d16-4f40-9dfd-6a03fb163c7d)


#### After
![Screenshot 2024-06-10 at 3 04 22 PM](https://github.com/Azure/LogicAppsUX/assets/102700317/7fbc4888-4a26-41a9-9389-abc4bebc5f53)
![Screenshot 2024-06-10 at 3 04 30 PM](https://github.com/Azure/LogicAppsUX/assets/102700317/d45e76e4-3e88-4986-a5bb-3c9f668c85f0)
