### PR TITLE
fix(designer): Canvas properly centered on load

### DIFF
--- a/libs/designer/src/lib/core/graphlayout/__test__/elklayout.spec.ts
+++ b/libs/designer/src/lib/core/graphlayout/__test__/elklayout.spec.ts
@@ -170,6 +170,8 @@ describe('elklayout', () => {
             data: {
               label: 'node1',
             },
+            height: 40,
+            width: 200,
           },
           {
             id: 'node2',
@@ -182,6 +184,8 @@ describe('elklayout', () => {
             data: {
               label: 'node2',
             },
+            height: 40,
+            width: 200,
           },
         ],
         [
@@ -271,24 +275,32 @@ describe('elklayout', () => {
             position: { x: 50, y: 100 },
             data: { label: 'manual' },
             type: WORKFLOW_NODE_TYPES.OPERATION_NODE,
+            width: 200,
+            height: 40,
           },
           {
             id: 'Increment_variable',
             type: WORKFLOW_NODE_TYPES.OPERATION_NODE,
             position: { x: 60, y: 80 },
             data: { label: 'Increment_variable' },
+            parentId: undefined,
+            width: 200,
+            height: 40,
           },
           {
             id: 'Initialize_variable',
             type: WORKFLOW_NODE_TYPES.OPERATION_NODE,
             position: { x: 70, y: 90 },
             data: { label: 'Initialize_variable' },
+            width: 200,
+            height: 40,
           },
           {
             id: 'ActionIf',
             type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
             position: { x: 307, y: 308 },
             data: { label: 'ActionIf' },
+            parentId: undefined,
           },
           {
             id: 'ActionIf-#scope',
@@ -296,6 +308,8 @@ describe('elklayout', () => {
             position: { x: 307, y: 308 },
             data: { label: 'ActionIf-#scope' },
             parentId: 'ActionIf',
+            width: 200,
+            height: 40,
           },
           {
             id: 'ActionIf-actions',
@@ -310,6 +324,8 @@ describe('elklayout', () => {
             position: { x: 50, y: 100 },
             data: { label: 'ActionIf-actions-#subgraph' },
             parentId: 'ActionIf-actions',
+            width: 200,
+            height: 40,
           },
           {
             id: 'Increment_variable2',
@@ -317,6 +333,8 @@ describe('elklayout', () => {
             position: { x: 150, y: 200 },
             data: { label: 'Increment_variable2' },
             parentId: 'ActionIf-actions',
+            width: 200,
+            height: 40,
           },
           {
             id: 'Increment_variable4',
@@ -324,6 +342,8 @@ describe('elklayout', () => {
             position: { x: 300, y: 301 },
             data: { label: 'Increment_variable4' },
             parentId: 'ActionIf-actions',
+            width: 200,
+            height: 40,
           },
           {
             id: 'ActionIf-elseActions',
@@ -338,6 +358,8 @@ describe('elklayout', () => {
             position: { x: 0, y: 0 },
             data: { label: 'ActionIf-elseActions-#subgraph' },
             parentId: 'ActionIf-elseActions',
+            width: 200,
+            height: 40,
           },
           {
             id: 'Increment_variable3',
@@ -345,12 +367,15 @@ describe('elklayout', () => {
             position: { x: 302, y: 303 },
             data: { label: 'Increment_variable3' },
             parentId: 'ActionIf-elseActions',
+            width: 200,
+            height: 40,
           },
           {
             id: 'EmptyScope',
             type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
             position: { x: 307, y: 308 },
             data: { label: 'EmptyScope' },
+            parentId: undefined,
           },
           {
             id: 'EmptyScope-#scope',
@@ -358,12 +383,16 @@ describe('elklayout', () => {
             position: { x: 0, y: 0 },
             data: { label: 'EmptyScope-#scope' },
             parentId: 'EmptyScope',
+            width: 200,
+            height: 40,
           },
           {
             id: 'Response',
             type: WORKFLOW_NODE_TYPES.OPERATION_NODE,
             position: { x: 304, y: 305 },
             data: { label: 'Response' },
+            width: 200,
+            height: 40,
           },
         ],
         [

--- a/libs/designer/src/lib/core/graphlayout/elklayout.ts
+++ b/libs/designer/src/lib/core/graphlayout/elklayout.ts
@@ -106,9 +106,14 @@ const convertElkGraphToReactFlow = (graph: ElkNode): [Node[], Edge[], number[]] 
           },
           parentId: node.id !== 'root' ? node.id : undefined,
           type: n.layoutOptions?.['nodeType'] ?? defaultNodeType,
-          width: n.width,
-          height: n.height,
         };
+
+        if (n.width) {
+          nodeObject.width = n.width;
+        }
+        if (n.height) {
+          nodeObject.height = n.height;
+        }
 
         const nodeArrayIndex = nodes.push(nodeObject);
 

--- a/libs/designer/src/lib/core/graphlayout/elklayout.ts
+++ b/libs/designer/src/lib/core/graphlayout/elklayout.ts
@@ -106,12 +106,9 @@ const convertElkGraphToReactFlow = (graph: ElkNode): [Node[], Edge[], number[]] 
           },
           parentId: node.id !== 'root' ? node.id : undefined,
           type: n.layoutOptions?.['nodeType'] ?? defaultNodeType,
+          width: n.width,
+          height: n.height,
         };
-
-        if (n?.children) {
-          nodeObject.width = n.width;
-          nodeObject.height = n.height;
-        }
 
         const nodeArrayIndex = nodes.push(nodeObject);
 

--- a/libs/designer/src/lib/ui/CanvasFinder.tsx
+++ b/libs/designer/src/lib/ui/CanvasFinder.tsx
@@ -1,0 +1,85 @@
+import { PanelLocation } from '@microsoft/designer-ui';
+import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNodes, useReactFlow } from '@xyflow/react';
+
+import { useIsPanelCollapsed } from '../core/state/panel/panelSelectors';
+import { useIsGraphEmpty } from '../core/state/workflow/workflowSelectors';
+import { clearFocusNode } from '../core/state/workflow/workflowSlice';
+import { DEFAULT_NODE_SIZE } from '../core/utils/graph';
+import type { RootState, AppDispatch } from '../core';
+
+export interface CanvasFinderProps {
+  panelLocation: PanelLocation;
+}
+
+export const CanvasFinder = (props: CanvasFinderProps) => {
+  const { panelLocation } = props;
+  const focusNodeId = useSelector((state: RootState) => state.workflow.focusedCanvasNodeId);
+  const isEmpty = useIsGraphEmpty();
+  const { setCenter, getZoom } = useReactFlow();
+  const dispatch = useDispatch<AppDispatch>();
+
+  const isPanelCollapsed = useIsPanelCollapsed();
+  const [firstLoad, setFirstLoad] = useState(true);
+
+  const nodes = useNodes();
+  const focusNode = useMemo(() => nodes.find((node) => node.id === focusNodeId), [focusNodeId, nodes]);
+  const firstNode = useMemo(() => nodes[0], [nodes]);
+
+  // Center the canvas on the first node when the workflow is first loaded
+  useEffect(() => {
+    if (!firstLoad) {
+      return;
+    }
+
+    if (isEmpty) {
+      // If first load is an empty workflow, set canvas to center
+      setCenter(DEFAULT_NODE_SIZE.width / 2, DEFAULT_NODE_SIZE.height, { zoom: 1 });
+      setFirstLoad(false);
+    } else {
+      // Wait for useLayout to finish and return us the first node data
+      if (!firstNode) {
+        return;
+      }
+
+      const xTarget = (firstNode?.position?.x ?? 0) + (firstNode?.width ?? DEFAULT_NODE_SIZE.width) / 2; // Center X on node midpoint
+      setCenter(xTarget, 150, { zoom: 1 });
+      setFirstLoad(false);
+    }
+  }, [setCenter, isEmpty, firstLoad, firstNode]);
+
+  // Center the canvas on the focused node when set
+  const setCanvasCenterToFocus = useCallback(() => {
+    if ((!focusNode?.position?.x && !focusNode?.position?.y) || !focusNode?.width || !focusNode?.height) {
+      return;
+    }
+
+    let xRawPos = focusNode?.position?.x ?? 0;
+    const yRawPos = focusNode?.position?.y ?? 0;
+
+    // If the panel is open, reduce X space
+    if (!isPanelCollapsed) {
+      // Move center to the right if Panel is located to the left; otherwise move center to the left.
+      const directionMultiplier = panelLocation === PanelLocation.Left ? -1 : 1;
+      xRawPos += (directionMultiplier * 630) / 2 / getZoom();
+    }
+
+    const xTarget = xRawPos + (focusNode?.width ?? DEFAULT_NODE_SIZE.width) / 2; // Center X on node midpoint
+    const yTarget = yRawPos + (focusNode?.height ?? DEFAULT_NODE_SIZE.height); // Center Y on bottom edge
+
+    setCenter(xTarget, yTarget, {
+      zoom: getZoom(),
+      duration: 500,
+    });
+
+    dispatch(clearFocusNode());
+  }, [isPanelCollapsed, dispatch, focusNode, panelLocation, setCenter, getZoom]);
+
+  useEffect(() => {
+    setCanvasCenterToFocus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusNode]);
+
+  return null;
+};


### PR DESCRIPTION
## Main Changes

- Split the focusNode and initialization centering logic apart
- Moved CanvasFinder component to it's own file
- Fixed issue where width and height were not being passed to operation nodes

Fixes https://github.com/Azure/LogicAppsUX/issues/5224