### PR TITLE
feat(vscode): Add C# Unit Test Project Creation for Logic Apps

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -89,8 +89,15 @@ const getWorkflowsPick = async (projectPath: string) => {
   return picks;
 };
 
-// Function to create an empty C# test project
-//TODO: Add Doc String
+/**
+ * Creates an empty C# test project within the specified project directory.
+ *
+ * @param {IAzureConnectorsContext} context - The context for Azure Connectors.
+ * @param {string} projectPath - The path to the project directory.
+ * @param {string} workflowName - The name of the workflow for which the test project is being created.
+ * @param {string} unitTestName - The name of the unit test to be created.
+ * @returns {Promise<void>} - A promise that resolves when the test project has been created.
+ */
 export async function createEmptyCSharpTestProject(
   context: IAzureConnectorsContext,
   projectPath: string,
@@ -119,14 +126,29 @@ export async function createEmptyCSharpTestProject(
     // Copy and modify .csproj file
     await createCsprojFile(testProjectPath, testProjectName, templateFolderName, csprojFileName);
 
-    //TODO: Localize Info Message
-    vscode.window.showInformationMessage(`Created C# test project: ${testProjectName} in ${testsDirectory}`);
+    vscode.window.showInformationMessage(
+      localize('info.createCSharpTestProject', 'Created C# test project: {0} in {1}', testProjectName, testsDirectory)
+    );
   } catch (error) {
-    //TODO: Localize Error
-    vscode.window.showErrorMessage(`Failed to create C# test project: ${error instanceof Error ? error.message : String(error)}`);
+    vscode.window.showErrorMessage(
+      localize(
+        'error.createCSharpTestProject',
+        'Failed to create C# test project: {0}',
+        error instanceof Error ? error.message : String(error)
+      )
+    );
   }
 
-  //TODO: Add doc string
+  /**
+   * Creates a .cs file in the specified test project path by using a template.
+   *
+   * @param {string} testProjectPath - The path to the test project directory.
+   * @param {string} unitTestName - The name of the unit test to be created.
+   * @param {string} workflowName - The name of the workflow for which the test project is being created.
+   * @param {string} templateFolderName - The folder name where the template is located.
+   * @param {string} csFileName - The name of the .cs file template.
+   * @returns {Promise<void>} - A promise that resolves when the .cs file has been created.
+   */
   async function createCsFile(
     testProjectPath: string,
     unitTestName: string,
@@ -144,7 +166,15 @@ export async function createEmptyCSharpTestProject(
     await fs.writeFile(csFilePath, csFileContent);
   }
 
-  ///Todo: Add doc String
+  /**
+   * Creates a .csproj file in the specified test project path by using a template.
+   *
+   * @param {string} testProjectPath - The path to the test project directory.
+   * @param {string} testProjectName - The name of the test project.
+   * @param {string} templateFolderName - The folder name where the template is located.
+   * @param {string} csprojFileName - The name of the .csproj file template.
+   * @returns {Promise<void>} - A promise that resolves when the .csproj file has been created.
+   */
   async function createCsprojFile(
     testProjectPath: string,
     testProjectName: string,

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -41,8 +41,22 @@ export async function createUnitTest(context: IAzureConnectorsContext, node: vsc
       validateInput: async (name: string): Promise<string | undefined> => await validateUnitTestName(projectPath, workflowName, name),
     });
 
-    const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName, null, runId);
-    await openDesignerObj?.createPanel();
+    //Ask user to choose between codeless and codeful scenarios
+    const scenarioChoice = await context.ui.showQuickPick(
+      [
+        { label: 'Codeless', description: 'Create unit test using designer' },
+        { label: 'Codeful', description: 'Create empty C# test project' },
+      ],
+      { placeHolder: 'Select unit test creation method' }
+    );
+
+    if (scenarioChoice.label === 'Codeless') {
+      const openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode, unitTestName, null, runId);
+      await openDesignerObj?.createPanel();
+    } else {
+      //Create empty C# test project
+      await createEmptyCSharpTestProject(context, projectPath, workflowName, unitTestName);
+    }
   } else {
     vscode.window.showInformationMessage(localize('expectedWorkspace', 'In order to create unit tests, you must have a workspace open.'));
   }
@@ -73,3 +87,17 @@ const getWorkflowsPick = async (projectPath: string) => {
   picks.sort((a, b) => a.label.localeCompare(b.label));
   return picks;
 };
+
+// Function to create an empty C# test project
+async function createEmptyCSharpTestProject(
+  context: IAzureConnectorsContext,
+  projectPath: string,
+  workflowName: string,
+  unitTestName: string
+): Promise<void> {
+  // TODO: Implement the creation of an empty C# test project
+  // This function should create the necessary files and folder structure for a C# test project
+  // You may want to use the 'fs' module to create files and folders
+
+  vscode.window.showInformationMessage(`Created empty C# test project for ${workflowName} with test name ${unitTestName}`);
+}

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFile
@@ -1,0 +1,77 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//------------------------------------------------------------
+
+using SampleUnitTestProject.Mocks;
+namespace <%= namespace %>
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Azure.Workflows.Common.Entities;
+    using Microsoft.Azure.Workflows.UnitTesting.Definitions;
+    using Microsoft.Azure.Workflows.UnitTesting.TestHost;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json.Linq;
+
+    [TestClass]
+    public class <%= unitTestName %>
+    {
+        private string WorkflowDefinition;
+        private Dictionary<string, OperationMock> Mocks;
+        private UnitTestEngine UnitTestExecutor;
+
+        public <%= unitTestName %>()
+        {
+            this.UnitTestExecutor = new UnitTestEngine();
+            this.WorkflowDefinition = File.ReadAllText(@"./<%= workflowName %>/workflow.json");
+            var mockData = JObject.Parse(File.ReadAllText(@"<%= workflowName %>Mocks.json"));
+            this.Mocks = mockData.ToObject<Dictionary<string, OperationMock>>();
+        }
+
+        [TestMethod]
+        public void ExecuteWorkflow_WithMockTrigger_ShouldSucceed()
+        {
+            // Arrange – define mocks either from a static source or as a lambda function
+            var triggerMock = new OperationMock("When_a_HTTP_request_is_received", FlowStatus.Succeeded, new JObject()
+            {
+                { "body", new JObject() { { "isReleased", true }, { "isEnabled", false }, { "isFlag", false } } }
+            });
+
+            // Act 
+            var unitTestFlowRun = this.UnitTestExecutor.ExecuteWorkflow(this.WorkflowDefinition, this.Mocks, triggerMock).Result;
+
+            // Assert
+            Assert.IsNotNull(unitTestFlowRun);
+            Assert.AreEqual(FlowStatus.Succeeded, unitTestFlowRun.Properties.Status);
+            Assert.AreEqual("myvalue", unitTestFlowRun.Properties.Actions["Get_Rows_Receipt"].Outputs.Value<string>());
+        }
+
+        [TestMethod]
+        public void ExecuteWorkflow_WithMockAction_ShouldSucceed_Dynamic()
+        {
+            // Arrange – define mocks either from a static source or as a lambda function
+            var triggerMock = this.Mocks["When_a_HTTP_request_is_received"];
+            this.Mocks["Get_Rows_Receipt"] = new OperationMock("Get_Rows_Receipt", FlowStatus.Succeeded, this.MockDynamicActionOutputCallback);
+
+            // Act 
+            var unitTestFlowRun = this.UnitTestExecutor.ExecuteWorkflow(this.WorkflowDefinition, this.Mocks, triggerMock).Result;
+
+            // Assert
+            Assert.IsNotNull(unitTestFlowRun);
+            Assert.AreEqual(FlowStatus.Succeeded, unitTestFlowRun.Properties.Status);
+            Assert.AreEqual("myvalue", unitTestFlowRun.Properties.Actions["Get_Rows_Receipt"].Outputs.Value<string>());
+        }
+
+        #region Mock generator helpers
+        public JToken MockDynamicActionOutputCallback(UnitTestExecutionContext context)
+        {
+            if (context.Trigger.Status == FlowStatus.Succeeded && context.Trigger.Outputs["body"]["isReleased"].ToString() == "true")
+            {
+                this.Mocks["Get_Rows_Receipt"].Outputs["body"]["value"][0]["ProductStatus"] = context.Trigger.Outputs["body"];
+            }
+            this.Mocks["Get_Rows_Receipt"].Outputs["body"]["value"]["trackingid"] = new MyDummyTestService().GetTrackingId();
+            return this.Mocks["Get_Rows_Receipt"].Outputs;
+        }
+        #endregion
+    }
+}

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestProjectFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestProjectFile
@@ -1,0 +1,53 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <TargetFramework>net6</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Library</OutputType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <!-- Please replace 'LogicAppFolder' with the name of your folder that contains your logic app project. -->
+    <LogicAppFolder>LogicApp</LogicAppFolder>
+    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    <SelfContained>false</SelfContained>
+ </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" />
+    <PackageReference Include="Microsoft.Azure.Workflows.Webjobs.Sdk" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+  </ItemGroup>
+
+<Target Name="Task" AfterTargets="Compile">
+    <ItemGroup>
+        <DirsToClean2 Include="..\$(LogicAppFolder)\lib\custom" />
+      </ItemGroup>
+      <RemoveDir Directories="@(DirsToClean2)" />
+ </Target>
+ 
+  <Target Name="CopyExtensionFiles" AfterTargets="ParameterizedFunctionJsonGeneratorNetCore">
+    <ItemGroup>
+        <CopyFiles Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\net8\**\*.*" CopyToOutputDirectory="PreserveNewest" Exclude="$(MSBuildProjectDirectory)\bin\$(Configuration)\net8\*.*" />
+      <CopyFiles2 Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\net8\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(CopyFiles)" DestinationFolder="..\$(LogicAppFolder)\lib\custom\%(RecursiveDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CopyFiles2)" DestinationFolder="..\$(LogicAppFolder)\lib\custom\net8\" SkipUnchangedFiles="true" />
+    <ItemGroup>
+        <MoveFiles Include="..\$(LogicAppFolder)\lib\custom\bin\*.*" />
+    </ItemGroup>
+
+   <Move SourceFiles="@(MoveFiles)" DestinationFolder="..\$(LogicAppFolder)\lib\custom\net8" />
+    <ItemGroup>
+       <DirsToClean Include="..\$(LogicAppFolder)\lib\custom\bin" />
+     </ItemGroup>
+       <RemoveDir Directories="@(DirsToClean)" />
+  </Target>
+ 
+  <ItemGroup>
+      <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="bin\$(Configuration)\net8\" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
[work Item Link](https://msazure.visualstudio.com/One/_workitems/edit/29074612)

## Requirement Checklist
* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes or features)
* [x] Docs have been added or updated (for bug fixes or features)

## Type of Change
* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior
Currently, the Logic Apps extension only supports creating unit tests using the designer panel (codeless scenario). There is no option to create a C# unit test project for developers who prefer a code-first approach.

## New Behavior
This PR adds the ability to create an empty C# unit test project when users choose the "codeful" scenario from both the "Show run" UI and the right click "create unit test" command from a workflow. The new feature:
1. Prompts the user to choose between "codeless" and "codeful" scenarios
2. For the "codeful" scenario, creates a new C# test project with:
   - A .csproj file
   - A test class file with sample unit tests
   - Necessary folder structure and configuration

## Impact of Change
This change enhances the existing functionality without breaking any current features. It provides more flexibility for developers working with Logic Apps.

## Screenshots or Videos (if applicable)

Changes Captured: 
- Right click workflow name or select "create unit test from run" to prompt the vs code window prompt:   
![image](https://github.com/user-attachments/assets/7a74c94f-2500-4d6d-b604-b27cbe5863c3)

- Enter unit test name
![image](https://github.com/user-attachments/assets/67513265-c56c-4dfd-925d-5bc04f564493)

- select project type: 
![image](https://github.com/user-attachments/assets/a53fd494-13e8-48fc-a123-95988c20507d)

If "codeless" is selected - designer panel is prompted: 
![image](https://github.com/user-attachments/assets/174a9028-b3ea-44e4-9fb2-ebdc5fcf1bbb)

if "codeful" is selected - creates new blank c# project with sample template 
![image](https://github.com/user-attachments/assets/8c521bf1-9bb0-4316-9c58-ce4f0ae2cc19)
## Implementation Details

### New Files
- `assets/TestProjectTemplate/TestClassFile.cs.template`: Template for the C# test class
- `assets/TestProjectTemplate/TestProjectFile.csproj.template`: Template for the C# project file

### Modified Files
- `apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts`: Updated to include the new "codeful" scenario

### Key Changes
1. Added a new function `createEmptyCSharpTestProject` to handle C# test project creation
2. Modified the `createUnitTest` function to prompt for scenario selection
3. Implemented template-based file creation for C# test projects

### Testing
- Manually tested the new "codeful" scenario workflow
- Manually tested the old code in regression scenarios to ensure codeless functionality still valid 

## Next Steps
- Consider adding support for planned [SDK & Packaging Updates](https://msazure.visualstudio.com/One/_workitems/edit/29086382)