### PR TITLE
fix(vscode): Add Parameters.json in .Net project conversion

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/switchToDotnetProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/switchToDotnetProject.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import {
   connectionsFileName,
+  parametersFileName,
   funcIgnoreFileName,
   funcVersionSetting,
   hostFileName,
@@ -252,6 +253,10 @@ async function getArtifactNamesFromProject(target: vscode.Uri): Promise<Record<s
     if (file === connectionsFileName) {
       artifactDict['connections'].push(connectionsFileName);
       continue;
+    }
+
+    if (file === parametersFileName) {
+      artifactDict['connections'].push(parametersFileName);
     }
 
     if (file === 'Artifacts') {


### PR DESCRIPTION
* [X] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    Bug fix to add parameters.json to the csproj file when converting to a .Net project

- **What is the current behavior?** (You can also link to an open issue here)
    parameters.json file is not properly included in the resulting .csproj file, which causes build issues when opened in VSCode or Visual Studio

- **What is the new behavior (if this is a feature change)?**
    converted file opens and builds properly in VSCode

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    No

- **Please Include Screenshots or Videos of the intended change**:
    N/A