### PR TITLE
fix(designer): allow designer to revalidate assertions when it is deleted

### DIFF
--- a/libs/designer/src/lib/core/state/unitTest/unitTestSlice.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestSlice.ts
@@ -134,6 +134,11 @@ const checkAssertionsErrors = (state: UnitTestState) => {
   }
 };
 
+/**
+ * Revalidates all assertions in the unit test state.
+ * This function clears existing validation errors and performs a fresh validation on all assertions.
+ * @param {UnitTestState} state - The current unit test state.
+ */
 const revalidateAllAssertions = (state: UnitTestState) => {
   state.validationErrors.assertions = {};
   Object.values(state.assertions).forEach((assertion) => {

--- a/libs/designer/src/lib/core/state/unitTest/unitTestSlice.ts
+++ b/libs/designer/src/lib/core/state/unitTest/unitTestSlice.ts
@@ -134,6 +134,20 @@ const checkAssertionsErrors = (state: UnitTestState) => {
   }
 };
 
+const revalidateAllAssertions = (state: UnitTestState) => {
+  state.validationErrors.assertions = {};
+  Object.values(state.assertions).forEach((assertion) => {
+    const { name, id, assertionString } = assertion;
+    const validationErrors = {
+      name: validateAssertion(id, { name }, 'name', state.assertions),
+      expression: validateAssertion(id, { expression: assertionString }, 'expression', state.assertions),
+    };
+    if (validationErrors.name || validationErrors.expression) {
+      state.validationErrors.assertions[id] = validationErrors;
+    }
+  });
+};
+
 const unitTestSlice = createSlice({
   name: 'unitTest',
   initialState: initialUnitTestState,
@@ -231,6 +245,8 @@ const unitTestSlice = createSlice({
     deleteAssertion: (state: UnitTestState, action: PayloadAction<DeleteAssertionsPayload>) => {
       const { assertionId } = action.payload;
       delete state.assertions[assertionId];
+      revalidateAllAssertions(state);
+      //only runs if there are validation errors for that specific assertion
       if (state.validationErrors.assertions[assertionId]) {
         delete state.validationErrors.assertions[assertionId];
       }


### PR DESCRIPTION
[work Item Link](https://msazure.visualstudio.com/One/_workitems/edit/28547983)

# Pull Request
* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes/features)

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When an assertion is deleted, the "Assertion name already exists." warning continues to display even though the assertion with the duplicate name has been removed.

## What is the new behavior?
The validation errors are cleared and revalidated when an assertion is deleted. This ensures that the "Assertion name already exists." warning is removed when the assertion with the duplicate name is deleted. Additionally, all remaining assertions are revalidated to ensure the state is consistent.

### Changes made:
1. Updated the `deleteAssertion` reducer to call `checkAssertionsErrors(state)` after deleting an assertion and its associated validation errors. This ensures that the validation errors are cleared and revalidated after the deletion.
2. Ensured that `checkAssertionsErrors` is used consistently across the reducers to handle validation after any changes (addition, deletion, or update) to assertions.


## Please Include Screenshots or Videos of the intended change:

Before: 
![image](https://github.com/user-attachments/assets/75f0abd4-bc6d-4aa0-b22e-395bf8640293)

After: 
![image](https://github.com/user-attachments/assets/79799d5b-6295-4506-82e0-bd9295c84daa)

deleting the assertion, designer updates to remove false error warning: 
![image](https://github.com/user-attachments/assets/5b5e80bc-eb46-46c4-ac13-a8c14f19724a)
 



