### PR TITLE
fix: Adding PATCH method in IHttpClient

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/HttpClient.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/HttpClient.ts
@@ -73,6 +73,26 @@ export class HttpClient implements IHttpClient {
     }
   }
 
+  async patch<ReturnType, BodyType>(options: HttpRequestOptions<BodyType>): Promise<ReturnType> {
+    const response = await axios.patch(getRequestUrl(options), options.content, {
+      headers: {
+        ...this._extraHeaders,
+        ...options.headers,
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${environment.armToken}`,
+      },
+    });
+    if (!isSuccessResponse(response.status)) {
+      return Promise.reject(response);
+    }
+
+    try {
+      return response.data;
+    } catch {
+      return response as any;
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async delete<ReturnType>(options: HttpRequestOptions<unknown>): Promise<ReturnType> {
     const response = await axios.delete(getRequestUrl(options), {

--- a/apps/Standalone/src/designer/app/LocalDesigner/httpClient.ts
+++ b/apps/Standalone/src/designer/app/LocalDesigner/httpClient.ts
@@ -11,6 +11,9 @@ export class HttpClient implements IHttpClient {
   async put<ReturnType, BodyType>(_options: HttpRequestOptions<BodyType>): Promise<ReturnType> {
     return {} as any;
   }
+  async patch<ReturnType, BodyType>(_options: HttpRequestOptions<BodyType>): Promise<ReturnType> {
+    return {} as any;
+  }
   async delete<ReturnType>(_options: HttpRequestOptions<unknown>): Promise<ReturnType> {
     return {} as any;
   }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/httpClient.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/httpClient.ts
@@ -23,5 +23,6 @@ export interface IHttpClient {
   get<ReturnType>(options: HttpRequestOptions<unknown>): Promise<ReturnType>;
   post<ReturnType, BodyType>(options: HttpRequestOptions<BodyType>): Promise<ReturnType>;
   put<ReturnType, BodyType>(options: HttpRequestOptions<BodyType>): Promise<ReturnType>;
+  patch<ReturnType, BodyType>(options: HttpRequestOptions<BodyType>): Promise<ReturnType>;
   delete<ReturnType>(options: HttpRequestOptions<unknown>): Promise<ReturnType>;
 }

--- a/libs/vscode-extension/src/lib/services/httpClient.ts
+++ b/libs/vscode-extension/src/lib/services/httpClient.ts
@@ -104,6 +104,37 @@ export class HttpClient implements IHttpClient {
       return responseData.data as any;
     }
   }
+  async patch<ReturnType, BodyType>(options: HttpRequestOptions<BodyType>): Promise<ReturnType> {
+    const isArmId = isArmResourceId(options.uri);
+    const request = {
+      ...options,
+      url: this.getRequestUrl(options),
+      headers: {
+        ...this._extraHeaders,
+        ...options.headers,
+        Authorization: `${isArmId ? this._accessToken : ''} `,
+        'Content-Type': 'application/json',
+      },
+      data: options.content,
+      commandName: 'Designer.httpClient.patch',
+    };
+    const responseData = await axios({
+      ...request,
+      method: HTTP_METHODS.PATCH,
+    }).catch((error) => {
+      return { status: error.response.status, data: error.response.data };
+    });
+    if (!isSuccessResponse(responseData.status)) {
+      return Promise.reject(responseData);
+    }
+
+    try {
+      return JSON.parse(responseData.data);
+    } catch {
+      return responseData.data as any;
+    }
+  }
+
   async delete<ReturnType>(options: HttpRequestOptions<unknown>): Promise<ReturnType> {
     const request = {
       ...options,


### PR DESCRIPTION
## Requirement Checklist

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->
IHttpClient did not have PATCH method earlier. So with this PR it will have PATCH method which is required for hybrid logic apps specifically in the file system connection creation time.

## New Behavior
Adding the PATCH functionality in the HttpClient as this is being used by the fileSystem connection creation client. For hybrid logic apps this would be useful to create connection. 

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->
## Impact of Change
IHttpClient will not support API calls with PATCH method.

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
