### PR TITLE
fix(designer): Render nested structures correctly for mocked objects

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -1129,7 +1129,17 @@ const parseOutputMock = (outputs: Record<string, ValueSegment[]>): Record<string
   const outputValues: Record<string, any> = {};
   for (const [key, value] of Object.entries(outputs)) {
     if (value && value.length > 0) {
-      outputValues[key] = value[0].value;
+      // Parse the value if it's a string that looks like JSON
+      if (typeof value[0].value === 'string' && (value[0].value.startsWith('[') || value[0].value.startsWith('{'))) {
+        try {
+          outputValues[key] = JSON.parse(value[0].value);
+        } catch {
+          // If parsing fails, use the original value
+          outputValues[key] = value[0].value;
+        }
+      } else {
+        outputValues[key] = value[0].value;
+      }
     }
   }
   return unifyOutputs(outputValues);
@@ -1152,7 +1162,7 @@ const unifyOutputs = (outputs: Record<string, any>): Record<string, any> => {
         currentLevel[part] = outputs[key];
       } else {
         if (!currentLevel[part]) {
-          currentLevel[part] = {};
+          currentLevel[part] = Array.isArray(outputs[key]) ? [] : {};
         }
         currentLevel = currentLevel[part];
       }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/workflow.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/workflow.ts
@@ -24,6 +24,7 @@ export interface OutputInfo {
   title: string;
   value?: string;
   alias?: string;
+  children?: OutputInfo[]; // Added children property
 }
 
 export interface IWorkflowService {


### PR DESCRIPTION
Bug work item: [Link to Work Item Here](https://msazure.visualstudio.com/One/_workitems/edit/28688291)

## Requirement Checklist

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

The current UX does not correctly render nested structures in mocked objects. For example, a JSON object with a `Person` entity, which includes nested properties like `Name` and `Age`, is being displayed as a flat object in the UI. The visual representation does not reflect the hierarchical structure of the data, leading to confusion and a lack of clarity.

## New Behavior

With this update, the UX will render nested structures properly. The `Person` object will now display `Name` and `Age` as subsections within the `Person` container, reflecting the intended hierarchical structure of the JSON. This change will ensure that nested properties are visually organized in a way that accurately represents their relationships.

## Impact of Change

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

**Before:**
![Flat Object](link-to-flat-object-image)
Mocked objects with nested structure aren't currently being rendered properly in the UX

the following Json with a person object that has nested sub structures:
![image](https://github.com/user-attachments/assets/6a146226-81c0-4537-89ae-f6270b53d035)

is rendered in the UX as a flat object without nested structure
![image](https://github.com/user-attachments/assets/085d99f0-1369-464e-a31a-f9176bcd446a)

it should instead render Name and Age as a subsection of "Person"

**After:**
![Nested Object](link-to-nested-object-image)
