### PR TITLE
fix(designer): Un-revert panel changes & fix sizing to accommodate that change

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
@@ -239,7 +239,7 @@ const DesignerEditorConsumption = () => {
             }}
             runInstance={runInstanceData}
           >
-            <div style={{ height: 'inherit', width: 'inherit' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', height: 'inherit', width: 'inherit' }}>
               <DesignerCommandBar
                 id={workflowId}
                 saveWorkflow={saveWorkflowFromDesigner}

--- a/libs/designer-ui/src/lib/panel/__test__/__snapshots__/panelcontainer.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/__test__/__snapshots__/panelcontainer.spec.tsx.snap
@@ -8,12 +8,14 @@ exports[`ui/workflowparameters/workflowparameter > should construct 1`] = `
   mountNode={
     {
       "className": "msla-panel-host-container",
+      "element": undefined,
     }
   }
   open={true}
   position="end"
   style={
     {
+      "position": "absolute",
       "width": "630px",
     }
   }

--- a/libs/designer-ui/src/lib/panel/__test__/panelcontainer.spec.tsx
+++ b/libs/designer-ui/src/lib/panel/__test__/panelcontainer.spec.tsx
@@ -41,6 +41,6 @@ describe('ui/workflowparameters/workflowparameter', () => {
     const panel = renderer.getRenderOutput();
 
     expect(panel.props.className).toBe('msla-panel-container');
-    expect(panel.props.style).toEqual({ width: minimal.overrideWidth });
+    expect(panel.props.style).toEqual({ position: 'absolute', width: minimal.overrideWidth });
   });
 });

--- a/libs/designer-ui/src/lib/panel/panelUtil.ts
+++ b/libs/designer-ui/src/lib/panel/panelUtil.ts
@@ -50,4 +50,5 @@ export interface CommonPanelProps {
   layerProps?: any;
   panelLocation: PanelLocation;
   isResizeable?: boolean;
+  mountNode?: HTMLElement;
 }

--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -59,6 +59,7 @@ export const PanelContainer = ({
   setOverrideWidth,
   overrideWidth,
   isResizeable,
+  mountNode,
 }: PanelContainerProps) => {
   const intl = useIntl();
 
@@ -181,10 +182,11 @@ export const PanelContainer = ({
       modalType="non-modal"
       mountNode={{
         className: 'msla-panel-host-container',
+        element: mountNode,
       }}
       open={true}
       position={isRight ? 'end' : 'start'}
-      style={{ width: drawerWidth }}
+      style={{ position: 'absolute', width: drawerWidth }}
     >
       {isEmptyPane || isCollapsed ? (
         <Button

--- a/libs/designer-ui/src/lib/styles.less
+++ b/libs/designer-ui/src/lib/styles.less
@@ -81,7 +81,6 @@
 
 .msla-designer-canvas {
   display: inline-block;
-  min-height: 600px;
   margin: 0 auto;
   min-width: 100%;
   height: 100%;

--- a/libs/designer-ui/src/lib/styles.less
+++ b/libs/designer-ui/src/lib/styles.less
@@ -81,9 +81,10 @@
 
 .msla-designer-canvas {
   display: inline-block;
+  flex: 1;
   margin: 0 auto;
   min-width: 100%;
-  height: 100%;
+
   @media only screen and (max-width: calc(@card-max-width + 40)) {
     width: 100%;
     min-width: @card-min-width;

--- a/libs/designer-ui/src/lib/styles.less
+++ b/libs/designer-ui/src/lib/styles.less
@@ -163,6 +163,7 @@
 }
 
 .msla-panel-mode {
+  position: relative;
 
   .msla-drop-zone-viewmanager2 {
     display: flex;

--- a/libs/designer/src/lib/core/DesignerProvider.tsx
+++ b/libs/designer/src/lib/core/DesignerProvider.tsx
@@ -51,7 +51,11 @@ export const DesignerProvider = ({ id, locale = 'en', options, children }: Desig
         <ProviderWrappedContext.Provider value={options.services}>
           <ThemeProvider theme={azTheme}>
             <FluentProvider theme={webTheme}>
-              <div data-color-scheme={themeName} className={`msla-theme-${themeName}`} style={{ height: '100vh', overflow: 'hidden' }}>
+              <div
+                data-color-scheme={themeName}
+                className={`msla-theme-${themeName}`}
+                style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}
+              >
                 <IntlProvider
                   locale={locale}
                   defaultLocale={locale}

--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -26,7 +26,7 @@ import type { CustomPanelLocation } from '@microsoft/designer-ui';
 import type { WorkflowNodeType } from '@microsoft/logic-apps-shared';
 import { useWindowDimensions, WORKFLOW_NODE_TYPES, useThrottledEffect } from '@microsoft/logic-apps-shared';
 import type { CSSProperties } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import KeyboardBackendFactory, { isKeyboardDragTrigger } from 'react-dnd-accessible-backend';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { DndProvider, createTransition, MouseTransition } from 'react-dnd-multi-backend';
@@ -87,6 +87,8 @@ export const Designer = (props: DesignerProps) => {
     },
     [dispatch]
   );
+
+  const designerContainerRef = useRef<HTMLDivElement>(null);
 
   const emptyWorkflowPlaceholderNodes = [
     {
@@ -206,7 +208,7 @@ export const Designer = (props: DesignerProps) => {
   return (
     <DndProvider options={DND_OPTIONS}>
       {preloadSearch ? <SearchPreloader /> : null}
-      <div className="msla-designer-canvas msla-panel-mode" style={copilotPadding}>
+      <div className="msla-designer-canvas msla-panel-mode" ref={designerContainerRef} style={copilotPadding}>
         <ReactFlowProvider>
           <ReactFlow
             nodeTypes={nodeTypes}
@@ -232,7 +234,12 @@ export const Designer = (props: DesignerProps) => {
               hideAttribution: true,
             }}
           >
-            <PanelRoot panelLocation={panelLocation} customPanelLocations={customPanelLocations} isResizeable={true} />
+            <PanelRoot
+              panelContainerRef={designerContainerRef}
+              panelLocation={panelLocation}
+              customPanelLocations={customPanelLocations}
+              isResizeable={true}
+            />
             {backgroundProps ? <Background {...backgroundProps} /> : null}
             <DeleteModal />
             <DesignerContextualMenu />

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -194,6 +194,7 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
   };
 
   const commonPanelProps: CommonPanelProps = {
+    ...props,
     isCollapsed: collapsed,
     toggleCollapse: dismissPanel,
     overrideWidth,

--- a/libs/designer/src/lib/ui/panel/panelRoot.tsx
+++ b/libs/designer/src/lib/ui/panel/panelRoot.tsx
@@ -25,7 +25,8 @@ import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 
 export interface PanelRootProps {
-  panelLocation?: PanelLocation;
+  panelContainerRef: React.MutableRefObject<HTMLElement | null>;
+  panelLocation: PanelLocation;
   customPanelLocations?: CustomPanelLocation[];
   isResizeable?: boolean;
 }
@@ -36,13 +37,15 @@ const layerProps = {
 };
 
 export const PanelRoot = (props: PanelRootProps): JSX.Element => {
-  const { panelLocation = PanelLocation.Right, customPanelLocations, isResizeable } = props;
+  const { panelContainerRef, panelLocation, customPanelLocations, isResizeable } = props;
   const dispatch = useDispatch<AppDispatch>();
   const isDarkMode = useIsDarkMode();
 
   const collapsed = useIsPanelCollapsed();
   const currentPanelMode = useCurrentPanelMode();
   const focusReturnElementId = useFocusReturnElementId();
+
+  const panelContainerElement = panelContainerRef.current;
 
   const [width, setWidth] = useState<PanelSize | string>(PanelSize.Auto);
 
@@ -99,8 +102,9 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element => {
       layerProps,
       panelLocation: customLocation ?? panelLocation ?? PanelLocation.Right,
       isResizeable,
+      mountNode: panelContainerElement || undefined,
     };
-  }, [customPanelLocations, collapsed, dismissPanel, width, panelLocation, isResizeable, currentPanelMode]);
+  }, [customPanelLocations, collapsed, dismissPanel, width, panelContainerElement, panelLocation, isResizeable, currentPanelMode]);
 
   const onRenderFooterContent = useMemo(
     () => (currentPanelMode === 'WorkflowParameters' ? () => <WorkflowParametersPanelFooter /> : undefined),


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Reuse of `height: 100%` causes some issues w/ designer height and panel height. See also #5384.

## New Behavior

Containers are now properly aligned using flex sizing attributes to prevent reuse of `height: 100%`.

I've verified this change works in:

- Power Automate Portal (requires adding `display: flex` to `.fl-V3DesignerPage-innerContainer` in host code base)
- LAUX standalone w/ top command bar
- LAUX standalone w/ floating command bar

I am unable to test in Logic Apps Portal.

## Impact of Change

* [x] **This is a breaking change.**

## Screenshots or Videos (if applicable)

### Before

![image](https://github.com/user-attachments/assets/020ae73e-5411-409c-854c-c4bea3641bc7)

### After

![image](https://github.com/user-attachments/assets/7fd13fee-10f8-47cc-8938-bacff2b9ff3a)

![image](https://github.com/user-attachments/assets/3d1c5ed3-f2e7-49d3-b886-43f8e423d253)

![image](https://github.com/user-attachments/assets/0d9e7fc3-8116-4e32-a98f-84a89ba3629f)

![image](https://github.com/user-attachments/assets/cd0e5636-001f-4003-8406-f21f6c2ceec8)