### PR TITLE
fix(designer-ui): Extract toolbar format buttons into component files

### DIFF
--- a/libs/designer-ui/src/lib/html/plugins/toolbar/Format.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/Format.tsx
@@ -1,31 +1,24 @@
 import constants from '../../../constants';
 import fontColorSvgDark from '../icons/dark/font-color.svg';
-import linkDark from '../icons/dark/link.svg';
 import paintBucketSvgDark from '../icons/dark/paint-bucket.svg';
-import boldDark from '../icons/dark/type-bold.svg';
-import italicDark from '../icons/dark/type-italic.svg';
-import underlineDark from '../icons/dark/type-underline.svg';
 import fontColorSvgLight from '../icons/light/font-color.svg';
-import linkLight from '../icons/light/link.svg';
 import paintBucketSvgLight from '../icons/light/paint-bucket.svg';
-import boldLight from '../icons/light/type-bold.svg';
-import italicLight from '../icons/light/type-italic.svg';
-import underlineLight from '../icons/light/type-underline.svg';
+import { FormatBoldButton } from './buttons/FormatBoldButton';
+import { FormatItalicButton } from './buttons/FormatItalicButton';
+import { FormatLinkButton } from './buttons/FormatLinkButton';
+import { FormatUnderlineButton } from './buttons/FormatUnderlineButton';
 import { DropdownColorPicker } from './DropdownColorPicker';
 import { getSelectedNode, sanitizeUrl } from './helper/functions';
 import { useTheme } from '@fluentui/react';
-import { ToolbarButton } from '@fluentui/react-components';
 import { $isLinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link';
 import { $getSelectionStyleValueForProperty, $patchStyleText } from '@lexical/selection';
 import { mergeRegister } from '@lexical/utils';
-import { isApple } from '@microsoft/logic-apps-shared';
 import type { LexicalEditor } from 'lexical';
 import {
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_NORMAL,
-  FORMAT_TEXT_COMMAND,
   KEY_MODIFIER_COMMAND,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
@@ -140,81 +133,6 @@ export const Format = ({ activeEditor, readonly }: FormatProps) => {
     [applyStyleText]
   );
 
-  const insertLink = useCallback(() => {
-    if (isLink) {
-      activeEditor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
-    } else {
-      activeEditor.dispatchCommand(TOGGLE_LINK_COMMAND, sanitizeUrl('https://'));
-    }
-  }, [activeEditor, isLink]);
-
-  const boldTitleMac = intl.formatMessage({
-    defaultMessage: 'Bold (⌘B)',
-    id: 'ciLkfU',
-    description: 'Command for bold text for Mac users',
-  });
-  const boldTitleMacAriaLabel = intl.formatMessage({
-    defaultMessage: 'Format text as bold. Shortcut: ⌘B',
-    id: 'S138/4',
-    description: 'label to make bold text for Mac users',
-  });
-  const boldTitleNonMac = intl.formatMessage({
-    defaultMessage: 'Bold (Ctrl+B)',
-    id: 'Lnqh6h',
-    description: 'Command for bold text for non-mac users',
-  });
-  const boldTitleNonMacAriaLabel = intl.formatMessage({
-    defaultMessage: 'Format text as bold. Shortcut: Ctrl+B',
-    id: 'YR1uWE',
-    description: 'label to make bold text for nonMac users',
-  });
-
-  const italicTitleMac = intl.formatMessage({
-    defaultMessage: 'Italic (⌘I)',
-    id: 'elD6+N',
-    description: 'Command for italic text for Mac users',
-  });
-  const italicTitleMacAriaLabel = intl.formatMessage({
-    defaultMessage: 'Format text as italic. Shortcut: ⌘I',
-    id: 'YdQw4/',
-    description: 'label to make italic text for Mac users',
-  });
-  const italicTitleNonMac = intl.formatMessage({
-    defaultMessage: 'Italic (Ctrl+I)',
-    id: 'dfmH55',
-    description: 'Command for italic text for non-mac users',
-  });
-  const italicTitleNonMacAriaLabel = intl.formatMessage({
-    defaultMessage: 'Format text as italic. Shortcut: Ctrl+I',
-    id: 'gIx5ys',
-    description: 'label to make italic text for nonMac users',
-  });
-
-  const underlineTitleMac = intl.formatMessage({
-    defaultMessage: 'Underline (⌘U)',
-    id: 'KYX5Do',
-    description: 'Command for underline text for Mac users',
-  });
-  const underlineTitleMacAriaLabel = intl.formatMessage({
-    defaultMessage: 'Format text as underline. Shortcut: ⌘U',
-    id: 'qBkxGU',
-    description: 'label to make underline text for Mac users',
-  });
-  const underlineTitleNonMac = intl.formatMessage({
-    defaultMessage: 'Underline (Ctrl+U)',
-    id: 'lwlg2K',
-    description: 'Command for underline text for non-mac users',
-  });
-  const underlineTitleNonMacAriaLabel = intl.formatMessage({
-    defaultMessage: 'Format text as underline. Shortcut: Ctrl+U',
-    id: 'YJlS8E',
-    description: 'label to make underline text for nonMac users',
-  });
-  const insertLinkLabel = intl.formatMessage({
-    defaultMessage: 'Insert Link',
-    id: 'tUCptx',
-    description: 'label to insert link',
-  });
   const backgroundColorTitle = intl.formatMessage({
     defaultMessage: 'Background Color',
     id: 'r7ZizR',
@@ -228,39 +146,9 @@ export const Format = ({ activeEditor, readonly }: FormatProps) => {
 
   return (
     <>
-      <ToolbarButton
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
-        }}
-        className={`toolbar-item spaced ${isBold ? 'active' : ''}`}
-        title={isApple() ? boldTitleMac : boldTitleNonMac}
-        aria-label={isApple() ? boldTitleMacAriaLabel : boldTitleNonMacAriaLabel}
-        disabled={readonly}
-        icon={<img className={'format'} src={isInverted ? boldDark : boldLight} alt={'bold icon'} />}
-      />
-      <ToolbarButton
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
-        }}
-        className={`toolbar-item spaced ${isItalic ? 'active' : ''}`}
-        title={isApple() ? italicTitleMac : italicTitleNonMac}
-        aria-label={isApple() ? italicTitleMacAriaLabel : italicTitleNonMacAriaLabel}
-        disabled={readonly}
-        icon={<img className={'format'} src={isInverted ? italicDark : italicLight} alt={'italic icon'} />}
-      />
-      <ToolbarButton
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
-        }}
-        className={`toolbar-item spaced ${isUnderline ? 'active' : ''}`}
-        title={isApple() ? underlineTitleMac : underlineTitleNonMac}
-        aria-label={isApple() ? underlineTitleMacAriaLabel : underlineTitleNonMacAriaLabel}
-        disabled={readonly}
-        icon={<img className={'format'} src={isInverted ? underlineDark : underlineLight} alt={'underline icon'} />}
-      />
+      <FormatBoldButton activeEditor={activeEditor} isToggledOn={isBold} readonly={readonly} />
+      <FormatItalicButton activeEditor={activeEditor} isToggledOn={isItalic} readonly={readonly} />
+      <FormatUnderlineButton activeEditor={activeEditor} isToggledOn={isUnderline} readonly={readonly} />
       <DropdownColorPicker
         editor={activeEditor}
         disabled={readonly}
@@ -281,15 +169,7 @@ export const Format = ({ activeEditor, readonly }: FormatProps) => {
         onChange={onBgColorSelect}
         title={backgroundColorTitle}
       />
-      <ToolbarButton
-        onMouseDown={(e) => e.preventDefault()}
-        disabled={readonly}
-        onClick={insertLink}
-        className={`toolbar-item spaced ${isLink ? 'active' : ''}`}
-        aria-label={insertLinkLabel}
-        title={insertLinkLabel}
-        icon={<img className={'format'} src={isInverted ? linkDark : linkLight} alt={'link icon'} />}
-      />
+      <FormatLinkButton activeEditor={activeEditor} isToggledOn={isLink} readonly={readonly} />
     </>
   );
 };

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatBoldButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatBoldButton.tsx
@@ -1,0 +1,59 @@
+import { FORMAT_TEXT_COMMAND, type LexicalEditor } from 'lexical';
+import { useIntl } from 'react-intl';
+import boldDark from '../icons/dark/type-bold.svg';
+import boldLight from '../icons/light/type-bold.svg';
+import { FormatButton } from './FormatButton';
+
+interface FormatBoldButtonProps {
+  activeEditor: LexicalEditor;
+  isToggledOn: boolean;
+  readonly: boolean;
+}
+
+export const FormatBoldButton: React.FC<FormatBoldButtonProps> = (props) => {
+  const { activeEditor, isToggledOn, readonly } = props;
+
+  const intl = useIntl();
+
+  const boldTitleMac = intl.formatMessage({
+    defaultMessage: 'Bold (⌘B)',
+    id: 'ciLkfU',
+    description: 'Command for bold text for Mac users',
+  });
+  const boldTitleMacAriaLabel = intl.formatMessage({
+    defaultMessage: 'Format text as bold. Shortcut: ⌘B',
+    id: 'S138/4',
+    description: 'label to make bold text for Mac users',
+  });
+  const boldTitleNonMac = intl.formatMessage({
+    defaultMessage: 'Bold (Ctrl+B)',
+    id: 'Lnqh6h',
+    description: 'Command for bold text for non-mac users',
+  });
+  const boldTitleNonMacAriaLabel = intl.formatMessage({
+    defaultMessage: 'Format text as bold. Shortcut: Ctrl+B',
+    id: 'YR1uWE',
+    description: 'label to make bold text for nonMac users',
+  });
+
+  return (
+    <FormatButton
+      icons={{
+        dark: boldDark,
+        label: 'bold',
+        light: boldLight,
+      }}
+      isToggledOn={isToggledOn}
+      onClick={() => {
+        activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
+      }}
+      readonly={readonly}
+      strings={{
+        label: boldTitleNonMacAriaLabel,
+        labelMac: boldTitleMacAriaLabel,
+        title: boldTitleNonMac,
+        titleMac: boldTitleMac,
+      }}
+    />
+  );
+};

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatBoldButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatBoldButton.tsx
@@ -1,7 +1,7 @@
 import { FORMAT_TEXT_COMMAND, type LexicalEditor } from 'lexical';
 import { useIntl } from 'react-intl';
-import boldDark from '../icons/dark/type-bold.svg';
-import boldLight from '../icons/light/type-bold.svg';
+import boldDark from '../../icons/dark/type-bold.svg';
+import boldLight from '../../icons/light/type-bold.svg';
 import { FormatButton } from './FormatButton';
 
 interface FormatBoldButtonProps {

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatButton.tsx
@@ -1,0 +1,47 @@
+import { useTheme } from '@fluentui/react';
+import { mergeClasses, ToolbarButton } from '@fluentui/react-components';
+import { isApple } from '@microsoft/logic-apps-shared';
+
+export interface FormatButtonProps {
+  icons: {
+    dark: string;
+    label: string;
+    light: string;
+  };
+  isToggledOn: boolean;
+  onClick: () => void;
+  readonly: boolean;
+  strings: {
+    label?: string;
+    labelMac?: string;
+    title: string;
+    titleMac?: string;
+  };
+}
+
+export const FormatButton: React.FC<FormatButtonProps> = (props) => {
+  const {
+    icons: { dark: iconDark, label: iconLabel, light: iconLight },
+    isToggledOn,
+    onClick,
+    readonly,
+    strings: { label, labelMac, title, titleMac },
+  } = props;
+
+  const { isInverted } = useTheme();
+
+  const buttonTitle = isApple() && titleMac ? titleMac : title;
+  const buttonLabel = (isApple() && labelMac ? labelMac : label) || buttonTitle;
+
+  return (
+    <ToolbarButton
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className={mergeClasses('toolbar-item', 'spaced', isToggledOn && 'active')}
+      title={buttonTitle}
+      aria-label={buttonLabel}
+      disabled={readonly}
+      icon={<img className="format" src={isInverted ? iconDark : iconLight} alt={`${iconLabel} icon`} />}
+    />
+  );
+};

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatItalicButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatItalicButton.tsx
@@ -1,0 +1,59 @@
+import { FORMAT_TEXT_COMMAND, type LexicalEditor } from 'lexical';
+import { useIntl } from 'react-intl';
+import italicDark from '../icons/dark/type-italic.svg';
+import italicLight from '../icons/light/type-italic.svg';
+import { FormatButton } from './FormatButton';
+
+interface FormatItalicButtonProps {
+  activeEditor: LexicalEditor;
+  isToggledOn: boolean;
+  readonly: boolean;
+}
+
+export const FormatItalicButton: React.FC<FormatItalicButtonProps> = (props) => {
+  const { activeEditor, isToggledOn, readonly } = props;
+
+  const intl = useIntl();
+
+  const italicTitleMac = intl.formatMessage({
+    defaultMessage: 'Italic (⌘I)',
+    id: 'elD6+N',
+    description: 'Command for italic text for Mac users',
+  });
+  const italicTitleMacAriaLabel = intl.formatMessage({
+    defaultMessage: 'Format text as italic. Shortcut: ⌘I',
+    id: 'YdQw4/',
+    description: 'label to make italic text for Mac users',
+  });
+  const italicTitleNonMac = intl.formatMessage({
+    defaultMessage: 'Italic (Ctrl+I)',
+    id: 'dfmH55',
+    description: 'Command for italic text for non-mac users',
+  });
+  const italicTitleNonMacAriaLabel = intl.formatMessage({
+    defaultMessage: 'Format text as italic. Shortcut: Ctrl+I',
+    id: 'gIx5ys',
+    description: 'label to make italic text for nonMac users',
+  });
+
+  return (
+    <FormatButton
+      icons={{
+        dark: italicDark,
+        label: 'italic',
+        light: italicLight,
+      }}
+      isToggledOn={isToggledOn}
+      onClick={() => {
+        activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
+      }}
+      readonly={readonly}
+      strings={{
+        label: italicTitleNonMacAriaLabel,
+        labelMac: italicTitleMacAriaLabel,
+        title: italicTitleNonMac,
+        titleMac: italicTitleMac,
+      }}
+    />
+  );
+};

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatItalicButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatItalicButton.tsx
@@ -1,7 +1,7 @@
 import { FORMAT_TEXT_COMMAND, type LexicalEditor } from 'lexical';
 import { useIntl } from 'react-intl';
-import italicDark from '../icons/dark/type-italic.svg';
-import italicLight from '../icons/light/type-italic.svg';
+import italicDark from '../../icons/dark/type-italic.svg';
+import italicLight from '../../icons/light/type-italic.svg';
 import { FormatButton } from './FormatButton';
 
 interface FormatItalicButtonProps {

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatLinkButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatLinkButton.tsx
@@ -1,0 +1,48 @@
+import { useTheme } from '@fluentui/react';
+import { mergeClasses, ToolbarButton } from '@fluentui/react-components';
+import { TOGGLE_LINK_COMMAND } from '@lexical/link';
+import type { LexicalEditor } from 'lexical';
+import { useCallback } from 'react';
+import { useIntl } from 'react-intl';
+import { sanitizeUrl } from '../helper/functions';
+import linkDark from '../icons/dark/link.svg';
+import linkLight from '../icons/light/link.svg';
+
+interface FormatLinkButtonProps {
+  activeEditor: LexicalEditor;
+  isToggledOn: boolean;
+  readonly: boolean;
+}
+
+export const FormatLinkButton: React.FC<FormatLinkButtonProps> = (props) => {
+  const { activeEditor, isToggledOn, readonly } = props;
+
+  const { isInverted } = useTheme();
+  const intl = useIntl();
+
+  const insertLink = useCallback(() => {
+    if (isToggledOn) {
+      activeEditor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
+    } else {
+      activeEditor.dispatchCommand(TOGGLE_LINK_COMMAND, sanitizeUrl('https://'));
+    }
+  }, [activeEditor, isToggledOn]);
+
+  const insertLinkLabel = intl.formatMessage({
+    defaultMessage: 'Insert Link',
+    id: 'tUCptx',
+    description: 'label to insert link',
+  });
+
+  return (
+    <ToolbarButton
+      onMouseDown={(e) => e.preventDefault()}
+      disabled={readonly}
+      onClick={insertLink}
+      className={mergeClasses('toolbar-item', 'spaced', isToggledOn && 'active')}
+      aria-label={insertLinkLabel}
+      title={insertLinkLabel}
+      icon={<img className={'format'} src={isInverted ? linkDark : linkLight} alt={'link icon'} />}
+    />
+  );
+};

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatLinkButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatLinkButton.tsx
@@ -1,5 +1,3 @@
-import { useTheme } from '@fluentui/react';
-import { mergeClasses, ToolbarButton } from '@fluentui/react-components';
 import { TOGGLE_LINK_COMMAND } from '@lexical/link';
 import type { LexicalEditor } from 'lexical';
 import { useCallback } from 'react';
@@ -7,6 +5,7 @@ import { useIntl } from 'react-intl';
 import linkDark from '../../icons/dark/link.svg';
 import linkLight from '../../icons/light/link.svg';
 import { sanitizeUrl } from '../helper/functions';
+import { FormatButton } from './FormatButton';
 
 interface FormatLinkButtonProps {
   activeEditor: LexicalEditor;
@@ -17,7 +16,6 @@ interface FormatLinkButtonProps {
 export const FormatLinkButton: React.FC<FormatLinkButtonProps> = (props) => {
   const { activeEditor, isToggledOn, readonly } = props;
 
-  const { isInverted } = useTheme();
   const intl = useIntl();
 
   const insertLink = useCallback(() => {
@@ -35,14 +33,18 @@ export const FormatLinkButton: React.FC<FormatLinkButtonProps> = (props) => {
   });
 
   return (
-    <ToolbarButton
-      onMouseDown={(e) => e.preventDefault()}
-      disabled={readonly}
+    <FormatButton
+      icons={{
+        dark: linkDark,
+        label: 'link',
+        light: linkLight,
+      }}
+      isToggledOn={isToggledOn}
       onClick={insertLink}
-      className={mergeClasses('toolbar-item', 'spaced', isToggledOn && 'active')}
-      aria-label={insertLinkLabel}
-      title={insertLinkLabel}
-      icon={<img className={'format'} src={isInverted ? linkDark : linkLight} alt={'link icon'} />}
+      readonly={readonly}
+      strings={{
+        title: insertLinkLabel,
+      }}
     />
   );
 };

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatLinkButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatLinkButton.tsx
@@ -4,9 +4,9 @@ import { TOGGLE_LINK_COMMAND } from '@lexical/link';
 import type { LexicalEditor } from 'lexical';
 import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
+import linkDark from '../../icons/dark/link.svg';
+import linkLight from '../../icons/light/link.svg';
 import { sanitizeUrl } from '../helper/functions';
-import linkDark from '../icons/dark/link.svg';
-import linkLight from '../icons/light/link.svg';
 
 interface FormatLinkButtonProps {
   activeEditor: LexicalEditor;

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatUnderlineButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatUnderlineButton.tsx
@@ -1,7 +1,7 @@
 import { FORMAT_TEXT_COMMAND, type LexicalEditor } from 'lexical';
 import { useIntl } from 'react-intl';
-import underlineDark from '../icons/dark/type-underline.svg';
-import underlineLight from '../icons/light/type-underline.svg';
+import underlineDark from '../../icons/dark/type-underline.svg';
+import underlineLight from '../../icons/light/type-underline.svg';
 import { FormatButton } from './FormatButton';
 
 interface FormatUnderlineButtonProps {

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatUnderlineButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/FormatUnderlineButton.tsx
@@ -1,0 +1,59 @@
+import { FORMAT_TEXT_COMMAND, type LexicalEditor } from 'lexical';
+import { useIntl } from 'react-intl';
+import underlineDark from '../icons/dark/type-underline.svg';
+import underlineLight from '../icons/light/type-underline.svg';
+import { FormatButton } from './FormatButton';
+
+interface FormatUnderlineButtonProps {
+  activeEditor: LexicalEditor;
+  isToggledOn: boolean;
+  readonly: boolean;
+}
+
+export const FormatUnderlineButton: React.FC<FormatUnderlineButtonProps> = (props) => {
+  const { activeEditor, isToggledOn, readonly } = props;
+
+  const intl = useIntl();
+
+  const underlineTitleMac = intl.formatMessage({
+    defaultMessage: 'Underline (⌘U)',
+    id: 'KYX5Do',
+    description: 'Command for underline text for Mac users',
+  });
+  const underlineTitleMacAriaLabel = intl.formatMessage({
+    defaultMessage: 'Format text as underline. Shortcut: ⌘U',
+    id: 'qBkxGU',
+    description: 'label to make underline text for Mac users',
+  });
+  const underlineTitleNonMac = intl.formatMessage({
+    defaultMessage: 'Underline (Ctrl+U)',
+    id: 'lwlg2K',
+    description: 'Command for underline text for non-mac users',
+  });
+  const underlineTitleNonMacAriaLabel = intl.formatMessage({
+    defaultMessage: 'Format text as underline. Shortcut: Ctrl+U',
+    id: 'YJlS8E',
+    description: 'label to make underline text for nonMac users',
+  });
+
+  return (
+    <FormatButton
+      icons={{
+        dark: underlineDark,
+        label: 'underline',
+        light: underlineLight,
+      }}
+      isToggledOn={isToggledOn}
+      onClick={() => {
+        activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
+      }}
+      readonly={readonly}
+      strings={{
+        label: underlineTitleNonMacAriaLabel,
+        labelMac: underlineTitleMacAriaLabel,
+        title: underlineTitleNonMac,
+        titleMac: underlineTitleMac,
+      }}
+    />
+  );
+};

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/HtmlViewToggleButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/HtmlViewToggleButton.tsx
@@ -1,6 +1,6 @@
-import { useTheme } from "@fluentui/react";
-import { mergeClasses, ToolbarButton } from "@fluentui/react-components";
-import { useIntl } from "react-intl";
+import { useTheme } from '@fluentui/react';
+import { mergeClasses, ToolbarButton } from '@fluentui/react-components';
+import { useIntl } from 'react-intl';
 import codeToggleDark from '../../icons/dark/code-toggle.svg';
 import codeToggleLight from '../../icons/light/code-toggle.svg';
 

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/RedoButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/RedoButton.tsx
@@ -1,12 +1,12 @@
-import { ToolbarButton } from "@fluentui/react-components";
+import { useTheme } from '@fluentui/react';
+import { ToolbarButton } from '@fluentui/react-components';
 import { isApple } from '@microsoft/logic-apps-shared';
-import type { LexicalEditor} from "lexical";
-import { REDO_COMMAND } from "lexical";
+import type { LexicalEditor } from 'lexical';
+import { REDO_COMMAND } from 'lexical';
+import { useIntl } from 'react-intl';
 import clockWiseArrowDark from '../../icons/dark/arrow-clockwise.svg';
 import clockWiseArrowLight from '../../icons/light/arrow-clockwise.svg';
 import { CLOSE_DROPDOWN_COMMAND } from '../helper/Dropdown';
-import { useTheme } from "@fluentui/react";
-import { useIntl } from "react-intl";
 
 interface RedoButtonProps {
   activeEditor: LexicalEditor;

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/UndoButton.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/buttons/UndoButton.tsx
@@ -1,9 +1,9 @@
-import { useTheme } from "@fluentui/react";
-import { ToolbarButton } from "@fluentui/react-components";
+import { useTheme } from '@fluentui/react';
+import { ToolbarButton } from '@fluentui/react-components';
 import { isApple } from '@microsoft/logic-apps-shared';
-import type { LexicalEditor } from "lexical";
-import { UNDO_COMMAND } from "lexical";
-import { useIntl } from "react-intl";
+import type { LexicalEditor } from 'lexical';
+import { UNDO_COMMAND } from 'lexical';
+import { useIntl } from 'react-intl';
 import counterClockWiseArrowDark from '../../icons/dark/arrow-counterclockwise.svg';
 import counterClockWiseArrowLight from '../../icons/light/arrow-counterclockwise.svg';
 import { CLOSE_DROPDOWN_COMMAND } from '../helper/Dropdown';

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/hooks/useCloseDropdownOnScroll.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/hooks/useCloseDropdownOnScroll.ts
@@ -1,6 +1,6 @@
-import type { LexicalEditor } from "lexical";
-import { useEffect } from "react";
-import { CLOSE_DROPDOWN_COMMAND } from "../helper/Dropdown";
+import type { LexicalEditor } from 'lexical';
+import { useEffect } from 'react';
+import { CLOSE_DROPDOWN_COMMAND } from '../helper/Dropdown';
 
 export const useCloseDropdownOnScroll = (activeEditor: LexicalEditor) => {
   useEffect(() => {


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [ ] Feature
* [x] Other

## Current Behavior

Formatting buttons in the WYSIWYG toolbar are all hosted within `Format.tsx`, making them difficult to reuse or extend.

## New Behavior

All formatting buttons have been moved to their own reusable components. This change is similar to what was done in #5158, and will be used in future work.

## Impact of Change

No functional or breaking changes. Refactoring only.