### PR TITLE
fix(designer-ui): Fix UI issues with pinned node when using left-side panel

### DIFF
--- a/libs/designer-ui/src/lib/panel/__test__/__snapshots__/panelcontainer.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/__test__/__snapshots__/panelcontainer.spec.tsx.snap
@@ -20,7 +20,7 @@ exports[`ui/workflowparameters/workflowparameter > should construct 1`] = `
 >
   <React.Fragment>
     <div
-      className="msla-panel-container-nested"
+      className="msla-panel-container-nested msla-panel-container-nested-right"
     >
       <React.Fragment />
     </div>

--- a/libs/designer-ui/src/lib/panel/panel.less
+++ b/libs/designer-ui/src/lib/panel/panel.less
@@ -21,6 +21,7 @@
 
   .msla-panel-header {
     border-top: 3px solid transparent;
+    display: flex;
     padding-top: 12px;
     padding-bottom: 12px;
 
@@ -138,6 +139,10 @@
 
     &.msla-panel-container-nested-left {
       flex-direction: row-reverse;
+
+      .msla-panel-header {
+        flex-direction: row-reverse;
+      }
 
       .msla-panel-card-header {
         margin-left: @panel-padding;
@@ -277,14 +282,15 @@
 
   .collapse-toggle {
     &.left {
-      float: right;
       transform: rotate(180deg);
       &.collapsed {
         transform: rotate(0deg);
       }
+      &.empty {
+        align-self: flex-end;
+      }
     }
     &.right {
-      float: left;
       transform: rotate(0deg);
       &.collapsed {
         transform: rotate(180deg);

--- a/libs/designer-ui/src/lib/panel/panel.less
+++ b/libs/designer-ui/src/lib/panel/panel.less
@@ -1,6 +1,8 @@
 @import (reference) '../variables.less';
 
 .msla-panel-container {
+  @panel-padding: 16px;
+
   display: flex;
   justify-content: space-between;
 
@@ -126,6 +128,7 @@
   }
 
   .msla-panel-container-nested {
+
     box-sizing: border-box;
     display: flex;
     flex: 1;
@@ -133,9 +136,30 @@
     max-height: 100%;
     width: 100%;
 
-    &.msla-panel-container-nested-dual .msla-panel-layout {
-      flex: 0 0 50%;
-      min-width: 0;
+    &.msla-panel-container-nested-left {
+      flex-direction: row-reverse;
+
+      .msla-panel-card-header {
+        margin-left: @panel-padding;
+      }
+    }
+
+    &.msla-panel-container-nested-right {
+      .msla-panel-layout-pinned .msla-panel-card-header {
+        margin-left: @panel-padding;
+      }
+    }
+
+    &.msla-panel-container-nested-dual {
+      .msla-panel-layout {
+        flex: 0 0 50%;
+        min-width: 0;
+      }
+
+      > .msla-panel-contents {
+        flex: 0.5 0 0;
+        min-width: 0;
+      }
     }
 
     .msla-panel-layout {
@@ -146,7 +170,6 @@
 
       &.msla-panel-layout-pinned .msla-panel-header {
         border-top-color: @pinned-item-color;
-        padding-left: 16px;
       }
 
       > div {
@@ -159,7 +182,7 @@
           flex-direction: column;
           max-width: 100%;
           overflow-y: auto;
-          padding: 0 16px 16px;
+          padding: 0 @panel-padding @panel-padding;
 
           > div {
             display: flex;
@@ -175,11 +198,6 @@
           }
         }
       }
-    }
-
-    &.msla-panel-container-nested-dual > .msla-panel-contents {
-      flex: 0.5 0 0;
-      min-width: 0;
     }
   }
 

--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -190,7 +190,7 @@ export const PanelContainer = ({
         <Button
           appearance="subtle"
           aria-label={panelCollapseTitle}
-          className={mergeClasses('collapse-toggle', isRight ? 'right' : 'left', isCollapsed && 'collapsed')}
+          className={mergeClasses('collapse-toggle', isRight ? 'right' : 'left', isCollapsed && 'collapsed', 'empty')}
           icon={<ChevronDoubleRightFilled />}
           onClick={toggleCollapse}
         />

--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -14,8 +14,6 @@ import type { CommonPanelProps } from './panelUtil';
 import { PanelLocation, PanelScope, PanelSize } from './panelUtil';
 import type { PanelNodeData } from './types';
 
-const horizontalPadding = '2rem';
-
 export type PanelContainerProps = {
   noNodeSelected: boolean;
   panelScope: PanelScope;
@@ -105,7 +103,6 @@ export const PanelContainer = ({
           canResubmit={canResubmit}
           onUnpinAction={canUnpin ? onUnpinAction : undefined}
           resubmitOperation={() => resubmitOperation?.(nodeId)}
-          horizontalPadding={horizontalPadding}
           commentChange={() => onCommentChange(nodeId)}
           toggleCollapse={toggleCollapse}
           onTitleChange={onTitleChange}
@@ -203,6 +200,7 @@ export const PanelContainer = ({
           <div
             className={mergeClasses(
               'msla-panel-container-nested',
+              `msla-panel-container-nested-${panelLocation.toLowerCase()}`,
               !isEmptyPane && pinnedNodeIfDifferent && 'msla-panel-container-nested-dual'
             )}
           >

--- a/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheader.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheader.spec.tsx.snap
@@ -52,7 +52,6 @@ exports[`lib/panel/panelHeader/main > should render 1`] = `
   </button>
   <div
     className="msla-panel-card-header"
-    style={{}}
   >
     <div
       className="fui-Spinner r1k3z50n msla-card-header-spinner"
@@ -207,7 +206,6 @@ exports[`lib/panel/panelHeader/main > should render with panel header menu 1`] =
   </button>
   <div
     className="msla-panel-card-header"
-    style={{}}
   >
     <div
       className="fui-Spinner r1k3z50n msla-card-header-spinner"

--- a/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
@@ -34,7 +34,6 @@ export interface PanelHeaderProps {
   suppressDefaultNodeSelectFunctionality?: boolean;
   readOnlyMode?: boolean;
   renameTitleDisabled?: boolean;
-  horizontalPadding: string;
   canResubmit?: boolean;
   resubmitOperation?: () => void;
   onUnpinAction?: () => void;
@@ -134,7 +133,6 @@ export const PanelHeader = (props: PanelHeaderProps): JSX.Element => {
     suppressDefaultNodeSelectFunctionality,
     readOnlyMode,
     renameTitleDisabled,
-    horizontalPadding,
     canResubmit,
     resubmitOperation,
     onUnpinAction,
@@ -189,7 +187,7 @@ export const PanelHeader = (props: PanelHeaderProps): JSX.Element => {
       {shouldHideCollapseButton ? undefined : <CollapseButton {...props} isRight={isRight} nodeId={nodeId} />}
       {!noNodeOnCardLevel && !isCollapsed ? (
         <>
-          <div className={'msla-panel-card-header'} style={isRight ? {} : { paddingLeft: horizontalPadding }}>
+          <div className={'msla-panel-card-header'}>
             {iconComponent}
             <div className={'msla-panel-card-title-container'}>
               <PanelHeaderTitle

--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -66,7 +66,7 @@ const edgeTypes = {
   HIDDEN_EDGE: HiddenEdge,
 } as EdgeTypes;
 export interface CanvasFinderProps {
-  panelLocation?: PanelLocation;
+  panelLocation: PanelLocation;
 }
 export const CanvasFinder = (props: CanvasFinderProps) => {
   const { panelLocation } = props;
@@ -102,7 +102,7 @@ export const CanvasFinder = (props: CanvasFinderProps) => {
     // If the panel is open, reduce X space
     if (!isPanelCollapsed) {
       // Move center to the right if Panel is located to the left; otherwise move center to the left.
-      const directionMultiplier = panelLocation && panelLocation === PanelLocation.Left ? -1 : 1;
+      const directionMultiplier = panelLocation === PanelLocation.Left ? -1 : 1;
       xRawPos += (directionMultiplier * 630) / 2;
     }
 
@@ -136,7 +136,7 @@ export const SearchPreloader = () => {
 };
 
 export const Designer = (props: DesignerProps) => {
-  const { backgroundProps, panelLocation, customPanelLocations } = props;
+  const { backgroundProps, panelLocation = PanelLocation.Right, customPanelLocations } = props;
 
   const [nodes, edges, flowSize] = useLayout();
   const isEmpty = useIsGraphEmpty();


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

If using left-side panel, pinned nodes cause incorrect padding, show the pinned node on the right instead of left, and prevent the collapse chevron from appearing in the correct place. (See screenshots section.)

## New Behavior

Padding, button position, and node order has been corrected. (See screenshots section.)

## Impact of Change

No major impact.

## Screenshots or Videos (if applicable)

### Before

![image](https://github.com/user-attachments/assets/cc002275-ca81-49c4-bdd1-7fb035687f92)

![image](https://github.com/user-attachments/assets/bb10095c-9141-4fa1-8bb2-2e1d38b7b98a)

### After

![pinned-panel-left](https://github.com/user-attachments/assets/79e516a8-0823-4884-a87b-408f03be9799)

![pinned-panel-right](https://github.com/user-attachments/assets/c0b4f406-bb85-4f7c-85fa-32599c710467)