### PR TITLE
fix(vscode): Add validation for error response structure

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2284,8 +2284,7 @@ export async function loadDynamicValuesForParameter(
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.SUCCEEDED }, editorOptions: { options: dynamicValues } };
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);
-    const errorData = error?.response ? error?.response?.data : error?.data;
-    const message = errorData?.error?.message ?? rootMessage;
+    const message = error?.response?.data?.error?.message ?? rootMessage;
 
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.FAILED, error: { ...error, message } } };
   }
@@ -2336,8 +2335,7 @@ export async function fetchDynamicValuesForParameter(
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.SUCCEEDED }, editorOptions: { options: dynamicValues } };
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);
-    const errorData = error?.response ? error?.response?.data : error?.data;
-    const message = errorData?.error?.message ?? rootMessage;
+    const message = error?.response?.data?.error?.message ?? rootMessage;
 
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.FAILED, error: { ...error, message } } };
   }

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2284,7 +2284,7 @@ export async function loadDynamicValuesForParameter(
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.SUCCEEDED }, editorOptions: { options: dynamicValues } };
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);
-    const errorData = error?.response?.data ? error?.response?.data : error?.data;
+    const errorData = error?.response ? error?.response?.data : error?.data;
     const message = errorData?.error?.message ?? rootMessage;
 
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.FAILED, error: { ...error, message } } };
@@ -2336,7 +2336,9 @@ export async function fetchDynamicValuesForParameter(
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.SUCCEEDED }, editorOptions: { options: dynamicValues } };
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);
-    const message = error?.response?.data?.error?.message ?? rootMessage;
+    const errorData = error?.response ? error?.response?.data : error?.data;
+    const message = errorData?.error?.message ?? rootMessage;
+
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.FAILED, error: { ...error, message } } };
   }
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2285,7 +2285,6 @@ export async function loadDynamicValuesForParameter(
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);
     const message = error?.response?.data?.error?.message ?? rootMessage;
-
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.FAILED, error: { ...error, message } } };
   }
 
@@ -2336,7 +2335,6 @@ export async function fetchDynamicValuesForParameter(
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);
     const message = error?.response?.data?.error?.message ?? rootMessage;
-
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.FAILED, error: { ...error, message } } };
   }
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -2284,7 +2284,9 @@ export async function loadDynamicValuesForParameter(
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.SUCCEEDED }, editorOptions: { options: dynamicValues } };
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);
-    const message = error?.response?.data?.error?.message ?? rootMessage;
+    const errorData = error?.response?.data ? error?.response?.data : error?.data;
+    const message = errorData?.error?.message ?? rootMessage;
+
     propertiesToUpdate = { dynamicData: { status: DynamicCallStatus.FAILED, error: { ...error, message } } };
   }
 

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/http.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/http.ts
@@ -14,8 +14,9 @@ export const parseErrorMessage = (error: any, defaultErrorMessage?: string): str
       return message;
     }
 
-    if(error?.data?.error?.message) {
-      return error?.data?.error?.message;
+    message = error?.data?.error?.message;
+    if (message) {
+      return message;
     }
 
     // Response text needs to be parsed to get internal error message

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/http.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/http.ts
@@ -14,6 +14,10 @@ export const parseErrorMessage = (error: any, defaultErrorMessage?: string): str
       return message;
     }
 
+    if(error?.data?.error?.message) {
+      return error?.data?.error?.message;
+    }
+
     // Response text needs to be parsed to get internal error message
     if (error?.responseText) {
       message = parseErrorMessage(JSON.parse(error.responseText), defaultErrorMessage);


### PR DESCRIPTION
This pull request primarily involves changes to error handling in two functions, `loadDynamicValuesForParameter` and `fetchDynamicValuesForParameter`, within the `libs/designer/src/lib/core/utils/parameters/helper.ts` file. The changes improve the way error messages are extracted from the error object, allowing for more robust error handling.


* In both `loadDynamicValuesForParameter` and `fetchDynamicValuesForParameter`, the error message extraction logic has been modified. Now, it first checks if the error has a `response` property before trying to extract the `data` property. If there's no `response` property, it falls back to the `data` property of the error object. This change ensures that the appropriate error message is extracted and displayed, even if the error object structure varies. 
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

Fix #5142 


## Screenshots or Videos (if applicable)




https://github.com/user-attachments/assets/b8512348-841a-43b7-9ccb-f796cde58996

