### PR TITLE
fix(designer): Fixed small portal css issue with upgrading reactflow

### DIFF
--- a/libs/designer/src/lib/ui/styles.less
+++ b/libs/designer/src/lib/ui/styles.less
@@ -23,11 +23,12 @@
 
 .node-handle {
   visibility: hidden;
+	transform: translate(-50%, 0%);
   &.top {
-    transform: translate(-50%, 50%);
+		top: 0px;
   }
   &.bottom {
-    transform: translate(-50%, -50%);
+		bottom: 0px;
   }
 }
 
@@ -124,6 +125,8 @@
   width: 20px !important;
   height: 20px !important;
   font-size: 16px;
+	border-bottom: 1px solid #eee;
+	box-sizing: content-box;
 }
 
 .react-flow__edge-path {


### PR DESCRIPTION
## Main Changes

Fluent had a few styling changes that were a part of the recent update.
These changes were only visible in portal.
We don't see them in standalone since we are importing both the new and the old files in standalone (since data-mapper-v1 is still using old react-flow)
I've adjusted our styling to fix these two issues.

---

### Portal issue
![image](https://github.com/user-attachments/assets/2199c1e8-2c4c-40c7-a2d8-402987ab57b8)

### With fix
![image](https://github.com/user-attachments/assets/cdadb8c5-4aa3-45d9-b87d-0e42c71b087a)
