### PR TITLE
feat(vscode): Added C# dev kit as a Dependency to Logic Apps

### DIFF
--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -1022,7 +1022,8 @@
     "ms-azuretools.vscode-azurefunctions",
     "azurite.azurite",
     "ms-azuretools.vscode-azureresourcegroups",
-    "ms-dotnettools.csharp"
+    "ms-dotnettools.csharp", 
+     "ms-dotnettools.csdevkit"
   ],
   "activationEvents": [
     "onCommand:azureLogicAppsStandard.openDesigner",


### PR DESCRIPTION
## Requirement Checklist

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->
The current Logic Apps extension does not include the C# Dev Kit as a dependency, meaning users have to manually install the C# development tools and xUnit testing framework support.
[Work Item Link](https://msazure.visualstudio.com/One/_workitems/edit/29074630)

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->
With this change, the C# Dev Kit will be automatically installed alongside the Logic Apps extension. The C# Dev Kit supports the xUnit testing framework, which will be leveraged in the frontend for implementing the unit test codeful approach. This ensures that users have the necessary tools for C# development and xUnit testing without any additional manual installation steps.

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->
* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
N/A
