### PR TITLE
feat(Designer): Increased browse operation request page size to 5k

### DIFF
--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
@@ -110,8 +110,8 @@ export const OperationSearchHeader = (props: OperationSearchHeaderProps) => {
       {displayRuntimeInfo || displayActionType ? (
         <div style={{ display: 'grid', grid: 'auto-flow / 1fr 1fr', gridColumnGap: '8px' }}>
           {displayRuntimeInfo && runtimeFilters.length > 0 ? (
-            <div>
-              <Label>{intl.formatMessage({ defaultMessage: 'Runtime', id: 'g5A6Bn', description: 'Filter by label' })} </Label>
+            <div style={{ display: 'inherit' }}>
+              <Label>{intl.formatMessage({ defaultMessage: 'Runtime', id: 'g5A6Bn', description: 'Filter by label' })}</Label>
               <Dropdown
                 placeholder={
                   filters?.['runtime']
@@ -135,8 +135,8 @@ export const OperationSearchHeader = (props: OperationSearchHeaderProps) => {
             </div>
           ) : null}
           {displayActionType ? (
-            <div>
-              <Label> {intl.formatMessage({ defaultMessage: 'Action Type', id: 'TRpSCQ', description: 'Filter by label' })}</Label>
+            <div style={{ display: 'inherit' }}>
+              <Label>{intl.formatMessage({ defaultMessage: 'Action Type', id: 'TRpSCQ', description: 'Filter by label' })}</Label>
               <Dropdown
                 placeholder={
                   filters?.['actionType']

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
@@ -59,7 +59,7 @@ export abstract class BaseSearchService implements ISearchService {
     uri: string,
     queryParams?: any,
     pageNumber = 0,
-    pageSize = 2500
+    pageSize = 5000
   ): Promise<{ value: any[]; hasMore: boolean }> {
     if (this._isDev) {
       return { value: [], hasMore: false };


### PR DESCRIPTION
## Main Changes

Arjun helped increase the number of operations we can request for at once from 2.5k to 5k, speeding things up by a couple calls!
Operation search/browse should load a little quicker from this small change.

I also fixed a small UI bug in search, the dropdowns were not the right width after updating to V9 a few weeks ago.
Fixed screenshot below:
![image](https://github.com/Azure/LogicAppsUX/assets/25409734/adf9c598-dc8a-411e-af8d-b71782fccd92)
