### PR TITLE
fix(designer): Ensure panel is closed when nodes are deselected

### DIFF
--- a/libs/designer/src/lib/core/state/panelV2/panelSlice.ts
+++ b/libs/designer/src/lib/core/state/panelV2/panelSlice.ts
@@ -110,8 +110,10 @@ export const panelSlice = createSlice({
       state.workflowParametersContent = getInitialWorkflowParametersContentState();
 
       if (clearPinnedState) {
+        state.isCollapsed = true;
         state.operationContent = getInitialOperationContentState();
       } else {
+        state.isCollapsed = !state.operationContent.pinnedNodeId;
         state.operationContent = {
           ...getInitialOperationContentState(),
           pinnedNodeId: state.operationContent.pinnedNodeId,
@@ -162,8 +164,6 @@ export const panelSlice = createSlice({
     },
     changePanelNode: (state, action: PayloadAction<string>) => {
       const selectedNodes = [action.payload];
-
-      clearPanel();
 
       state.isCollapsed = false;
       state.currentPanelMode = 'Operation';
@@ -230,8 +230,6 @@ export const panelSlice = createSlice({
     ) => {
       const { focusReturnElementId, nodeId, nodeIds, panelMode, referencePanelMode } = action.payload;
       const selectedNodes = nodeIds ? nodeIds : nodeId ? [nodeId] : [];
-
-      clearPanel();
 
       state.currentPanelMode = panelMode;
       state.isCollapsed = false;

--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -226,7 +226,7 @@ export const Designer = (props: DesignerProps) => {
             translateExtent={clampPan ? translateExtent : undefined}
             onMove={(_e, viewport) => setZoom(viewport.zoom)}
             minZoom={0.05}
-            onPaneClick={() => dispatch(clearPanel({}))}
+            onPaneClick={() => dispatch(clearPanel())}
             disableKeyboardA11y={true}
             onlyRenderVisibleElements={!userInferredTabNavigation}
             proOptions={{


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

When canvas is clicked (to deselect node), panel remains open. This is a regression caused by #5202.

## New Behavior

Panel now closes when node is deselected.

*Note: There is a remaining issue where the panel will not show as open if there is a pinned node & no selected node. Will fix this separately, to keep this PR scope small.*

## Impact of Change

No breaking changes.

## Screenshots or Videos (if applicable)

### Before

![close-panel-broken](https://github.com/user-attachments/assets/58a0de82-0ace-4cb8-b9be-98260879856f)

### After

![close-panel-fixed](https://github.com/user-attachments/assets/ed8d44c0-b905-4c6f-81a3-4f07c30c733c)