### PR TITLE
fix(designer): Ensure skipped actions are not mocked

### DIFF
--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -244,12 +244,16 @@ export const deserializeUnitTestDefinition = (
 
     const actionResult = unitTestDefinition.actionMocks[actionName].properties?.status;
 
-    if (supportedAction && (actionResult === ActionResults.SUCCESS || actionResult === ActionResults.FAILED)) {
-      mockResults[actionName] = {
-        actionResult: unitTestDefinition.actionMocks[actionName].properties?.status ?? ActionResults.SUCCESS,
-        output: parseOutputsToValueSegment(mockOutputs),
-        isCompleted: !isNullOrEmpty(mockOutputs),
-      };
+    if (supportedAction) {
+      if (actionResult === ActionResults.SUCCESS || actionResult === ActionResults.FAILED) {
+        mockResults[actionName] = {
+          actionResult: actionResult,
+          output: parseOutputsToValueSegment(mockOutputs),
+          isCompleted: !isNullOrEmpty(mockOutputs),
+        };
+      } else {
+        delete mockResults[actionName];
+      }
     }
   });
 

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -232,11 +232,25 @@ export const deserializeUnitTestDefinition = (
 
   Object.keys(unitTestDefinition.actionMocks).forEach((actionName) => {
     const mockOutputs = unitTestDefinition.actionMocks[actionName].outputs ?? {};
-    mockResults[actionName] = {
-      actionResult: unitTestDefinition.actionMocks[actionName].properties?.status ?? ActionResults.SUCCESS,
-      output: parseOutputsToValueSegment(mockOutputs),
-      isCompleted: !isNullOrEmpty(mockOutputs),
-    };
+    const action = definition.actions && definition.actions[actionName];
+    const type = action?.type?.toLowerCase();
+    const supportedAction =
+      type === 'http' ||
+      type === 'invokefunction' ||
+      type === ConnectionType.ServiceProvider ||
+      type === ConnectionType.Function ||
+      type === ConnectionType.ApiManagement ||
+      type === ConnectionType.ApiConnection;
+
+    const actionResult = unitTestDefinition.actionMocks[actionName].properties?.status;
+
+    if (supportedAction && (actionResult === ActionResults.SUCCESS || actionResult === ActionResults.FAILED)) {
+      mockResults[actionName] = {
+        actionResult: unitTestDefinition.actionMocks[actionName].properties?.status ?? ActionResults.SUCCESS,
+        output: parseOutputsToValueSegment(mockOutputs),
+        isCompleted: !isNullOrEmpty(mockOutputs),
+      };
+    }
   });
 
   // deserialize assertions


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix to ensure skipped actions and nonmockable actions are not mocked when a unit test is created from an existing run.
- **What is the current behavior?** (You can also link to an open issue here)
Skipped actions and nonmockable actions are mocked when a unit test is created from an existing run.
- **What is the new behavior (if this is a feature change)?**
Only mockable actions that have the success or failed state are mocked.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
- **Please Include Screenshots or Videos of the intended change**:
