### PR TITLE
fix(templates): Fixing dynamic imports of workflow images to always contain hard coded extension

### DIFF
--- a/libs/designer/src/lib/core/state/templates/templateSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/templateSlice.ts
@@ -286,7 +286,7 @@ const loadTemplateFromGithub = async (templateName: string, manifest: Template.M
 
     const images: Record<string, any> = {};
     for (const key of Object.keys(templateManifest.images)) {
-      images[key] = (await import(`${templatesPathFromState}/${templateName}/${templateManifest.images[key]}`)).default;
+      images[key] = (await import(`${templatesPathFromState}/${templateName}/${templateManifest.images[key]}.png`)).default;
     }
 
     const parametersDefinitions = templateManifest.parameters?.reduce((result: Record<string, Template.ParameterDefinition>, parameter) => {

--- a/libs/designer/src/lib/ui/styles.less
+++ b/libs/designer/src/lib/ui/styles.less
@@ -2,6 +2,7 @@
 @import './settings/sections/runafterconfiguration/runafterconfiguration.less';
 @import './connections/runAfterIndicator/styles.less';
 @import './panel/connectionsPanel/connectionsPanel.less';
+@import './templates/styles.less';
 @import (css) '~reactflow/dist/style.css';
 
 .react-flow__edge {

--- a/libs/designer/src/lib/ui/templates/connections/connector.tsx
+++ b/libs/designer/src/lib/ui/templates/connections/connector.tsx
@@ -11,13 +11,6 @@ import { useEffect } from 'react';
 import type { ConnectorInfo } from '../../../core/templates/utils/queries';
 import { useConnectorInfo } from '../../../core/templates/utils/queries';
 
-export const iconStyles = {
-  root: {
-    width: 20,
-    height: 20,
-  },
-};
-
 export const ConnectorIcon = ({
   connectorId,
   operationId,

--- a/libs/designer/src/lib/ui/templates/index.tsx
+++ b/libs/designer/src/lib/ui/templates/index.tsx
@@ -1,6 +1,3 @@
-import './styles.less';
-import '../styles.less';
-
 export * from './TemplatesDesigner';
 export * from './filters/templateFilters';
 export * from './connections/displayConnections';


### PR DESCRIPTION
There was an issue with the import path given for dynamic imports and according to this limitation https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations this was only failing when integrated in portal.
