### PR TITLE
fix(designer-ui): Remove problematic call to `setIsValuePlaintext`

### DIFF
--- a/libs/designer-ui/src/lib/html/index.tsx
+++ b/libs/designer-ui/src/lib/html/index.tsx
@@ -44,7 +44,6 @@ export const HTMLEditor = ({ initialValue, onChange, ...baseEditorProps }: BaseE
       <HTMLChangePlugin
         isValuePlaintext={isValuePlaintext}
         setIsSwitchFromPlaintextBlocked={setIsSwitchFromPlaintextBlocked}
-        setIsValuePlaintext={setIsValuePlaintext}
         setValue={onValueChange}
       />
     </EditorWrapper>

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
@@ -28,7 +28,6 @@ export interface HTMLChangePluginProps {
 export const HTMLChangePlugin = ({ isValuePlaintext, setIsSwitchFromPlaintextBlocked, setValue }: HTMLChangePluginProps) => {
   const onChange = (editorState: EditorState, editor: LexicalEditor) => {
     const nodeMap = new Map<string, ValueSegment>();
-    const isNewValuePlaintext = isValuePlaintext;
 
     editorState.read(() => {
       const editorString = getChildrenNodes($getRoot(), nodeMap);
@@ -36,7 +35,7 @@ export const HTMLChangePlugin = ({ isValuePlaintext, setIsSwitchFromPlaintextBlo
 
       setIsSwitchFromPlaintextBlocked(!isSafeForLexical);
 
-      convertEditorState(editor, nodeMap, { isValuePlaintext: isNewValuePlaintext }).then(setValue);
+      convertEditorState(editor, nodeMap, { isValuePlaintext }).then(setValue);
     });
   };
   return <OnChangePlugin ignoreSelectionChange onChange={onChange} />;

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
@@ -22,29 +22,19 @@ import { $getRoot } from 'lexical';
 export interface HTMLChangePluginProps {
   isValuePlaintext: boolean;
   setIsSwitchFromPlaintextBlocked: (value: boolean) => void;
-  setIsValuePlaintext: (isValuePlaintext: boolean) => void;
   setValue: (newVal: ValueSegment[]) => void;
 }
 
-export const HTMLChangePlugin = ({
-  isValuePlaintext,
-  setIsSwitchFromPlaintextBlocked,
-  setIsValuePlaintext,
-  setValue,
-}: HTMLChangePluginProps) => {
+export const HTMLChangePlugin = ({ isValuePlaintext, setIsSwitchFromPlaintextBlocked, setValue }: HTMLChangePluginProps) => {
   const onChange = (editorState: EditorState, editor: LexicalEditor) => {
     const nodeMap = new Map<string, ValueSegment>();
-    let isNewValuePlaintext = isValuePlaintext;
+    const isNewValuePlaintext = isValuePlaintext;
 
     editorState.read(() => {
       const editorString = getChildrenNodes($getRoot(), nodeMap);
       const isSafeForLexical = isHtmlStringValueSafeForLexical(editorString, nodeMap);
 
       setIsSwitchFromPlaintextBlocked(!isSafeForLexical);
-      if (!isSafeForLexical) {
-        isNewValuePlaintext = true;
-        setIsValuePlaintext(isNewValuePlaintext);
-      }
 
       convertEditorState(editor, nodeMap, { isValuePlaintext: isNewValuePlaintext }).then(setValue);
     });


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix

## What is the current behavior? (You can also link to an open issue here)

If you paste or type some HTML into the rich text editor which is not considered Lexical-safe, the HTML editor assumes that this is unsafe and forces the editor to switch to the code view (plaintext editor).

This is problematic from a technical point of view because it causes the editor to be deleted and recreated (firing blur events, re-renders, etc.), but also from a user point of view because it switches the user into the other mode without them being aware of it.

## What is the new behavior (if this is a feature change)?

As it turns out, the above behavior is actually completely unneeded.

- If you are typing in the rich text editor, everything you type should be Lexical-safe; that is, typing HTML there is not actually HTML, it's just plaintext (i.e., typing `<div>` is actually `&lt;div&gt;`). So, it's Lexical-safe and we don't need to force you to the code view.
- If you are typing in the code view, you are... already in the code view, so we don't need to force you to the code view.

Therefore, the new behavior is that we don't check whether to forcibly switch the user to code view when new text is entered. The behavior that remains is whether the button to switch from code view to rich text view is enabled.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

## Please Include Screenshots or Videos of the intended change:

### Before

![no-set-broken](https://github.com/Azure/LogicAppsUX/assets/1350074/4df28853-bd8e-4a97-8f58-c5fdb0ffa968)

### After

![no-set-working](https://github.com/Azure/LogicAppsUX/assets/1350074/e5795e68-ad9e-4ad8-885c-1e18474e40d7)