### PR TITLE
fix(vscode): Update functions extension bundle to workflows

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/getDebugSymbolDll.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/getDebugSymbolDll.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { debugSymbolDll } from '../../../constants';
+import { debugSymbolDll, extensionBundleId } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { getFunctionsCommand } from '../../utils/funcCoreTools/funcVersion';
@@ -12,7 +12,7 @@ import * as path from 'path';
 
 export async function getDebugSymbolDll(): Promise<string> {
   const bundleFolderRoot = await getExtensionBundleFolder();
-  const bundleFolder = path.join(bundleFolderRoot, 'Microsoft.Azure.Functions.ExtensionBundle.Workflows');
+  const bundleFolder = path.join(bundleFolderRoot, extensionBundleId);
   let bundleVersionNumber = '0.0.0';
 
   const bundleFolders = await fse.readdir(bundleFolder);

--- a/apps/vs-code-designer/src/app/utils/bundleFeed.ts
+++ b/apps/vs-code-designer/src/app/utils/bundleFeed.ts
@@ -2,13 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import {
-  defaultVersionRange,
-  defaultBundleId,
-  localSettingsFileName,
-  defaultExtensionBundlePathValue,
-  extensionBundleId,
-} from '../../constants';
+import { defaultVersionRange, extensionBundleId, localSettingsFileName, defaultExtensionBundlePathValue } from '../../constants';
 import { getLocalSettingsJson } from './appSettings/localSettings';
 import { downloadAndExtractDependency } from './binaries';
 import { getJsonFeed } from './feed';
@@ -26,12 +20,12 @@ import * as vscode from 'vscode';
  * @returns {Promise<IBundleFeed>} Returns bundle extension object.
  */
 async function getBundleFeed(context: IActionContext, bundleMetadata: IBundleMetadata | undefined): Promise<IBundleFeed> {
-  const bundleId: string = (bundleMetadata && bundleMetadata.id) || defaultBundleId;
+  const bundleId: string = (bundleMetadata && bundleMetadata.id) || extensionBundleId;
 
   const envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
   // Only use an aka.ms link for the most common case, otherwise we will dynamically construct the url
   let url: string;
-  if (!envVarUri && bundleId === defaultBundleId) {
+  if (!envVarUri && bundleId === extensionBundleId) {
     url = 'https://aka.ms/AA66i2x';
   } else {
     const baseUrl: string = envVarUri || 'https://functionscdn.azureedge.net/public';
@@ -65,7 +59,7 @@ async function getBundleDependencyFeed(
   context: IActionContext,
   bundleMetadata: IBundleMetadata | undefined
 ): Promise<IBundleDependencyFeed> {
-  const bundleId: string = (bundleMetadata && bundleMetadata?.id) || defaultBundleId;
+  const bundleId: string = (bundleMetadata && bundleMetadata?.id) || extensionBundleId;
   const projectPath: string | undefined = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
   let envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
   if (projectPath) {
@@ -112,7 +106,7 @@ export async function addDefaultBundle(context: IActionContext, hostJson: IHostJ
   }
 
   hostJson.extensionBundle = {
-    id: defaultBundleId,
+    id: extensionBundleId,
     version: versionRange,
   };
 }

--- a/apps/vs-code-designer/src/app/utils/bundleFeed.ts
+++ b/apps/vs-code-designer/src/app/utils/bundleFeed.ts
@@ -26,7 +26,7 @@ async function getBundleFeed(context: IActionContext, bundleMetadata: IBundleMet
   // Only use an aka.ms link for the most common case, otherwise we will dynamically construct the url
   let url: string;
   if (!envVarUri && bundleId === extensionBundleId) {
-    url = 'https://aka.ms/AA66i2x';
+    url = 'https://aka.ms/AAqvc78';
   } else {
     const baseUrl: string = envVarUri || 'https://functionscdn.azureedge.net/public';
     url = `${baseUrl}/ExtensionBundles/${bundleId}/index-v2.json`;

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -217,7 +217,6 @@ export const ProjectDirectoryPath = 'ProjectDirectoryPath';
 export const extensionVersionKey = 'FUNCTIONS_EXTENSION_VERSION';
 export const azureStorageTypeSetting = 'Files';
 // Project
-export const defaultBundleId = 'Microsoft.Azure.Functions.ExtensionBundle';
 export const defaultVersionRange = '[1.*, 2.0.0)'; // Might need to be changed
 export const funcWatchProblemMatcher = '$func-watch';
 export const extInstallCommand = 'extensions install';


### PR DESCRIPTION
This pull request primarily focuses on refactoring the `apps/vs-code-designer` codebase to replace the usage of `defaultBundleId` with `extensionBundleId`. This change is reflected across multiple files and functions. 



* The `debugSymbolDll` import statement now includes `extensionBundleId` and the `bundleFolder` path now uses `extensionBundleId` instead of the hard-coded string. 

* The `defaultBundleId` import has been removed and replaced by `extensionBundleId` in all instances. This includes changes in the `getBundleFeed`, `getBundleDependencyFeed`, and `addDefaultBundle` functions. 

* The `defaultBundleId` constant has been removed.

