### PR TITLE
fix(vscode): Refactor Parameters.json into a separate artifact class when converting to NuGet project

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/switchToDotnetProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/switchToDotnetProject.ts
@@ -195,6 +195,10 @@ async function updateBuildFile(context: IActionContext, target: vscode.Uri, dotn
     xmlBuildFile = addFileToBuildPath(xmlBuildFile, connectionFile);
   }
 
+  for (const parametersFile of projectArtifacts['parameters']) {
+    xmlBuildFile = addFileToBuildPath(xmlBuildFile, parametersFile);
+  }
+
   if (projectArtifacts['lib']) {
     xmlBuildFile = addLibToPublishPath(xmlBuildFile);
   }
@@ -245,6 +249,7 @@ async function getArtifactNamesFromProject(target: vscode.Uri): Promise<Record<s
   const artifactDict: Record<string, string[]> = {
     workflows: [],
     connections: [],
+    parameters: [],
     artifacts: [],
     lib: [],
   };
@@ -256,7 +261,7 @@ async function getArtifactNamesFromProject(target: vscode.Uri): Promise<Record<s
     }
 
     if (file === parametersFileName) {
-      artifactDict['connections'].push(parametersFileName);
+      artifactDict['parameters'].push(parametersFileName);
     }
 
     if (file === 'Artifacts') {


### PR DESCRIPTION
* [X] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
   Fit and Finish: Refactor GetArtifactNamesFromProject to separate the parameters.json file into its own separate artifact class to remove ambiguity with the connections.json file

- **What is the current behavior?** (You can also link to an open issue here)
  Strict refactoring, no behavior change

- **What is the new behavior (if this is a feature change)?**
  Strict refactoring, no behavior change

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No

- **Please Include Screenshots or Videos of the intended change**:
  Strict refactoring, no behavior change
