### PR TITLE
feat(Templates): Download Template Image Instead of Using URL

### DIFF
--- a/downloadTemplates.js
+++ b/downloadTemplates.js
@@ -3,6 +3,7 @@ import { existsSync, createWriteStream } from 'fs';
 import { mkdir, writeFile, rm } from 'fs/promises';
 import { Readable } from 'stream';
 import { finished } from 'stream/promises';
+import client from 'https';
 
 const baseURL = `https://raw.githubusercontent.com/azure/LogicAppsTemplates/master`;
 const templatesFolder = `./libs/designer/src/lib/core/templates/templateFiles`;
@@ -41,16 +42,21 @@ const downloadTemplate = async (path) => {
       await downloadJsonArtifact(`${path}/${artifact.file}`);
     }
   }
-  templateManifest.images = {
-    light: `${baseURL}/${path}/${templateManifest.images.light}.png`,
-    dark: `${baseURL}/${path}/${templateManifest.images.dark}.png`,
-  };
-  await await writeFile(templateManifestFileLocation, JSON.stringify(templateManifest, null, 2));
+  await downloadImage(`${path}/${templateManifest.images.light}.png`);
+  await downloadImage(`${path}/${templateManifest.images.dark}.png`);
+  await writeFile(templateManifestFileLocation, JSON.stringify(templateManifest, null, 2));
 };
 
 const downloadJsonArtifact = async (path) => {
   const artifactUrl = `${baseURL}/${path}`;
   await downloadFile(artifactUrl, `${templatesFolder}/${path}`);
+};
+
+const downloadImage = async (path) => {
+  const artifactUrl = `${baseURL}/${path}`;
+  client.get(artifactUrl, (res) => {
+    res.pipe(createWriteStream(`${templatesFolder}/${path}`));
+  });
 };
 
 const run = async () => {

--- a/downloadTemplates.js
+++ b/downloadTemplates.js
@@ -1,18 +1,21 @@
 /* eslint-disable no-undef */
 import { existsSync, createWriteStream } from 'fs';
-import { mkdir, writeFile, rm } from 'fs/promises';
-import { Readable } from 'stream';
-import { finished } from 'stream/promises';
+import { mkdir, rm } from 'fs/promises';
 import client from 'https';
 
 const baseURL = `https://raw.githubusercontent.com/azure/LogicAppsTemplates/master`;
 const templatesFolder = `./libs/designer/src/lib/core/templates/templateFiles`;
 
-const downloadFile = async (url, fileName) => {
-  const res = await fetch(url);
-  const fileStream = createWriteStream(fileName, { flags: 'wx' });
-  await finished(Readable.fromWeb(res.body).pipe(fileStream));
-  return fetch(url);
+const downloadFile = async (path) => {
+  const artifactUrl = `${baseURL}/${path}`;
+  client.get(artifactUrl, (res) => {
+    res.pipe(createWriteStream(`${templatesFolder}/${path}`));
+  });
+};
+
+const downloadFetchFile = async (path) => {
+  downloadFile(path);
+  return await fetch(`${baseURL}/${path}`);
 };
 
 const removeTemplatesFolderIfPresent = async () => {
@@ -25,47 +28,23 @@ const createTemplatesFolder = async (path) => {
   await mkdir(`${templatesFolder}/${path}`, { recursive: true });
 };
 
-const downloadManifest = async () => {
-  const manifestUrl = `${baseURL}/manifest.json`;
-  const manifestLocation = `${templatesFolder}/manifest.json`;
-  const res = await downloadFile(manifestUrl, manifestLocation);
-  return await res.json();
-};
-
 const downloadTemplate = async (path) => {
-  const templateManifestUrl = `${baseURL}/${path}/manifest.json`;
-  const templateManifestFileLocation = `${templatesFolder}/${path}/manifest.json`;
-  const templateManifest = await (await downloadFile(templateManifestUrl, templateManifestFileLocation)).json();
+  const templateManifest = await (await downloadFetchFile(`${path}/manifest.json`)).json();
   for (const artifact of templateManifest.artifacts) {
-    if (artifact.file.endsWith('.json')) {
-      // We only support .json for now
-      await downloadJsonArtifact(`${path}/${artifact.file}`);
-    }
+    await downloadFile(`${path}/${artifact.file}`);
   }
-  await downloadImage(`${path}/${templateManifest.images.light}.png`);
-  await downloadImage(`${path}/${templateManifest.images.dark}.png`);
-  await writeFile(templateManifestFileLocation, JSON.stringify(templateManifest, null, 2));
-};
-
-const downloadJsonArtifact = async (path) => {
-  const artifactUrl = `${baseURL}/${path}`;
-  await downloadFile(artifactUrl, `${templatesFolder}/${path}`);
-};
-
-const downloadImage = async (path) => {
-  const artifactUrl = `${baseURL}/${path}`;
-  client.get(artifactUrl, (res) => {
-    res.pipe(createWriteStream(`${templatesFolder}/${path}`));
-  });
+  await downloadFile(`${path}/${templateManifest.images.light}.png`);
+  await downloadFile(`${path}/${templateManifest.images.dark}.png`);
 };
 
 const run = async () => {
   await removeTemplatesFolderIfPresent();
   await createTemplatesFolder('');
-  const value = await downloadManifest();
-  for (const path of value) {
-    await createTemplatesFolder(path);
-    await downloadTemplate(path);
+  const registeredManifestNames = await (await downloadFetchFile('manifest.json')).json();
+
+  for (const manifestName of registeredManifestNames) {
+    await createTemplatesFolder(manifestName);
+    await downloadTemplate(manifestName);
   }
 };
 

--- a/libs/designer/src/lib/core/state/templates/templateSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/templateSlice.ts
@@ -284,6 +284,13 @@ const loadTemplateFromGithub = async (templateName: string, manifest: Template.M
     const templateManifest: Template.Manifest =
       manifest ?? (await import(`./../../templates/templateFiles/${templateName}/manifest.json`)).default;
 
+    const imagesWithPaths: Record<string, string> = {};
+    for (const imageType of Object.keys(templateManifest.images)) {
+      imagesWithPaths[imageType] = (
+        await import(`./../../templates/templateFiles/${templateName}/${templateManifest.images[imageType]}.png`)
+      ).default;
+    }
+
     const parametersDefinitions = templateManifest.parameters?.reduce((result: Record<string, Template.ParameterDefinition>, parameter) => {
       result[parameter.name] = {
         ...parameter,
@@ -299,7 +306,7 @@ const loadTemplateFromGithub = async (templateName: string, manifest: Template.M
       kind: templateManifest.kinds?.length === 1 ? templateManifest.kinds[0] : undefined,
       parameterDefinitions: parametersDefinitions,
       connections: templateManifest.connections,
-      images: templateManifest.images,
+      images: imagesWithPaths,
       errors: {
         workflow: undefined,
         kind: undefined,


### PR DESCRIPTION
## Requirement Checklist

* [X] The commit message follows our guidelines

## Type of Change

* [] Bug fix
* [ ] Feature
* [X] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

Uses URL to load template images

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

Uses file stream to download the image, then uses the relative url to load the image

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
