### PR TITLE
fix(Designer): Fixed error log error object passing in `updateCallbackUrlInInputs`

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -443,7 +443,8 @@ export const updateCallbackUrlInInputs = async (
       LoggerService().log({
         level: LogEntryLevel.Error,
         area: 'CallbackUrl_Update',
-        message: `Unable to initialize callback url for manual trigger, error ${error}`,
+        message: 'Unable to initialize callback url for manual trigger.',
+        error: error instanceof Error ? error : undefined,
       });
     }
   }


### PR DESCRIPTION
## Main Changes

Fixed passing of the error object to logger service in the `updateCallbackUrlInInputs` function.
It was showing in Kusto as just `[object Object]` string.
Now we will be able to inspect the error object like we do with other logs.