### PR TITLE
chore(meta): Hotfix "Fix panel not respecting designer container" into 4.51

### DIFF
--- a/libs/designer-ui/src/lib/panel/__test__/__snapshots__/panelcontainer.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/__test__/__snapshots__/panelcontainer.spec.tsx.snap
@@ -36,12 +36,14 @@ exports[`ui/workflowparameters/workflowparameter > should construct 2`] = `
   mountNode={
     {
       "className": "msla-panel-host-container",
+      "element": undefined,
     }
   }
   open={true}
   position="end"
   style={
     {
+      "position": "absolute",
       "width": "630px",
     }
   }

--- a/libs/designer-ui/src/lib/panel/__test__/panelcontainer.spec.tsx
+++ b/libs/designer-ui/src/lib/panel/__test__/panelcontainer.spec.tsx
@@ -41,6 +41,6 @@ describe('ui/workflowparameters/workflowparameter', () => {
     const panel = renderer.getRenderOutput();
 
     expect(panel.props.className).toBe('msla-panel-container');
-    expect(panel.props.style).toEqual({ width: minimal.overrideWidth });
+    expect(panel.props.style).toEqual({ position: 'absolute', width: minimal.overrideWidth });
   });
 });

--- a/libs/designer-ui/src/lib/panel/panelUtil.ts
+++ b/libs/designer-ui/src/lib/panel/panelUtil.ts
@@ -50,4 +50,5 @@ export interface CommonPanelProps {
   layerProps?: any;
   panelLocation: PanelLocation;
   isResizeable?: boolean;
+  mountNode?: HTMLElement;
 }

--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -59,6 +59,7 @@ export const PanelContainer = ({
   setOverrideWidth,
   overrideWidth,
   isResizeable,
+  mountNode,
 }: PanelContainerProps) => {
   const intl = useIntl();
 
@@ -181,10 +182,11 @@ export const PanelContainer = ({
       modalType="non-modal"
       mountNode={{
         className: 'msla-panel-host-container',
+        element: mountNode,
       }}
       open={true}
       position={isRight ? 'end' : 'start'}
-      style={{ width: drawerWidth }}
+      style={{ position: 'absolute', width: drawerWidth }}
     >
       {isEmptyPane || isCollapsed ? (
         <Button

--- a/libs/designer-ui/src/lib/styles.less
+++ b/libs/designer-ui/src/lib/styles.less
@@ -240,6 +240,8 @@
 }
 
 .msla-panel-mode {
+  position: relative;
+
   .msla-drop-zone-container {
     display: flex;
     justify-content: center;

--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -26,7 +26,7 @@ import type { CustomPanelLocation } from '@microsoft/designer-ui';
 import type { WorkflowNodeType } from '@microsoft/logic-apps-shared';
 import { useWindowDimensions, WORKFLOW_NODE_TYPES, useThrottledEffect } from '@microsoft/logic-apps-shared';
 import type { CSSProperties } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import KeyboardBackendFactory, { isKeyboardDragTrigger } from 'react-dnd-accessible-backend';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { DndProvider, createTransition, MouseTransition } from 'react-dnd-multi-backend';
@@ -85,6 +85,8 @@ export const Designer = (props: DesignerProps) => {
     },
     [dispatch]
   );
+
+  const designerContainerRef = useRef<HTMLDivElement>(null);
 
   const emptyWorkflowPlaceholderNodes = [
     {
@@ -177,7 +179,7 @@ export const Designer = (props: DesignerProps) => {
   return (
     <DndProvider options={DND_OPTIONS}>
       {preloadSearch ? <SearchPreloader /> : null}
-      <div className="msla-designer-canvas msla-panel-mode" style={copilotPadding}>
+      <div className="msla-designer-canvas msla-panel-mode" ref={designerContainerRef} style={copilotPadding}>
         <ReactFlowProvider>
           <ReactFlow
             nodeTypes={nodeTypes}
@@ -202,7 +204,12 @@ export const Designer = (props: DesignerProps) => {
               hideAttribution: true,
             }}
           >
-            <PanelRoot panelLocation={panelLocation} customPanelLocations={customPanelLocations} isResizeable={true} />
+            <PanelRoot
+              panelContainerRef={designerContainerRef}
+              panelLocation={panelLocation}
+              customPanelLocations={customPanelLocations}
+              isResizeable={true}
+            />
             {backgroundProps ? <Background {...backgroundProps} /> : null}
             <DeleteModal />
           </ReactFlow>

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -192,6 +192,7 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
   };
 
   const commonPanelProps: CommonPanelProps = {
+    ...props,
     isCollapsed: collapsed,
     toggleCollapse: dismissPanel,
     overrideWidth,

--- a/libs/designer/src/lib/ui/panel/panelRoot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelRoot.tsx
@@ -25,7 +25,8 @@ import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 
 export interface PanelRootProps {
-  panelLocation?: PanelLocation;
+  panelContainerRef: React.MutableRefObject<HTMLElement | null>;
+  panelLocation: PanelLocation;
   customPanelLocations?: CustomPanelLocation[];
   isResizeable?: boolean;
 }
@@ -36,13 +37,15 @@ const layerProps = {
 };
 
 export const PanelRoot = (props: PanelRootProps): JSX.Element => {
-  const { panelLocation = PanelLocation.Right, customPanelLocations, isResizeable } = props;
+  const { panelContainerRef, panelLocation, customPanelLocations, isResizeable } = props;
   const dispatch = useDispatch<AppDispatch>();
   const isDarkMode = useIsDarkMode();
 
   const collapsed = useIsPanelCollapsed();
   const currentPanelMode = useCurrentPanelMode();
   const focusReturnElementId = useFocusReturnElementId();
+
+  const panelContainerElement = panelContainerRef.current;
 
   const [width, setWidth] = useState<PanelSize | string>(PanelSize.Auto);
 
@@ -99,8 +102,9 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
       layerProps,
       panelLocation: customLocation ?? panelLocation ?? PanelLocation.Right,
       isResizeable,
+      mountNode: panelContainerElement || undefined,
     };
-  }, [customPanelLocations, collapsed, dismissPanel, width, panelLocation, isResizeable, currentPanelMode]);
+  }, [customPanelLocations, collapsed, dismissPanel, width, panelContainerElement, panelLocation, isResizeable, currentPanelMode]);
 
   const onRenderFooterContent = useMemo(
     () => (currentPanelMode === 'WorkflowParameters' ? () => <WorkflowParametersPanelFooter /> : undefined),


### PR DESCRIPTION
In Power Automate, we see the following issue after v4.51 due to panel changes:

![image](https://github.com/user-attachments/assets/55ba39df-5b62-497f-8838-2ebb7ec09e6d)
![image](https://github.com/user-attachments/assets/a227fca7-bc83-42a7-b00a-953fb8715bb7)

This is due to the panel being outside the designer hierarchy, thus `z-index` does not properly adjust for the panel. This bug was already fixed in `main` with #5259, so we would like to port that fix back to v4.51.