### PR TITLE
feat(vscode): Add stage regions for deployment and sql connection string for hybrid

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppHostingPlanStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppHostingPlanStep.ts
@@ -11,6 +11,7 @@ import { ConnectedEnvironmentStep } from './HybridLogicAppsSteps/ConnectedEnviro
 import { ResourceGroupListStep } from '@microsoft/vscode-azext-azureutils';
 import { sendAzureRequest } from '../../../utils/requestUtils';
 import { HTTP_METHODS } from '@microsoft/logic-apps-shared';
+import { workflowAppApiVersion } from '../../../../constants';
 
 export class LogicAppHostingPlanStep extends AzureWizardPromptStep<ILogicAppWizardContext> {
   public async prompt(wizardContext: ILogicAppWizardContext): Promise<void> {
@@ -54,7 +55,7 @@ export class LogicAppHostingPlanStep extends AzureWizardPromptStep<ILogicAppWiza
   }
 
   private async getAllLocations(wizardContext: ILogicAppWizardContext): Promise<string[]> {
-    const url = `https://management.azure.com/subscriptions/${wizardContext.subscriptionId}/providers/Microsoft.Web/georegions?api-version=2018-11-01`;
+    const url = `/subscriptions/${wizardContext.subscriptionId}/providers/Microsoft.Web/georegions?api-version=${workflowAppApiVersion}`;
     const locationsResponse = await sendAzureRequest(url, wizardContext, HTTP_METHODS.GET, wizardContext);
     const locations = (locationsResponse.parsedBody as { value }).value.map((loc) => loc.name) as string[];
     return locations;

--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppHostingPlanStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppHostingPlanStep.ts
@@ -43,9 +43,9 @@ export class LogicAppHostingPlanStep extends AzureWizardPromptStep<ILogicAppWiza
     if (useHybrid) {
       this.setHybridPlanProperties(wizardContext);
       promptSteps.push(new ResourceGroupListStep(), new ConnectedEnvironmentStep());
-      return { promptSteps: promptSteps };
+    } else {
+      promptSteps.push(new AppServicePlanListStep(suppressCreate), new ResourceGroupListStep());
     }
-    promptSteps.push(new AppServicePlanListStep(suppressCreate), new ResourceGroupListStep());
     return { promptSteps: promptSteps };
   }
 

--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppHostingPlanStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppHostingPlanStep.ts
@@ -5,10 +5,12 @@
 import type { ILogicAppWizardContext } from '@microsoft/vscode-extension-logic-apps';
 import { localize } from '../../../../localize';
 import { setSiteOS } from '../../../tree/subscriptionTree/SubscriptionTreeItem';
-import { AppServicePlanListStep } from '@microsoft/vscode-azext-azureappservice';
+import { AppServicePlanListStep, CustomLocationListStep } from '@microsoft/vscode-azext-azureappservice';
 import { AzureWizardPromptStep, type IAzureQuickPickItem, type IWizardOptions } from '@microsoft/vscode-azext-utils';
 import { ConnectedEnvironmentStep } from './HybridLogicAppsSteps/ConnectedEnvironmentStep';
 import { ResourceGroupListStep } from '@microsoft/vscode-azext-azureutils';
+import { sendAzureRequest } from '../../../utils/requestUtils';
+import { HTTP_METHODS } from '@microsoft/logic-apps-shared';
 
 export class LogicAppHostingPlanStep extends AzureWizardPromptStep<ILogicAppWizardContext> {
   public async prompt(wizardContext: ILogicAppWizardContext): Promise<void> {
@@ -35,10 +37,26 @@ export class LogicAppHostingPlanStep extends AzureWizardPromptStep<ILogicAppWiza
 
   public async getSubWizard(wizardContext: ILogicAppWizardContext): Promise<IWizardOptions<ILogicAppWizardContext> | undefined> {
     const { suppressCreate, useHybrid } = wizardContext;
+    const promptSteps = [];
+    CustomLocationListStep.addStep(wizardContext as any, promptSteps);
     if (useHybrid) {
-      wizardContext.newSiteName = wizardContext.newSiteName.toLowerCase();
-      return { promptSteps: [new ResourceGroupListStep(), new ConnectedEnvironmentStep()] };
+      this.setHybridPlanProperties(wizardContext);
+      promptSteps.push(new ResourceGroupListStep(), new ConnectedEnvironmentStep());
+      return { promptSteps: promptSteps };
     }
-    return { promptSteps: [new AppServicePlanListStep(suppressCreate), new ResourceGroupListStep()] };
+    promptSteps.push(new AppServicePlanListStep(suppressCreate), new ResourceGroupListStep());
+    return { promptSteps: promptSteps };
+  }
+
+  private setHybridPlanProperties(wizardContext: ILogicAppWizardContext) {
+    wizardContext.newSiteName = wizardContext.newSiteName.toLowerCase();
+    CustomLocationListStep.setLocationSubset(wizardContext, this.getAllLocations(wizardContext), 'Microsoft.Resources');
+  }
+
+  private async getAllLocations(wizardContext: ILogicAppWizardContext): Promise<string[]> {
+    const url = `https://management.azure.com/subscriptions/${wizardContext.subscriptionId}/providers/Microsoft.Web/georegions?api-version=2018-11-01`;
+    const locationsResponse = await sendAzureRequest(url, wizardContext, HTTP_METHODS.GET, wizardContext);
+    const locations = (locationsResponse.parsedBody as { value }).value.map((loc) => loc.name) as string[];
+    return locations;
   }
 }

--- a/apps/vs-code-designer/src/app/commands/deploy/storageAccountSteps/CustomLocationStorageAccountStep.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/storageAccountSteps/CustomLocationStorageAccountStep.ts
@@ -28,7 +28,7 @@ export class CustomLocationStorageAccountStep extends AzureWizardPromptStep<ILog
   }
 
   public shouldPrompt(wizardContext: ILogicAppWizardContext): boolean {
-    return wizardContext.customLocation && wizardContext.storageType === undefined;
+    return wizardContext.useHybrid && wizardContext.storageType === undefined;
   }
 
   public async getSubWizard(wizardContext: ILogicAppWizardContext): Promise<IWizardOptions<ILogicAppWizardContext> | undefined> {

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -1,4 +1,4 @@
-import { localSettingsFileName, managementApiPrefix } from '../../../../constants';
+import { localSettingsFileName, managementApiPrefix, workflowAppApiVersion } from '../../../../constants';
 import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
 import { getLocalSettingsJson } from '../../../utils/appSettings/localSettings';
@@ -48,11 +48,10 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
 
   constructor(context: IActionContext, node: Uri) {
     const workflowName = path.basename(path.dirname(node.fsPath));
-    const apiVersion = '2018-11-01';
     const panelName = `${workspace.name}-${workflowName}`;
     const panelGroupKey = ext.webViewKey.designerLocal;
 
-    super(context, workflowName, panelName, apiVersion, panelGroupKey, false, true, false);
+    super(context, workflowName, panelName, workflowAppApiVersion, panelGroupKey, false, true, false);
 
     this.workflowFilePath = node.fsPath;
   }

--- a/apps/vs-code-designer/src/app/tree/subscriptionTree/SubscriptionTreeItem.ts
+++ b/apps/vs-code-designer/src/app/tree/subscriptionTree/SubscriptionTreeItem.ts
@@ -28,7 +28,6 @@ import {
   AppInsightsCreateStep,
   AppInsightsListStep,
   AppKind,
-  CustomLocationListStep,
   ParsedSite,
   SiteNameStep,
   WebsiteOS,
@@ -123,7 +122,6 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
     const executeSteps: AzureWizardExecuteStep<IAppServiceWizardContext>[] = [];
 
     promptSteps.push(new SiteNameStep());
-    CustomLocationListStep.addStep(context as any, promptSteps);
     promptSteps.push(new LogicAppHostingPlanStep());
     promptSteps.push(new CustomLocationStorageAccountStep());
 


### PR DESCRIPTION
This pull request primarily focuses on changes in the `vs-code-designer` application, specifically in the `createLogicAppSteps` and `openDesigner` commands. The changes include the importation of new modules, the modification of method parameters, and the update of API versions. The changes aim to enhance the application's functionality and maintain its compatibility with the latest API versions.


1. Changes in `LogicAppHostingPlanStep.ts`:
   * Imported `CustomLocationListStep`, `sendAzureRequest`, and `HTTP_METHODS` from their respective modules. These new imports are used in the subsequent changes in this file.
   * In the `getSubWizard` method, the logic was updated to add `CustomLocationListStep` and `ResourceGroupListStep` to `promptSteps` when `useHybrid` is true. A new method `setHybridPlanProperties` was also introduced to set properties for hybrid plans.

2. Changes in `CustomLocationStorageAccountStep.ts`:
   * The `shouldPrompt` method was updated to check for `useHybrid` instead of `customLocation`. This change aligns the condition with the updated logic in `LogicAppHostingPlanStep.ts`.

3. Changes in `openDesignerForLocalProject.ts`:
   * Imported `workflowAppApiVersion` from `constants`. This constant is used to replace the hardcoded API version in the `OpenDesignerForLocalProject` class.
   * The `OpenDesignerForLocalProject` constructor was updated to use `workflowAppApiVersion` instead of the hardcoded '2018-11-01'. This change ensures that the class uses the latest API version.

4. Changes in `SubscriptionTreeItem.ts`:
   * Removed `CustomLocationListStep` from the import list and the `addStep` method call in the `SubscriptionTreeItem` class. This change reflects the updated logic in `LogicAppHostingPlanStep.ts` and `CustomLocationStorageAccountStep.ts`.