### PR TITLE
fix(vscode): Auto Runtime Dependencies installation of latest FuncCoreTools

### DIFF
--- a/apps/vs-code-designer/src/app/utils/bundleFeed.ts
+++ b/apps/vs-code-designer/src/app/utils/bundleFeed.ts
@@ -68,7 +68,7 @@ async function getBundleDependencyFeed(
   }
 
   const baseUrl: string = envVarUri || 'https://functionscdn.azureedge.net/public';
-  const url = `${baseUrl}/ExtensionBundles/${bundleId}.Workflows/dependency.json`;
+  const url = `${baseUrl}/ExtensionBundles/${bundleId}/dependency.json`;
   return getJsonFeed(context, url);
 }
 


### PR DESCRIPTION

Fixes extension bundle URL for dependencies
