### PR TITLE
fix(Designer): OAuth tenant selection visibility logic fix

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/__test__/mocks/connectionParameters.ts
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/__test__/mocks/connectionParameters.ts
@@ -105,6 +105,9 @@ export const mockOauthWithTenantParameters: Record<string, ConnectionParameter> 
         IsFirstParty: 'True',
         AzureActiveDirectoryResourceId: 'https://management.core.windows.net/',
       },
+      customParameters: {
+        tenantId: {},
+      },
     },
   },
   'token:clientId': {

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -238,7 +238,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
   );
 
   const unfilteredParameters: Record<string, ConnectionParameterSetParameter | ConnectionParameter> = useMemo(
-    () => (isMultiAuth ? { ...multiAuthParams } : { ...singleAuthParams }) ?? {},
+    () => (isMultiAuth ? { ...multiAuthParams } : { ...singleAuthParams }),
     [isMultiAuth, multiAuthParams, singleAuthParams]
   );
 
@@ -302,7 +302,10 @@ export const CreateConnection = (props: CreateConnectionProps) => {
       isTenantServiceEnabled() &&
       usingAadConnection &&
       isUsingOAuth &&
-      Object.keys(connectionParameters ?? {}).some((key) => equals(key, SERVICE_PRINCIPLE_CONSTANTS.CONFIG_ITEM_KEYS.TOKEN_TENANT_ID)),
+      Object.keys(connectionParameters?.['token']?.oAuthSettings?.customParameters ?? {}).some((key: string) => equals(key, 'tenantId')) &&
+      Object.keys(connectionParameters ?? {}).some((key: string) =>
+        equals(key, SERVICE_PRINCIPLE_CONSTANTS.CONFIG_ITEM_KEYS.TOKEN_TENANT_ID)
+      ),
     [connectionParameters, isUsingOAuth, usingAadConnection]
   );
 

--- a/libs/logic-apps-shared/src/utils/src/lib/models/connector.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/connector.ts
@@ -131,7 +131,7 @@ export interface OAuthSetting {
   redirectMode?: string;
   redirectUrl: string;
   properties: OAuthSettingProperties;
-  customParameters: Record<string, any>;
+  customParameters?: Record<string, any>;
 }
 
 export interface ManagedIdentitySetting {

--- a/libs/logic-apps-shared/src/utils/src/lib/models/connector.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/connector.ts
@@ -127,9 +127,11 @@ export interface OAuthSettingProperties {
 export interface OAuthSetting {
   clientId: string;
   identityProvider: string;
-  redirectUrl: string;
   scopes: string[];
+  redirectMode?: string;
+  redirectUrl: string;
   properties: OAuthSettingProperties;
+  customParameters: Record<string, any>;
 }
 
 export interface ManagedIdentitySetting {


### PR DESCRIPTION
## Main Changes

- Removed oauth tenant selection for connectors that were not supposed to have it
- Now dependent on the `tenantId` custom parameter in the oAuthSettings

### Hidden
![image](https://github.com/user-attachments/assets/c825266c-7d75-4af8-a873-c8a725986135)

### Shown
![image](https://github.com/user-attachments/assets/125b4563-32cf-4ade-aa94-491615ddf52b)


Fixes https://github.com/Azure/LogicAppsUX/issues/5293