### PR TITLE
fix(designer): Fixed scope node collapse button keyboard interaction

### DIFF
--- a/libs/designer-ui/src/lib/card/scopeCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/scopeCard/index.tsx
@@ -72,8 +72,6 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
           draggable={draggable}
           style={colorVars}
           onContextMenu={contextMenu.handle}
-          onKeyDown={keyboardInteraction.keyDown}
-          onKeyUp={keyboardInteraction.keyUp}
         >
           {isMonitoringView ? (
             <StatusPill
@@ -86,7 +84,13 @@ export const ScopeCard: React.FC<ScopeCardProps> = ({
           ) : null}
           <div className="msla-scope-card-content">
             <div className={css('msla-selection-box', 'white-outline', selected && 'selected')} />
-            <button className="msla-scope-card-title-button" ref={focusRef as any} onClick={handleClick}>
+            <button
+              className="msla-scope-card-title-button"
+              ref={focusRef as any}
+              onClick={handleClick}
+              onKeyDown={keyboardInteraction.keyDown}
+              onKeyUp={keyboardInteraction.keyUp}
+            >
               <div className="msla-scope-card-title-box">
                 <div className={css('gripper-section', draggable && 'draggable')}>{draggable ? <Gripper /> : null}</div>
                 <div className="panel-card-content-icon-section">{cardIcon}</div>

--- a/libs/designer-ui/src/lib/card/subgraphCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/subgraphCard/index.tsx
@@ -15,7 +15,7 @@ interface SubgraphCardProps {
   title: string;
   subgraphType: SubgraphType;
   collapsed?: boolean;
-  handleCollapse?: (event: { currentTarget: any }) => void;
+  handleCollapse?: () => void;
   selected?: boolean;
   readOnly?: boolean;
   onClick?(id?: string): void;
@@ -43,7 +43,8 @@ export const SubgraphCard: React.FC<SubgraphCardProps> = ({
 }) => {
   const intl = useIntl();
 
-  const keyboardInteraction = useCardKeyboardInteraction(() => onClick?.(data.id), onDeleteClick);
+  const mainKeyboardInteraction = useCardKeyboardInteraction(() => onClick?.(data.id), onDeleteClick);
+  const collapseKeyboardInteraction = useCardKeyboardInteraction(handleCollapse);
   const contextMenu = useCardContextMenu();
 
   const addCaseLabel = intl.formatMessage({
@@ -130,8 +131,8 @@ export const SubgraphCard: React.FC<SubgraphCardProps> = ({
           className="msla-subgraph-title"
           onClick={handleTitleClick}
           onContextMenu={contextMenu.handle}
-          onKeyDown={keyboardInteraction.keyUp}
-          onKeyUp={keyboardInteraction.keyDown}
+          onKeyDown={mainKeyboardInteraction.keyUp}
+          onKeyUp={mainKeyboardInteraction.keyDown}
         >
           <div className="msla-subgraph-title-text">{data.title}</div>
           {errorMessage ? <ErrorBanner errorLevel={errorLevel} errorMessage={errorMessage} /> : null}
@@ -156,11 +157,9 @@ export const SubgraphCard: React.FC<SubgraphCardProps> = ({
           tabIndex={0}
           className={css('msla-subgraph-card', data.size)}
           style={colorVars}
-          onClick={(e) => {
-            handleCollapse?.(e);
-          }}
-          onKeyDown={keyboardInteraction.keyUp}
-          onKeyUp={keyboardInteraction.keyDown}
+          onClick={handleCollapse}
+          onKeyDown={collapseKeyboardInteraction.keyUp}
+          onKeyUp={collapseKeyboardInteraction.keyDown}
         >
           <div className={css('msla-selection-box', 'white-outline', selected && 'selected')} tabIndex={-1} />
           <div className="msla-subgraph-title msla-subgraph-title-text">{data.title}</div>

--- a/libs/designer-ui/src/lib/nodeCollapseToggle/index.tsx
+++ b/libs/designer-ui/src/lib/nodeCollapseToggle/index.tsx
@@ -1,12 +1,13 @@
 import { TooltipHost, DirectionalHint, Icon, css } from '@fluentui/react';
 import { FontSizes } from '@fluentui/theme';
+import { useCardKeyboardInteraction } from '../card/hooks';
 import { useIntl } from 'react-intl';
 
 interface NodeCollapseToggleProps {
   disabled?: boolean;
   collapsed?: boolean;
   onSmallCard?: boolean;
-  handleCollapse?: (event: { currentTarget: any }) => void;
+  handleCollapse?: () => void;
 }
 
 const NodeCollapseToggle = (props: NodeCollapseToggleProps) => {
@@ -28,6 +29,8 @@ const NodeCollapseToggle = (props: NodeCollapseToggleProps) => {
   const iconName = collapsed ? 'ChevronDown' : 'ChevronUp';
   const toggleText = collapsed ? EXPAND_TEXT : COLLAPSE_TEXT;
 
+  const keyboardInteraction = useCardKeyboardInteraction(handleCollapse);
+
   return (
     <TooltipHost content={toggleText} directionalHint={DirectionalHint.rightCenter}>
       <button
@@ -35,6 +38,8 @@ const NodeCollapseToggle = (props: NodeCollapseToggleProps) => {
         disabled={disabled}
         className={css('msla-collapse-toggle', disabled && 'disabled', onSmallCard && 'small')}
         onClick={handleCollapse}
+        onKeyDown={keyboardInteraction.keyDown}
+        onKeyUp={keyboardInteraction.keyUp}
       >
         <Icon iconName={iconName} styles={{ root: { fontSize: FontSizes.small } }} />
       </button>


### PR DESCRIPTION
## Main Changes

Scope nodes' expand/collapse toggle was not triggerable via keyboard, it would instead open the nodes' details panel.
This has been fixed and scope nodes can now be expanded / collapsed via keyboard.