### PR TITLE
test(designer): Add smoke test for expression editor including dynamic content

### DIFF
--- a/e2e/designer/TokenPicker.spec.ts
+++ b/e2e/designer/TokenPicker.spec.ts
@@ -35,7 +35,7 @@ test.describe(
       await page.getByLabel('Content').click();
       await page.locator('button').filter({ hasText: '' }).click();
       await page.getByRole('button', { name: 'length(collection) Returns' }).click();
-      await page.getByRole('tab', { name: 'Dynamic content Dynamic' }).click();
+      await page.getByText('Dynamic content').click();
       await expect(page.locator('.msla-expression-editor-container')).toBeVisible();
       await page.getByRole('button', { name: 'ArrayVariable', exact: true }).click();
       await expect(page.locator('.msla-expression-editor-container')).toContainText("length(variables('ArrayVariable'))");

--- a/e2e/designer/TokenPicker.spec.ts
+++ b/e2e/designer/TokenPicker.spec.ts
@@ -11,6 +11,7 @@ test.describe(
       await page.goto('/');
 
       await GoToMockWorkflow(page, 'Panel');
+
       await page.getByLabel('Parse JSON operation, Data').click();
       await page.getByLabel('Content').click();
       await page.locator('button').filter({ hasText: '' }).click();
@@ -24,6 +25,20 @@ test.describe(
       await page.getByPlaceholder('Search').click();
       await page.getByPlaceholder('Search').fill('OCSR');
       await expect(page.getByRole('button', { name: 'EILCO Admin Nominations-OCSA' })).toBeVisible();
+    });
+
+    test('Expression Editor works with dynamic content', async ({ page }) => {
+      await page.goto('/');
+
+      await GoToMockWorkflow(page, 'Panel');
+      await page.getByLabel('Parse JSON operation, Data').click();
+      await page.getByLabel('Content').click();
+      await page.locator('button').filter({ hasText: '' }).click();
+      await page.getByRole('button', { name: 'length(collection) Returns' }).click();
+      await page.getByRole('tab', { name: 'Dynamic content Dynamic' }).click();
+      await expect(page.locator('.msla-expression-editor-container')).toBeVisible();
+      await page.getByRole('button', { name: 'ArrayVariable', exact: true }).click();
+      await expect(page.locator('.msla-expression-editor-container')).toContainText("length(variables('ArrayVariable'))");
     });
   }
 );


### PR DESCRIPTION
This pull request includes enhancements to the `e2e/designer/TokenPicker.spec.ts` file, focusing on improving the test coverage for the Expression Editor and dynamic content handling.

Enhancements to test coverage:

* Added a new test case to verify that the Expression Editor works correctly with dynamic content. The test navigates to the mock workflow, interacts with the Parse JSON operation, and checks the visibility and content of the Expression Editor. (`e2e/designer/TokenPicker.spec.ts`)

* Included additional steps in the test setup to interact with the Parse JSON operation and the Content field, ensuring that the Expression Editor is properly triggered. (`e2e/designer/TokenPicker.spec.ts`)