### PR TITLE
fix(designer-ui): Prevent `AriaSearchResultsAlert` from returning `undefined`

### DIFF
--- a/libs/designer-ui/src/lib/ariaSearchResults/ariaSearchResultsAlert.tsx
+++ b/libs/designer-ui/src/lib/ariaSearchResults/ariaSearchResultsAlert.tsx
@@ -24,5 +24,5 @@ export const AriaSearchResultsAlert = ({ resultCount, resultDescription }: AriaS
 
   return showAlert ? (
     <div className={'msla-aria-search-results'} role="alert">{`${resultCount} ${resultDescription} ${ariaResultCount}`}</div>
-  ) : undefined;
+  ) : null;
 };


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

If `showAlert` is `false`, `AriaSearchResultsAlert` will return `undefined`. This is [valid in React 18](https://github.com/reactwg/react-18/discussions/75), but not prior versions, and results in [an error](https://react.dev/errors/152?invariant=152&args%5B%5D=Tp):

![image](https://github.com/user-attachments/assets/2a95509a-9f4d-4606-a774-382c2cc97e4c)

## New Behavior

We now return `null` instead of `undefined` which is valid in React versions 17 and lower.

## Impact of Change

No breaking changes.