### PR TITLE
feat(designer): Allow Copilot to reference dynamic input/data while creating expression

### DIFF
--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -24,7 +24,7 @@ import { SimpleQueryBuilder } from '../../querybuilder/SimpleQueryBuilder';
 import { ScheduleEditor } from '../../recurrence';
 import { SchemaEditor } from '../../schemaeditor';
 import { TableEditor } from '../../table';
-import type { TokenGroup } from '../../tokenpicker/models/token';
+import type { TokenGroup } from '@microsoft/logic-apps-shared';
 import { useId } from '../../useId';
 import type { SettingProps } from './';
 import { CustomTokenField, isCustomEditor } from './customTokenField';

--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -5,7 +5,7 @@ import { CLOSE_TOKENPICKER } from '../editor/base/plugins/CloseTokenPicker';
 import type { ExpressionEditorEvent } from '../expressioneditor';
 import { ExpressionEditor } from '../expressioneditor';
 import { PanelSize } from '../panel/panelUtil';
-import type { TokenGroup } from './models/token';
+import type { TokenGroup } from '@microsoft/logic-apps-shared';
 import TokenPickerHandler from './plugins/TokenPickerHandler';
 import UpdateTokenNode from './plugins/UpdateTokenNode';
 import { TokenPickerFooter } from './tokenpickerfooter';
@@ -32,7 +32,7 @@ export const TokenPickerMode = {
 } as const;
 export type TokenPickerMode = (typeof TokenPickerMode)[keyof typeof TokenPickerMode];
 
-export type { Token as OutputToken } from './models/token';
+export type { Token as OutputToken } from '@microsoft/logic-apps-shared';
 
 const directionalHint = DirectionalHint.leftTopEdge;
 const gapSpace = 10;
@@ -267,6 +267,7 @@ export function TokenPicker({
         ref={containerRef}
       >
         <Nl2fExpressionAssistant
+          tokenGroup={tokenGroup ?? []}
           isFullScreen={fullScreen}
           expression={expression}
           isFixErrorRequest={expressionEditorError !== ''}

--- a/libs/designer-ui/src/lib/tokenpicker/nl2fExpressionAssistant.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/nl2fExpressionAssistant.tsx
@@ -15,11 +15,12 @@ import {
 import type { ExpressionEditorEvent } from '../../lib/expressioneditor';
 import { TokenPickerMode } from '.';
 import useIntl from 'react-intl/src/components/useIntl';
-import type { Nl2fSuggestedExpression } from '@microsoft/logic-apps-shared';
+import type { Nl2fSuggestedExpression, TokenGroup } from '@microsoft/logic-apps-shared';
 import { CopilotService, LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
 import { ProgressCardWithStopButton } from '../../lib/chatbot';
 
 export interface INl2fExpressionAssistantProps {
+  tokenGroup?: TokenGroup[];
   isFullScreen: boolean;
   expression: ExpressionEditorEvent;
   isFixErrorRequest: boolean;
@@ -30,6 +31,7 @@ export interface INl2fExpressionAssistantProps {
 }
 
 export const Nl2fExpressionAssistant: FC<INl2fExpressionAssistantProps> = ({
+  tokenGroup,
   isFullScreen,
   expression,
   isFixErrorRequest,
@@ -209,7 +211,7 @@ export const Nl2fExpressionAssistant: FC<INl2fExpressionAssistantProps> = ({
       setIsGeneratingAnswer(true);
 
       try {
-        const response = await CopilotService().getNl2fExpressions(query, expression.value, signal);
+        const response = await CopilotService().getNl2fExpressions(query, expression.value, tokenGroup, signal);
         if (response.errorMessage) {
           setNl2fOutputError(response.errorMessage);
           setSuggestedExpressions(undefined);

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
@@ -5,7 +5,6 @@ import type { TokenNodeProps } from '../editor/base/nodes/tokenNode';
 import { INSERT_TOKEN_NODE } from '../editor/base/plugins/InsertTokenNode';
 import { SINGLE_VALUE_SEGMENT } from '../editor/base/plugins/SingleValueSegment';
 import type { ExpressionEditorEvent } from '../expressioneditor';
-import type { TokenGroup, Token as TokenGroupToken } from './models/token';
 import { UPDATE_TOKEN_NODE } from './plugins/UpdateTokenNode';
 import type { GetValueSegmentHandler } from './tokenpickersection/tokenpickeroption';
 import { getExpressionOutput, getExpressionTokenTitle } from './util';
@@ -20,7 +19,7 @@ import {
   guid,
   isCopilotServiceEnabled,
 } from '@microsoft/logic-apps-shared';
-import type { Expression } from '@microsoft/logic-apps-shared';
+import type { Expression, TokenGroup, Token as TokenGroupToken } from '@microsoft/logic-apps-shared';
 import type { LexicalEditor, NodeKey } from 'lexical';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -3,7 +3,7 @@ import { TokenPickerMode } from '../';
 import type { ValueSegment } from '../../editor';
 import { INSERT_TOKEN_NODE } from '../../editor/base/plugins/InsertTokenNode';
 import { SINGLE_VALUE_SEGMENT } from '../../editor/base/plugins/SingleValueSegment';
-import type { Token, TokenGroup } from '../models/token';
+import type { TokenGroup, Token } from '@microsoft/logic-apps-shared';
 import { getReducedTokenList, hasAdvanced } from './tokenpickerhelpers';
 import type { TokenPickerBaseProps } from './tokenpickersection';
 import { Icon, useTheme } from '@fluentui/react';

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickersection.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickersection.tsx
@@ -1,7 +1,7 @@
 import { getWindowDimensions, TokenPickerMode } from '..';
 import type { ValueSegment } from '../../editor';
 import type { ExpressionEditorEvent } from '../../expressioneditor';
-import type { TokenGroup } from '../models/token';
+import type { TokenGroup } from '@microsoft/logic-apps-shared';
 import { TokenPickerNoDynamicContent } from './tokenpickernodynamiccontent';
 import { TokenPickerNoMatches } from './tokenpickernomatches';
 import type { GetValueSegmentHandler } from './tokenpickeroption';

--- a/libs/designer-ui/src/lib/tokenpicker/util.ts
+++ b/libs/designer-ui/src/lib/tokenpicker/util.ts
@@ -1,5 +1,4 @@
-import type { Token } from './models/token';
-import type { Expression, ExpressionFunction, ExpressionLiteral } from '@microsoft/logic-apps-shared';
+import type { Expression, ExpressionFunction, ExpressionLiteral, Token } from '@microsoft/logic-apps-shared';
 import { ExpressionType, UnsupportedException } from '@microsoft/logic-apps-shared';
 
 export function getExpressionTokenTitle(expression: Expression): string {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/copilot.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/copilot.ts
@@ -1,4 +1,5 @@
 import { AssertionErrorCode, AssertionException } from '../../utils/src';
+import type { TokenGroup } from '../../utils/src';
 
 export interface Nl2fSuggestedExpression {
   suggestedExpression: string;
@@ -10,7 +11,12 @@ export interface Nl2fExpressionResult {
 }
 
 export interface ICopilotService {
-  getNl2fExpressions: (query: string, originalExpression?: string, signal?: AbortSignal) => Promise<Nl2fExpressionResult>;
+  getNl2fExpressions: (
+    query: string,
+    originalExpression?: string,
+    tokenGroup?: TokenGroup[],
+    signal?: AbortSignal
+  ) => Promise<Nl2fExpressionResult>;
 }
 
 let service: ICopilotService;

--- a/libs/logic-apps-shared/src/utils/src/lib/models/index.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/index.ts
@@ -15,6 +15,7 @@ export * from './dataMapSchema';
 export * from './helpers';
 export * from './uiInteractionData';
 export * from './topLevelDropdownMenuItem';
+export * from './token';
 
 import * as LogicApps from './logicApps';
 import * as LogicAppsV2 from './logicAppsV2';

--- a/libs/logic-apps-shared/src/utils/src/lib/models/token.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/token.ts
@@ -1,5 +1,15 @@
-import type { TokenType } from '../../editor';
-import type { OpenAPIV2 } from '@microsoft/logic-apps-shared';
+import type { OpenAPIV2 } from '../../';
+
+export const TokenType = {
+  FX: 'fx',
+  ITEM: 'item',
+  ITERATIONINDEX: 'iterationIndex',
+  OUTPUTS: 'outputs',
+  PARAMETER: 'parameter',
+  VARIABLE: 'variable',
+} as const;
+
+export type TokenType = (typeof TokenType)[keyof typeof TokenType];
 
 export interface Token {
   key: string;


### PR DESCRIPTION
## Requirement Checklist

* [X] The commit message follows our guidelines
* [X] Tests for the changes have been added (for bug fixes or features)
* [X] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [X] Feature
* [ ] Other

## Current Behavior

right now copilot is not given reference input data, making the ai expression builder not as great as a user experience as possible. 

## New Behavior

Allow Copilot to reference dynamic input/data while creating expression, allowing for a better user experience.
