### PR TITLE
fix(vscode): Update bundle dependencies to dotnetVersions 

### DIFF
--- a/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
+++ b/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
@@ -89,7 +89,7 @@ export async function validateAndInstallBinaries(context: IActionContext) {
         context.telemetry.properties.lastStep = 'validateDotNetIsLatest';
         await runWithDurationTelemetry(context, 'azureLogicAppsStandard.validateDotNetIsLatest', async () => {
           progress.report({ increment: 20, message: '.NET SDK' });
-          const dotnetDependencies = dependenciesVersions?.dotnetMulti ?? dependenciesVersions?.dotnet;
+          const dotnetDependencies = dependenciesVersions?.dotnetVersions ?? dependenciesVersions?.dotnet;
           await timeout(
             validateDotNetIsLatest,
             '.NET SDK',

--- a/libs/vscode-extension/src/lib/models/bundleFeed.ts
+++ b/libs/vscode-extension/src/lib/models/bundleFeed.ts
@@ -18,5 +18,5 @@ export interface IBundleDependencyFeed {
   dotnet?: string;
   funcCoreTools?: string;
   nodejs?: string;
-  dotnetMulti?: string;
+  dotnetVersions?: string;
 }


### PR DESCRIPTION
Update bundle dependencies to dotnetVersions
Cherry-pick of following:
https://github.com/Azure/LogicAppsUX/pull/5014

