### PR TITLE
fix(Designer): Fixed foreach dynamic item() / items() token issue

### DIFF
--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -277,7 +277,7 @@ const getArrayDetailsForNestedForeach = (
   repetitionContext: RepetitionContext,
   state: RootState
 ): ImplicitForeachDetails => {
-  let shouldAddAnyForeach = false;
+  let shouldAdd = false;
   const arrayDetails: ImplicitForeachArrayDetails[] = [];
   const actionName = token.outputInfo.actionName;
   let parentArrayKey = getParentArrayKey(token.key);
@@ -309,12 +309,9 @@ const getArrayDetailsForNestedForeach = (
       return checkArrayInRepetition(actionName, repetitionValue, parentArrayKey, data?.expression, data?.output, areOutputsManifestBased);
     });
 
-    const shouldAdd = !isSplitOn && !alreadyInLoop;
-    if (!shouldAddAnyForeach && shouldAdd) {
-      shouldAddAnyForeach = shouldAdd;
-    }
+    shouldAdd = !isSplitOn && !alreadyInLoop;
 
-    if (shouldAdd && data?.expression) {
+    if (data?.expression) {
       arrayDetails.push({ parentArrayKey, parentArrayValue: data.expression });
     }
 
@@ -322,7 +319,7 @@ const getArrayDetailsForNestedForeach = (
     parentArray = data?.token.arrayDetails?.parentArrayName;
   }
 
-  return { shouldAdd: shouldAddAnyForeach, arrayDetails };
+  return { shouldAdd, arrayDetails };
 };
 
 const getParentArrayExpression = (


### PR DESCRIPTION
## Main Changes

Previously if you had an action's output being split by a foreach node, if you added a token from the split value to a nested action, the token would be defined as `item()['key']` rather than `items('foreach_action')['key']`.
The issue here was that the `items()` token relied on having arrayData for the parent foreach, and the population of that arrayData was only being called if we were creating the foreach node as well.  If the node already existed, we skipped it and thus add a `item()` token instead.
In this PR I removed the check on if we are creating a new foreach node, instead populating the array details both if we create a foreach, and if it already exists.


Fixes https://github.com/Azure/LogicAppsUX/issues/5119