### PR TITLE
fix(designer): Fixed fluent `autoload` property causing console error issue

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheader.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheader.spec.tsx.snap
@@ -6,7 +6,6 @@ exports[`lib/panel/panelHeader/main > should render 1`] = `
 >
   <button
     aria-label="Collapse"
-    autoFocus={true}
     className="fui-Button r1alrhcs collapse-toggle right ___1p24v7a_y4hy550 fhovq9v f1p3nwhy f11589ue f1q5o8ev f1pdflbu fkfq4zb f1t94bn6 f1s2uweq fr80ssc f1ukrpxl fecsdlb fnwyq0v ft1hn21 fuxngvv fy5bs14 fsv2rcd f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1omzyqd f1dfjoow f1j98vj9 fj8yq94 f4xjyn1 f1et0tmh f9ddjv3 f1wi8ngl f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
     data-automation-id="msla-panel-header-collapse-nav"
     id="msla-panel-header-collapse-nav"
@@ -160,7 +159,6 @@ exports[`lib/panel/panelHeader/main > should render with panel header menu 1`] =
 >
   <button
     aria-label="Collapse"
-    autoFocus={true}
     className="fui-Button r1alrhcs collapse-toggle right ___1p24v7a_y4hy550 fhovq9v f1p3nwhy f11589ue f1q5o8ev f1pdflbu fkfq4zb f1t94bn6 f1s2uweq fr80ssc f1ukrpxl fecsdlb fnwyq0v ft1hn21 fuxngvv fy5bs14 fsv2rcd f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1omzyqd f1dfjoow f1j98vj9 fj8yq94 f4xjyn1 f1et0tmh f9ddjv3 f1wi8ngl f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
     data-automation-id="msla-panel-header-collapse-nav"
     id="msla-panel-header-collapse-nav"

--- a/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { PanelLocation, PanelScope } from '../panelUtil';
 import { PanelHeaderComment } from './panelheadercomment';
 import type { TitleChangeHandler } from './panelheadertitle';
@@ -13,7 +14,7 @@ import {
 import type { IButton } from '@fluentui/react/lib/Button';
 import { Icon } from '@fluentui/react/lib/Icon';
 import { css } from '@fluentui/react/lib/Utilities';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 
 export const handleOnEscapeDown = (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
@@ -130,11 +131,19 @@ export const PanelHeader = ({
 
     const className: string = css('collapse-toggle', isRight ? 'right' : 'left', isCollapsed && 'collapsed');
 
+    const ref = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+      if (!isCollapsed) {
+        ref.current?.focus();
+      }
+    }, [isCollapsed]);
+
     return (
       <Tooltip relationship="label" positioning={'before'} content={buttonText}>
         <Button
-          autoFocus={!isCollapsed}
           id="msla-panel-header-collapse-nav"
+          ref={ref}
           appearance="subtle"
           icon={<DismissIcon />}
           className={className}


### PR DESCRIPTION
## Main Changes

Fixes an issue where the autofocus property on one of our fluent buttons was causing a large amount of console errors.

Fixes: https://github.com/Azure/LogicAppsUX/issues/5189

