### PR TITLE
fix(designer): Set aside collapsed slice action when search and clear them when found

### DIFF
--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -255,7 +255,6 @@ export const workflowSlice = createSlice({
       });
     },
     setFocusNode: (state: WorkflowState, action: PayloadAction<string>) => {
-      state.collapsedGraphIds = getParentsUncollapseFromGraphState(state, action.payload);
       state.focusedCanvasNodeId = action.payload;
     },
     clearFocusNode: (state: WorkflowState) => {
@@ -289,6 +288,12 @@ export const workflowSlice = createSlice({
     },
     setCollapsedGraphIds: (state: WorkflowState, action: PayloadAction<Record<string, boolean>>) => {
       state.collapsedGraphIds = action.payload;
+    },
+    setCollapsedGraphIdsFromNodeId: (state: WorkflowState, action: PayloadAction<string>) => {
+      state.collapsedGraphIds = getParentsUncollapseFromGraphState(state, action.payload);
+    },
+    clearCollapsedGraphIds: (state: WorkflowState) => {
+      state.collapsedGraphIds = {};
     },
     toggleCollapsedGraphId: (state: WorkflowState, action: PayloadAction<string>) => {
       if (getRecordEntry(state.collapsedGraphIds, action.payload) === true) {
@@ -548,6 +553,8 @@ export const {
   removeEdgeFromRunAfter,
   clearFocusNode,
   setFocusNode,
+  setCollapsedGraphIdsFromNodeId,
+  clearCollapsedGraphIds,
   replaceId,
   setRunIndex,
   setRepetitionRunData,

--- a/libs/designer/src/lib/ui/CanvasFinder.tsx
+++ b/libs/designer/src/lib/ui/CanvasFinder.tsx
@@ -5,7 +5,7 @@ import { useInternalNode, useNodes, useReactFlow } from '@xyflow/react';
 
 import { useIsPanelCollapsed } from '../core/state/panel/panelSelectors';
 import { useIsGraphEmpty } from '../core/state/workflow/workflowSelectors';
-import { clearFocusNode } from '../core/state/workflow/workflowSlice';
+import { clearCollapsedGraphIds, clearFocusNode } from '../core/state/workflow/workflowSlice';
 import { DEFAULT_NODE_SIZE } from '../core/utils/graph';
 import type { RootState, AppDispatch } from '../core';
 
@@ -74,6 +74,7 @@ export const CanvasFinder = (props: CanvasFinderProps) => {
     });
 
     dispatch(clearFocusNode());
+    dispatch(clearCollapsedGraphIds());
   }, [focusNode, isPanelCollapsed, setCenter, getZoom, dispatch, panelLocation]);
 
   useEffect(() => {

--- a/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
@@ -2,7 +2,7 @@ import { useHostOptions } from '../../../core/state/designerOptions/designerOpti
 import { useOperationVisuals } from '../../../core/state/operation/operationSelector';
 import { changePanelNode } from '../../../core/state/panel/panelSlice';
 import { useNodeDisplayName, useNodeIds } from '../../../core/state/workflow/workflowSelectors';
-import { setFocusNode } from '../../../core/state/workflow/workflowSlice';
+import { setCollapsedGraphIdsFromNodeId, setFocusNode } from '../../../core/state/workflow/workflowSlice';
 import { SearchBox, FocusTrapZone } from '@fluentui/react';
 import { Button } from '@fluentui/react-components';
 import { bundleIcon, Dismiss24Filled, Dismiss24Regular } from '@fluentui/react-icons';
@@ -35,6 +35,7 @@ const NodeSearchCard = ({ node, displayRuntimeInfo }: { node: string; displayRun
         operationActionData={{ id: node, title: displayName, isTrigger: false, brandColor, iconUri }}
         showImage={true}
         onClick={(_: string) => {
+          dispatch(setCollapsedGraphIdsFromNodeId(node));
           dispatch(setFocusNode(node));
           dispatch(changePanelNode(node));
         }}


### PR DESCRIPTION
This pull request includes several updates to the `workflowSlice` in the `libs/designer` module, focusing on managing the collapsed state of graph nodes. The changes introduce new actions to handle the collapsed graph IDs and update the relevant components to use these new actions.

Fixes #5495 
Fixes #5486 


  - Added `setCollapsedGraphIdsFromNodeId` and `clearCollapsedGraphIds` actions to manage the collapsed state of graph nodes.
  - Removed the call to `getParentsUncollapseFromGraphState` from the `setFocusNode` action.
  - Exported the new actions from the slice.


  - Imported and dispatched the `clearCollapsedGraphIds` action in the `CanvasFinder` component. 

  - Imported and dispatched the `setCollapsedGraphIdsFromNodeId` action in the `NodeSearchPanel` component. 


https://github.com/user-attachments/assets/e6ec0295-c1b5-4944-9820-2e0f7c839bc3

