### PR TITLE
fix(vscode): Allow script generation without connections and click in project root

### DIFF
--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -46,11 +46,7 @@ export async function generateDeploymentScripts(context: IActionContext, project
     const workspaceFolder = await getWorkspaceFolder(context);
     const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
     const connectionsJson = await getConnectionsJson(projectPath);
-    if (isEmptyString(connectionsJson)) {
-      return;
-    }
-
-    const connectionsData: ConnectionsData = JSON.parse(connectionsJson);
+    const connectionsData: ConnectionsData = isEmptyString(connectionsJson) ? {} : JSON.parse(connectionsJson);
     const isParameterized = await isConnectionsParameterized(connectionsData);
 
     if (!isParameterized) {

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -34,9 +34,8 @@ import axios from 'axios';
 import * as path from 'path';
 import * as portfinder from 'portfinder';
 import * as vscode from 'vscode';
-import { window } from 'vscode';
 
-export async function generateDeploymentScripts(context: IActionContext, projectRoot: vscode.Uri): Promise<void> {
+export async function generateDeploymentScripts(context: IActionContext): Promise<void> {
   try {
     ext.outputChannel.show();
     ext.outputChannel.appendLog(localize('initScriptGen', 'Initiating script generation...'));
@@ -45,6 +44,7 @@ export async function generateDeploymentScripts(context: IActionContext, project
     showPreviewWarning(extensionCommand.generateDeploymentScripts);
     const workspaceFolder = await getWorkspaceFolder(context);
     const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
+    const projectRoot = vscode.Uri.file(projectPath);
     const connectionsJson = await getConnectionsJson(projectPath);
     const connectionsData: ConnectionsData = isEmptyString(connectionsJson) ? {} : JSON.parse(connectionsJson);
     const isParameterized = await isConnectionsParameterized(connectionsData);
@@ -54,7 +54,7 @@ export async function generateDeploymentScripts(context: IActionContext, project
         'parameterizeInDeploymentScripts',
         'Allow parameterization for connections? Declining cancels generation for deployment scripts.'
       );
-      const result = await window.showInformationMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.no);
+      const result = await vscode.window.showInformationMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.no);
       if (result === DialogResponses.yes) {
         await parameterizeConnections(context);
         context.telemetry.properties.parameterizeConnectionsInDeploymentScripts = 'true';
@@ -214,7 +214,7 @@ export async function callConsumptionApi(scriptContext: IAzureScriptWizard, inpu
 async function handleApiResponse(zipContent: Buffer | Buffer[], targetDirectory: string): Promise<void> {
   try {
     if (!zipContent) {
-      window.showErrorMessage(localize('invalidApiResponseContent', 'Invalid API response content.'));
+      vscode.window.showErrorMessage(localize('invalidApiResponseContent', 'Invalid API response content.'));
       ext.outputChannel.appendLog(localize('invalidApiResponseExiting', 'Invalid API response received. Exiting...'));
       return;
     }


### PR DESCRIPTION

This pull request includes changes to the `generateDeploymentScripts.ts` file in the `vs-code-designer` app. The changes primarily focus on simplifying the code and improving the readability. The `projectRoot` parameter has been removed from the `generateDeploymentScripts` function, and it is now defined within the function itself. The `connectionsData` object is now created using a ternary operator to avoid unnecessary conditionals. The `window` import has been removed and replaced with `vscode.window` for better clarity.

* Removed the `projectRoot` parameter from the `generateDeploymentScripts` function and defined it within the function using `vscode.Uri.file(projectPath)`.
* Simplified the creation of the `connectionsData` object using a ternary operator. Replaced `window.showInformationMessage` with `vscode.window.showInformationMessage` for better clarity.
* Replaced `window.showErrorMessage` with `vscode.window.showErrorMessage` for better clarity.


Fixes #4924 
