### PR TITLE
fix(designer-ui): Remove `forceFocusInsideTrap` attribute (v4.45 only)

### DIFF
--- a/libs/designer-ui/src/lib/panel/__test__/__snapshots__/panelcontainer.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/__test__/__snapshots__/panelcontainer.spec.tsx.snap
@@ -8,8 +8,6 @@ exports[`ui/workflowparameters/workflowparameter > should construct. 1`] = `
   focusTrapZoneProps={
     {
       "disabled": false,
-      "firstFocusableTarget": "#msla-panel-header-collapse-nav",
-      "forceFocusInsideTrap": true,
     }
   }
   hasCloseButton={false}

--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -177,8 +177,6 @@ export const PanelContainer = ({
       onRenderHeader={renderHeader ?? defaultRenderHeader}
       focusTrapZoneProps={{
         disabled: isCollapsed,
-        firstFocusableTarget: '#msla-panel-header-collapse-nav',
-        forceFocusInsideTrap: !isCollapsed,
       }}
       elementToFocusOnDismiss={selectedElement}
       isBlocking={false}


### PR DESCRIPTION
This is a hotfix for some focus-related issues we are seeing in Power Automate after taking v4.45.

The code affected in this change is no longer in main branch, so this PR addresses the issue directly in v4.45.