### PR TITLE
meta(bugs): Add operating system dropdown for bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,6 +44,17 @@ body:
       required: true
 
   - type: dropdown
+    id: operatingSystem
+    attributes:
+      label: Which operating system are you using?
+      options:
+        - Windows
+        - MacOS
+        - Linux
+    validations:
+      required: true
+
+  - type: dropdown
     id: designerType
     attributes:
       label: Are you using new designer or old designer


### PR DESCRIPTION
This pull request includes a small but important change to the bug report issue template to improve the clarity and completeness of bug reports.


* Added a new dropdown field to capture the operating system being used by the reporter.