### PR TITLE
feat(designer): Add unit testing for parseErrorMessage function

### DIFF
--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/http.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/http.spec.ts
@@ -1,0 +1,45 @@
+import { parseErrorMessage } from '../http';
+import { describe, it, expect } from 'vitest';
+
+const mockError = {
+  message: 'Request failed with status code 400',
+  name: 'AxiosError',
+  stack: 'AxiosError: Request failed with status code 400',
+  code: 'ERR_BAD_REQUEST',
+  status: 400,
+};
+
+describe('parseErrorMessage', () => {
+  it('Should return the same error message from error object when has a message property', () => {
+    expect(parseErrorMessage(mockError)).toEqual(mockError.message);
+  });
+
+  it('Should return the same error message from error object when is inside data.error property', () => {
+    expect(parseErrorMessage({ data: { error: mockError } })).toEqual(mockError.message);
+  });
+
+  it('Should return the same error message when error object is string and is inside responseText property', () => {
+    const stringError = JSON.stringify(mockError);
+    expect(parseErrorMessage({ responseText: stringError })).toEqual(mockError.message);
+  });
+
+  it('Should return the same error string when parameter is send as string', () => {
+    expect(parseErrorMessage(mockError.message)).toEqual(mockError.message);
+  });
+
+  it('Should return Unknown error when parameter is undefined or null and there is no default error message', () => {
+    expect(parseErrorMessage(undefined)).toEqual('Unknown error');
+    expect(parseErrorMessage(null)).toEqual('Unknown error');
+  });
+
+  it('Should return Could not parse error message. when string is does not have a json structure inside responseText property', () => {
+    expect(parseErrorMessage({ responseText: '{' })).toEqual('Could not parse error message.');
+  });
+
+  it('Should return the default error message sent as param when error is empty string, null or undefined', () => {
+    const defaultErrorMessage = 'Default error message';
+    expect(parseErrorMessage('', defaultErrorMessage)).toEqual(defaultErrorMessage);
+    expect(parseErrorMessage(undefined, defaultErrorMessage)).toEqual(defaultErrorMessage);
+    expect(parseErrorMessage(null, defaultErrorMessage)).toEqual(defaultErrorMessage);
+  });
+});

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/http.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/http.ts
@@ -14,7 +14,7 @@ export const parseErrorMessage = (error: any, defaultErrorMessage?: string): str
       return message;
     }
 
-    message = error?.data?.error?.message;
+    message = error?.data?.error?.message ?? undefined;
     if (message) {
       return message;
     }


### PR DESCRIPTION
This pull request includes changes to the `libs/logic-apps-shared` package, specifically to the `http` utility and its associated tests. The changes primarily focus on enhancing the error handling capabilities of the `parseErrorMessage` function and ensuring its behavior is thoroughly tested.

* The `parseErrorMessage` function has been modified to ensure that if `error.data.error.message` is not available, `undefined` is returned instead of potentially returning a truthy value that isn't a message. This change ensures that the function's behavior is more predictable and consistent.

* A comprehensive suite of tests for the `parseErrorMessage` function has been added. These tests cover various scenarios to ensure the function behaves as expected when provided with different types and structures of error objects. This includes scenarios where the error object has a `message` property, is nested inside `data.error`, is a string inside `responseText`, is sent as a string, is `undefined` or `null`, doesn't have a JSON structure inside `responseText`, and when the error is an empty string, `null` or `undefined` with a default error message provided.