### PR TITLE
test(all): Switch use of `%p` in `it.each` to specific parameter types for Vitest compat

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/__test__/editorToSegment.spec.ts
@@ -156,7 +156,7 @@ describe('lib/editor/base/utils/editorToSegment', () => {
           { type: ValueSegmentType.LITERAL, value: ' t3' },
         ],
       ],
-    ])('parses segments out of %p with appropriate node map', (input, expectedTokens) => {
+    ])('parses segments out of "%s" with appropriate node map', (input, expectedTokens) => {
       const nodeMap = new Map<string, ValueSegment>();
       nodeMap.set(`@{variables('abc')}`, { id: '', ...getInitializeVariableAbcToken() });
       nodeMap.set(`@{variables('@{')}`, { id: '', ...getInitializeVariableOpenBraceToken() });
@@ -185,7 +185,7 @@ describe('lib/editor/base/utils/editorToSegment', () => {
         `Text before @{body('Create_new_folder')?['{Link}']} text after`,
         [{ type: ValueSegmentType.LITERAL, value: `Text before @{body('Create_new_folder')?['{Link}']} text after` }],
       ],
-    ])('parses segments out of %p with an empty node map', (input, expectedTokens) => {
+    ])('parses segments out of "%s" with an empty node map', (input, expectedTokens) => {
       const nodeMap = new Map<string, ValueSegment>();
 
       const segments = convertStringToSegments(input, nodeMap, { tokensEnabled: true });

--- a/libs/designer-ui/src/lib/editor/base/utils/__test__/parsesegments.spec.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/__test__/parsesegments.spec.ts
@@ -12,7 +12,7 @@ describe('lib/editor/base/utils/parseSegments', () => {
       ['plain text', 'plain text'],
       [`text @{concat('%3C')} text`, `text @{concat('<')} text`],
       [`text @{concat('<')} text`, `text @{concat('<')} text`],
-    ])('should properly decode DOM-safe in: %p', (input, expected) => {
+    ])('should properly decode DOM-safe in: "%s"', (input, expected) => {
       const nodeMap = new Map<string, ValueSegment>();
       nodeMap.set(`concat('<')`, {} as unknown as ValueSegment);
 
@@ -25,7 +25,7 @@ describe('lib/editor/base/utils/parseSegments', () => {
       ['plain text', 'plain text'],
       [`text @{concat('<')} text`, `text @{concat('%3C')} text`],
       [`text @{concat('%3C')} text`, `text @{concat('%3C')} text`],
-    ])('should properly encode segments to be DOM-safe in: %p', (input, expected) => {
+    ])('should properly encode segments to be DOM-safe in: "%s"', (input, expected) => {
       const nodeMap = new Map<string, ValueSegment>();
       nodeMap.set(`concat('<')`, {} as unknown as ValueSegment);
 
@@ -46,7 +46,7 @@ describe('lib/editor/base/utils/parseSegments', () => {
         `@{replace(replace(replace('abc','&lt;','<'),'&gt;','>'),'&quot;','"')}`,
         `@{replace(replace(replace('abc','&lt;','<'),'&gt;','>'),'&quot;','"')}`,
       ],
-    ])('should properly decode Lexical-safe segments in: %p', (input, expected) => {
+    ])('should properly decode Lexical-safe segments in: "%s"', (input, expected) => {
       const nodeMap = new Map<string, ValueSegment>();
       nodeMap.set(`concat('&lt;')`, {} as unknown as ValueSegment);
       nodeMap.set(`replace(replace(replace('abc','&lt;','<'),'&gt;','>'),'&quot;','"')`, {} as unknown as ValueSegment);
@@ -68,7 +68,7 @@ describe('lib/editor/base/utils/parseSegments', () => {
         `@{replace(replace(replace('abc','%26lt;','<'),'%26gt;','>'),'%26quot;','%22')}`,
         `@{replace(replace(replace('abc','%26lt;','<'),'%26gt;','>'),'%26quot;','%22')}`,
       ],
-    ])('should properly encode segments to be Lexical-safe in: %p', (input, expected) => {
+    ])('should properly encode segments to be Lexical-safe in: "%s"', (input, expected) => {
       const nodeMap = new Map<string, ValueSegment>();
       nodeMap.set(`concat('&lt;')`, {} as unknown as ValueSegment);
       nodeMap.set(`replace(replace(replace('abc','&lt;','<'),'&gt;','>'),'&quot;','"')`, {} as unknown as ValueSegment);

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/__test__/util.spec.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/__test__/util.spec.ts
@@ -25,7 +25,7 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ['<span id="@{variables(\'abc\')}">text</span>', '<span id="@{variables(\'abc\')}">text</span>'],
       ['<span id="@{concat(\'&lt;\')}">text</span>', '<span id="@{concat(\'&lt;\')}">text</span>'],
       ['<span id="@{concat(\'%26lt;\')}">text</span>', '<span id="@{concat(\'%26lt;\')}">text</span>'],
-    ])('should properly convert HTML: %p', (input, expected) => {
+    ])('should properly convert HTML: "%s"', (input, expected) => {
       expect(cleanHtmlString(input)).toBe(expected);
     });
   });
@@ -36,7 +36,7 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ['white-space: pre-wrap;', undefined],
       ['color: red; white-space: pre-wrap;', 'color: red;'],
       ['white-space: pre-wrap; color: red;', 'color: red;'],
-    ])('should return style=%p as %p', (input, expected) => {
+    ])('should return style="%s" as "%s"', (input, expected) => {
       expect(cleanStyleAttribute(input)).toBe(expected);
     });
   });
@@ -50,7 +50,7 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ["$[concat(...),concat('%3C()%3E'),#AD008C]$", "$[concat(...),concat('<()>'),#AD008C]$"],
       ["@{concat('abc')}", "@{concat('abc')}"],
       ["@{concat('%3C()%3E')}", "@{concat('<()>')}"],
-    ])('should properly decode segments in: %p', (input, expected) => {
+    ])('should properly decode segments in: "%s"', (input, expected) => {
       expect(decodeSegmentValueInDomContext(input)).toBe(expected);
     });
   });
@@ -64,7 +64,7 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ["$[concat(...),concat('<()>'),#AD008C]$", "$[concat(...),concat('%3C()%3E'),#AD008C]$"],
       ["@{concat('abc')}", "@{concat('abc')}"],
       ["@{concat('<()>')}", "@{concat('%3C()%3E')}"],
-    ])('should properly encode segments in: %p', (input, expected) => {
+    ])('should properly encode segments in: "%s"', (input, expected) => {
       expect(encodeSegmentValueInDomContext(input)).toBe(expected);
     });
   });
@@ -83,7 +83,7 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ["@{concat('abc')}", "@{concat('abc')}"],
       ["@{concat('%26lt;')}", "@{concat('&lt;')}"],
       ["@{concat('%26amp;lt;')}", "@{concat('&amp;lt;')}"],
-    ])('should properly decode segments in: %p', (input, expected) => {
+    ])('should properly decode segments in: "%s"', (input, expected) => {
       expect(decodeSegmentValueInLexicalContext(input)).toBe(expected);
     });
   });
@@ -102,7 +102,7 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ["@{concat('abc')}", "@{concat('abc')}"],
       ["@{concat('&lt;')}", "@{concat('%26lt;')}"],
       ["@{concat('&amp;lt;')}", "@{concat('%26amp;lt;')}"],
-    ])('should properly encode segments in: %p', (input, expected) => {
+    ])('should properly encode segments in: "%s"', (input, expected) => {
       expect(encodeSegmentValueInLexicalContext(input)).toBe(expected);
     });
   });
@@ -132,7 +132,7 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ['img', 'src', true],
       ['table', 'class', true],
       ['table', 'cellpadding', true],
-    ])('should return <%s %s="..." /> as supported=%p', (inputTag, inputAttr, expected) => {
+    ])('should return <%s %s="..." /> as supported="%s"', (inputTag, inputAttr, expected) => {
       expect(isAttributeSupportedByHtmlEditor(inputTag, inputAttr)).toBe(expected);
     });
   });
@@ -148,7 +148,7 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ['small string using <h1>', true, case2],
       ['large string using <a>, <u>, <h3>, <span>', true, case3],
       ['small string using <section>', false, case4],
-    ])('should return %p as supported=%p', (_caseName, expected, inputString) => {
+    ])('should return "%s" as supported="%s"', (_caseName, expected, inputString) => {
       const nodeMap = new Map<string, ValueSegment>();
       expect(isHtmlStringValueSafeForLexical(inputString, nodeMap)).toBe(expected);
     });
@@ -183,7 +183,7 @@ describe('lib/html/plugins/toolbar/helper/util', () => {
       ['strong', true],
       ['u', true],
       ['ul', true],
-    ])('should return <%s /> as supported=%p', (inputTag, expected) => {
+    ])('should return <%s /> as supported="%s"', (inputTag, expected) => {
       expect(isTagNameSupportedByLexical(inputTag)).toBe(expected);
     });
   });

--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
@@ -2511,7 +2511,7 @@ describe('core/utils/parameters/helper', () => {
 
       // For values using `body/*` syntax, use OUTPUTS.
       ['outputs.$.body/subject', 'Get_event_(V3)', `outputs('Get_event_(V3)')`],
-    ])('correctly gets the token expression for %p', (key, actionName, expected) => {
+    ])('correctly gets the token expression for "%s"', (key, actionName, expected) => {
       expect(getTokenExpressionMethodFromKey(key, actionName)).toBe(expected);
     });
   });

--- a/libs/logic-apps-shared/src/parsers/lib/common/helpers/__test__/keysutility.spec.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/common/helpers/__test__/keysutility.spec.ts
@@ -90,7 +90,7 @@ describe('Parameter Key Utility Tests', () => {
       ['body.foo', 'body~1foo'],
       ['body/foo', 'body.body/foo'],
       ['body/foo/Bar', 'body.body/foo.body/foo/Bar'],
-    ])('%p evaluates to %p', (input, expected) => {
+    ])('"%s" evaluates to "%s"', (input, expected) => {
       expect(ParameterKeyUtility.expandAndEncodePropertySegment(input)).toBe(expected);
     });
   });

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/color.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/color.spec.ts
@@ -9,7 +9,7 @@ describe('lib/helpers/color', () => {
     [100, 150, 200, 0.6, 193, 213, 233],
     [100, 150, 200, 0.8, 224, 234, 244],
     [100, 150, 200, 1.0, 255, 255, 255],
-  ])('lighten (%p,%p,%p) by %p', (inputR, inputG, inputB, amount, expectedR, expectedG, expectedB) => {
+  ])('lighten ("%s","%s","%s") by "%s"', (inputR, inputG, inputB, amount, expectedR, expectedG, expectedB) => {
     expect(lighten({ blue: inputB, green: inputG, red: inputR }, amount)).toMatchObject({
       blue: expectedB,
       green: expectedG,

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/color.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/color.spec.ts
@@ -9,7 +9,7 @@ describe('lib/helpers/color', () => {
     [100, 150, 200, 0.6, 193, 213, 233],
     [100, 150, 200, 0.8, 224, 234, 244],
     [100, 150, 200, 1.0, 255, 255, 255],
-  ])('lighten ("%s","%s","%s") by "%s"', (inputR, inputG, inputB, amount, expectedR, expectedG, expectedB) => {
+  ])('lighten (%i,%i,%i) by %d', (inputR, inputG, inputB, amount, expectedR, expectedG, expectedB) => {
     expect(lighten({ blue: inputB, green: inputG, red: inputR }, amount)).toMatchObject({
       blue: expectedB,
       green: expectedG,

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/functions.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/functions.spec.ts
@@ -73,7 +73,7 @@ describe('lib/helpers/functions', () => {
       ['foo', 'FOO', true],
       ['ßß', 'SSSS', true],
       ['ς', 'Σ', true],
-    ])('returns the correct result for %p=%p, case-insensitive true/default', (a, b, expected) => {
+    ])('returns the correct result for "%s"="%s", case-insensitive true/default', (a, b, expected) => {
       expect(equals(a, b)).toBe(expected);
       expect(equals(a, b, true)).toBe(expected);
     });
@@ -86,7 +86,7 @@ describe('lib/helpers/functions', () => {
       ['foo', 'FOO', false],
       ['ßß', 'SSSS', false],
       ['ς', 'Σ', false],
-    ])('returns the correct result for %p=%p, case-insensitive false', (a, b, expected) => {
+    ])('returns the correct result for "%s"="%s", case-insensitive false', (a, b, expected) => {
       expect(equals(a, b, false)).toBe(expected);
     });
   });


### PR DESCRIPTION
Vitest does not support Jest's `%p` in `.each` test names (see [`.each` in Vitest docs](https://vitest.dev/api/#test-each)). Upon transition from Jest to Vitest, these were not updated. This PR updates those to their equivalent value.

Example change in test names before and after:

![image](https://github.com/user-attachments/assets/2da7129b-082f-48eb-a941-68170220f95b)

![image](https://github.com/user-attachments/assets/58b150b2-9c77-436d-8f1a-bad7ab4c7bb1)