### PR TITLE
feat(docs): Add sanitizing instructions to HAR file

### DIFF
--- a/apps/docs/docs/tsg.mdx
+++ b/apps/docs/docs/tsg.mdx
@@ -64,6 +64,10 @@ If you are experiencing issues with the designer loading, or with any network re
 3. Refresh the page and reproduce the issue
 4. Once you have reproduced the issue, right-click anywhere in the grid of network requests, select **Save as HAR with Content**, and save the file to your computer
 5. Your HAR file is now ready to be sent
+6. If you want to sanitize the HAR file before sending, follow these steps: 
+    1. Upload the HAR file to the [sanitizer tool](https://aka.ms/sanitizer) to remove any sensitive information.
+    2. Download the sanitized zip file.
+    3. Upload the *.sanitized.zip file to the incident/issue as an attachment.
 
 :::caution Warning on sensitive information
 

--- a/apps/docs/docs/tsg.mdx
+++ b/apps/docs/docs/tsg.mdx
@@ -65,9 +65,9 @@ If you are experiencing issues with the designer loading, or with any network re
 4. Once you have reproduced the issue, right-click anywhere in the grid of network requests, select **Save as HAR with Content**, and save the file to your computer
 5. Your HAR file is now ready to be sent
 6. If you want to sanitize the HAR file before sending, follow these steps: 
-    1. Upload the HAR file to the [sanitizer tool](https://aka.ms/sanitizer) to remove any sensitive information.
-    2. Download the sanitized zip file.
-    3. Upload the *.sanitized.zip file to the incident/issue as an attachment.
+    1. Upload the HAR file to the [sanitizer tool](https://aka.ms/sanitizer) to remove any sensitive information
+    2. Download the sanitized zip file
+    3. Upload the *.sanitized.zip file to the incident/issue as an attachment
 
 :::caution Warning on sensitive information
 


### PR DESCRIPTION
This pull request includes a change to the `tsg.mdx` file in the `apps/docs/docs` directory. The change provides additional instructions on how to sanitize a HAR file before sending it, which includes uploading the file to a sanitizer tool, downloading the sanitized zip file, and then uploading this sanitized file as an attachment to the incident/issue.



<img width="1013" alt="Screenshot 2024-06-27 at 2 25 47 PM" src="https://github.com/Azure/LogicAppsUX/assets/102700317/19f6d69b-6d1b-48e7-8565-f1a1bcbdfe74">
