### PR TITLE
fix(designer-ui): Fix wrapping of connection display when panel is narrow

### DIFF
--- a/libs/designer-ui/src/lib/panel/panel.less
+++ b/libs/designer-ui/src/lib/panel/panel.less
@@ -143,16 +143,16 @@
 
   .msla-panel-content-container {
     margin: 0px -2rem;
-		padding: 1rem 2rem;
-		overflow-y: auto;
-		height: inherit;
+    padding: 1rem 2rem;
+    overflow-y: auto;
+    height: inherit;
   }
 
-	.msla-node-details-panel {
-		height: 100%;
-		display: flex;
-		flex-direction: column;
-	}
+  .msla-node-details-panel {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
 
   .msla-tab-component-container {
     .msla-panel-about-container {
@@ -233,16 +233,31 @@
 }
 
 .connection-display {
-  display: flex;
-  margin: 8px 0px;
-  gap: 8px;
-  justify-content: space-between;
-
   .connection-info {
+    align-items: flex-start;
     display: flex;
-    column-gap: 8px;
+    flex-direction: row;
     flex-wrap: wrap;
-    align-items: center;
+    justify-content: flex-start;
+
+    .connection-info-labels {
+      align-items: center;
+      display: flex;
+      flex-direction: row;
+      gap: 8px;
+
+      > svg {
+        flex: 0 0 16px;
+      }
+
+      .label {
+        white-space: nowrap;
+      }
+    }
+
+    .change-connection-button {
+      margin-left: 15px;
+    }
   }
 
   .connection-info-error {

--- a/libs/designer-ui/src/lib/panel/panel.less
+++ b/libs/designer-ui/src/lib/panel/panel.less
@@ -245,6 +245,7 @@
       display: flex;
       flex-direction: row;
       gap: 8px;
+      max-width: 100%;
 
       > svg {
         flex: 0 0 16px;

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/connectionDisplay.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/connectionDisplay.tsx
@@ -91,10 +91,13 @@ export const ConnectionDisplay = (props: ConnectionDisplayProps) => {
   return (
     <div className="connection-display">
       <div className="connection-info">
-        <LinkMultiple16Regular />
-        <Label className="label" text={connectionName ? connectionDisplayTextWithName : connectionDisplayTextWithoutName} />
+        <div className="connection-info-labels">
+          <LinkMultiple16Regular />
+          <Label className="label" text={connectionName ? connectionDisplayTextWithName : connectionDisplayTextWithoutName} />
+        </div>
         {readOnly ? null : (
           <Button
+            className="change-connection-button"
             id="change-connection-button"
             size="small"
             appearance="subtle"


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

When side panel is narrow, connection information (below parameter inputs) wraps very awkwardly and can flow off the screen if a connection name is too long.

## New Behavior

Even in narrow side panels, connection information wraps correctly, and ellipsis is used if connection name is too long.

## Impact of Change

UI changes only.

## Screenshots or Videos (if applicable)

### Before

![connection-display-too-wrapped](https://github.com/user-attachments/assets/55d1e589-3da9-4dbc-af73-35d2d2e37a5b)

### After

![connection-display-proper-wrap](https://github.com/user-attachments/assets/233a0890-635f-4312-814a-e6dd17b0a159)