### PR TITLE
feat(designer): Update input token styling to increase size

### DIFF
--- a/libs/designer-ui/src/lib/token/token.less
+++ b/libs/designer-ui/src/lib/token/token.less
@@ -14,14 +14,13 @@
 .msla-input-token {
   background-repeat: no-repeat;
   background-size: @token-height @token-height;
-  padding-left: 34px;
+  padding-left: 24px;
   margin: 0 2px;
   display: inline-flex;
   padding-right: 4px;
   position: relative;
-  gap: 4px;
   user-select: none;
-  max-width: 120px;
+  max-width: 144px;
 
   .msla-token-title {
     overflow: hidden;


### PR DESCRIPTION
A small styling change to increase the size of the input token and the number of visible characters in the token name. 

**Before**

![image](https://github.com/Azure/LogicAppsUX/assets/135278983/484a0b5a-2d3f-4498-a9ca-15cd1036f2ed)


**After:**

![image](https://github.com/Azure/LogicAppsUX/assets/135278983/463f075b-1d93-4ea3-8267-2f418c9e35f6)
