### PR TITLE
fix(designer): Cleaning up legacy dynamic values and tree calls to always return an array in case of api call successv

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/utils/helper.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/helper.ts
@@ -179,21 +179,7 @@ export const removeQuotes = (s: string): string => {
 };
 
 export const getDropdownOptionsFromOptions = (editorOptions: any): ComboboxItem[] => {
-  let dropdownOptions: ComboboxItem[] = editorOptions?.options?.value ?? editorOptions?.options ?? [];
-  // sometimes the options are nested in an object, this does a search to find the array of options
-  if (!Array.isArray(dropdownOptions)) {
-    const valuesArray = Object.values(dropdownOptions).find(Array.isArray);
-    if (valuesArray) {
-      dropdownOptions = valuesArray.map((option) => {
-        const { displayName, key, value } = option ?? {};
-        return {
-          key: key ?? option,
-          value: value ?? option,
-          displayName: displayName ?? option,
-        };
-      });
-    }
-  }
+  let dropdownOptions: ComboboxItem[] = editorOptions?.options ?? [];
 
   // handle cases where the displayName is not a string
   dropdownOptions = dropdownOptions.map((option) => {

--- a/libs/designer/src/lib/core/queries/__test__/connector.spec.ts
+++ b/libs/designer/src/lib/core/queries/__test__/connector.spec.ts
@@ -1,0 +1,117 @@
+import { getLegacyDynamicValues } from '../connector';
+import { ConnectorService, InitConnectorService, InitLoggerService } from '@microsoft/logic-apps-shared';
+import { expect, describe, test, beforeAll, vitest } from 'vitest';
+
+describe('ConnectorDynamicQueries', () => {
+  describe('getLegacyDynamicValues', () => {
+    const connectionId = '/connections/test';
+    const connectorId = '/connectionProviders/test';
+    const extension = {
+      operationId: 'test',
+      parameters: {},
+      'value-collection': '',
+      'value-path': 'value',
+      'value-title': 'title',
+      'value-selectable': 'selectable',
+    };
+
+    const loggerService: any = {
+      log() {},
+    };
+    const connectorService: any = {
+      getLegacyDynamicContent() {
+        return Promise.resolve({
+          items: collectionData,
+          nested: { values: collectionData },
+          empty: [],
+          object: { a: 'a' },
+          primitive: [1, 2, 3],
+          objectArray: { a: 'b', values: [{ value: 5, title: '5' }] },
+        });
+      },
+    };
+    const collectionData = [
+      { key: 'key1', value: 1, title: 'title1' },
+      { key: 'key2', value: 2, title: 'title2', selectable: false },
+    ];
+    const expectedValued = [
+      { value: 1, displayName: 'title1', disabled: false },
+      { value: 2, displayName: 'title2', disabled: true },
+    ];
+
+    beforeAll(() => {
+      InitLoggerService([loggerService]);
+      InitConnectorService(connectorService);
+    });
+
+    test('should return dynamic values correctly from collection specified path', async () => {
+      const collectionIsEmpty = { ...extension, 'value-collection': 'empty' };
+      let dynamicValues = await getLegacyDynamicValues(connectionId, connectorId, {}, collectionIsEmpty, 'object');
+      expect(dynamicValues).toBeDefined();
+      expect(dynamicValues.length).toEqual(0);
+      expect(dynamicValues).toEqual([]);
+
+      const collectionAtSingleLevel = { ...extension, 'value-collection': 'items' };
+      dynamicValues = await getLegacyDynamicValues(connectionId, connectorId, {}, collectionAtSingleLevel, 'object');
+      expect(dynamicValues).toBeDefined();
+      expect(dynamicValues.length).toEqual(2);
+      expect(dynamicValues).toEqual(expectedValued);
+
+      const collectionAtNestedLevel = { ...extension, 'value-collection': 'nested/values' };
+      dynamicValues = await getLegacyDynamicValues(connectionId, connectorId, {}, collectionAtNestedLevel, 'object');
+      expect(dynamicValues).toBeDefined();
+      expect(dynamicValues.length).toEqual(2);
+      expect(dynamicValues).toEqual(expectedValued);
+    });
+
+    test('should return dynamic values correctly when response is an array', async () => {
+      vitest.spyOn(ConnectorService(), 'getLegacyDynamicContent').mockResolvedValue(collectionData);
+
+      const dynamicValues = await getLegacyDynamicValues(connectionId, connectorId, {}, extension, 'object');
+      expect(dynamicValues).toBeDefined();
+      expect(dynamicValues.length).toEqual(2);
+      expect(dynamicValues).toEqual(expectedValued);
+    });
+
+    test('should return dynamic values correctly when array type is not an object', async () => {
+      const result = [
+        expect.objectContaining({ value: 1, displayName: '1' }),
+        expect.objectContaining({ value: 2, displayName: '2' }),
+        expect.objectContaining({ value: 3, displayName: '3' }),
+      ];
+
+      const collectionAtSingleLevel = { ...extension, 'value-collection': 'primitive' };
+      const dynamicValues = await getLegacyDynamicValues(connectionId, connectorId, {}, collectionAtSingleLevel, 'number');
+      expect(dynamicValues).toBeDefined();
+      expect(dynamicValues.length).toEqual(3);
+      expect(dynamicValues).toEqual(result);
+    });
+
+    test('should return an array from first available array from response or empty array when collection path cannot find array from response', async () => {
+      const collectionSpecifiedNotPresent = { ...extension, 'value-collection': 'absent' };
+      let dynamicValues = await getLegacyDynamicValues(connectionId, connectorId, {}, collectionSpecifiedNotPresent, 'object');
+      expect(dynamicValues).toBeDefined();
+      expect(dynamicValues.length).toEqual(2);
+      expect(dynamicValues).toEqual(expectedValued);
+
+      const collectionSpecifiedIsObject = { ...extension, 'value-collection': 'object' };
+      dynamicValues = await getLegacyDynamicValues(connectionId, connectorId, {}, collectionSpecifiedIsObject, 'object');
+      expect(dynamicValues).toBeDefined();
+      console.log(dynamicValues);
+      expect(dynamicValues.length).toEqual(0);
+      expect(dynamicValues).toEqual([]);
+
+      const collectionSpecifiedAsObjectAndPresentInTwoLevels = { ...extension, 'value-collection': 'objectArray' };
+      dynamicValues = await getLegacyDynamicValues(
+        connectionId,
+        connectorId,
+        {},
+        collectionSpecifiedAsObjectAndPresentInTwoLevels,
+        'object'
+      );
+      expect(dynamicValues).toBeDefined();
+      expect(dynamicValues.length).toEqual(1);
+      expect(dynamicValues).toEqual([{ value: 5, displayName: '5', disabled: false }]);
+    });
+  });
+});

--- a/libs/designer/src/lib/core/queries/connector.ts
+++ b/libs/designer/src/lib/core/queries/connector.ts
@@ -16,6 +16,8 @@ import {
   getJSONValue,
   getObjectPropertyValue,
   isNullOrUndefined,
+  LoggerService,
+  LogEntryLevel,
 } from '@microsoft/logic-apps-shared';
 
 export const getLegacyDynamicValues = async (
@@ -40,21 +42,46 @@ export const getLegacyDynamicValues = async (
     () => service.getLegacyDynamicContent(connectionId, connectorId, parameters, managedIdentityProperties)
   );
 
-  const values = getObjectPropertyValue(response, extension['value-collection'] ? extension['value-collection'].split('/') : []);
-  if (values && Array.isArray(values)) {
-    return values.map((property: any) => {
-      let value: any;
-      let displayName: any;
-      let isSelectable = true;
+  const values = Array.isArray(response)
+    ? response
+    : getObjectPropertyValue(response, extension['value-collection'] ? extension['value-collection'].split('/') : []);
+  let collectionData = values;
+  if (!values || !Array.isArray(values)) {
+    LoggerService().log({
+      level: LogEntryLevel.Warning,
+      area: 'getLegacyDynamicValues',
+      message: 'Values returned from Legacy dynamic call is not an array',
+      args: [
+        `connectorId: ${connectorId}`,
+        `operationId: ${extension.operationId}`,
+        `arrayType: ${parameterArrayType}`,
+        `collectionPath: ${extension['value-collection']}`,
+        response,
+      ],
+    });
 
-      if (parameterArrayType && parameterArrayType !== Types.Object) {
-        displayName = value = getJSONValue(property);
-      } else {
-        value = getObjectPropertyValue(property, extension['value-path'].split('/'));
-        displayName = extension['value-title'] ? getObjectPropertyValue(property, extension['value-title'].split('/')) : value;
-      }
+    if (isNullOrUndefined(response)) {
+      return [];
+    }
 
-      const description = extension['value-description']
+    const possibleCollectionData = values ?? response;
+    collectionData = typeof possibleCollectionData === Types.Object ? getFirstArrayProperty(possibleCollectionData) : [];
+  }
+
+  return collectionData.map((property: any) => {
+    let value: any;
+    let displayName: any;
+    let isSelectable = true;
+    let description: string | undefined;
+
+    if (parameterArrayType && parameterArrayType !== Types.Object) {
+      value = parameterArrayType === Types.String ? property.toString() : getJSONValue(property);
+      displayName = value.toString();
+    } else {
+      value = getObjectPropertyValue(property, extension['value-path'] ? extension['value-path'].split('/') : []);
+      displayName = (extension['value-title'] ? getObjectPropertyValue(property, extension['value-title'].split('/')) : value)?.toString();
+
+      description = extension['value-description']
         ? getObjectPropertyValue(property, extension['value-description'].split('/'))
         : undefined;
 
@@ -64,12 +91,10 @@ export const getLegacyDynamicValues = async (
           isSelectable = selectableValue;
         }
       }
+    }
 
-      return { value, displayName, description, disabled: !isSelectable };
-    });
-  }
-
-  return response;
+    return { value, displayName, description, disabled: !isSelectable };
+  });
 };
 
 export const getListDynamicValues = async (
@@ -171,20 +196,33 @@ export const getLegacyDynamicTreeItems = async (
   );
 
   const { collectionPath, titlePath, folderPropertyPath, mediaPropertyPath } = pickerInfo;
-  const values = collectionPath ? getPropertyValue(response, collectionPath) : response;
+  const values = Array.isArray(response) ? response : collectionPath ? getPropertyValue(response, collectionPath) : response;
+  let collectionData = values;
 
-  if (values && Array.isArray(values)) {
-    return values.map((value: any) => {
-      return {
-        value,
-        displayName: getPropertyValue(value, titlePath as string),
-        isParent: !!getPropertyValue(value, folderPropertyPath as string),
-        mediaType: mediaPropertyPath ? getPropertyValue(value, mediaPropertyPath) : undefined,
-      };
+  if (!values || !Array.isArray(values)) {
+    LoggerService().log({
+      level: LogEntryLevel.Warning,
+      area: 'getLegacyDynamicTreeItems',
+      message: 'Tree items returned from Legacy dynamic call is not an array',
+      args: [`connectorId: ${connectorId}`, `operationId: ${operationId}`, `collectionPath: ${collectionPath}`, response],
     });
+
+    if (isNullOrUndefined(response)) {
+      return [];
+    }
+
+    const possibleCollectionData = values ?? response;
+    collectionData = typeof possibleCollectionData === Types.Object ? getFirstArrayProperty(possibleCollectionData) : [];
   }
 
-  return response;
+  return collectionData.map((value: any) => {
+    return {
+      value,
+      displayName: (getPropertyValue(value, titlePath as string) ?? '').toString(),
+      isParent: !!getPropertyValue(value, folderPropertyPath as string),
+      mediaType: mediaPropertyPath ? getPropertyValue(value, mediaPropertyPath) : undefined,
+    };
+  });
 };
 
 export const getDynamicTreeItems = async (
@@ -218,4 +256,14 @@ const getParametersKey = (parameters: Record<string, any>): string => {
     (result: string, parameterKey: string) => `${result}, ${parameterKey}-${JSON.stringify(parameters[parameterKey])}`,
     ''
   );
+};
+
+const getFirstArrayProperty = (value: any): any[] => {
+  for (const key of Object.keys(value)) {
+    if (Array.isArray(value[key])) {
+      return value[key];
+    }
+  }
+
+  return [];
 };

--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
@@ -1986,8 +1986,26 @@ describe('core/utils/parameters/helper', () => {
         };
         const inputParameter: InputParameter = {
           default: true,
-          editor: undefined,
-          editorOptions: undefined,
+          editor: 'combobox',
+          editorOptions: {
+            options: [
+              {
+                displayName: '',
+                key: '',
+                value: '',
+              },
+              {
+                displayName: 'Yes',
+                key: 'Yes',
+                value: 'true',
+              },
+              {
+                displayName: 'No',
+                key: 'No',
+                value: 'false',
+              },
+            ],
+          },
           enum: [
             { displayName: '', value: '' },
             { displayName: 'Yes', value: true },
@@ -2367,8 +2385,8 @@ describe('core/utils/parameters/helper', () => {
         };
         const inputParameter: InputParameter = {
           dynamicValues: undefined,
-          editor: undefined,
-          editorOptions: undefined,
+          editor: 'combobox',
+          editorOptions: { options },
           enum: options,
           in: 'body',
           key: 'body.$.linkType',
@@ -2388,10 +2406,7 @@ describe('core/utils/parameters/helper', () => {
           editor: 'combobox',
           editorOptions: { options },
           editorViewModel: undefined,
-          schema: {
-            ...inputSchema,
-            'x-ms-editor': 'combobox',
-          },
+          schema: inputSchema,
         });
       });
 
@@ -2411,8 +2426,8 @@ describe('core/utils/parameters/helper', () => {
         };
         const inputParameter: InputParameter = {
           dynamicValues: undefined,
-          editor: undefined,
-          editorOptions: undefined,
+          editor: 'combobox',
+          editorOptions: { options },
           key: '', // Not defined in OpenAPI.
           name: '', // Not defined in OpenAPI.
           schema: inputSchema,
@@ -2428,10 +2443,7 @@ describe('core/utils/parameters/helper', () => {
           editor: 'combobox',
           editorOptions: { options },
           editorViewModel: undefined,
-          schema: {
-            ...inputSchema,
-            'x-ms-editor': 'combobox',
-          },
+          schema: inputSchema,
         });
       });
     });
@@ -2525,7 +2537,7 @@ describe('core/utils/parameters/helper', () => {
       [`body('A1')`, 'body.$', 'A1', `body('A1')`],
       [`body('A1')`, 'body.$.body.B1', 'A1', `body('A1')['body']['B1']`],
     ])('correctly gets the token expression for nested body property for "%s"', (method, key, actionName, expected) => {
-      expect(generateExpressionFromKey(method, key, actionName, /* isInsideArray */false, /* required */true)).toBe(expected);
+      expect(generateExpressionFromKey(method, key, actionName, /* isInsideArray */ false, /* required */ true)).toBe(expected);
     });
   });
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -72,7 +72,6 @@ import {
   isLegacyDynamicValuesExtension,
   ParameterLocations,
   ExpressionType,
-  ExtensionProperties,
   createEx,
   convertToStringLiteral,
   decodePropertySegment,
@@ -121,7 +120,6 @@ import {
 } from '@microsoft/logic-apps-shared';
 import type {
   AuthProps,
-  ComboboxItem,
   DictionaryEditorItemProps,
   DropdownItem,
   FloatingActionMenuOutputViewModel,
@@ -400,7 +398,7 @@ export function getParameterEditorProps(
   _shouldIgnoreDefaultValue: boolean,
   nodeMetadata?: Record<string, any>
 ): ParameterEditorProps {
-  const { dynamicValues, type, itemSchema, visibility, value, enum: schemaEnum, format } = parameter;
+  const { dynamicValues, type, itemSchema, visibility, value, format } = parameter;
   let { editor, editorOptions, schema } = parameter;
   let editorViewModel: any;
   if (editor === constants.EDITOR.DICTIONARY) {
@@ -476,38 +474,6 @@ export function getParameterEditorProps(
       editor = constants.EDITOR.ARRAY;
       editorViewModel = { ...toArrayViewModelSchema(itemSchema), uncastedValue: parameterValue };
       schema = { ...schema, ...{ 'x-ms-editor': editor } };
-    } else if (
-      (schemaEnum || schema?.enum || (schemaEnum && schema?.[ExtensionProperties.CustomEnum])) &&
-      !equals(visibility, Visibility.Internal)
-    ) {
-      editor = constants.EDITOR.COMBOBOX;
-      schema = { ...schema, ...{ 'x-ms-editor': editor } };
-
-      let schemaEnumOptions: ComboboxItem[];
-      if (schema[ExtensionProperties.CustomEnum]) {
-        schemaEnumOptions = schema[ExtensionProperties.CustomEnum];
-      } else if (schemaEnum) {
-        schemaEnumOptions = schemaEnum.map((enumItem) => {
-          return {
-            ...enumItem,
-            value: enumItem.value?.toString(),
-            key: enumItem.displayName,
-          };
-        });
-      } else {
-        schemaEnumOptions = schema.enum.map(
-          (val: string): ComboboxItem => ({
-            displayName: val,
-            key: val,
-            value: val,
-          })
-        );
-      }
-
-      editorOptions = {
-        ...editorOptions,
-        options: schemaEnumOptions,
-      };
     } else {
       editorOptions = undefined;
     }

--- a/libs/logic-apps-shared/src/parsers/lib/common/__test__/schemaprocessor.spec.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/common/__test__/schemaprocessor.spec.ts
@@ -21,6 +21,69 @@ describe('SchemaProcessor Tests', () => {
     });
   }
 
+  it('should return correct editor and editor options for static enums', () => {
+    const schema = {
+      type: 'number',
+      enum: [1, 2],
+    };
+
+    const parameters = new SchemaProcessor().getSchemaProperties(schema);
+
+    expect(parameters.length).toBe(1);
+
+    const root = parameters[0];
+    expect(root.key).toBe('$');
+    expect(root.enum).toEqual([
+      { value: 1, displayName: '1' },
+      { value: 2, displayName: '2' },
+    ]);
+    expect(root.editor).toBe('combobox');
+    expect(root.editorOptions).toBeDefined();
+    expect(root.editorOptions?.options).toEqual([
+      { key: '1', displayName: '1', value: 1 },
+      { key: '2', displayName: '2', value: 2 },
+    ]);
+  });
+
+  it('should return correct editor and editor options for dynamic values', () => {
+    const schema = {
+      type: 'number',
+      'x-ms-dynamic-values': {},
+    };
+
+    const parameters = new SchemaProcessor().getSchemaProperties(schema);
+
+    expect(parameters.length).toBe(1);
+
+    const root = parameters[0];
+    expect(root.key).toBe('$');
+    expect(root.editor).toBe('combobox');
+    expect(root.editorOptions).toBeDefined();
+    expect(root.editorOptions?.options).toEqual([]);
+  });
+
+  it('should return correct editor and editor options for when both enum and dynamic values are specfied', () => {
+    const schema = {
+      type: 'number',
+      enum: [1, 2],
+      'x-ms-dynamic-values': {},
+    };
+
+    const parameters = new SchemaProcessor().getSchemaProperties(schema);
+
+    expect(parameters.length).toBe(1);
+
+    const root = parameters[0];
+    expect(root.key).toBe('$');
+    expect(root.enum).toEqual([
+      { value: 1, displayName: '1' },
+      { value: 2, displayName: '2' },
+    ]);
+    expect(root.editor).toBe('combobox');
+    expect(root.editorOptions).toBeDefined();
+    expect(root.editorOptions?.options).toEqual([]);
+  });
+
   it('should expand oneof properties properly.', () => {
     const schema = {
       oneOf: [

--- a/libs/logic-apps-shared/src/parsers/lib/common/helpers/utils.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/common/helpers/utils.ts
@@ -191,17 +191,49 @@ export function getArrayOutputMetadata(schema: SchemaObject, required: boolean, 
   return {};
 }
 
-export function getEditorForParameter(parameter: SchemaObject, dynamicValues: ParameterDynamicValues | undefined): string | undefined {
-  if (!dynamicValues) {
+export function getEditorForParameter(
+  parameter: SchemaObject,
+  dynamicValues: ParameterDynamicValues | undefined,
+  $enum: EnumObject[] | undefined
+): string | undefined {
+  // If the parameter is in an array, break out so we render the array editor
+  if (parameter?.type === Constants.Types.Array) {
     return parameter[Constants.ExtensionProperties.Editor];
   }
-  if (parameter?.type === Constants.Types.Array) {
-    return parameter[Constants.ExtensionProperties.Editor]; // If the parameter is in an array, break out so we render the array editor
+
+  if (!dynamicValues && !$enum) {
+    return parameter[Constants.ExtensionProperties.Editor];
   }
-  if (isLegacyDynamicValuesTreeExtension(dynamicValues) || isDynamicTreeExtension(dynamicValues)) {
-    return 'filepicker';
+
+  // Dynamic Values
+  if (dynamicValues) {
+    if (isLegacyDynamicValuesTreeExtension(dynamicValues) || isDynamicTreeExtension(dynamicValues)) {
+      return 'filepicker';
+    }
+    return 'combobox';
   }
+
+  // Static Enum
   return 'combobox';
+}
+
+export function getEditorOptionsForParameter(
+  parameter: SchemaObject,
+  dynamicValues: ParameterDynamicValues | undefined,
+  $enum: EnumObject[] | undefined
+): any {
+  const editorOptions = parameter[Constants.ExtensionProperties.EditorOptions];
+  if (!dynamicValues && !$enum) {
+    return editorOptions;
+  }
+
+  // Dynamic Values
+  if (dynamicValues) {
+    return { options: [] };
+  }
+
+  // Static Enum
+  return { ...editorOptions, options: $enum?.map((value) => ({ ...value, key: value.displayName })) };
 }
 
 type MakeDefinitionReducer = (previous: Record<string, any>, current: string) => Record<string, any>;

--- a/libs/logic-apps-shared/src/parsers/lib/common/schemaprocessor.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/common/schemaprocessor.ts
@@ -6,6 +6,7 @@ import * as ParameterKeyUtility from './helpers/keysutility';
 import {
   dereferenceRefSchema,
   getEditorForParameter,
+  getEditorOptionsForParameter,
   getEnum,
   getKnownTitles,
   getKnownTitlesFromKey,
@@ -326,14 +327,16 @@ export class SchemaProcessor {
       const dynamicValues = getParameterDynamicValues(schema);
       const key = keyPrefix || this.options.keyPrefix || '$';
       const description = schema.description;
+      const $enum = getEnum(schema, this.options.required);
       schemaProperties.push({
         alias: this.options.useAliasedIndexing ? schema[SwaggerConstants.ExtensionProperties.Alias] : undefined,
         default: schema.default,
         description,
         dynamicValues,
         dynamicSchema: getParameterDynamicSchema(schema),
-        editor: getEditorForParameter(schema, dynamicValues),
-        editorOptions: dynamicValues ? { options: [] } : schema[SwaggerConstants.ExtensionProperties.EditorOptions],
+        enum: $enum,
+        editor: getEditorForParameter(schema, dynamicValues, $enum),
+        editorOptions: getEditorOptionsForParameter(schema, dynamicValues, $enum),
         format: schema.format,
         isInsideArray: this.options.parentProperty && this.options.parentProperty.isArray,
         isNested: this.options.isNested,
@@ -484,10 +487,10 @@ export class SchemaProcessor {
     const dynamicallyAdded = schema[SwaggerConstants.ExtensionProperties.DynamicallyAdded];
     const dynamicSchema = getParameterDynamicSchema(schema);
     const dynamicValues = getParameterDynamicValues(schema);
-    const editor = getEditorForParameter(schema, dynamicValues);
-    const editorOptions = dynamicValues ? { options: [] } : schema[SwaggerConstants.ExtensionProperties.EditorOptions];
-    const encode = schema[SwaggerConstants.ExtensionProperties.Encode];
     const $enum = getEnum(schema, $required);
+    const editor = getEditorForParameter(schema, dynamicValues, $enum);
+    const editorOptions = getEditorOptionsForParameter(schema, dynamicValues, $enum);
+    const encode = schema[SwaggerConstants.ExtensionProperties.Encode];
     const format = schema.format;
     const itemSchema = this._dereferenceRefSchema(schema.items as OpenApiSchema);
     const isInsideArray = parentProperty && parentProperty.isArray;


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Change
For some connectors which did not correctly have the dynamic values returned the changes were made in editor code, moved it to dynamic call code to always return an array.
Also moved stamping of editor and editor options in schema processor for static enums because it made more sense there since enum was already available.
Removed the code which tried to pick some array in editor code.
