### PR TITLE
feat(designer): Allow deleting a node without affecting selected node ID in state

### DIFF
--- a/libs/designer/src/lib/core/state/designerView/designerViewInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewInterfaces.ts
@@ -1,5 +1,5 @@
 export interface DesignerViewState {
   showMinimap?: boolean;
   clampPan?: boolean;
-  showDeleteModal: boolean;
+  showDeleteModalNodeId?: string;
 }

--- a/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -9,6 +9,6 @@ export const useClampPan = () => {
   return useSelector((state: RootState) => state.designerView.clampPan);
 };
 
-export const useShowDeleteModal = () => {
-  return useSelector((state: RootState) => state.designerView.showDeleteModal);
+export const useShowDeleteModalNodeId = () => {
+  return useSelector((state: RootState) => state.designerView.showDeleteModalNodeId);
 };

--- a/libs/designer/src/lib/core/state/designerView/designerViewSlice.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewSlice.ts
@@ -1,11 +1,12 @@
 import { resetWorkflowState } from '../global';
 import type { DesignerViewState } from './designerViewInterfaces';
+import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState: DesignerViewState = {
   showMinimap: false,
   clampPan: true,
-  showDeleteModal: false,
+  showDeleteModalNodeId: undefined,
 };
 
 export const designerViewSlice = createSlice({
@@ -18,8 +19,8 @@ export const designerViewSlice = createSlice({
     toggleClampPan: (state: DesignerViewState) => {
       state.clampPan = !state.clampPan;
     },
-    setShowDeleteModal: (state: DesignerViewState, action) => {
-      state.showDeleteModal = action.payload;
+    setShowDeleteModalNodeId: (state: DesignerViewState, action: PayloadAction<string | undefined>) => {
+      state.showDeleteModalNodeId = action.payload;
     },
   },
   extraReducers: (builder) => {
@@ -27,6 +28,6 @@ export const designerViewSlice = createSlice({
   },
 });
 
-export const { toggleMinimap, toggleClampPan, setShowDeleteModal } = designerViewSlice.actions;
+export const { toggleMinimap, toggleClampPan, setShowDeleteModalNodeId } = designerViewSlice.actions;
 
 export default designerViewSlice.reducer;

--- a/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -10,7 +10,7 @@ import {
   useReadOnly,
   useSuppressDefaultNodeSelectFunctionality,
 } from '../../core/state/designerOptions/designerOptionsSelectors';
-import { setShowDeleteModal } from '../../core/state/designerView/designerViewSlice';
+import { setShowDeleteModalNodeId } from '../../core/state/designerView/designerViewSlice';
 import { ErrorLevel } from '../../core/state/operation/operationMetadataSlice';
 import {
   useOperationErrorInfo,
@@ -228,8 +228,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
   }, [dispatch, handleNodeSelection]);
 
   const deleteClick = useCallback(() => {
-    dispatch(setSelectedNodeId(id));
-    dispatch(setShowDeleteModal(true));
+    dispatch(setShowDeleteModalNodeId(id));
   }, [dispatch, id]);
 
   const copyClick = useCallback(() => {

--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -2,7 +2,7 @@ import constants from '../../common/constants';
 import { getMonitoringError } from '../../common/utilities/error';
 import { moveOperation } from '../../core/actions/bjsworkflow/move';
 import { useMonitoringView, useReadOnly } from '../../core/state/designerOptions/designerOptionsSelectors';
-import { setShowDeleteModal } from '../../core/state/designerView/designerViewSlice';
+import { setShowDeleteModalNodeId } from '../../core/state/designerView/designerViewSlice';
 import {
   useBrandColor,
   useIconUri,
@@ -10,7 +10,7 @@ import {
   useTokenDependencies,
 } from '../../core/state/operation/operationSelector';
 import { useIsNodeSelected } from '../../core/state/panel/panelSelectors';
-import { changePanelNode, selectPanelTab, setSelectedNodeId } from '../../core/state/panel/panelSlice';
+import { changePanelNode, selectPanelTab } from '../../core/state/panel/panelSlice';
 import { useAllOperations, useOperationQuery } from '../../core/state/selectors/actionMetadataSelector';
 import { useSettingValidationErrors } from '../../core/state/setting/settingSelector';
 import {
@@ -183,8 +183,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
   }, [dispatch, scopeId]);
 
   const deleteClick = useCallback(() => {
-    dispatch(setSelectedNodeId(scopeId));
-    dispatch(setShowDeleteModal(true));
+    dispatch(setShowDeleteModalNodeId(scopeId));
   }, [dispatch, scopeId]);
 
   const copyClick = useCallback(() => {

--- a/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
@@ -4,11 +4,11 @@ import { useOperationInfo, type AppDispatch } from '../../core';
 import { initializeSwitchCaseFromManifest } from '../../core/actions/bjsworkflow/add';
 import { getOperationManifest } from '../../core/queries/operation';
 import { useMonitoringView, useReadOnly } from '../../core/state/designerOptions/designerOptionsSelectors';
-import { setShowDeleteModal } from '../../core/state/designerView/designerViewSlice';
+import { setShowDeleteModalNodeId } from '../../core/state/designerView/designerViewSlice';
 import { useIconUri, useParameterValidationErrors } from '../../core/state/operation/operationSelector';
 import { useIsNodeSelected } from '../../core/state/panel/panelSelectors';
 import { useIsNodePinned } from '../../core/state/panelV2/panelSelectors';
-import { changePanelNode, setSelectedNodeId } from '../../core/state/panel/panelSlice';
+import { changePanelNode } from '../../core/state/panel/panelSlice';
 import {
   useActionMetadata,
   useIsGraphCollapsed,
@@ -96,8 +96,7 @@ const SubgraphCardNode = ({ data, targetPosition = Position.Top, sourcePosition 
   );
 
   const deleteClick = useCallback(() => {
-    dispatch(setSelectedNodeId(id));
-    dispatch(setShowDeleteModal(true));
+    dispatch(setShowDeleteModalNodeId(id));
   }, [dispatch, id]);
 
   const contextMenuItems: JSX.Element[] = useMemo(

--- a/libs/designer/src/lib/ui/common/DeleteModal/DeleteModal.tsx
+++ b/libs/designer/src/lib/ui/common/DeleteModal/DeleteModal.tsx
@@ -1,19 +1,19 @@
 import type { AppDispatch } from '../../../core';
-import { useSelectedNodeId, useNodeMetadata, useNodeDisplayName } from '../../../core';
+import { useNodeMetadata, useNodeDisplayName } from '../../../core';
 import { deleteOperation, deleteGraphNode } from '../../../core/actions/bjsworkflow/delete';
-import { useShowDeleteModal } from '../../../core/state/designerView/designerViewSelectors';
-import { setShowDeleteModal } from '../../../core/state/designerView/designerViewSlice';
+import { useShowDeleteModalNodeId } from '../../../core/state/designerView/designerViewSelectors';
+import { setShowDeleteModalNodeId } from '../../../core/state/designerView/designerViewSlice';
 import { useWorkflowNode } from '../../../core/state/workflow/workflowSelectors';
 import { deleteSwitchCase } from '../../../core/state/workflow/workflowSlice';
 import { DeleteNodeModal } from '@microsoft/designer-ui';
-import { WORKFLOW_NODE_TYPES, removeIdTag } from '@microsoft/logic-apps-shared';
+import { WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
 import { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
 const DeleteModal = () => {
   const dispatch = useDispatch<AppDispatch>();
 
-  const nodeId = removeIdTag(useSelectedNodeId()) ?? '';
+  const nodeId = useShowDeleteModalNodeId();
   const nodeName = useNodeDisplayName(nodeId);
   const nodeData = useWorkflowNode(nodeId);
   const metadata = useNodeMetadata(nodeId);
@@ -21,11 +21,10 @@ const DeleteModal = () => {
 
   const isTrigger = useMemo(() => !!(metadata?.graphId === 'root' && metadata?.isRoot), [metadata]);
 
-  const showDeleteModal = useShowDeleteModal();
-  const onDismiss = useCallback(() => dispatch(setShowDeleteModal(false)), [dispatch]);
+  const onDismiss = useCallback(() => dispatch(setShowDeleteModalNodeId(undefined)), [dispatch]);
 
   const handleDelete = useCallback(() => {
-    if (!nodeData) {
+    if (!nodeId || !nodeData) {
       return;
     }
     const { type } = nodeData;
@@ -59,10 +58,10 @@ const DeleteModal = () => {
 
   return (
     <DeleteNodeModal
-      nodeId={nodeId}
+      nodeId={nodeId ?? ''}
       nodeName={nodeName}
       nodeType={nodeData?.type}
-      isOpen={showDeleteModal}
+      isOpen={!!nodeId}
       onDismiss={onDismiss}
       onConfirm={handleDelete}
     />

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -11,11 +11,11 @@ import {
 } from '../../../core';
 import { renameCustomCode } from '../../../core/state/customcode/customcodeSlice';
 import { useReadOnly, useSuppressDefaultNodeSelectFunctionality } from '../../../core/state/designerOptions/designerOptionsSelectors';
-import { setShowDeleteModal } from '../../../core/state/designerView/designerViewSlice';
+import { setShowDeleteModalNodeId } from '../../../core/state/designerView/designerViewSlice';
 import { ErrorLevel, updateParameterEditorViewModel } from '../../../core/state/operation/operationMetadataSlice';
 import { useIconUri, useOperationErrorInfo } from '../../../core/state/operation/operationSelector';
 import { useIsPanelCollapsed, useSelectedPanelTabId } from '../../../core/state/panel/panelSelectors';
-import { expandPanel, selectPanelTab, setSelectedNodeId, updatePanelLocation } from '../../../core/state/panel/panelSlice';
+import { expandPanel, selectPanelTab, updatePanelLocation } from '../../../core/state/panel/panelSlice';
 import { useOperationQuery } from '../../../core/state/selectors/actionMetadataSelector';
 import { useNodeDescription, useRunData, useRunInstance } from '../../../core/state/workflow/workflowSelectors';
 import { replaceId, setNodeDescription } from '../../../core/state/workflow/workflowSlice';
@@ -86,8 +86,7 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
   }, [dispatch]);
 
   const deleteClick = useCallback(() => {
-    dispatch(setSelectedNodeId(selectedNode));
-    dispatch(setShowDeleteModal(true));
+    dispatch(setShowDeleteModalNodeId(selectedNode));
   }, [dispatch, selectedNode]);
 
   const handleCommentMenuClick = (_: React.MouseEvent<HTMLElement>): void => {


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior

When a node is deleted, it is first "selected". This is not problematic today where it is possible to select only one node at a time, but to support future work where multiple nodes may be selected, it is not sufficient.

## New Behavior

Node deletion modal is decoupled from selected node. It now tracks its own node ID for deletion.

## Impact of Change

The `useShowDeleteModal` selector is not exported so there should be no breaking changes.

## Screenshots or Videos (if applicable)

Below illustrates post-change, functionality remains intact as it exists today.

![delete-still-works](https://github.com/user-attachments/assets/45547e5a-bfe2-4365-9657-e8e5410dc755)