### PR TITLE
fix(vscode): Update unit test tree when adding test file

### DIFF
--- a/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
+++ b/apps/vs-code-designer/src/app/tree/unitTestTree/index.ts
@@ -26,6 +26,7 @@ import {
   tests,
   TestRunProfileKind,
 } from 'vscode';
+import { getUnitTestName } from '../../utils/unitTests';
 
 export type TestData = TestWorkspace | TestWorkflow | TestFile;
 
@@ -207,7 +208,6 @@ const getOrCreateWorkspace = (controller: TestController, workspaceName: string,
  */
 const getOrCreateFile = async (controller: TestController, uri: Uri) => {
   const workspaceName = uri.fsPath.split(path.sep).slice(-5)[0];
-  const testName = path.basename(uri.fsPath);
   const workflowName = path.basename(path.dirname(uri.fsPath));
 
   const existingWorkspaceTest = controller.items.get(workspaceName);
@@ -216,8 +216,11 @@ const getOrCreateFile = async (controller: TestController, uri: Uri) => {
     const existingWorkflowTest = existingWorkspaceTest.children.get(`${workspaceName}/${workflowName}`);
 
     if (existingWorkflowTest) {
-      const existingFileTest = existingWorkflowTest.children.get(`${workspaceName}/${workflowName}/${testName}`);
-      return { file: existingFileTest, data: ext.testData.get(existingFileTest) as TestFile };
+      const testName = getUnitTestName(uri.fsPath);
+      const unitTestFileName = path.basename(uri.fsPath);
+      const fileTestItem = controller.createTestItem(`${workspaceName}/${workflowName}/${unitTestFileName}`, testName, uri);
+      existingWorkflowTest.children.add(fileTestItem);
+      return {};
     }
     const workflowTestItem = controller.createTestItem(`${workspaceName}/${workflowName}`, workflowName, uri);
     workflowTestItem.canResolveChildren = true;


### PR DESCRIPTION
This pull request primarily focuses on refactoring the unit test tree structure in the `apps/vs-code-designer` application. The changes include importing a new utility function to get unit test names, removing the usage of the `path.basename(uri.fsPath)` to get the test name, and creating a new test item with the help of the imported utility function.


* Imported the `getUnitTestName` utility function to fetch the unit test name more accurately.
* Removed the usage of `path.basename(uri.fsPath)` to get the test name, which was previously used to create the test item.
*  Created a new test item using the `getUnitTestName` utility function and added it to the existing workflow test's children. This change also includes the removal of the existing file test return statement.