### PR TITLE
feat(vscode): Add telemetry for refreshing expired connection keys

### DIFF
--- a/apps/vs-code-designer/src/app/utils/codeless/connection.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/connection.ts
@@ -225,7 +225,7 @@ export async function getConnectionsAndSettingsToUpdate(
       );
     } else if (
       localSettings.Values[`${referenceKey}-connectionKey`] &&
-      isKeyExpired(jwtTokenHelper, Date.now(), localSettings.Values[`${referenceKey}-connectionKey`], 192)
+      isKeyExpired(jwtTokenHelper, Date.now(), localSettings.Values[`${referenceKey}-connectionKey`], 3)
     ) {
       const resolvedConnectionReference = resolveConnectionsReferences(JSON.stringify(reference), undefined, localSettings.Values);
       const connectionRefreshMessage = localize(

--- a/apps/vs-code-designer/src/app/utils/codeless/connection.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/connection.ts
@@ -31,7 +31,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { parameterizeConnection } from './parameterizer';
 import { window } from 'vscode';
-import { ext } from '../../../extensionVariables';
 
 export async function getConnectionsFromFile(context: IActionContext, workflowFilePath: string): Promise<string> {
   const projectRoot: string = await getLogicAppProjectRoot(context, workflowFilePath);
@@ -228,13 +227,8 @@ export async function getConnectionsAndSettingsToUpdate(
       isKeyExpired(jwtTokenHelper, Date.now(), localSettings.Values[`${referenceKey}-connectionKey`], 3)
     ) {
       const resolvedConnectionReference = resolveConnectionsReferences(JSON.stringify(reference), undefined, localSettings.Values);
-      const connectionRefreshMessage = localize(
-        'connectionKeyRefresh',
-        'Connection key for {0} has expired. Refreshing connection key.',
-        referenceKey
-      );
 
-      ext.log(connectionRefreshMessage);
+      context.telemetry.properties.connectionKeyRefresh = `${referenceKey}-connectionKey refreshed`;
       accessToken = accessToken ? accessToken : await getAuthorizationToken(/* credentials */ undefined, azureTenantId);
       referencesToAdd[referenceKey] = await getConnectionReference(
         referenceKey,


### PR DESCRIPTION
Added telemetry for expired connection keys and information message when keys have been refreshed.


<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/eb54b22a-92c3-4c9a-9c18-58da275c4147">
