### PR TITLE
fix(designer): Encode and Decode tokens with html tags

### DIFF
--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/HTMLChangePlugin.tsx
@@ -78,7 +78,7 @@ export const convertEditorState = (
           }
           if (attribute.name === 'id' && !isValuePlaintext) {
             // If we're in the rich HTML editor, encoding occurs at the element level since they are all wrapped in <span>.
-            const idValue = element.getAttribute('id') ?? ''; // e.g., "@{concat('&lt;', '"')}"
+            const idValue = decodeURIComponent(element.getAttribute('id') ?? ''); // e.g., "@{concat('&lt;', '"')}"
             idValues.push(idValue);
             const encodedIdValue = encodeSegmentValueInLexicalContext(idValue); // e.g., "@{concat('%26lt;', '%22')}"
             element.setAttribute('id', encodedIdValue);
@@ -122,7 +122,7 @@ export const convertEditorState = (
 export const canReplaceSpanWithId = (idValue: string, nodeMap: Map<string, ValueSegment>): boolean => {
   const processedId = removeAllNewlines(idValue);
   for (const [key, value] of nodeMap) {
-    const processedKey = removeAllNewlines(key);
+    const processedKey = encodeSegmentValueInLexicalContext(removeAllNewlines(key));
     if (processedId === processedKey && value !== undefined) {
       return true;
     }

--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
@@ -126,8 +126,8 @@ export const getDomFromHtmlEditorString = (htmlEditorString: string, nodeMap: Ma
   // Comments at the start of a DOM are lost when parsing HTML strings, so we wrap the HTML string in a <div>.
   const wrappedHtmlEditorString = `<div>${htmlEditorString}</div>`;
 
-  const purifiedHtmlEditorString = DomPurify.sanitize(wrappedHtmlEditorString, { ADD_TAGS: ['#comment'] });
-  const encodedHtmlEditorString = encodeStringSegmentTokensInDomContext(purifiedHtmlEditorString, nodeMap);
+  const purifiedHtmlEditorString = DomPurify.sanitize(encodeURIComponent(wrappedHtmlEditorString), { ADD_TAGS: ['#comment'] });
+  const encodedHtmlEditorString = encodeStringSegmentTokensInDomContext(decodeURIComponent(purifiedHtmlEditorString), nodeMap);
 
   const tempElement = document.createElement('div', {});
   tempElement.innerHTML = encodedHtmlEditorString;


### PR DESCRIPTION
This pull request focuses on improving the handling of encoded and decoded values in the HTML editor plugin. The main changes involve ensuring that values are properly encoded and decoded at the correct stages of processing.


* Modified `convertEditorState` to decode the `id` attribute value before processing and re-encode it afterward.
* Updated `canReplaceSpanWithId` to encode the key value before comparison.
* Adjusted `getDomFromHtmlEditorString` to encode the wrapped HTML string before sanitization and decode it afterward.



https://github.com/user-attachments/assets/650e4490-4405-42bc-9e57-5f27ccfdad83



Fixes #5487 

### Reason of changes 
- When getting the `element.getAttribute('id')` the class wasn't getting decoded therefore token didn't match the id of the tag element. Was getting `"@{join(variables('numbertest'), '%3Cbr/%3E')}"` instead of `"@{join(variables('numbertest'), '<br/>')}" `
