### PR TITLE
fix(designer): Fixed edge context menu positioning

### DIFF
--- a/libs/designer/src/lib/ui/common/EdgeContextualMenu/EdgeContextualMenu.tsx
+++ b/libs/designer/src/lib/ui/common/EdgeContextualMenu/EdgeContextualMenu.tsx
@@ -186,7 +186,7 @@ export const EdgeContextualMenu = () => {
 
   return (
     <>
-      <div ref={ref} style={{ position: 'absolute', top: location?.y, left: location?.x }} />
+      <div ref={ref} style={{ position: 'fixed', top: location?.y, left: location?.x }} />
       <Popover
         onOpenChange={(_, data) => setOpen(data.open)}
         trapFocus


### PR DESCRIPTION
## Main Changes

Fixed edge context menu positioning.
The position values being passed were relative to the viewport, so we need to use `fixed` to position relative to the viewport.

![image](https://github.com/user-attachments/assets/d3eaddab-0903-4960-82eb-74eeb99bc493)
