### PR TITLE
fix(designer): Fix empty mock results tab when mock unsupported 

### DIFF
--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/mockResultsTab/mockResultsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/mockResultsTab/mockResultsTab.tsx
@@ -77,7 +77,7 @@ const MockResultsTab = () => {
         );
       }
     },
-    [nodeName, dispatch, mocks.actionResult, mocks.errorMessage, mocks.errorCode]
+    [dispatch, mocks?.actionResult, mocks?.errorCode, mocks?.errorMessage, nodeName]
   );
 
   const onActionResultUpdate = useCallback(
@@ -102,7 +102,7 @@ const MockResultsTab = () => {
         );
       }
     },
-    [nodeName, dispatch, mocks.errorMessage, mocks.errorCode]
+    [nodeName, dispatch, mocks?.errorMessage, mocks?.errorCode]
   );
 
   const outputs: OutputsField[] = filteredOutputs.map((output: OutputInfo) => {
@@ -139,8 +139,8 @@ const MockResultsTab = () => {
       onActionResultUpdate={onActionResultUpdate}
       outputs={outputs}
       mocks={mocks}
-      errorMessage={mocks.errorMessage ?? ''}
-      errorCode={mocks.errorCode ?? ''}
+      errorMessage={mocks?.errorMessage ?? ''}
+      errorCode={mocks?.errorCode ?? ''}
       onMockUpdate={onMockUpdate}
     />
   );


### PR DESCRIPTION
### Pull Request Description
Work item Link: https://msazure.visualstudio.com/One/_workitems/edit/28661067
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes/features)

- **What kind of change does this PR introduce?** 
  Bug fix

- **What is the current behavior?**
  The Mock Results Tab displays a blank page when a user selects an action with no mockable outputs, leading to confusion as there is no indication that no mockable outputs are available.

- **What is the new behavior (if this is a feature change)?**
  The Mock Results Tab now displays a message indicating that no mockable outputs are available for the selected action, providing clarity to the user and improving the user experience.

- **Does this PR introduce a breaking change?**
  No breaking changes. Users will not need to make any changes to their application due to this PR.

- **Please Include Screenshots or Videos of the intended change**:

**Before**:
![Before](link_to_screenshot_or_video)
![image](https://github.com/Azure/LogicAppsUX/assets/129120366/164e0b1b-fed5-4de0-b61b-5207e80c5f33)
Blank page when prompting mock results tab

**After**:
![After](link_to_screenshot_or_video)
![image](https://github.com/Azure/LogicAppsUX/assets/129120366/3c404566-ec7a-4376-9be4-25bf01e7eb92)


---

This update ensures that users are properly informed when there are no mockable outputs available, enhancing the usability of the Mock Results Tab.