### PR TITLE
feat(vscode): Introduce check for duplicate names in container app

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ContainerAppNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ContainerAppNameStep.ts
@@ -10,8 +10,6 @@ import { createContainerClient } from '../../../../utils/azureClients';
 import type { ContainerAppsAPIClient } from '@azure/arm-appcontainers';
 
 export class ContainerAppNameStep extends AzureWizardPromptStep<ILogicAppWizardContext> {
-  public hideStepCount = true;
-
   public async prompt(context: ILogicAppWizardContext): Promise<void> {
     const hasValidName = await ContainerAppNameStep.isNameAvailable(context, context.resourceGroup.name, context.newSiteName);
 

--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ContainerAppNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ContainerAppNameStep.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
+import type { ILogicAppWizardContext } from '@microsoft/vscode-extension-logic-apps';
+import { localize } from '../../../../../localize';
+import { createContainerClient } from '../../../../utils/azureClients';
+import type { ContainerAppsAPIClient } from '@azure/arm-appcontainers';
+
+export class ContainerAppNameStep extends AzureWizardPromptStep<ILogicAppWizardContext> {
+  public hideStepCount = true;
+
+  public async prompt(context: ILogicAppWizardContext): Promise<void> {
+    const hasValidName = await ContainerAppNameStep.isNameAvailable(context, context.resourceGroup.name, context.newSiteName);
+
+    if (hasValidName) {
+      return;
+    }
+
+    const prompt: string = localize(
+      'newLogicAppName',
+      'Enter a new logic app name, the logic app "{0}" already exists in resource group "{1}".',
+      context.newSiteName,
+      context.resourceGroup.name
+    );
+
+    context.newSiteName = (
+      await context.ui.showInputBox({
+        prompt,
+        validateInput: ContainerAppNameStep.validateInput,
+        asyncValidationTask: (name: string) => this.validateNameAvailable(context, name),
+      })
+    ).trim();
+  }
+
+  public shouldPrompt(): boolean {
+    return true;
+  }
+
+  public static validateInput(name: string | undefined): string | undefined {
+    name = name ? name.trim() : '';
+
+    const { minLength, maxLength } = { minLength: 1, maxLength: 32 };
+    if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(name)) {
+      return localize(
+        'invalidChar',
+        `A name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character and cannot have '--'.`
+      );
+    }
+    if (name.length < minLength || name.length > maxLength) {
+      return localize('invalidLength', 'The name must be between {0} and {1} characters.', minLength, maxLength);
+    }
+
+    return undefined;
+  }
+
+  private async validateNameAvailable(context: ILogicAppWizardContext, name: string): Promise<string | undefined> {
+    const resourceGroupName: string = context.resourceGroup.name;
+    if (!(await ContainerAppNameStep.isNameAvailable(context, resourceGroupName, name))) {
+      return localize('containerAppExists', 'The container app "{0}" already exists in resource group "{1}".', name, resourceGroupName);
+    }
+    return undefined;
+  }
+
+  public static async isNameAvailable(
+    context: ILogicAppWizardContext,
+    resourceGroupName: string,
+    containerAppName: string
+  ): Promise<boolean> {
+    const client: ContainerAppsAPIClient = await createContainerClient(context);
+    try {
+      await client.containerApps.get(resourceGroupName, containerAppName);
+      return false;
+    } catch (_e) {
+      return true;
+    }
+  }
+}

--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppHostingPlanStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/LogicAppHostingPlanStep.ts
@@ -12,6 +12,7 @@ import { ResourceGroupListStep } from '@microsoft/vscode-azext-azureutils';
 import { sendAzureRequest } from '../../../utils/requestUtils';
 import { HTTP_METHODS } from '@microsoft/logic-apps-shared';
 import { workflowAppApiVersion } from '../../../../constants';
+import { ContainerAppNameStep } from './HybridLogicAppsSteps/ContainerAppNameStep';
 
 export class LogicAppHostingPlanStep extends AzureWizardPromptStep<ILogicAppWizardContext> {
   public async prompt(wizardContext: ILogicAppWizardContext): Promise<void> {
@@ -42,7 +43,7 @@ export class LogicAppHostingPlanStep extends AzureWizardPromptStep<ILogicAppWiza
     CustomLocationListStep.addStep(wizardContext as any, promptSteps);
     if (useHybrid) {
       this.setHybridPlanProperties(wizardContext);
-      promptSteps.push(new ResourceGroupListStep(), new ConnectedEnvironmentStep());
+      promptSteps.push(new ResourceGroupListStep(), new ContainerAppNameStep(), new ConnectedEnvironmentStep());
     } else {
       promptSteps.push(new AppServicePlanListStep(suppressCreate), new ResourceGroupListStep());
     }


### PR DESCRIPTION
This pull request introduces a new step for creating Logic Apps in hybrid environments, ensuring that container app names are validated and unique within a resource group. The key changes include the addition of the `ContainerAppNameStep` class and its integration into the existing Logic App creation workflow.

* Introduced `ContainerAppNameStep` class to prompt for and validate container app names. This class ensures that the names are unique within the specified resource group and meet naming conventions.


  * Imported `ContainerAppNameStep` to integrate it into the Logic App creation steps.
  * Modified the `LogicAppHostingPlanStep` class to include `ContainerAppNameStep` in the prompt steps for hybrid plans, ensuring container app names are validated during the creation process.

<img width="1715" alt="Screenshot 2024-08-07 at 11 51 11 AM" src="https://github.com/user-attachments/assets/a3b8341b-f905-4b7a-b886-07578b39a25a">

