### PR TITLE
fix(vscode): Fixed issue where isDesignTime is not set properly and to correct workflow-designtime local.settings.json

### DIFF
--- a/apps/vs-code-designer/src/app/commands/appSettings/downloadAppSettings.ts
+++ b/apps/vs-code-designer/src/app/commands/appSettings/downloadAppSettings.ts
@@ -38,7 +38,7 @@ export async function downloadAppSettingsInternal(context: IActionContext, clien
   const localSettingsPath: string = await getLocalSettingsFile(context, message);
   const localSettingsUri: vscode.Uri = vscode.Uri.file(localSettingsPath);
 
-  let localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, localSettingsPath, true /* allowOverwrite */);
+  let localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, localSettingsPath);
 
   const isEncrypted: boolean | undefined = localSettings.IsEncrypted;
 


### PR DESCRIPTION
## Requirement Checklist

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->
Sometimes workflow-designtime local.settings.json has the key AzureWebJobsSecretStorageType removed and AzureWebJobsStorage added.

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->
Ensures that the workflow-designtime local.settings.json has the key AzureWebJobsSecretStorageType with the approriate value and AzureWebJobsStorage removed.

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->
This change should prevent users from encountering the following host start up error:
"Microsoft.Azure.WebJobs.Script.WebHost: Secret initialization from Blob storage failed due to missing both an Azure Storage connection string and a SAS connection uri. For Blob Storage, please provide at least one of these. If you intend to use files for secrets, add an App Setting key 'AzureWebJobsSecretStorageType' with value 'Files'."

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
