### PR TITLE
feat(designer-ui): Add badge for read-only connection to show reason

### DIFF
--- a/libs/designer-ui/src/lib/panel/panel.less
+++ b/libs/designer-ui/src/lib/panel/panel.less
@@ -234,7 +234,7 @@
 
 .connection-display {
   .connection-info {
-    align-items: flex-start;
+    align-items: center;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -255,21 +255,15 @@
         white-space: nowrap;
       }
     }
-
-    .change-connection-button {
-      margin-left: 15px;
-    }
   }
 
-  .connection-info-error {
+  .connection-info-badge {
     display: flex;
-    align-items: center;
-    gap: 4px;
-    color: #a80000;
+  }
 
-    .connection-info-error-text {
-      text-wrap: nowrap;
-    }
+  .change-connection-button,
+  .connection-info-badge {
+    margin-left: 15px;
   }
 }
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/connectionDisplay.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/connectionDisplay.tsx
@@ -2,23 +2,24 @@ import { openPanel } from '../../../../../core';
 import { useIsOperationMissingConnection } from '../../../../../core/state/connection/connectionSelector';
 import { useIsXrmConnectionReferenceMode } from '../../../../../core/state/designerOptions/designerOptionsSelectors';
 import { useIsConnectionRequired, useOperationInfo } from '../../../../../core/state/selectors/actionMetadataSelector';
-import { Badge, Button, Spinner } from '@fluentui/react-components';
-import { LinkMultiple16Regular, ErrorCircle16Filled } from '@fluentui/react-icons';
+import { Badge, Button, InfoLabel, Spinner } from '@fluentui/react-components';
+import { ErrorCircle16Filled, LinkMultiple16Regular } from '@fluentui/react-icons';
+import { Label } from '@microsoft/designer-ui';
 import { useCallback, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
-import { Label } from '@microsoft/designer-ui';
 
 interface ConnectionDisplayProps {
   connectionName: string | undefined;
   nodeId: string;
   readOnly: boolean;
+  readOnlyReason?: string;
   isLoading?: boolean;
   hasError: boolean;
 }
 
 export const ConnectionDisplay = (props: ConnectionDisplayProps) => {
-  const { connectionName, nodeId, isLoading = false, readOnly } = props;
+  const { connectionName, nodeId, hasError, isLoading = false, readOnly, readOnlyReason } = props;
 
   const intl = useIntl();
   const dispatch = useDispatch();
@@ -88,12 +89,20 @@ export const ConnectionDisplay = (props: ConnectionDisplayProps) => {
     description: 'Text to show when there is an error with the connection',
   });
 
+  const labelText = connectionName ? connectionDisplayTextWithName : connectionDisplayTextWithoutName;
+
   return (
     <div className="connection-display">
       <div className="connection-info">
         <div className="connection-info-labels">
           <LinkMultiple16Regular />
-          <Label className="label" text={connectionName ? connectionDisplayTextWithName : connectionDisplayTextWithoutName} />
+          {readOnly && readOnlyReason ? (
+            <InfoLabel className="label" info={readOnlyReason} size="small">
+              {labelText}
+            </InfoLabel>
+          ) : (
+            <Label className="label" text={labelText} />
+          )}
         </div>
         {readOnly ? null : (
           <Button
@@ -107,14 +116,15 @@ export const ConnectionDisplay = (props: ConnectionDisplayProps) => {
             {openChangeConnectionText}
           </Button>
         )}
+        <div style={{ flex: 1 }} />
+        {hasError ? (
+          <div className="connection-info-badge">
+            <Badge appearance="ghost" color="danger" icon={<ErrorCircle16Filled />}>
+              {connectionErrorText}
+            </Badge>
+          </div>
+        ) : null}
       </div>
-      {props.hasError ? (
-        <div className="connection-info-error">
-          <Badge appearance="ghost" color="danger" icon={<ErrorCircle16Filled />}>
-            {connectionErrorText}
-          </Badge>
-        </div>
-      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## New Behavior

A badge is shown to reveal the reason a connection is in read-only state, if specified.

## Impact of Change

No breaking changes. Some class name changes.

## Screenshots or Videos (if applicable)

![image](https://github.com/user-attachments/assets/5f6df790-1e0a-4687-b7ab-5cad79ccdb1a)