### PR TITLE
fix(designer): Fix node rename focus issue

### DIFF
--- a/downloadTemplates.js
+++ b/downloadTemplates.js
@@ -1,32 +1,40 @@
-import fs from 'fs-extra';
+/* eslint-disable no-undef */
+import { existsSync, createWriteStream } from 'fs';
+import { mkdir, writeFile, rm } from 'fs/promises';
+import { Readable } from 'stream';
+import { finished } from 'stream/promises';
 
 const baseURL = `https://raw.githubusercontent.com/azure/LogicAppsTemplates/master`;
 const templatesFolder = `./libs/designer/src/lib/core/templates/templateFiles`;
 
-const removeTemplatesFolderIfPresent = () => {
-  if (fs.existsSync(templatesFolder)) {
-    fs.rmSync(templatesFolder, { recursive: true });
+const downloadFile = async (url, fileName) => {
+  const res = await fetch(url);
+  const fileStream = createWriteStream(fileName, { flags: 'wx' });
+  await finished(Readable.fromWeb(res.body).pipe(fileStream));
+  return fetch(url);
+};
+
+const removeTemplatesFolderIfPresent = async () => {
+  if (existsSync(templatesFolder)) {
+    await rm(templatesFolder, { recursive: true });
   }
 };
 
 const createTemplatesFolder = async (path) => {
-  await fs.mkdir(`${templatesFolder}/${path}`, { recursive: true });
+  await mkdir(`${templatesFolder}/${path}`, { recursive: true });
 };
 
 const downloadManifest = async () => {
   const manifestUrl = `${baseURL}/manifest.json`;
-  // eslint-disable-next-line no-undef
-  const manifestRes = await fetch(manifestUrl);
-  const data = await manifestRes.json();
-  await fs.writeFile(`${templatesFolder}/manifest.json`, JSON.stringify(data, null, 2));
-  return data;
+  const manifestLocation = `${templatesFolder}/manifest.json`;
+  const res = await downloadFile(manifestUrl, manifestLocation);
+  return await res.json();
 };
 
 const downloadTemplate = async (path) => {
   const templateManifestUrl = `${baseURL}/${path}/manifest.json`;
-  // eslint-disable-next-line no-undef
-  const templateManifestRes = await fetch(templateManifestUrl);
-  const templateManifest = await templateManifestRes.json();
+  const templateManifestFileLocation = `${templatesFolder}/${path}/manifest.json`;
+  const templateManifest = await (await downloadFile(templateManifestUrl, templateManifestFileLocation)).json();
   for (const artifact of templateManifest.artifacts) {
     if (artifact.file.endsWith('.json')) {
       // We only support .json for now
@@ -37,20 +45,16 @@ const downloadTemplate = async (path) => {
     light: `${baseURL}/${path}/${templateManifest.images.light}.png`,
     dark: `${baseURL}/${path}/${templateManifest.images.dark}.png`,
   };
-
-  await fs.writeFile(`${templatesFolder}/${path}/manifest.json`, JSON.stringify(templateManifest, null, 2));
+  await writeFile(templateManifestFileLocation, JSON.stringify(templateManifest, null, 2));
 };
 
 const downloadJsonArtifact = async (path) => {
   const artifactUrl = `${baseURL}/${path}`;
-  // eslint-disable-next-line no-undef
-  const artifactRes = await fetch(artifactUrl);
-  const data = await artifactRes.json();
-  await fs.writeFile(`${templatesFolder}/${path}`, JSON.stringify(data, null, 2));
+  await downloadFile(artifactUrl, `${templatesFolder}/${path}`);
 };
 
 const run = async () => {
-  removeTemplatesFolderIfPresent();
+  await removeTemplatesFolderIfPresent();
   await createTemplatesFolder('');
   const value = await downloadManifest();
   for (const path of value) {

--- a/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
+++ b/libs/designer-ui/src/lib/panel/panelheader/panelheader.tsx
@@ -133,12 +133,6 @@ export const PanelHeader = ({
 
     const ref = useRef<HTMLButtonElement>(null);
 
-    useEffect(() => {
-      if (!isCollapsed) {
-        ref.current?.focus();
-      }
-    }, [isCollapsed]);
-
     return (
       <Tooltip relationship="label" positioning={'before'} content={buttonText}>
         <Button


### PR DESCRIPTION
## Main Changes
Our panel focus code was a little too aggressive and was firing off when users would be renaming a node.
Each keypress would send focus to the collapse button.
This PR just removes the focus useEffect that caused this.

We have a refactored panel component in main and this is not an issue, this functionality will be returned in our next release.

Pulled in a fixed version of downloadTemplates.js