### PR TITLE
fix(designer): Add support for `accountName` field

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/__test__/selectConnection.helpers.spec.ts
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/__test__/selectConnection.helpers.spec.ts
@@ -1,6 +1,11 @@
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
-import { compareFlattenedConnections, flattenConnection } from '../selectConnection.helpers';
-import { Connection } from '@microsoft/logic-apps-shared';
+import {
+  compareFlattenedConnections,
+  flattenConnection,
+  getLabelForConnection,
+  getSubLabelForConnection,
+} from '../selectConnection.helpers';
+import { Connection, ConnectionProperties } from '@microsoft/logic-apps-shared';
 
 const mockApi: Connection['properties']['api'] = {
   brandColor: '#008372',
@@ -87,6 +92,31 @@ describe('selectConnection helpers', () => {
         statuses: [{ status: 'Error' }],
         type: 'type',
       });
+    });
+  });
+
+  describe('getLabelForConnection', () => {
+    it('should get the display name', () => {
+      expect(getLabelForConnection(mockConnectionWithErrors.properties)).toBe('displayName');
+    });
+  });
+
+  describe('getSubLabelForConnection', () => {
+    it.each<[string, ConnectionProperties, string | undefined]>([
+      ['undefined if no valid sub label', mockConnectionWithErrors.properties, undefined],
+      ['account name if available', { ...mockConnectionWithErrors.properties, accountName: 'jdoe@example.com' }, 'jdoe@example.com'],
+      [
+        'authenticated user name if available',
+        { ...mockConnectionWithErrors.properties, authenticatedUser: { name: 'jdoe@example.com' } },
+        'jdoe@example.com',
+      ],
+      [
+        'authenticated user name if available',
+        { ...mockConnectionWithErrors.properties, parameterValues: { gateway: { id: 'jdoe', name: 'jdoe@example.com', type: 'gateway' } } },
+        'jdoe@example.com',
+      ],
+    ])('should handle "%s" case', (_caseName, properties, expected) => {
+      expect(getSubLabelForConnection(properties)).toBe(expected);
     });
   });
 });

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/__test__/selectConnection.helpers.spec.ts
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/__test__/selectConnection.helpers.spec.ts
@@ -111,7 +111,7 @@ describe('selectConnection helpers', () => {
         'jdoe@example.com',
       ],
       [
-        'authenticated user name if available',
+        'gateway name if available',
         { ...mockConnectionWithErrors.properties, parameterValues: { gateway: { id: 'jdoe', name: 'jdoe@example.com', type: 'gateway' } } },
         'jdoe@example.com',
       ],

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/connectionTable.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/connectionTable.tsx
@@ -114,7 +114,7 @@ export const ConnectionTable = (props: ConnectionTableProps): JSX.Element => {
         }),
       renderCell: (item) => {
         const label = item.displayName;
-        const subLabel = item.parameterValues?.gateway?.name ?? item.authenticatedUser?.name;
+        const subLabel = item.parameterValues?.gateway?.name ?? item.authenticatedUser?.name ?? item.accountName;
         return (
           <div className="msla-connection-row-display-name">
             <Text block={true} className="msla-connection-row-display-name-label" size={300}>

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/connectionTable.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/connectionTable.tsx
@@ -17,7 +17,12 @@ import { useCallback, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { ConnectionTableDetailsButton } from './connectionTableDetailsButton';
 import type { ConnectionWithFlattenedProperties } from './selectConnection.helpers';
-import { compareFlattenedConnections, flattenConnection } from './selectConnection.helpers';
+import {
+  compareFlattenedConnections,
+  flattenConnection,
+  getLabelForConnection,
+  getSubLabelForConnection,
+} from './selectConnection.helpers';
 
 export interface ConnectionTableProps {
   connections: Connection[];
@@ -113,8 +118,8 @@ export const ConnectionTable = (props: ConnectionTableProps): JSX.Element => {
           description: 'Column header for connection display name',
         }),
       renderCell: (item) => {
-        const label = item.displayName;
-        const subLabel = item.parameterValues?.gateway?.name ?? item.authenticatedUser?.name ?? item.accountName;
+        const label = getLabelForConnection(item);
+        const subLabel = getSubLabelForConnection(item);
         return (
           <div className="msla-connection-row-display-name">
             <Text block={true} className="msla-connection-row-display-name-label" size={300}>

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.helpers.ts
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.helpers.ts
@@ -1,4 +1,4 @@
-import type { Connection } from '@microsoft/logic-apps-shared';
+import type { Connection, ConnectionProperties } from '@microsoft/logic-apps-shared';
 import { getConnectionErrors } from '@microsoft/logic-apps-shared';
 
 export type ConnectionWithFlattenedProperties = Omit<Connection, 'properties'> & Connection['properties'] & { invalid: boolean };
@@ -21,4 +21,12 @@ export const compareFlattenedConnections = (a: ConnectionWithFlattenedProperties
     return -1;
   }
   return a.displayName.localeCompare(b.displayName);
+};
+
+export const getLabelForConnection = (item: ConnectionProperties): string => {
+  return item.displayName;
+};
+
+export const getSubLabelForConnection = (item: ConnectionProperties): string | undefined => {
+  return item.parameterValues?.gateway?.name ?? item.authenticatedUser?.name ?? item.accountName;
 };


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Email is not shown in connection table if connection object uses `accountName` instead of `authenticatedUser`.

- **What is the new behavior (if this is a feature change)?**

Connection table shows email regardless of format.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

- **Please Include Screenshots or Videos of the intended change**:

![image](https://github.com/user-attachments/assets/8a3f8ee0-8f86-4363-af1c-a1ba2169a9e9)
