### PR TITLE
fix(Data Mapper): Update auto layout logic to only run when there are intersecting nodes on canvas

### DIFF
--- a/libs/data-mapper-v2/src/core/state/DataMapSlice.ts
+++ b/libs/data-mapper-v2/src/core/state/DataMapSlice.ts
@@ -62,7 +62,6 @@ export interface DataMapOperationState {
   xsltContent: string;
   inlineFunctionInputOutputKeys: string[];
   lastAction: string;
-  fullLayoutNeeded: boolean;
   loadedMapMetadata?: MapMetadataV2;
   // Save the temporary state of edges to be used for rendering when tree node is expanded/collapsed
   // This info is not saved in LML which is why it is stored separately in the store
@@ -88,7 +87,6 @@ export interface DataMapOperationState {
 
 const emptyPristineState: DataMapOperationState = {
   dataMapConnections: {},
-  fullLayoutNeeded: false,
   dataMapLML: '',
   functionNodes: {},
   flattenedSourceSchema: {},
@@ -239,7 +237,6 @@ export const dataMapSlice = createSlice({
       const targetSchemaSortArray = flattenSchemaIntoSortArray(targetSchema.schemaTreeRoot);
 
       const functionNodes: FunctionDictionary = createFunctionDictionary(dataMapConnections, flattenedTargetSchema);
-      const fullLayoutNeeded = !metadata;
       assignFunctionNodePositionsFromMetadata(dataMapConnections, metadata?.functionNodes ?? [], functionNodes);
 
       const newState: DataMapOperationState = {
@@ -250,7 +247,6 @@ export const dataMapSlice = createSlice({
         sourceSchemaOrdering: sourceSchemaSortArray,
         flattenedTargetSchema,
         functionNodes,
-        fullLayoutNeeded,
         targetSchemaOrdering: targetSchemaSortArray,
         dataMapConnections: dataMapConnections ?? {},
         loadedMapMetadata: metadata,

--- a/libs/data-mapper-v2/src/ui/hooks/useAutoLayout.ts
+++ b/libs/data-mapper-v2/src/ui/hooks/useAutoLayout.ts
@@ -1,9 +1,9 @@
 import Elk, { type ElkNode } from 'elkjs/lib/elk.bundled.js';
 import { useEffect, useState } from 'react';
-import { type Node, type Edge, type XYPosition, useStore } from '@xyflow/react';
+import { type Node, type Edge, type XYPosition, useStore, useReactFlow } from '@xyflow/react';
 import { isFunctionNode } from '../../utils/ReactFlow.Util';
-import { useDispatch, useSelector } from 'react-redux';
-import type { AppDispatch, RootState } from '../../core/state/Store';
+import { useDispatch } from 'react-redux';
+import type { AppDispatch } from '../../core/state/Store';
 import { updateFunctionNodesPosition } from '../../core/state/DataMapSlice';
 
 // the layout direction (T = top, R = right, B = bottom, L = left, TB = top to bottom, ...)
@@ -99,7 +99,7 @@ function compareNodes(xs: Map<string, Node>, ys: Map<string, Node>) {
 const useAutoLayout = () => {
   const dispatch = useDispatch<AppDispatch>();
   const [isLayouted, setIsLayouted] = useState(false);
-  const fullLayoutNeeded = useSelector((state: RootState) => state.dataMap.present.curDataMapOperation.fullLayoutNeeded);
+  const { getIntersectingNodes } = useReactFlow();
   // Here we are storing a map of the nodes and edges in the flow. By using a
   // custom equality function as the second argument to `useStore`, we can make
   // sure the layout algorithm only runs when something has changed that should
@@ -116,13 +116,32 @@ const useAutoLayout = () => {
   );
 
   useEffect(() => {
-    const nodes = [...elements.nodeMap.values()];
-    const edges = [...elements.edgeMap.values()];
-    const functionNodes = nodes.filter((node) => isFunctionNode(node.id));
     // Only run the layout if there are nodes and they have been initialized with
     // their dimensions
     // does not run on first node placed
-    if (functionNodes.length === 0 || isLayouted || !fullLayoutNeeded) {
+    if (isLayouted) {
+      return;
+    }
+
+    const nodes = [...elements.nodeMap.values()];
+    const edges = [...elements.edgeMap.values()];
+    const functionNodes = nodes.filter((node) => isFunctionNode(node.id));
+
+    if (functionNodes.length === 0) {
+      return;
+    }
+
+    let intersectingNodeCount = 0;
+    for (const node of functionNodes) {
+      const intersectingNodes = getIntersectingNodes(node);
+      intersectingNodeCount += intersectingNodes.length;
+      if (intersectingNodeCount > 1) {
+        break;
+      }
+    }
+
+    if (functionNodes.length > 0 && intersectingNodeCount === 0) {
+      setIsLayouted(true);
       return;
     }
 
@@ -148,7 +167,7 @@ const useAutoLayout = () => {
     };
 
     runLayout(nodes, edges);
-  }, [elements, dispatch, isLayouted]);
+  }, [elements, dispatch, isLayouted, getIntersectingNodes]);
 };
 
 export default useAutoLayout;


### PR DESCRIPTION
## Requirement Checklist

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

## Impact of Change

Updating the Auto-layout logic so it only updates the position on first load and also only when there are intersecting function-nodes.
This prevents any auto-layout when a new function node is added (Day 0 scenario)

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
