### PR TITLE
fix(shared): Add `objectId` and `tenantId` to `authenticatedUser`

### DIFF
--- a/libs/logic-apps-shared/src/utils/src/lib/models/connection.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/connection.ts
@@ -48,8 +48,14 @@ export interface ValueObject {
   value: any;
 }
 
+export interface ConnectionAuthenticatedUser {
+  name?: string;
+  objectId?: string;
+  tenantId?: string;
+}
+
 export interface ConnectionProperties {
-  authenticatedUser?: { name?: string };
+  authenticatedUser?: ConnectionAuthenticatedUser;
   connectionParameters?: Record<string, ConnectionParameter>;
   connectionParametersSet?: ConnectionParameterSet;
   createdBy?: Principal;


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Fields for object & tenant IDs are missing from `ConnectionProperties.authenticatedUser`.

## New Behavior

Above fields have been added.

## Impact of Change

No breaking changes.