### PR TITLE
fix(designer): Fixed issue with some advanced parameters not initializing properly

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1309,6 +1309,7 @@ export function updateParameterWithValues(
 
   const clonedParameterValue =
     typeof parameterValue === 'object' && !Array.isArray(parameterValue) ? clone(parameterValue) : parameterValue;
+  const unreadParameterValues = clone(clonedParameterValue);
 
   if (isNullOrUndefined(clonedParameterValue) && useDefault) {
     // assign the default value to input parameter
@@ -1363,19 +1364,19 @@ export function updateParameterWithValues(
             }
 
             parameters.push(transformInputParameter(descendantInputParameter, descendantValue, /* invisible */ false));
-            deletePropertyValueWithSpecifiedPathSegment(clonedParameterValue, extraSegments);
+            deletePropertyValueWithSpecifiedPathSegment(unreadParameterValues, extraSegments);
             if (alternativeParameterKeyExtraSegment) {
-              deletePropertyValueWithSpecifiedPathSegment(clonedParameterValue, alternativeParameterKeyExtraSegment);
+              deletePropertyValueWithSpecifiedPathSegment(unreadParameterValues, alternativeParameterKeyExtraSegment);
             }
           }
 
           // for the rest properties, create corresponding invisible parameter to preserve the value when serialize
           if (createInvisibleParameter) {
-            for (const restPropertyName of Object.keys(clonedParameterValue)) {
+            for (const restPropertyName of Object.keys(unreadParameterValues)) {
               if (dynamicSchemaKeyPrefixes.some((prefix) => restPropertyName.startsWith(prefix))) {
                 continue;
               }
-              const propertyValue = clonedParameterValue[restPropertyName];
+              const propertyValue = unreadParameterValues[restPropertyName];
               if (propertyValue !== undefined) {
                 const childKeySegments = [...keySegments, { value: restPropertyName, type: SegmentType.Property }];
                 const restInputParameter: ResolvedParameter = {
@@ -1995,121 +1996,127 @@ export const loadDynamicContentForInputsInNode = async (
   getState: () => RootState,
   operationDefinition?: any
 ): Promise<void> => {
-  for (const inputKey of Object.keys(inputDependencies)) {
-    const info = inputDependencies[inputKey];
-    if (info.dependencyType === 'ApiSchema') {
-      dispatch(
-        clearDynamicIO({
-          nodeId,
-          inputs: true,
-          outputs: false,
-          dynamicParameterKeys: getAllDependentDynamicParameters(
-            inputKey,
-            getState().operations.dependencies[nodeId].inputs,
-            getState().operations.inputParameters[nodeId]
-          ),
-        })
+  for (const [inputKey, info] of Object.entries(inputDependencies)) {
+    if (info.dependencyType !== 'ApiSchema') {
+      continue;
+    }
+
+    dispatch(
+      clearDynamicIO({
+        nodeId,
+        inputs: true,
+        outputs: false,
+        dynamicParameterKeys: getAllDependentDynamicParameters(
+          inputKey,
+          getState().operations.dependencies[nodeId].inputs,
+          getState().operations.inputParameters[nodeId]
+        ),
+      })
+    );
+
+    if (!isDynamicDataReadyToLoad(info)) {
+      continue;
+    }
+
+    const rootState = getState();
+    const allInputs = rootState.operations.inputParameters[nodeId];
+    const variables = getAllVariables(rootState.tokens.variables);
+
+    try {
+      const inputSchema = await tryGetInputDynamicSchema(
+        nodeId,
+        operationInfo,
+        info,
+        allInputs,
+        variables,
+        connectionReference,
+        rootState.workflowParameters.definitions,
+        dispatch
       );
-      if (isDynamicDataReadyToLoad(info)) {
-        const rootState = getState();
-        const allInputs = rootState.operations.inputParameters[nodeId];
-        const variables = getAllVariables(rootState.tokens.variables);
+      const allInputParameters = getAllInputParameters(allInputs);
 
-        try {
-          const inputSchema = await tryGetInputDynamicSchema(
-            nodeId,
+      // In the case of retry policy, it is treated as an input
+      // avoid pushing a parameter for it as it is already being
+      // handled in the settings store.
+      // NOTE: this could be expanded to more settings that are treated as inputs.
+      const newOperationDefinition = operationDefinition ? clone(operationDefinition) : operationDefinition;
+      if (newOperationDefinition?.inputs?.[PropertyName.RETRYPOLICY]) {
+        delete newOperationDefinition.inputs.retryPolicy;
+      }
+
+      const allInputKeys = allInputParameters.map((param) => param.parameterKey);
+      const schemaInputs = inputSchema
+        ? await getDynamicInputsFromSchema(
+            inputSchema,
+            info.parameter as InputParameter,
             operationInfo,
-            info,
-            allInputs,
-            variables,
-            connectionReference,
-            rootState.workflowParameters.definitions,
-            dispatch
-          );
-          const allInputParameters = getAllInputParameters(allInputs);
+            allInputKeys,
+            newOperationDefinition
+          )
+        : [];
+      const inputsWithSchema = schemaInputs.map((input) => ({ ...input, schema: input }));
+      const inputParameters = toParameterInfoMap(inputsWithSchema, operationDefinition);
 
-          // In the case of retry policy, it is treated as an input
-          // avoid pushing a parameter for it as it is already being
-          // handled in the settings store.
-          // NOTE: this could be expanded to more settings that are treated as inputs.
-          const newOperationDefinition = operationDefinition ? clone(operationDefinition) : operationDefinition;
-          if (newOperationDefinition?.inputs?.[PropertyName.RETRYPOLICY]) {
-            delete newOperationDefinition.inputs.retryPolicy;
-          }
+      updateTokenMetadataInParameters(nodeId, inputParameters, getState());
 
-          const allInputKeys = allInputParameters.map((param) => param.parameterKey);
-          const schemaInputs = inputSchema
-            ? await getDynamicInputsFromSchema(
-                inputSchema,
-                info.parameter as InputParameter,
-                operationInfo,
-                allInputKeys,
-                newOperationDefinition
-              )
-            : [];
-          const inputsWithSchema = schemaInputs.map((input) => ({ ...input, schema: input }));
-          const inputParameters = toParameterInfoMap(inputsWithSchema, operationDefinition);
+      let swagger: SwaggerParser | undefined = undefined;
+      if (!OperationManifestService().isSupported(operationInfo.type, operationInfo.kind)) {
+        const { parsedSwagger } = await getConnectorWithSwagger(operationInfo.connectorId);
+        swagger = parsedSwagger;
+      }
 
-          updateTokenMetadataInParameters(nodeId, inputParameters, getState());
+      const updatedParameters = [...allInputs.parameterGroups[ParameterGroupKeys.DEFAULT].parameters];
 
-          let swagger: SwaggerParser | undefined = undefined;
-          if (!OperationManifestService().isSupported(operationInfo.type, operationInfo.kind)) {
-            const { parsedSwagger } = await getConnectorWithSwagger(operationInfo.connectorId);
-            swagger = parsedSwagger;
-          }
-
-          const updatedParameters = [...allInputs.parameterGroups[ParameterGroupKeys.DEFAULT].parameters];
-          for (const input of inputParameters) {
-            const index = updatedParameters.findIndex((parameter) => parameter.parameterKey === input.parameterKey);
-            if (index > -1) {
-              updatedParameters.splice(index, 1, input);
-            } else {
-              updatedParameters.push(input);
-            }
-          }
-          const newNodeInputs = {
-            ...allInputs,
-            parameterGroups: {
-              ...allInputs.parameterGroups,
-              [ParameterGroupKeys.DEFAULT]: { ...allInputs.parameterGroups[ParameterGroupKeys.DEFAULT], parameters: updatedParameters },
-            },
-          };
-
-          const dependencies = getInputDependencies(newNodeInputs, schemaInputs, swagger);
-
-          dispatch(addDynamicInputs({ nodeId, groupId: ParameterGroupKeys.DEFAULT, inputs: updatedParameters, dependencies }));
-
-          // Recursively load dynamic content for the newly added dynamic inputs
-          return updateDynamicDataInNode(
-            nodeId,
-            isTrigger,
-            operationInfo,
-            connectionReference,
-            { outputs: {}, inputs: dependencies },
-            dispatch,
-            getState,
-            operationDefinition
-          );
-        } catch (error: any) {
-          const message = parseErrorMessage(error);
-          const intl = getIntl();
-          const errorMessage = intl.formatMessage(
-            {
-              defaultMessage: `Failed to retrieve dynamic inputs. Error details: ''{message}''`,
-              id: 'sytRna',
-              description: 'Error message to show when loading dynamic inputs failed',
-            },
-            { message }
-          );
-
-          dispatch(
-            updateErrorDetails({
-              id: nodeId,
-              errorInfo: { level: ErrorLevel.DynamicInputs, message: errorMessage, error, code: error.code },
-            })
-          );
+      for (const input of inputParameters) {
+        const index = updatedParameters.findIndex((parameter) => parameter.parameterKey === input.parameterKey);
+        if (index > -1) {
+          updatedParameters.splice(index, 1, input);
+        } else {
+          updatedParameters.push(input);
         }
       }
+
+      const newNodeInputs = {
+        ...allInputs,
+        parameterGroups: {
+          ...allInputs.parameterGroups,
+          [ParameterGroupKeys.DEFAULT]: { ...allInputs.parameterGroups[ParameterGroupKeys.DEFAULT], parameters: updatedParameters },
+        },
+      };
+
+      const dependencies = getInputDependencies(newNodeInputs, schemaInputs, swagger);
+
+      dispatch(addDynamicInputs({ nodeId, groupId: ParameterGroupKeys.DEFAULT, inputs: updatedParameters, dependencies }));
+
+      // Recursively load dynamic content for the newly added dynamic inputs
+      return updateDynamicDataInNode(
+        nodeId,
+        isTrigger,
+        operationInfo,
+        connectionReference,
+        { outputs: {}, inputs: dependencies },
+        dispatch,
+        getState,
+        operationDefinition
+      );
+    } catch (error: any) {
+      const message = parseErrorMessage(error);
+      const intl = getIntl();
+      const errorMessage = intl.formatMessage(
+        {
+          defaultMessage: `Failed to retrieve dynamic inputs. Error details: ''{message}''`,
+          id: 'sytRna',
+          description: 'Error message to show when loading dynamic inputs failed',
+        },
+        { message }
+      );
+
+      dispatch(
+        updateErrorDetails({
+          id: nodeId,
+          errorInfo: { level: ErrorLevel.DynamicInputs, message: errorMessage, error, code: error.code },
+        })
+      );
     }
   }
 };

--- a/libs/designer/src/lib/core/utils/swagger/inputsbuilder.ts
+++ b/libs/designer/src/lib/core/utils/swagger/inputsbuilder.ts
@@ -129,54 +129,56 @@ export function loadInputValuesFromDefinition(
   basePath: string,
   shouldUsePathTemplateFormat = false
 ): InputParameter[] {
+  if (!inputValue) {
+    return [];
+  }
+
   let result: InputParameter[] = [];
 
-  if (inputValue) {
-    const cloneInputValue = clone(inputValue);
-    const formDataInputParameters = inputParameters.filter((parameter) => parameter.in === ParameterLocations.FormData);
-    result = result.concat(loadFormDataValue(cloneInputValue, formDataInputParameters));
+  const cloneInputValue = clone(inputValue);
+  const formDataInputParameters = inputParameters.filter((parameter) => parameter.in === ParameterLocations.FormData);
+  result = result.concat(loadFormDataValue(cloneInputValue, formDataInputParameters));
 
-    const bodyInputs = getPropertyValue(cloneInputValue, PropertyName.BODY);
-    result = result.concat(
-      loadBodyValue(
-        bodyInputs,
-        inputParameters.filter((parameter) => parameter.in === ParameterLocations.Body)
-      )
-    );
+  const bodyInputs = getPropertyValue(cloneInputValue, PropertyName.BODY);
+  result = result.concat(
+    loadBodyValue(
+      bodyInputs,
+      inputParameters.filter((parameter) => parameter.in === ParameterLocations.Body)
+    )
+  );
 
-    const headersInputs = getPropertyValue(cloneInputValue, PropertyName.HEADERS);
-    result = result.concat(
-      loadHeadersValue(
-        headersInputs,
-        inputParameters.filter((parameter) => parameter.in === ParameterLocations.Header)
-      )
-    );
+  const headersInputs = getPropertyValue(cloneInputValue, PropertyName.HEADERS);
+  result = result.concat(
+    loadHeadersValue(
+      headersInputs,
+      inputParameters.filter((parameter) => parameter.in === ParameterLocations.Header)
+    )
+  );
 
-    const queriesInputParameters = inputParameters.filter((parameter) => parameter.in === ParameterLocations.Query);
-    const queriesInputs = getQueriesInputs(cloneInputValue, queriesInputParameters);
-    result = result.concat(loadQueryValue(queriesInputs, queriesInputParameters));
+  const queriesInputParameters = inputParameters.filter((parameter) => parameter.in === ParameterLocations.Query);
+  const queriesInputs = getQueriesInputs(cloneInputValue, queriesInputParameters);
+  result = result.concat(loadQueryValue(queriesInputs, queriesInputParameters));
 
-    const pathInputParameters = inputParameters.filter((parameter) => parameter.in === ParameterLocations.Path);
-    const pathInputs = getPathInputs(cloneInputValue, pathInputParameters, operationPath, basePath, shouldUsePathTemplateFormat);
+  const pathInputParameters = inputParameters.filter((parameter) => parameter.in === ParameterLocations.Path);
+  const pathInputs = getPathInputs(cloneInputValue, pathInputParameters, operationPath, basePath, shouldUsePathTemplateFormat);
 
-    result = result.concat(loadPathValue(pathInputs, pathInputParameters));
+  result = result.concat(loadPathValue(pathInputs, pathInputParameters));
 
-    // some builtin input parameters
-    const miscInputParameters = inputParameters.filter(
-      (parameter) =>
-        parameter.in !== ParameterLocations.Body &&
-        parameter.in !== ParameterLocations.Header &&
-        parameter.in !== ParameterLocations.Query &&
-        parameter.in !== ParameterLocations.Path &&
-        parameter.in !== ParameterLocations.FormData
-    );
+  // some builtin input parameters
+  const miscInputParameters = inputParameters.filter(
+    (parameter) =>
+      parameter.in !== ParameterLocations.Body &&
+      parameter.in !== ParameterLocations.Header &&
+      parameter.in !== ParameterLocations.Query &&
+      parameter.in !== ParameterLocations.Path &&
+      parameter.in !== ParameterLocations.FormData
+  );
 
-    const extensionInputs = getExtensionInputs(cloneInputValue);
-    result = result.concat(loadExtensionValue(extensionInputs, miscInputParameters));
+  const extensionInputs = getExtensionInputs(cloneInputValue);
+  result = result.concat(loadExtensionValue(extensionInputs, miscInputParameters));
 
-    const sortingKeys = inputParameters.map((item) => item.key);
-    result = sortByOrderedKeys(result, sortingKeys);
-  }
+  const sortingKeys = inputParameters.map((item) => item.key);
+  result = sortByOrderedKeys(result, sortingKeys);
 
   return result;
 }


### PR DESCRIPTION
## Main Changes

This PR fixes an issue where during parameter value initialization, some parameters do not seem to be read from the initial workflow data properly.
After investigating, what appears to be happening is that if we have body parameters with a nested path like the following `body.feature.test`, our initialization logic on some connectors/actions would first read `body.feature` and the value would be the object `{ test:  value }`.  This is an issue because we also have logic in place that removes read values from the object we pull the values from (to track which parameter values are not used, then we treat them as invisible parameters).  After we remove the parent data, if we dig in to try and reach the `test` parameter, it will have been removed by the prior read.

To fix this, I created a new object clone to track which values have been read, separate from the object we actually pull the data from.  So now if the connector has us read the `body.feature` value first, we can still get data from `body.feature.test`.

Fixes https://github.com/Azure/LogicAppsUX/issues/5129

// I also moved some checks around the improve readability of the files and not nest so many conditionals.

---

### Additional parameters with proper values
![image](https://github.com/user-attachments/assets/8adbecd6-a8fc-43b7-9c84-5c1ce568ee5b)
