### PR TITLE
fix(designer): Import copy control CSS

### DIFF
--- a/libs/designer-ui/src/lib/copyinputcontrol/copyinputcontrol.less
+++ b/libs/designer-ui/src/lib/copyinputcontrol/copyinputcontrol.less
@@ -12,7 +12,6 @@
   flex: 1;
 
   input {
-    background-color: #c1c1c1;
     font-size: @parameter-value-font-size;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -46,7 +45,6 @@
 .msla-theme-dark {
   .msla-copy-input-control-textbox {
     input {
-      background-color: #4f4f4f;
 
       // WebKit and Blink (Safari, Google Chrome, Opera 15+)
       &::-webkit-input-placeholder {

--- a/libs/designer-ui/src/lib/styles.less
+++ b/libs/designer-ui/src/lib/styles.less
@@ -30,6 +30,7 @@
 @import "./card/parameters/parameters.less";
 @import "./connectorsummarycard/connectorsummarycard.less";
 @import "./token/token.less";
+@import "./copyinputcontrol/copyinputcontrol.less";
 @import "./tokenpicker/tokenpicker.less";
 @import "./floatingactionmenu/_floatingactionmenu.less";
 @import "./monitoring/monitoring.less";


### PR DESCRIPTION
This pull request includes changes to the `libs/designer-ui` library, specifically focusing on the `copyinputcontrol` component's styles. The most important changes involve removing background colors for input elements and updating the main styles file to include the `copyinputcontrol` styles.


* Removed the background color for the input element in the default theme.
* Removed the background color for the input element in the dark theme.

* Added an import statement for the `copyinputcontrol` styles.


#### Before
<img width="676" alt="Screenshot 2024-08-07 at 3 13 49 PM" src="https://github.com/user-attachments/assets/257cabdf-42eb-4089-bb99-0a46a65ab202">
<img width="679" alt="Screenshot 2024-08-07 at 3 14 40 PM" src="https://github.com/user-attachments/assets/7e2bd5a9-fc37-47bb-b3d8-821f74da93ba">


#### After
<img width="660" alt="image" src="https://github.com/user-attachments/assets/148f1cfa-0fe5-4220-8d4e-65394b103427">
