### PR TITLE
feat(vscode): Introduce connected environment and file share step

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ConnectedEnvironmentStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ConnectedEnvironmentStep.ts
@@ -27,7 +27,7 @@ export class ConnectedEnvironmentStep extends AzureWizardPromptStep<ILogicAppWiz
     const connectedEnvironment = (await wizardContext.ui.showQuickPick(this.getPicks(wizardContext), { placeHolder })).data;
 
     wizardContext.connectedEnvironment = connectedEnvironment;
-    wizardContext.telemetry.properties.connectedEnvironment = wizardContext.containerApp?.name;
+    wizardContext.telemetry.properties.connectedEnvironment = wizardContext.connectedEnvironment.name;
   }
 
   /**

--- a/apps/vs-code-designer/src/app/commands/deploy/deployToFileShare.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/deployToFileShare.ts
@@ -1,0 +1,75 @@
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { ProgressLocation, window } from 'vscode';
+import { executeCommand } from '../../utils/funcCoreTools/cpUtils';
+import { localize } from '../../../localize';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import { ext } from '../../../extensionVariables';
+import { tryGetLogicAppProjectRoot } from '../../utils/verifyIsProject';
+import { getWorkspaceFolderPath } from '../workflows/switchDebugMode/switchDebugMode';
+import type { File } from '../../utils/codeless/common';
+import { getArtifactsPathInLocalProject, getWorkflowsPathInLocalProject } from '../../utils/codeless/common';
+import { connectionsFileName, hostFileName, parametersFileName, workflowFileName } from '../../../constants';
+import type { SlotTreeItem } from '../../tree/slotsTree/SlotTreeItem';
+
+export const deployToFileShare = async (context: IActionContext, node: SlotTreeItem) => {
+  await window.withProgress({ location: ProgressLocation.Notification }, async (progress) => {
+    const message: string = localize('uploadingFileShare', 'Uploading files to File Share...');
+    ext.outputChannel.appendLog(message);
+    progress.report({ message });
+
+    try {
+      const workspaceFolder = await getWorkspaceFolderPath(context);
+      const { hostName, path: fileSharePath, userName, password } = node.fileShare || {};
+
+      const projectPath: string | undefined = await tryGetLogicAppProjectRoot(context, workspaceFolder, true /* suppressPrompt */);
+      await executeCommand(undefined, undefined, `net use ${hostName}/${fileSharePath} ${password} /user:${userName}`);
+      await uploadRootFiles(projectPath, hostName, fileSharePath);
+      await uploadWorkflowsFiles(projectPath, hostName, fileSharePath);
+      await uploadeArtifactsFiles(projectPath, hostName, fileSharePath);
+    } catch (error) {
+      console.error(`Error deploying to file share: ${error.message}`);
+    }
+  });
+};
+
+const uploadFiles = async (files: File[], hostName: string, fileSharePath: string) => {
+  for (const file of files) {
+    await fse.copy(file.path, `${hostName}/${fileSharePath}`, { overwrite: true });
+  }
+};
+
+const uploadRootFiles = async (projectPath: string | undefined, hostName: string, fileSharePath: string) => {
+  const hostJsonPath: string = path.join(projectPath, hostFileName);
+  const parametersJsonPath: string = path.join(projectPath, parametersFileName);
+  const connectionsJsonPath: string = path.join(projectPath, connectionsFileName);
+  const rootFiles = [
+    { path: hostJsonPath, name: hostFileName },
+    { path: parametersJsonPath, name: parametersFileName },
+    { path: connectionsJsonPath, name: connectionsFileName },
+  ];
+  for (const rootFile of rootFiles) {
+    if (await fse.pathExists(rootFile.path)) {
+      await uploadFiles([{ path: rootFile.path, name: rootFile.name }], hostName, fileSharePath);
+    }
+  }
+};
+
+const uploadWorkflowsFiles = async (projectPath: string | undefined, hostName: string, fileSharePath: string) => {
+  const workflowFiles = await getWorkflowsPathInLocalProject(projectPath);
+  for (const workflowFile of workflowFiles) {
+    await uploadFiles([{ ...workflowFile, name: workflowFileName }], hostName, fileSharePath);
+  }
+};
+
+const uploadeArtifactsFiles = async (projectPath: string | undefined, hostName: string, fileSharePath: string) => {
+  const artifactsFiles = await getArtifactsPathInLocalProject(projectPath);
+
+  if (artifactsFiles.maps.length > 0) {
+    await uploadFiles(artifactsFiles.maps, hostName, fileSharePath);
+  }
+
+  if (artifactsFiles.schemas.length > 0) {
+    await uploadFiles(artifactsFiles.schemas, hostName, fileSharePath);
+  }
+};

--- a/apps/vs-code-designer/src/app/tree/slotsTree/SlotTreeItem.ts
+++ b/apps/vs-code-designer/src/app/tree/slotsTree/SlotTreeItem.ts
@@ -6,7 +6,13 @@ import { getIconPath } from '../../utils/tree/assets';
 import { LogicAppResourceTree } from '../LogicAppResourceTree';
 import type { ConfigurationsTreeItem } from '../configurationsTree/ConfigurationsTreeItem';
 import type { RemoteWorkflowTreeItem } from '../remoteWorkflowsTree/RemoteWorkflowTreeItem';
-import type { AppSettingsTreeItem, DeploymentsTreeItem, IDeployContext, ParsedSite } from '@microsoft/vscode-azext-azureappservice';
+import type {
+  AppSettingsTreeItem,
+  CustomLocation,
+  DeploymentsTreeItem,
+  IDeployContext,
+  ParsedSite,
+} from '@microsoft/vscode-azext-azureappservice';
 import { AzExtParentTreeItem } from '@microsoft/vscode-azext-utils';
 import type { AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
 import type {
@@ -25,7 +31,13 @@ export class SlotTreeItem extends AzExtParentTreeItem implements IProjectTreeIte
   public readonly source: ProjectSource = ProjectSource.Remote;
   public site: ParsedSite;
   public readonly appSettingsTreeItem: AppSettingsTreeItem;
-
+  public customLocation?: CustomLocation;
+  public fileShare?: {
+    hostName?: string;
+    path?: string;
+    userName?: string;
+    password?: string;
+  };
   public readonly contextValue: string;
 
   public resourceTree: LogicAppResourceTree;

--- a/apps/vs-code-designer/src/app/tree/subscriptionTree/SubscriptionTreeItem.ts
+++ b/apps/vs-code-designer/src/app/tree/subscriptionTree/SubscriptionTreeItem.ts
@@ -220,7 +220,10 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
     const resolved = new LogicAppResourceTree(subscription.subscription, nonNullProp(wizardContext, 'site'));
     await LogicAppResolver.getSubscriptionSites(context, subscription.subscription);
     await ext.rgApi.appResourceTree.refresh(context);
-    return new SlotTreeItem(subscription, resolved);
+    const slotTreeItem = new SlotTreeItem(subscription, resolved);
+    slotTreeItem.customLocation = wizardContext.customLocation;
+    slotTreeItem.fileShare = wizardContext.fileShare;
+    return slotTreeItem;
   }
 
   public isAncestorOfImpl(contextValue: string | RegExp): boolean {

--- a/apps/vs-code-designer/src/app/tree/subscriptionTree/SubscriptionTreeItem.ts
+++ b/apps/vs-code-designer/src/app/tree/subscriptionTree/SubscriptionTreeItem.ts
@@ -8,6 +8,7 @@ import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { ConnectEnvironmentStep } from '../../commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ConnectEnvironmentStep';
 import { ConnectedEnvironmentStep } from '../../commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ConnectedEnvironmentStep';
+import { ContainerAppCreateStep } from '../../commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ContainerAppCreateStep';
 import { LogicAppCreateStep } from '../../commands/createLogicApp/createLogicAppSteps/LogicAppCreateStep';
 import { LogicAppHostingPlanStep } from '../../commands/createLogicApp/createLogicAppSteps/LogicAppHostingPlanStep';
 import { AzureStorageAccountStep } from '../../commands/deploy/storageAccountSteps/AzureStorageAccountStep';
@@ -28,7 +29,6 @@ import {
   AppInsightsCreateStep,
   AppInsightsListStep,
   AppKind,
-  AppServicePlanCreateStep,
   CustomLocationListStep,
   ParsedSite,
   SiteNameStep,
@@ -156,6 +156,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
     executeSteps.push(new VerifyProvidersStep([webProvider, storageProvider, insightsProvider]));
     executeSteps.push(new LogicAppCreateStep());
     executeSteps.push(new ConnectEnvironmentStep());
+    executeSteps.push(new ContainerAppCreateStep());
 
     const title: string = localize('functionAppCreatingTitle', 'Create new Logic App (Standard) in Azure');
     const wizard: AzureWizard<IAppServiceWizardContext> = new AzureWizard(wizardContext, { promptSteps, executeSteps, title });
@@ -164,7 +165,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
     if (wizardContext.customLocation) {
       setSiteOS(wizardContext);
-      executeSteps.unshift(new AppServicePlanCreateStep());
+      executeSteps.pop();
     }
 
     wizardContext.activityTitle = localize(


### PR DESCRIPTION
This pull request primarily focuses on expanding the deployment capabilities of the application, specifically allowing deployment to a file share. The changes also include some refactoring to improve the code efficiency and readability.


* Added a condition to check if the deployment is to a file share and if so, it calls the `deployToFileShare` function. Also, imported the `deployToFileShare` function from `deployToFileShare.ts`.
* Created a new file that contains the `deployToFileShare` function and other helper functions necessary for deploying to a file share.

* Refactored the telemetry properties to use the connected environment name instead of the container app name.
* Added `customLocation` and `fileShare` properties to the `SlotTreeItem` class.
* Modified the `SubscriptionTreeItem` class to include the `ContainerAppCreateStep` in the execute steps and to set the `customLocation` and `fileShare` properties of the `SlotTreeItem`. 