### PR TITLE
feat(designer-ui): Allow makers to use `class` attributes and `table` styling in raw HTML

### DIFF
--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/__test__/util.spec.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/__test__/util.spec.ts
@@ -110,20 +110,28 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
   describe('isAttributeSupportedByHtmlEditor', () => {
     it.each<[string, string, boolean]>([
       ['', 'href', false],
+      ['a', 'class', true],
       ['a', '', false],
       ['a', 'href', true],
       ['a', 'id', true],
       ['a', 'style', true],
+      ['span', 'class', true],
+      ['span', 'cellpadding', false],
       ['span', 'href', false],
       ['span', 'id', true],
       ['span', 'style', true],
+      ['p', 'class', true],
+      ['p', 'cellpadding', false],
       ['p', 'href', false],
       ['p', 'id', true],
       ['p', 'style', true],
+      ['img', 'class', true],
       ['img', 'id', true],
       ['img', 'alt', true],
       ['img', 'script', false],
       ['img', 'src', true],
+      ['table', 'class', true],
+      ['table', 'cellpadding', true],
     ])('should return <%s %s="..." /> as supported=%p', (inputTag, inputAttr, expected) => {
       expect(isAttributeSupportedByHtmlEditor(inputTag, inputAttr)).toBe(expected);
     });

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
@@ -39,9 +39,10 @@ const lexicalSupportedTagNames = new Set([
   'ul',
 ]);
 const htmlEditorSupportedAttributes: { '*': string[] } & Record<string, string[]> = {
-  '*': ['id', 'style'],
+  '*': ['class', 'id', 'style'],
   a: ['href'],
   img: ['alt', 'src'],
+  table: ['border', 'cellpadding', 'cellspacing'],
 };
 
 export interface Position {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

- **What is the current behavior?** (You can also link to an open issue here)

Users are unable to use `class`-attribute-based styling in HTML editor, despite this being a valid use case. This was excluded at dev time in favor of `style`, but as `class` is still widely used, this change permits use of it.

- **What is the new behavior (if this is a feature change)?**

This PR allows use of CSS `class` attributes, as well as various `<table>` attributes that users often rely on for formatting emails.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/7ab81999-f87b-45e9-b2e6-e9ca4d8d0806)

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/e7077169-6ccc-4dda-8e63-99cd40ca22b1)

![image](https://github.com/Azure/LogicAppsUX/assets/1350074/183327fd-d06b-499c-a910-f46d3d2caaf4)