### PR TITLE
fix(vscode): Fix designtime local.settings overwriting 

### DIFF
--- a/apps/vs-code-designer/__mocks__/vscode.ts
+++ b/apps/vs-code-designer/__mocks__/vscode.ts
@@ -1,3 +1,0 @@
-module.exports = {
-  Uri: {},
-};

--- a/apps/vs-code-designer/__mocks__/vscode.ts
+++ b/apps/vs-code-designer/__mocks__/vscode.ts
@@ -1,0 +1,3 @@
+module.exports = {
+  Uri: {},
+};

--- a/apps/vs-code-designer/src/app/commands/appSettings/decryptLocalSettings.ts
+++ b/apps/vs-code-designer/src/app/commands/appSettings/decryptLocalSettings.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { extensionCommand } from '../../../constants';
-import type { Uri } from 'vscode';
-import { commands } from 'vscode';
+import { commands, type Uri } from 'vscode';
 
 /**
  * Executes command to decrypt local settings file.

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createLogicApp/ScriptProjectCreateStep.ts
@@ -2,7 +2,14 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { gitignoreFileName, hostFileName, localSettingsFileName, logicAppKind } from '../../../../../constants';
+import {
+  azureWebJobsStorageKey,
+  gitignoreFileName,
+  hostFileName,
+  localEmulatorConnectionString,
+  localSettingsFileName,
+  logicAppKind,
+} from '../../../../../constants';
 import { addDefaultBundle } from '../../../../utils/bundleFeed';
 import { confirmOverwriteFile, writeFormattedJson } from '../../../../utils/fs';
 import { ProjectCodeCreateStepBase } from '../../CodeProjectBase/ProjectCodeCreateStepBase';
@@ -59,7 +66,7 @@ export class ScriptProjectCreateStep extends ProjectCodeCreateStepBase {
       const localSettingsJson: ILocalSettingsJson = {
         IsEncrypted: false,
         Values: {
-          AzureWebJobsStorage: 'UseDevelopmentStorage=true',
+          [azureWebJobsStorageKey]: localEmulatorConnectionString,
           WORKFLOWS_SUBSCRIPTION_ID: '',
           FUNCTIONS_WORKER_RUNTIME: 'node',
           APP_KIND: logicAppKind,

--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
@@ -2,7 +2,16 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { gitignoreFileName, hostFileName, localSettingsFileName, logicAppKind, workerRuntimeKey } from '../../../../constants';
+import {
+  ProjectDirectoryPath,
+  appKindSetting,
+  azureWebJobsStorageKey,
+  gitignoreFileName,
+  hostFileName,
+  localSettingsFileName,
+  logicAppKind,
+  workerRuntimeKey,
+} from '../../../../constants';
 import { addDefaultBundle } from '../../../utils/bundleFeed';
 import { confirmOverwriteFile, writeFormattedJson } from '../../../utils/fs';
 import { getFunctionsWorkerRuntime } from '../../../utils/vsCodeConfig/settings';
@@ -47,9 +56,9 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
       const localSettingsJson: ILocalSettingsJson = {
         IsEncrypted: false,
         Values: {
-          AzureWebJobsStorage: '',
-          APP_KIND: logicAppKind,
-          ProjectDirectoryPath: path.join(context.projectPath),
+          [azureWebJobsStorageKey]: '',
+          [appKindSetting]: logicAppKind,
+          [ProjectDirectoryPath]: path.join(context.projectPath),
         },
       };
 

--- a/apps/vs-code-designer/src/app/commands/dataMapper/extensionConfig.ts
+++ b/apps/vs-code-designer/src/app/commands/dataMapper/extensionConfig.ts
@@ -1,5 +1,3 @@
-import { logicAppKind } from '../../../constants';
-
 export const webviewType = 'dataMapperWebview';
 
 export const supportedDataMapDefinitionFileExts = ['.lml', '.yml'];
@@ -16,15 +14,5 @@ export const defaultDataMapFilename = 'default';
 export const draftMapDefinitionSuffix = '.draft';
 export const mapDefinitionExtension = '.lml';
 export const mapXsltExtension = '.xslt';
-
-export const settingsFileContent = {
-  IsEncrypted: false,
-  Values: {
-    AzureWebJobsSecretStorageType: 'Files',
-    FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated',
-    ProjectDirectoryPath: 'should/be/set/by/code',
-    APP_KIND: logicAppKind,
-  },
-};
 
 export const backendRuntimeBaseUrl = 'http://localhost:';

--- a/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getLocalSettingsSchema } from '../localSettings';
+import {
+  ProjectDirectoryPath,
+  appKindSetting,
+  azureStorageTypeSetting,
+  azureWebJobsSecretStorageTypeKey,
+  azureWebJobsStorageKey,
+  localEmulatorConnectionString,
+  workerRuntimeKey,
+} from '../../../../constants';
+
+describe('utils/appSettings', () => {
+  describe('getLocalSettingsSchema', () => {
+    const projectPath = 'path/to/project';
+
+    it('Should have IsEncrypted property and Values property have basic schema', () => {
+      const settings = getLocalSettingsSchema(true);
+      expect(settings).toHaveProperty('IsEncrypted', false);
+      expect(settings).toHaveProperty('Values');
+      expect(settings['Values']).toHaveProperty(appKindSetting);
+      expect(settings['Values']).toHaveProperty(workerRuntimeKey);
+    });
+
+    it('Should not have ProjectDirectoryPath when project path param is not sent', () => {
+      const settings = getLocalSettingsSchema(true);
+      expect(settings).not.toHaveProperty(ProjectDirectoryPath);
+    });
+
+    it('Should have the AzureWebJobsSecretStorageType when is design time localsettings and have ProjectDirectoryPath property when sent', () => {
+      const settings = getLocalSettingsSchema(true, projectPath);
+      expect(settings['Values']).toHaveProperty(azureWebJobsSecretStorageTypeKey, azureStorageTypeSetting);
+      expect(settings['Values']).toHaveProperty(ProjectDirectoryPath, projectPath);
+    });
+
+    it('Should have the AzureWebJobsStorage when is not design time localsettings and have ProjectDirectoryPath property when sent', () => {
+      const settings = getLocalSettingsSchema(false, projectPath);
+      expect(settings['Values']).toHaveProperty(azureWebJobsStorageKey, localEmulatorConnectionString);
+      expect(settings['Values']).toHaveProperty(ProjectDirectoryPath, projectPath);
+    });
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
@@ -11,6 +11,7 @@ import {
   localEmulatorConnectionString,
   logicAppKind,
   workerRuntimeKey,
+  azureStorageTypeSetting,
 } from '../../../constants';
 import { localize } from '../../../localize';
 import { decryptLocalSettings } from '../../commands/appSettings/decryptLocalSettings';
@@ -24,8 +25,7 @@ import { MismatchBehavior, WorkerRuntime } from '@microsoft/vscode-extension-log
 import type { ILocalSettingsJson } from '@microsoft/vscode-extension-logic-apps';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import type { MessageItem } from 'vscode';
-import { Uri } from 'vscode';
+import { Uri, type MessageItem } from 'vscode';
 
 /**
  * Updates local.settings.json file.
@@ -192,23 +192,15 @@ export async function getAzureWebJobsStorage(context: IActionContext, projectPat
  * @returns The local settings schema.
  */
 export const getLocalSettingsSchema = (isDesignTime: boolean, projectPath?: string) => {
-  return isDesignTime
-    ? {
-        IsEncrypted: false,
-        Values: {
-          [azureWebJobsSecretStorageTypeKey]: 'Files',
-          [appKindSetting]: logicAppKind,
-          [workerRuntimeKey]: WorkerRuntime.Node,
-          ...(projectPath ? { [ProjectDirectoryPath]: projectPath } : {}),
-        },
-      }
-    : {
-        IsEncrypted: false,
-        Values: {
-          [azureWebJobsStorageKey]: localEmulatorConnectionString,
-          [appKindSetting]: logicAppKind,
-          [workerRuntimeKey]: WorkerRuntime.Node,
-          ...(projectPath ? { [ProjectDirectoryPath]: projectPath } : {}),
-        },
-      };
+  return {
+    IsEncrypted: false,
+    Values: {
+      [appKindSetting]: logicAppKind,
+      [workerRuntimeKey]: WorkerRuntime.Node,
+      ...(projectPath ? { [ProjectDirectoryPath]: projectPath } : {}),
+      ...(isDesignTime
+        ? { [azureWebJobsSecretStorageTypeKey]: azureStorageTypeSetting }
+        : { [azureWebJobsStorageKey]: localEmulatorConnectionString }),
+    },
+  };
 };

--- a/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
@@ -2,7 +2,16 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { azureWebJobsStorageKey, localSettingsFileName } from '../../../constants';
+import {
+  azureWebJobsStorageKey,
+  localSettingsFileName,
+  ProjectDirectoryPath,
+  appKindSetting,
+  azureWebJobsSecretStorageTypeKey,
+  localEmulatorConnectionString,
+  logicAppKind,
+  workerRuntimeKey,
+} from '../../../constants';
 import { localize } from '../../../localize';
 import { decryptLocalSettings } from '../../commands/appSettings/decryptLocalSettings';
 import { encryptLocalSettings } from '../../commands/appSettings/encryptLocalSettings';
@@ -11,7 +20,7 @@ import { writeFormattedJson } from '../fs';
 import { parseJson } from '../parseJson';
 import { DialogResponses, parseError } from '@microsoft/vscode-azext-utils';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
-import { MismatchBehavior } from '@microsoft/vscode-extension-logic-apps';
+import { MismatchBehavior, WorkerRuntime } from '@microsoft/vscode-extension-logic-apps';
 import type { ILocalSettingsJson } from '@microsoft/vscode-extension-logic-apps';
 import * as fse from 'fs-extra';
 import * as path from 'path';
@@ -23,14 +32,16 @@ import { Uri } from 'vscode';
  * @param {IActionContext} context - Command context.
  * @param {string} projectPath - Project path with local.settings.json file.
  * @param {boolean} settingsToAdd - Settings data to updata.
+ * @param {boolean} isDesignTime - A flag indicating whether it is design time or not.
  */
 export async function addOrUpdateLocalAppSettings(
   context: IActionContext,
   projectPath: string,
-  settingsToAdd: Record<string, string>
+  settingsToAdd: Record<string, string>,
+  isDesignTime = false
 ): Promise<void> {
   const localSettingsPath: string = path.join(projectPath, localSettingsFileName);
-  const settings: ILocalSettingsJson = await getLocalSettingsJson(context, localSettingsPath);
+  const settings: ILocalSettingsJson = await getLocalSettingsJson(context, localSettingsPath, isDesignTime);
 
   settings.Values = settings.Values || {};
   settings.Values = {
@@ -71,12 +82,14 @@ async function getDecriptedLocalSettings(
  * @param {IActionContext} context - Command context.
  * @param {string} localSettingsPath - File path.
  * @param {boolean} allowOverwrite - Allow overwrite on file.
+ * @param {boolean} isDesignTime - A flag indicating whether it is design time or not.
  * @returns {Promise<ILocalSettingsJson>} local.setting.json file.
  */
 export async function getLocalSettingsJson(
   context: IActionContext,
   localSettingsPath: string,
-  allowOverwrite = false
+  allowOverwrite = false,
+  isDesignTime = false
 ): Promise<ILocalSettingsJson> {
   if (fse.existsSync(localSettingsPath)) {
     const data: string = (await fse.readFile(localSettingsPath)).toString();
@@ -115,12 +128,7 @@ export async function getLocalSettingsJson(
     }
   }
 
-  return {
-    IsEncrypted: false,
-    Values: {
-      AzureWebJobsStorage: '',
-    },
-  };
+  return getLocalSettingsSchema(isDesignTime);
 }
 
 /**
@@ -176,3 +184,31 @@ export async function getAzureWebJobsStorage(context: IActionContext, projectPat
   const settings: ILocalSettingsJson = await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName));
   return settings.Values && settings.Values[azureWebJobsStorageKey];
 }
+
+/**
+ * Retrieves the local settings schema based on the project path and design time flag.
+ * @param {boolean} isDesignTime - A flag indicating whether it is design time or not.
+ * @param {string} projectPath - The path of the project.
+ * @returns The local settings schema.
+ */
+export const getLocalSettingsSchema = (isDesignTime: boolean, projectPath?: string) => {
+  return isDesignTime
+    ? {
+        IsEncrypted: false,
+        Values: {
+          [azureWebJobsSecretStorageTypeKey]: 'Files',
+          [appKindSetting]: logicAppKind,
+          [workerRuntimeKey]: WorkerRuntime.Node,
+          ...(projectPath ? { [ProjectDirectoryPath]: projectPath } : {}),
+        },
+      }
+    : {
+        IsEncrypted: false,
+        Values: {
+          [azureWebJobsStorageKey]: localEmulatorConnectionString,
+          [appKindSetting]: logicAppKind,
+          [workerRuntimeKey]: WorkerRuntime.Node,
+          ...(projectPath ? { [ProjectDirectoryPath]: projectPath } : {}),
+        },
+      };
+};

--- a/apps/vs-code-designer/src/app/utils/codeless/__test__/templates.test.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/__test__/templates.test.ts
@@ -2,7 +2,7 @@ import { type StandardApp, ProjectType } from '@microsoft/vscode-extension-logic
 import { describe, it, expect } from 'vitest';
 import { getCodelessWorkflowTemplate, getFunctionWorkflowTemplate } from '../templates';
 import { workflowKind } from '../../../../constants';
-import { isNullOrEmpty, isRecordNotEmpty } from '@microsoft/logic-apps-shared';
+import { isNullOrEmpty } from '@microsoft/logic-apps-shared';
 
 const methodName = 'testMethod';
 

--- a/apps/vs-code-designer/src/app/utils/fs.ts
+++ b/apps/vs-code-designer/src/app/utils/fs.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { localize } from '../../localize';
 import { isEmptyString } from '@microsoft/logic-apps-shared';
-import type { IActionContext } from '@microsoft/vscode-azext-utils';
-import { DialogResponses } from '@microsoft/vscode-azext-utils';
+import { DialogResponses, type IActionContext } from '@microsoft/vscode-azext-utils';
 import type { pathRelativeFunc } from '@microsoft/vscode-extension-logic-apps';
 import * as crypto from 'crypto';
 import * as fse from 'fs-extra';

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -215,6 +215,7 @@ export const appKindSetting = 'APP_KIND';
 export const workerRuntimeKey = 'FUNCTIONS_WORKER_RUNTIME';
 export const ProjectDirectoryPath = 'ProjectDirectoryPath';
 export const extensionVersionKey = 'FUNCTIONS_EXTENSION_VERSION';
+export const azureStorageTypeSetting = 'Files';
 // Project
 export const defaultBundleId = 'Microsoft.Azure.Functions.ExtensionBundle';
 export const defaultVersionRange = '[1.*, 2.0.0)'; // Might need to be changed

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -33,9 +33,6 @@ export const azuriteLocationSetting = 'location';
 // Functions
 export const func = 'func';
 export const functionsExtensionId = 'ms-azuretools.vscode-azurefunctions';
-export const workerRuntimeKey = 'FUNCTIONS_WORKER_RUNTIME';
-export const ProjectDirectoryPath = 'ProjectDirectoryPath';
-export const extensionVersionKey = 'FUNCTIONS_EXTENSION_VERSION';
 export const hostStartCommand = 'host start';
 export const hostStartTaskName = `${func}: ${hostStartCommand}`;
 export const funcPackageName = 'azure-functions-core-tools';
@@ -60,6 +57,7 @@ export const workflowTenantIdKey = 'WORKFLOWS_TENANT_ID';
 export const workflowManagementBaseURIKey = 'WORKFLOWS_MANAGEMENT_BASE_URI';
 export const workflowAppApiVersion = '2018-11-01';
 export const azureWebJobsStorageKey = 'AzureWebJobsStorage';
+export const azureWebJobsSecretStorageTypeKey = 'AzureWebJobsSecretStorageType';
 export const workflowappRuntime = 'node|14';
 export const viewOutput = localize('viewOutput', 'View Output');
 export const webhookRedirectHostUri = 'Workflows.WebhookRedirectHostUri';
@@ -214,7 +212,9 @@ export const targetBundleKey = 'FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI';
 // local.settings.json
 export const localEmulatorConnectionString = 'UseDevelopmentStorage=true';
 export const appKindSetting = 'APP_KIND';
-
+export const workerRuntimeKey = 'FUNCTIONS_WORKER_RUNTIME';
+export const ProjectDirectoryPath = 'ProjectDirectoryPath';
+export const extensionVersionKey = 'FUNCTIONS_EXTENSION_VERSION';
 // Project
 export const defaultBundleId = 'Microsoft.Azure.Functions.ExtensionBundle';
 export const defaultVersionRange = '[1.*, 2.0.0)'; // Might need to be changed

--- a/apps/vs-code-designer/vitest.config.ts
+++ b/apps/vs-code-designer/vitest.config.ts
@@ -3,6 +3,18 @@ import packageJson from './package.json';
 
 export default defineProject({
   plugins: [],
+  resolve: {
+    alias: [
+      {
+        find: 'vscode',
+        replacement: `${__dirname}/__mocks__/vscode`,
+      },
+      {
+        find: '@microsoft/vscode-azext-utils',
+        replacement: `${__dirname}/__mocks__/vscode`,
+      },
+    ],
+  },
   test: {
     name: packageJson.name,
     dir: './src',

--- a/apps/vs-code-designer/vitest.config.ts
+++ b/apps/vs-code-designer/vitest.config.ts
@@ -7,11 +7,11 @@ export default defineProject({
     alias: [
       {
         find: 'vscode',
-        replacement: `${__dirname}/__mocks__/vscode`,
+        replacement: `${__dirname}/node_modules/@types/vscode/index.d`,
       },
       {
         find: '@microsoft/vscode-azext-utils',
-        replacement: `${__dirname}/__mocks__/vscode`,
+        replacement: `${__dirname}/node_modules/@types/vscode/index.d`,
       },
     ],
   },


### PR DESCRIPTION
This pull request introduces changes primarily aimed at refactoring the project's settings management, improving code readability, and enhancing the test coverage. The modifications include consolidating imports, replacing hardcoded values with constants, adjusting the structure of local settings, and adding new test cases.



* Consolidated imports from 'vscode' into a single line.
* Replaced hardcoded values with constants and expanded the import list for better readability. 
* Similar changes were made as in `ScriptProjectCreateStep.ts` for code consistency.
* The local settings structure was adjusted to include a design time flag and improved key-value mapping. The function `getLocalSettingsSchema` was added to generate the schema based on the project path and design time flag.


*  New test cases were added to verify the correct behavior of the `getLocalSettingsSchema` function.


* The settings file content was replaced with the `getLocalSettingsSchema` function. 
* Removed unused settings file content. 
* Replaced hardcoded settings file content with the `getLocalSettingsSchema` function. 