### PR TITLE
fix(designer-ui): Prevent designer crashing when invalid regex is entered into combobox

### DIFF
--- a/libs/designer-ui/src/lib/combobox/helpers/__test__/isComboboxItemMatch.spec.ts
+++ b/libs/designer-ui/src/lib/combobox/helpers/__test__/isComboboxItemMatch.spec.ts
@@ -1,0 +1,24 @@
+import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
+import { ComboboxItem } from '../../..';
+import { isComboboxItemMatch } from '../isComboboxItemMatch';
+
+describe('lib/combobox/helpers/isComboboxItemMatch', () => {
+  test.each<[string, Partial<ComboboxItem>, boolean]>([
+    ['', { displayName: '' }, true],
+    ['', { displayName: 'My Special SharePoint Site' }, true],
+    ['My', { displayName: 'My Special SharePoint Site' }, true],
+    ['my', { displayName: 'My Special SharePoint Site' }, true],
+    ['my special', { displayName: 'My Special SharePoint Site' }, true],
+    [' ', { displayName: 'My Special SharePoint Site' }, true],
+    ['sharepoint', { displayName: 'My Special SharePoint Site' }, true],
+    ['SHAREPOINT', { displayName: 'My Special SharePoint Site' }, true],
+    ['MY SPECIAL SHAREPOINT SITE', { displayName: 'My Special SharePoint Site' }, true],
+    ['My Special Share\\Point Site', { displayName: 'My Special SharePoint Site' }, true],
+    ['foo', { displayName: 'My Special SharePoint Site' }, false],
+    ['bar', { displayName: 'My Special SharePoint Site' }, false],
+    ['sharePPoint', { displayName: 'My Special SharePoint Site' }, false],
+    ['mySpecial', { displayName: 'My Special SharePoint Site' }, false],
+  ])('indicates that "%s" filter matching against %o indicates %b', (searchValue, item, expected) => {
+    expect(isComboboxItemMatch(item as ComboboxItem, searchValue)).toBe(expected);
+  });
+});

--- a/libs/designer-ui/src/lib/combobox/helpers/__test__/isComboboxItemMatch.spec.ts
+++ b/libs/designer-ui/src/lib/combobox/helpers/__test__/isComboboxItemMatch.spec.ts
@@ -19,7 +19,7 @@ describe('lib/combobox/helpers/isComboboxItemMatch', () => {
     ['bar', { displayName: 'My Special SharePoint Site' }, false],
     ['sharePPoint', { displayName: 'My Special SharePoint Site' }, false],
     ['mySpecial', { displayName: 'My Special SharePoint Site' }, false],
-  ])('indicates that "%s" filter matching against %o indicates %b', (searchValue, item, expected) => {
+  ])('indicates that "%s" filter matching against %o indicates %s', (searchValue, item, expected) => {
     expect(isComboboxItemMatch(item as ComboboxItem, searchValue)).toBe(expected);
   });
 });

--- a/libs/designer-ui/src/lib/combobox/helpers/__test__/isComboboxItemMatch.spec.ts
+++ b/libs/designer-ui/src/lib/combobox/helpers/__test__/isComboboxItemMatch.spec.ts
@@ -15,10 +15,12 @@ describe('lib/combobox/helpers/isComboboxItemMatch', () => {
     ['MY SPECIAL SHAREPOINT SITE', { displayName: 'My Special SharePoint Site' }, true],
     ['My Special Share\\Point Site', { displayName: 'My Special SharePoint Site' }, true],
     ['My Special Share\\\\\\\\\\\\\\\\\\\\Point Site', { displayName: 'My Special SharePoint Site' }, true],
+    ['[', { displayName: 'My [] Site' }, true],
     ['foo', { displayName: 'My Special SharePoint Site' }, false],
     ['bar', { displayName: 'My Special SharePoint Site' }, false],
     ['sharePPoint', { displayName: 'My Special SharePoint Site' }, false],
     ['mySpecial', { displayName: 'My Special SharePoint Site' }, false],
+    ['[', { displayName: 'My Special SharePoint Site' }, false],
   ])('indicates that "%s" filter matching against %o indicates %s', (searchValue, item, expected) => {
     expect(isComboboxItemMatch(item as ComboboxItem, searchValue)).toBe(expected);
   });

--- a/libs/designer-ui/src/lib/combobox/helpers/__test__/isComboboxItemMatch.spec.ts
+++ b/libs/designer-ui/src/lib/combobox/helpers/__test__/isComboboxItemMatch.spec.ts
@@ -14,6 +14,7 @@ describe('lib/combobox/helpers/isComboboxItemMatch', () => {
     ['SHAREPOINT', { displayName: 'My Special SharePoint Site' }, true],
     ['MY SPECIAL SHAREPOINT SITE', { displayName: 'My Special SharePoint Site' }, true],
     ['My Special Share\\Point Site', { displayName: 'My Special SharePoint Site' }, true],
+    ['My Special Share\\\\\\\\\\\\\\\\\\\\Point Site', { displayName: 'My Special SharePoint Site' }, true],
     ['foo', { displayName: 'My Special SharePoint Site' }, false],
     ['bar', { displayName: 'My Special SharePoint Site' }, false],
     ['sharePPoint', { displayName: 'My Special SharePoint Site' }, false],

--- a/libs/designer-ui/src/lib/combobox/helpers/isComboboxItemMatch.ts
+++ b/libs/designer-ui/src/lib/combobox/helpers/isComboboxItemMatch.ts
@@ -1,0 +1,4 @@
+import type { ComboboxItem } from '..';
+
+export const isComboboxItemMatch = (item: ComboboxItem, searchValue: string) =>
+  new RegExp(searchValue.replace(/\\/g, '').toLowerCase()).test(item.displayName.toLowerCase());

--- a/libs/designer-ui/src/lib/combobox/helpers/isComboboxItemMatch.ts
+++ b/libs/designer-ui/src/lib/combobox/helpers/isComboboxItemMatch.ts
@@ -1,4 +1,4 @@
 import type { ComboboxItem } from '..';
 
 export const isComboboxItemMatch = (item: ComboboxItem, searchValue: string) =>
-  new RegExp(searchValue.replace(/\\/g, '').toLowerCase()).test(item.displayName.toLowerCase());
+  item.displayName.toLowerCase().includes(searchValue.replace(/\\/g, '').toLowerCase());

--- a/libs/designer-ui/src/lib/combobox/index.tsx
+++ b/libs/designer-ui/src/lib/combobox/index.tsx
@@ -13,6 +13,7 @@ import { isEmptySegments } from '../editor/base/utils/parsesegments';
 import { useRef, useState, useCallback, useMemo, useEffect } from 'react';
 import type { FormEvent } from 'react';
 import { useIntl } from 'react-intl';
+import { isComboboxItemMatch } from './helpers/isComboboxItemMatch';
 
 const ClearIcon = bundleIcon(Dismiss24Filled, Dismiss24Regular);
 
@@ -153,7 +154,7 @@ export const Combobox = ({
         ? [loadingOption]
         : errorDetails
           ? [errorOption]
-          : options.filter((option) => new RegExp(searchValue.replace(/\\/g, '').toLowerCase()).test(option.displayName.toLowerCase()));
+          : options.filter((option) => isComboboxItemMatch(option, searchValue));
 
       if (newOptions.length === 0) {
         const noValuesLabel = intl.formatMessage({


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

![image](https://github.com/user-attachments/assets/53bf2c70-f364-4f5c-89b5-0090db0e938b)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

If an invalid regular expression (can be as simple as `[` or something large and complex like in my GIFs) is entered into the search input for a combobox, the designer will crash.

## New Behavior

All input into combobox is permitted.

## Impact of Change

Not a breaking change.

## Screenshots or Videos (if applicable)

### Before

![image](https://github.com/user-attachments/assets/7c261d61-83a7-41ab-99a8-d4625c8037ad)

![paste-big-broken](https://github.com/user-attachments/assets/029b7026-1d60-4b5c-92b7-e214c6f51a4d)

### After

![paste-big-fixed](https://github.com/user-attachments/assets/494fdcf1-2006-41f3-a2d2-7205fd1b6d3b)