### PR TITLE
fix(vscode): Add hybrid in decision for storage account SQL

### DIFF
--- a/apps/vs-code-designer/src/app/commands/deploy/storageAccountSteps/CustomLocationStorageAccountStep.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/storageAccountSteps/CustomLocationStorageAccountStep.ts
@@ -32,7 +32,7 @@ export class CustomLocationStorageAccountStep extends AzureWizardPromptStep<ILog
   }
 
   public async getSubWizard(wizardContext: ILogicAppWizardContext): Promise<IWizardOptions<ILogicAppWizardContext> | undefined> {
-    if (wizardContext.customLocation) {
+    if (wizardContext.useHybrid) {
       const { storageType } = wizardContext;
       const storageAccountCreateOptions: INewStorageAccountDefaults = {
         kind: StorageAccountKind.Storage,


### PR DESCRIPTION
This pull request includes a change to the `CustomLocationStorageAccountStep` class in the `apps/vs-code-designer/src/app/commands/deploy/storageAccountSteps/CustomLocationStorageAccountStep.ts` file. The change modifies the condition in the `getSubWizard` method to check for `useHybrid` instead of `customLocation` in the `wizardContext` object.