### PR TITLE
fix(designer): Do not show tenant picker if tenant service is not enabled

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/__test__/createConnection.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/__test__/createConnection.spec.tsx
@@ -18,6 +18,12 @@ import {
   mockOauthWithTenantParameters,
   mockParameterSetsWithCredentialMapping,
 } from './mocks/connectionParameters';
+
+vi.mock('@microsoft/logic-apps-shared', async (importOriginal) => ({
+  ...((await importOriginal()) as object),
+  isTenantServiceEnabled: () => true,
+}));
+
 describe('ui/createConnection', () => {
   let renderer: ReactShallowRenderer.ShallowRenderer;
 

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -22,6 +22,7 @@ import {
   usesLegacyManagedIdentity,
   isUsingAadAuthentication,
   equals,
+  isTenantServiceEnabled,
 } from '@microsoft/logic-apps-shared';
 import type {
   GatewayServiceConfig,
@@ -296,6 +297,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
   const usingAadConnection = useMemo(() => (connector ? isUsingAadAuthentication(connector) : false), [connector]);
   const showTenantIdSelection = useMemo(
     () =>
+      isTenantServiceEnabled() &&
       usingAadConnection &&
       isUsingOAuth &&
       Object.keys(connectionParameters ?? {}).some((key) => equals(key, SERVICE_PRINCIPLE_CONSTANTS.CONFIG_ITEM_KEYS.TOKEN_TENANT_ID)),

--- a/libs/logic-apps-shared/src/designer-client-services/lib/tenant.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/tenant.ts
@@ -21,3 +21,7 @@ export const TenantService = (): ITenantService => {
 
   return service;
 };
+
+export const isTenantServiceEnabled = (): boolean => {
+  return !!service;
+};


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Tenant picker is shown even if tenant service is not provided, resulting in an error:

![image](https://github.com/user-attachments/assets/bc554611-66b6-47c2-b6e0-54242d8448b0)

## New Behavior

Tenant picker is only shown if tenant service is provided.

## Impact of Change

No breaking changes.