### PR TITLE
feat(designer): Decouple panel tabs from `useSelectedNodeId()`

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelUtil.ts
+++ b/libs/designer-ui/src/lib/panel/panelUtil.ts
@@ -24,7 +24,13 @@ export const PanelSize = {
 } as const;
 export type PanelSize = (typeof PanelSize)[keyof typeof PanelSize];
 
-export type PanelTabFn = (intl: IntlShape) => PanelTab;
+export type PanelTabFn = (intl: IntlShape, props: PanelTabProps) => PanelTab;
+
+export interface PanelTabProps {
+  isPanelPinned: boolean;
+  nodeId: string;
+}
+
 export interface PanelTab {
   id: string;
   title: string;

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -44,12 +44,12 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
   const dispatch = useDispatch<AppDispatch>();
 
   const readOnly = useReadOnly();
-
-  const panelTabs = usePanelTabs();
-  const selectedTab = useSelectedPanelTabId();
-
-  const collapsed = useIsPanelCollapsed();
   const selectedNode = useSelectedNodeId();
+  const selectedTab = useSelectedPanelTabId();
+  const collapsed = useIsPanelCollapsed();
+
+  const panelTabs = usePanelTabs({ nodeId: selectedNode });
+
   const runData = useRunData(selectedNode);
   const { isTriggerNode, nodesMetadata, idReplacements } = useSelector((state: RootState) => ({
     isTriggerNode: isRootNodeInGraph(selectedNode, 'root', state.workflow.nodesMetadata),

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/aboutTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/aboutTab.tsx
@@ -1,6 +1,5 @@
 import constants from '../../../../common/constants';
 import { useHostOptions } from '../../../../core/state/designerOptions/designerOptionsSelectors';
-import { useSelectedNodeId } from '../../../../core/state/panel/panelSelectors';
 import {
   useConnectorEnvironmentBadge,
   useConnectorName,
@@ -9,11 +8,11 @@ import {
   useOperationDocumentation,
   useOperationInfo,
 } from '../../../../core/state/selectors/actionMetadataSelector';
-import type { PanelTabFn } from '@microsoft/designer-ui';
+import type { PanelTabFn, PanelTabProps } from '@microsoft/designer-ui';
 import { About, getConnectorCategoryString } from '@microsoft/designer-ui';
 
-export const AboutTab = () => {
-  const nodeId = useSelectedNodeId();
+export const AboutTab: React.FC<PanelTabProps> = (props) => {
+  const { nodeId } = props;
   const operationInfo = useOperationInfo(nodeId);
   const { displayRuntimeInfo } = useHostOptions();
   const displayNameResult = useConnectorName(operationInfo);
@@ -40,7 +39,7 @@ export const AboutTab = () => {
   );
 };
 
-export const aboutTab: PanelTabFn = (intl) => ({
+export const aboutTab: PanelTabFn = (intl, props) => ({
   id: constants.PANEL_TAB_NAMES.ABOUT,
   title: intl.formatMessage({
     defaultMessage: 'About',
@@ -53,7 +52,7 @@ export const aboutTab: PanelTabFn = (intl) => ({
     description: 'An accessability label that describes the about tab',
   }),
   visible: true,
-  content: <AboutTab />,
+  content: <AboutTab {...props} />,
   order: 10,
   icon: 'Info',
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/codeViewTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/codeViewTab.tsx
@@ -1,16 +1,15 @@
 import constants from '../../../../common/constants';
 import { serializeOperation } from '../../../../core/actions/bjsworkflow/serializer';
-import { useSelectedNodeId } from '../../../../core/state/panel/panelSelectors';
 import { useActionMetadata } from '../../../../core/state/workflow/workflowSelectors';
 import type { RootState } from '../../../../core/store';
-import type { PanelTabFn } from '@microsoft/designer-ui';
+import type { PanelTabFn, PanelTabProps } from '@microsoft/designer-ui';
 import { Peek } from '@microsoft/designer-ui';
 import { isNullOrEmpty } from '@microsoft/logic-apps-shared';
 import { useQuery } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
 
-export const CodeViewTab = () => {
-  const nodeId = useSelectedNodeId();
+export const CodeViewTab: React.FC<PanelTabProps> = (props) => {
+  const { nodeId } = props;
   const nodeMetaData = useActionMetadata(nodeId) as any;
   const rootState = useSelector((state: RootState) => state);
   const queryData = useQuery(['serialization', { nodeId }], () => serializeOperation(rootState, nodeId), {
@@ -28,7 +27,7 @@ export const CodeViewTab = () => {
   return <Peek input={content} />;
 };
 
-export const codeViewTab: PanelTabFn = (intl) => ({
+export const codeViewTab: PanelTabFn = (intl, props) => ({
   id: constants.PANEL_TAB_NAMES.CODE_VIEW,
   title: intl.formatMessage({
     defaultMessage: 'Code View',
@@ -41,7 +40,7 @@ export const codeViewTab: PanelTabFn = (intl) => ({
     description: 'An accessability label that describes the code view tab',
   }),
   visible: true,
-  content: <CodeViewTab />,
+  content: <CodeViewTab {...props} />,
   order: 3,
   icon: 'Info',
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/monitoringTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/monitoringTab.tsx
@@ -1,19 +1,18 @@
 import constants from '../../../../../common/constants';
 import { getMonitoringTabError } from '../../../../../common/utilities/error';
 import { useBrandColor } from '../../../../../core/state/operation/operationSelector';
-import { useSelectedNodeId } from '../../../../../core/state/panel/panelSelectors';
 import { useRunData } from '../../../../../core/state/workflow/workflowSelectors';
 import { InputsPanel } from './inputsPanel';
 import { OutputsPanel } from './outputsPanel';
 import { PropertiesPanel } from './propertiesPanel';
 import { RunService, isNullOrUndefined } from '@microsoft/logic-apps-shared';
 import { ErrorSection } from '@microsoft/designer-ui';
-import type { PanelTabFn } from '@microsoft/designer-ui';
+import type { PanelTabFn, PanelTabProps } from '@microsoft/designer-ui';
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-export const MonitoringPanel: React.FC = () => {
-  const selectedNodeId = useSelectedNodeId();
+export const MonitoringPanel: React.FC<PanelTabProps> = (props) => {
+  const { nodeId: selectedNodeId } = props;
   const brandColor = useBrandColor(selectedNodeId);
   const runMetaData = useRunData(selectedNodeId);
   const { status: statusRun, error: errorRun, code: codeRun } = runMetaData ?? {};
@@ -62,7 +61,7 @@ export const MonitoringPanel: React.FC = () => {
   );
 };
 
-export const monitoringTab: PanelTabFn = (intl) => ({
+export const monitoringTab: PanelTabFn = (intl, props) => ({
   id: constants.PANEL_TAB_NAMES.MONITORING,
   title: intl.formatMessage({
     defaultMessage: 'Parameters',
@@ -75,7 +74,7 @@ export const monitoringTab: PanelTabFn = (intl) => ({
     description: 'An accessability label that describes the monitoring tab',
   }),
   visible: true,
-  content: <MonitoringPanel />,
+  content: <MonitoringPanel {...props} />,
   order: 0,
   icon: 'Info',
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -5,7 +5,7 @@ import { useHostOptions, useReadOnly } from '../../../../../core/state/designerO
 import type { ParameterGroup } from '../../../../../core/state/operation/operationMetadataSlice';
 import { DynamicLoadStatus, ErrorLevel } from '../../../../../core/state/operation/operationMetadataSlice';
 import { useDependencies, useNodesInitialized, useOperationErrorInfo } from '../../../../../core/state/operation/operationSelector';
-import { usePanelLocation, useSelectedNodeId } from '../../../../../core/state/panel/panelSelectors';
+import { usePanelLocation } from '../../../../../core/state/panel/panelSelectors';
 import {
   useAllowUserToChangeConnection,
   useConnectorName,
@@ -46,7 +46,15 @@ import {
   isCustomCode,
   toCustomEditorAndOptions,
 } from '@microsoft/designer-ui';
-import type { ChangeState, ParameterInfo, ValueSegment, OutputToken, TokenPickerMode, PanelTabFn } from '@microsoft/designer-ui';
+import type {
+  ChangeState,
+  ParameterInfo,
+  ValueSegment,
+  OutputToken,
+  TokenPickerMode,
+  PanelTabFn,
+  PanelTabProps,
+} from '@microsoft/designer-ui';
 import {
   EditorService,
   equals,
@@ -56,12 +64,13 @@ import {
   replaceWhiteSpaceWithUnderscore,
 } from '@microsoft/logic-apps-shared';
 import type { OperationInfo } from '@microsoft/logic-apps-shared';
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 
-export const ParametersTab = () => {
-  const selectedNodeId = useSelectedNodeId();
+export const ParametersTab: React.FC<PanelTabProps> = (props) => {
+  const { nodeId: selectedNodeId } = props;
   const nodeMetadata = useNodeMetadata(selectedNodeId);
   const inputs = useSelector((state: RootState) => state.operations.inputParameters[selectedNodeId]);
   const { tokenState, workflowParametersState } = useSelector((state: RootState) => ({
@@ -462,6 +471,7 @@ const ParameterSection = ({
   return (
     <SettingsSection
       id={group.id}
+      nodeId={nodeId}
       sectionName={group.description}
       title={group.description}
       settings={settings}
@@ -515,7 +525,7 @@ const hasParametersToAuthor = (parameterGroups: Record<string, ParameterGroup>):
   return Object.keys(parameterGroups).some((key) => parameterGroups[key].parameters.filter((p) => !p.hideInUI).length > 0);
 };
 
-export const parametersTab: PanelTabFn = (intl) => ({
+export const parametersTab: PanelTabFn = (intl, props) => ({
   id: constants.PANEL_TAB_NAMES.PARAMETERS,
   title: intl.formatMessage({
     defaultMessage: 'Parameters',
@@ -528,7 +538,7 @@ export const parametersTab: PanelTabFn = (intl) => ({
     description: 'Parameters tab description',
   }),
   visible: true,
-  content: <ParametersTab />,
+  content: <ParametersTab {...props} />,
   order: 0,
   icon: 'Info',
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/requestTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/requestTab.tsx
@@ -1,8 +1,8 @@
 import constants from '../../../../common/constants';
-import type { PanelTabFn } from '@microsoft/designer-ui';
+import type { PanelTabFn, PanelTabProps } from '@microsoft/designer-ui';
 import { RequestPanel } from '@microsoft/designer-ui';
 
-export const RequestPanelTab = () => {
+export const RequestPanelTab: React.FC<PanelTabProps> = () => {
   // TODO: Retrieve logic from a redux store?
   const requestHistory = [
     {
@@ -235,7 +235,7 @@ export const RequestPanelTab = () => {
   return <RequestPanel requestHistory={requestHistory} />;
 };
 
-export const monitorRequestTab: PanelTabFn = (intl) => ({
+export const monitorRequestTab: PanelTabFn = (intl, props) => ({
   title: intl.formatMessage({
     defaultMessage: 'Request History',
     id: 'WaTsxR',
@@ -248,7 +248,7 @@ export const monitorRequestTab: PanelTabFn = (intl) => ({
     description: 'The tab description for the request history tab on the operation panel',
   }),
   visible: true,
-  content: <RequestPanelTab />,
+  content: <RequestPanelTab {...props} />,
   order: 0,
   icon: 'Rerun',
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/retryTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/retryTab.tsx
@@ -1,16 +1,15 @@
 import constants from '../../../../common/constants';
-import { useSelectedNodeId } from '../../../../core/state/panel/panelSelectors';
 import { useRetryHistory } from '../../../../core/state/workflow/workflowSelectors';
-import type { PanelTabFn } from '@microsoft/designer-ui';
+import type { PanelTabFn, PanelTabProps } from '@microsoft/designer-ui';
 import { RetryPanel } from '@microsoft/designer-ui';
 
-export const RetryPanelTab = () => {
-  const selectedNodeId = useSelectedNodeId();
+export const RetryPanelTab: React.FC<PanelTabProps> = (props) => {
+  const { nodeId: selectedNodeId } = props;
   const histories = useRetryHistory(selectedNodeId);
   return histories ? <RetryPanel retryHistories={histories} /> : null;
 };
 
-export const monitorRetryTab: PanelTabFn = (intl) => ({
+export const monitorRetryTab: PanelTabFn = (intl, props) => ({
   id: constants.PANEL_TAB_NAMES.RETRY_HISTORY,
   title: intl.formatMessage({
     defaultMessage: 'Retry History',
@@ -23,7 +22,7 @@ export const monitorRetryTab: PanelTabFn = (intl) => ({
     description: 'An accessability label that describes the retry history tab',
   }),
   visible: true,
-  content: <RetryPanelTab />,
+  content: <RetryPanelTab {...props} />,
   order: 1,
   icon: 'Rerun',
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/settingsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/settingsTab.tsx
@@ -2,7 +2,7 @@ import constants from '../../../../common/constants';
 import { SettingsPanel } from '../../../settings/';
 import type { PanelTabFn } from '@microsoft/designer-ui';
 
-export const settingsTab: PanelTabFn = (intl) => ({
+export const settingsTab: PanelTabFn = (intl, props) => ({
   id: constants.PANEL_TAB_NAMES.SETTINGS,
   title: intl.formatMessage({
     defaultMessage: 'Settings',
@@ -15,6 +15,6 @@ export const settingsTab: PanelTabFn = (intl) => ({
     description: 'An accessability label that describes the settings tab',
   }),
   visible: true,
-  content: <SettingsPanel />,
+  content: <SettingsPanel {...props} />,
   order: 2,
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -3,7 +3,7 @@ import type { RootState } from '../../../core';
 import { useNodeMetadata, useOperationInfo } from '../../../core';
 import { usePanelTabHideKeys, useMonitoringView } from '../../../core/state/designerOptions/designerOptionsSelectors';
 import { useParameterValidationErrors } from '../../../core/state/operation/operationSelector';
-import { useSelectedNodeId } from '../../../core/state/panel/panelSelectors';
+import { useIsNodePinned } from '../../../core/state/panelV2/panelSelectors';
 import { useSettingValidationErrors } from '../../../core/state/setting/settingSelector';
 import { useHasSchema } from '../../../core/state/staticresultschema/staitcresultsSelector';
 import { useRetryHistory } from '../../../core/state/workflow/workflowSelectors';
@@ -16,70 +16,79 @@ import { monitorRetryTab } from './tabs/retryTab';
 import { scratchTab } from './tabs/scratchTab';
 import { settingsTab } from './tabs/settingsTab';
 import { testingTab } from './tabs/testingTab';
+import type { PanelTabProps } from '@microsoft/designer-ui';
 import { SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
-export const usePanelTabs = () => {
+export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
   const intl = useIntl();
 
   const isMonitoringView = useMonitoringView();
   const panelTabHideKeys = usePanelTabHideKeys();
 
-  const selectedNode = useSelectedNodeId();
-  const isTriggerNode = useSelector((state: RootState) => isRootNodeInGraph(selectedNode, 'root', state.workflow.nodesMetadata));
-  const operationInfo = useOperationInfo(selectedNode);
-  const nodeMetaData = useNodeMetadata(selectedNode);
+  const isPinnedNode = useIsNodePinned(nodeId);
+  const isTriggerNode = useSelector((state: RootState) => isRootNodeInGraph(nodeId, 'root', state.workflow.nodesMetadata));
+  const operationInfo = useOperationInfo(nodeId);
+  const nodeMetaData = useNodeMetadata(nodeId);
   const hasSchema = useHasSchema(operationInfo?.connectorId, operationInfo?.operationId);
-  const runHistory = useRetryHistory(selectedNode);
+  const runHistory = useRetryHistory(nodeId);
   const isScopeNode = operationInfo?.type.toLowerCase() === constants.NODE.TYPE.SCOPE;
-  const parameterValidationErrors = useParameterValidationErrors(selectedNode);
-  const settingValidationErrors = useSettingValidationErrors(selectedNode);
+  const parameterValidationErrors = useParameterValidationErrors(nodeId);
+  const settingValidationErrors = useSettingValidationErrors(nodeId);
+
+  const tabProps: PanelTabProps = useMemo(
+    () => ({
+      isPanelPinned: isPinnedNode,
+      nodeId,
+    }),
+    [isPinnedNode, nodeId]
+  );
 
   const monitoringTabItem = useMemo(
     () => ({
-      ...monitoringTab(intl),
+      ...monitoringTab(intl, tabProps),
       visible: !isScopeNode && isMonitoringView,
     }),
-    [intl, isMonitoringView, isScopeNode]
+    [intl, isMonitoringView, isScopeNode, tabProps]
   );
 
   const parametersTabItem = useMemo(
     () => ({
-      ...parametersTab(intl),
+      ...parametersTab(intl, tabProps),
       visible: !isMonitoringView,
       hasErrors: parameterValidationErrors.length > 0,
     }),
-    [intl, isMonitoringView, parameterValidationErrors]
+    [intl, isMonitoringView, tabProps, parameterValidationErrors]
   );
 
   const settingsTabItem = useMemo(
     () => ({
-      ...settingsTab(intl),
+      ...settingsTab(intl, tabProps),
       hasErrors: settingValidationErrors.length > 0,
     }),
-    [intl, settingValidationErrors]
+    [intl, tabProps, settingValidationErrors]
   );
 
-  const codeViewTabItem = useMemo(() => codeViewTab(intl), [intl]);
+  const codeViewTabItem = useMemo(() => codeViewTab(intl, tabProps), [intl, tabProps]);
 
   const testingTabItem = useMemo(
     () => ({
-      ...testingTab(intl),
+      ...testingTab(intl, tabProps),
       visible: !isTriggerNode && hasSchema && !isMonitoringView,
     }),
-    [intl, isTriggerNode, hasSchema, isMonitoringView]
+    [intl, isTriggerNode, hasSchema, isMonitoringView, tabProps]
   );
 
-  const aboutTabItem = useMemo(() => aboutTab(intl), [intl]);
+  const aboutTabItem = useMemo(() => aboutTab(intl, tabProps), [intl, tabProps]);
 
   const monitorRetryTabItem = useMemo(
     () => ({
-      ...monitorRetryTab(intl),
+      ...monitorRetryTab(intl, tabProps),
       visible: isMonitoringView && !!runHistory,
     }),
-    [intl, isMonitoringView, runHistory]
+    [intl, isMonitoringView, tabProps, runHistory]
   );
 
   const scratchTabItem = useMemo(
@@ -106,7 +115,6 @@ export const usePanelTabs = () => {
       monitorRetryTabItem,
       scratchTabItem,
     ]
-      .slice()
       .filter((a) => !panelTabHideKeys.includes(a.id as any))
       .filter((a) => a.visible)
       .sort((a, b) => a.order - b.order);

--- a/libs/designer/src/lib/ui/settings/__tests__/settingsection.spec.tsx
+++ b/libs/designer/src/lib/ui/settings/__tests__/settingsection.spec.tsx
@@ -1,7 +1,10 @@
 import { SettingsSection } from '../settingsection';
 import type { SettingsSectionProps } from '../settingsection';
 import * as ReactShallowRenderer from 'react-test-renderer/shallow';
-import { describe, beforeEach, afterEach, it, expect } from 'vitest';
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
+
+import * as PanelSelectors from '../../../core/state/panel/panelSelectors';
+
 describe('ui/settings/settingsection', () => {
   let minimal: SettingsSectionProps;
   let renderer: ReactShallowRenderer.ShallowRenderer;
@@ -92,7 +95,7 @@ describe('ui/settings/settingsection', () => {
         },
       ],
       onHeaderClick: () => {
-        jest.fn();
+        vi.fn();
       },
     };
     renderer = ReactShallowRenderer.createRenderer();
@@ -100,14 +103,19 @@ describe('ui/settings/settingsection', () => {
 
   afterEach(() => {
     renderer.unmount();
+    vi.resetAllMocks();
   });
 
   it('should construct', () => {
+    vi.spyOn(PanelSelectors, 'useSelectedNodeId').mockReturnValue('');
+
     const settingSection = renderer.render(<SettingsSection {...minimal} />);
     expect(settingSection).toMatchSnapshot();
   });
 
   it('should have child section when expanded', () => {
+    vi.spyOn(PanelSelectors, 'useSelectedNodeId').mockReturnValue('');
+
     const props: SettingsSectionProps = { ...minimal, expanded: true };
     renderer.render(<SettingsSection {...props} />);
 

--- a/libs/designer/src/lib/ui/settings/index.tsx
+++ b/libs/designer/src/lib/ui/settings/index.tsx
@@ -1,3 +1,4 @@
+import type { PanelTabProps } from '@microsoft/designer-ui';
 import constants from '../../common/constants';
 import { useOperationInfo } from '../../core';
 import { updateOutputsAndTokens } from '../../core/actions/bjsworkflow/initialize';
@@ -5,7 +6,6 @@ import type { Settings } from '../../core/actions/bjsworkflow/settings';
 import { useHostOptions, useReadOnly } from '../../core/state/designerOptions/designerOptionsSelectors';
 import { updateNodeSettings } from '../../core/state/operation/operationMetadataSlice';
 import { useRawInputParameters } from '../../core/state/operation/operationSelector';
-import { useSelectedNodeId } from '../../core/state/panel/panelSelectors';
 import { useOperationDownloadChunkMetadata, useOperationUploadChunkMetadata } from '../../core/state/selectors/actionMetadataSelector';
 import { useExpandedSections } from '../../core/state/setting/settingSelector';
 import { setExpandedSections } from '../../core/state/setting/settingSlice';
@@ -75,9 +75,9 @@ export interface MaximumWaitingRunsMetadata {
 
 export type HeaderClickHandler = (sectionName: SettingSectionName) => void;
 
-export const SettingsPanel = (): JSX.Element => {
+export const SettingsPanel: React.FC<PanelTabProps> = (props) => {
   const dispatch = useDispatch();
-  const selectedNode = useSelectedNodeId();
+  const { nodeId: selectedNode } = props;
   const readOnly = useReadOnly();
   const expandedSections = useExpandedSections();
   const operationInfo = useOperationInfo(selectedNode);

--- a/libs/designer/src/lib/ui/settings/sections/datahandling.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/datahandling.tsx
@@ -10,6 +10,7 @@ export interface DataHandlingSectionProps extends SectionProps {
 }
 
 export const DataHandling = ({
+  nodeId,
   readOnly,
   expanded,
   requestSchemaValidation,
@@ -48,6 +49,7 @@ export const DataHandling = ({
 
   const dataHandlingSectionProps: SettingsSectionProps = {
     id: 'dataHandling',
+    nodeId,
     title: dataHandlingTitle,
     expanded,
     isReadOnly: readOnly,

--- a/libs/designer/src/lib/ui/settings/sections/general.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/general.tsx
@@ -2,7 +2,6 @@ import type { SectionProps, ToggleHandler, TextChangeHandler, NumberChangeHandle
 import { SettingSectionName } from '..';
 import constants from '../../../common/constants';
 import { useNodeMetadata, useOperationInfo } from '../../../core';
-import { useSelectedNodeId } from '../../../core/state/panel/panelSelectors';
 import { useOutputParameters } from '../../../core/state/selectors/actionMetadataSelector';
 import { getSplitOnOptions } from '../../../core/utils/outputs';
 import type { SettingsSectionProps } from '../settingsection';
@@ -26,6 +25,7 @@ export interface GeneralSectionProps extends SectionProps {
 }
 
 export const General = ({
+  nodeId,
   readOnly,
   expanded,
   splitOn,
@@ -48,7 +48,6 @@ export const General = ({
   validationErrors,
 }: GeneralSectionProps): JSX.Element => {
   const intl = useIntl();
-  const nodeId = useSelectedNodeId();
   const nodesMetadata = useNodeMetadata(nodeId);
   const operationInfo = useOperationInfo(nodeId);
   const nodeOutputs = useOutputParameters(nodeId);
@@ -172,6 +171,7 @@ export const General = ({
 
   const generalSectionProps: SettingsSectionProps = {
     id: 'general',
+    nodeId,
     title: generalTitle,
     sectionName: SettingSectionName.GENERAL,
     isReadOnly: readOnly,

--- a/libs/designer/src/lib/ui/settings/sections/networking.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/networking.tsx
@@ -30,6 +30,7 @@ export interface NetworkingSectionProps extends SectionProps {
 }
 
 export const Networking = ({
+  nodeId,
   readOnly,
   expanded,
   validationErrors,
@@ -558,6 +559,7 @@ export const Networking = ({
 
   const networkingSectionProps: SettingsSectionProps = {
     id: 'networking',
+    nodeId,
     title: networking,
     sectionName: SettingSectionName.NETWORKING,
     expanded,

--- a/libs/designer/src/lib/ui/settings/sections/runafter.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/runafter.tsx
@@ -128,6 +128,7 @@ export const RunAfter = ({ nodeId, readOnly = false, expanded, onHeaderClick }: 
 
   const runAfterSectionProps: SettingsSectionProps = {
     id: 'runAfter',
+    nodeId,
     title: runAfterTitle,
     sectionName: SettingSectionName.RUNAFTER,
     expanded,

--- a/libs/designer/src/lib/ui/settings/sections/security.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/security.tsx
@@ -67,6 +67,7 @@ export const Security = ({
 
   const securitySectionProps: SettingsSectionProps = {
     id: 'security',
+    nodeId,
     title: securityTitle,
     sectionName: SettingSectionName.SECURITY,
     isReadOnly: readOnly,

--- a/libs/designer/src/lib/ui/settings/sections/tracking.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/tracking.tsx
@@ -14,6 +14,7 @@ export interface TrackingSectionProps extends SectionProps {
 }
 
 export const Tracking = ({
+  nodeId,
   readOnly,
   expanded,
   correlation,
@@ -65,6 +66,7 @@ export const Tracking = ({
 
   const trackingSectionProps: SettingsSectionProps = {
     id: 'tracking',
+    nodeId,
     title: trackingTitle,
     sectionName: SettingSectionName.TRACKING,
     expanded,

--- a/libs/designer/src/lib/ui/settings/settingsection.tsx
+++ b/libs/designer/src/lib/ui/settings/settingsection.tsx
@@ -121,6 +121,7 @@ export type Settings = SettingBase &
 
 type WarningDismissHandler = (key?: string, message?: string) => void;
 export interface SettingsSectionProps {
+  nodeId?: string;
   id?: string;
   title?: string;
   sectionName?: string;
@@ -136,6 +137,7 @@ export interface SettingsSectionProps {
 
 export const SettingsSection: FC<SettingsSectionProps> = ({
   id,
+  nodeId,
   title = 'Settings',
   sectionName,
   showHeading = true,
@@ -147,6 +149,9 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
   validationErrors,
   onDismiss,
 }) => {
+  const selectedNodeId = useSelectedNodeId();
+  const settingNodeId = nodeId ?? selectedNodeId;
+
   const intl = useIntl();
   const expandedLabel = intl.formatMessage({
     defaultMessage: 'Expanded',
@@ -180,7 +185,7 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
             />
           ))
         : null}
-      {expanded || !showHeading ? <Setting id={id} isReadOnly={isReadOnly} settings={settings} /> : null}
+      {expanded || !showHeading ? <Setting id={id} isReadOnly={isReadOnly} nodeId={settingNodeId} settings={settings} /> : null}
       {expanded && showSeparator ? <Divider className="msla-setting-section-divider" /> : null}
     </>
   );
@@ -211,10 +216,14 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
   );
 };
 
-const Setting = ({ id, settings, isReadOnly }: { id?: string; settings: Settings[]; isReadOnly?: boolean }): JSX.Element => {
+const Setting = ({
+  id,
+  nodeId,
+  settings,
+  isReadOnly,
+}: { id?: string; nodeId: string; settings: Settings[]; isReadOnly?: boolean }): JSX.Element => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const nodeId = useSelectedNodeId();
   const readOnly = useReadOnly();
   const [hideErrorMessage, setHideErrorMessage] = useState<boolean[]>(new Array(settings.length).fill(false));
 


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior

The tabs in the panel are tightly coupled with the `useSelectedNodeId()` selector property from the state, meaning that no matter how a tab is rendered or what its parent is, it will always show the Redux state's selected node.

## New Behavior

The tabs in the panel are now decouple from the `useSelectedNodeId()` selector, and instead use a prop, allowing `nodeDetailsPanel.tsx` to decide which node should be rendered in the panel.

## Impact of Change

There should be no breaking changes, just a refactor to pass values from the Redux state higher in the React hierarchy.