### PR TITLE
fix(designer): Fixed function operation output body token issue

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/functions.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/functions.ts
@@ -112,7 +112,6 @@ export const selectFunctionManifest = {
       type: 'object',
       properties: {
         body: {
-          type: 'any',
           title: 'Body',
         },
         headers: {


### PR DESCRIPTION
## Main Changes

The function operation's output token `body` was previously not appearing.
Having type = `any` was an invalid value, removing it makes the token appear as expected

Fixes https://github.com/Azure/LogicAppsUX/issues/5122
