### PR TITLE
feat(designer): [CredentialMapping] Updating the schema

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/__test__/createConnection.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/__test__/createConnection.spec.tsx
@@ -341,6 +341,7 @@ describe('ui/createConnection', () => {
                     {
                       credentialKeyName: 'myCredentialPasswordKey',
                       type: 'UserPassword',
+                      typeEnumValue: 1,
                     },
                   ],
                 },
@@ -357,6 +358,7 @@ describe('ui/createConnection', () => {
                     {
                       credentialKeyName: 'myCredentialUserKey',
                       type: 'UserPassword',
+                      typeEnumValue: 1,
                     },
                   ],
                 },
@@ -399,6 +401,7 @@ describe('ui/createConnection', () => {
                     {
                       credentialKeyName: 'myCredentialPasswordKey',
                       type: 'UserPassword',
+                      typeEnumValue: 1,
                     },
                   ],
                 },
@@ -415,6 +418,7 @@ describe('ui/createConnection', () => {
                     {
                       credentialKeyName: 'myCredentialPasswordKey',
                       type: 'UserPassword',
+                      typeEnumValue: 1,
                     },
                   ],
                 },

--- a/libs/logic-apps-shared/src/utils/src/lib/models/connector.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/connector.ts
@@ -105,6 +105,10 @@ export interface ParameterCredentialMapping {
    */
   type: string;
   /**
+   * Ordinal value of the type enum.
+   */
+  typeEnumValue: number;
+  /**
    * The key used to read the expected value from the credential for this parameter.
    */
   credentialKeyName: string;


### PR DESCRIPTION
In the context of creating a creating a connection with a credential (instead of username+password), the connector will return the list of credential types that are supported.
Today, this field is the enum string name of the credential connection type.
In order to query CDS without having to manually map the enum to its ordinal, we are adding the value in the AAPT-Connector contract.
Updating here, so that the info is passed to the UX

[Design note here](https://microsoft.sharepoint.com/:w:/t/MicrosoftFlowCore/EcbBBxvLdcZJrOhlDAltL-kBKDIOHLGKZmP4uA0lV64r-g?e=zBNWNj)

[AAPT-Connector PR here](https://msazure.visualstudio.com/One/_git/AAPT-connectors/pullrequest/10231609): [uiflow] Adding the type enum value to credential mapping

- **Please check if the PR fulfills these requirements**

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Please Include Screenshots or Videos of the intended change**:
