### PR TITLE
fix(designer): Fixed invalid assertionStrings preventing editing of unit test

### DIFF
--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -260,8 +260,12 @@ export const deserializeUnitTestDefinition = (
   // deserialize assertions
   const assertions = Object.values(unitTestDefinition.assertions).map((assertion) => {
     const { name, description, assertionString } = assertion;
-    const uncastAssertionString = ExpressionParser.parseTemplateExpression(assertionString) as ExpressionFunction;
-    return { name, description, assertionString: uncastAssertionString.expression };
+    try {
+      const uncastAssertionString = ExpressionParser.parseTemplateExpression(assertionString) as ExpressionFunction;
+      return { name, description, assertionString: uncastAssertionString.expression };
+    } catch (ParserException) {
+      return { name, description, assertionString: '' };
+    }
   });
 
   return { mockResults, assertions: assertions };


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix to ensure unit test is editable if assertionString is modified to be invalid in the code view.
- **What is the current behavior?** (You can also link to an open issue here)
The designer from the unit test with the invalid assertionString does not render.
- **What is the new behavior (if this is a feature change)?**
Designer renders and the invalid assertionString populates as blank.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
- **Please Include Screenshots or Videos of the intended change**:
