### PR TITLE
fix(vscode): Load node settings to monitoring view in remote app

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
@@ -105,14 +105,13 @@ export class OpenDesignerForAzureResource extends OpenDesignerBase {
   }
 
   private async getDesignerPanelMetadata(): Promise<IDesignerPanelMetadata> {
-    const parameters = await this.node.getParametersData();
     const credentials: ServiceClientCredentials = this.node.credentials;
     const accessToken: string = await getAuthorizationToken(credentials);
 
     return {
       panelId: this.panelName,
       connectionsData: await this.node.getConnectionsData(),
-      parametersData: parameters,
+      parametersData: await this.node.getParametersData(),
       localSettings: await this.node.getAppSettings(),
       artifacts: await this.node.getArtifacts(),
       workflowDetails: await this.node.getChildWorkflows(this.context),

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import path from 'path';
 import { workflowAppApiVersion } from '../../../../constants';
 import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
@@ -24,7 +25,7 @@ import type { IDesignerPanelMetadata, IWorkflowFileContent } from '@microsoft/vs
 import { ExtensionCommand, ProjectName } from '@microsoft/vscode-extension-logic-apps';
 import * as vscode from 'vscode';
 import type { WebviewPanel } from 'vscode';
-import { ViewColumn } from 'vscode';
+import { Uri, ViewColumn } from 'vscode';
 
 export default class openMonitoringViewForAzureResource extends OpenMonitoringViewBase {
   private node: RemoteWorkflowTreeItem;
@@ -57,17 +58,19 @@ export default class openMonitoringViewForAzureResource extends OpenMonitoringVi
       ViewColumn.Active, // Editor column to show the new webview panel in.
       this.getPanelOptions()
     );
+    this.panel.iconPath = {
+      light: Uri.file(path.join(ext.context.extensionPath, 'assets', 'dark', 'workflow.svg')),
+      dark: Uri.file(path.join(ext.context.extensionPath, 'assets', 'light', 'workflow.svg')),
+    };
     this.panelMetadata = await this.getDesignerPanelMetadata();
 
     this.baseUrl = getWorkflowManagementBaseURI(this.node);
     const accessToken = await getAuthorizationToken(this.node.credentials);
-    const connectionsData: string = await this.node.getConnectionsData();
-    const parametersData = await this.node.getParametersData();
 
     this.panel.webview.html = await this.getWebviewContent({
-      connectionsData: connectionsData,
-      parametersData: parametersData,
-      localSettings: {},
+      connectionsData: this.panelMetadata.connectionsData,
+      parametersData: this.panelMetadata.parametersData || {},
+      localSettings: this.panelMetadata.localSettings,
       azureDetails: {
         enabled: true,
         accessToken,
@@ -158,7 +161,6 @@ export default class openMonitoringViewForAzureResource extends OpenMonitoringVi
   private async getDesignerPanelMetadata(): Promise<IDesignerPanelMetadata> {
     const credentials: ServiceClientCredentials = this.node.credentials;
     const accessToken: string = await getAuthorizationToken(credentials);
-    const parameters = await this.node.getParametersData();
 
     return {
       panelId: this.panelName,
@@ -166,7 +168,7 @@ export default class openMonitoringViewForAzureResource extends OpenMonitoringVi
       localSettings: await this.node.getAppSettings(),
       workflowDetails: await this.node.getChildWorkflows(this.context),
       artifacts: await this.node.getArtifacts(),
-      parametersData: parameters,
+      parametersData: await this.node.getParametersData(),
       accessToken,
       azureDetails: {
         enabled: true,

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
@@ -24,7 +24,7 @@ import { promises, readFileSync } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import type { WebviewPanel } from 'vscode';
-import { ViewColumn } from 'vscode';
+import { Uri, ViewColumn } from 'vscode';
 import { getArtifactsInLocalProject } from '../../../utils/codeless/artifacts';
 
 export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
@@ -55,6 +55,10 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
       ViewColumn.Active, // Editor column to show the new webview panel in.
       this.getPanelOptions()
     );
+    this.panel.iconPath = {
+      light: Uri.file(path.join(ext.context.extensionPath, 'assets', 'dark', 'workflow.svg')),
+      dark: Uri.file(path.join(ext.context.extensionPath, 'assets', 'light', 'workflow.svg')),
+    };
 
     this.projectPath = await getLogicAppProjectRoot(this.context, this.workflowFilePath);
     const connectionsData = await getConnectionsFromFile(this.context, this.workflowFilePath);


### PR DESCRIPTION
Send node local settings to monitoring view in remote app
