### PR TITLE
feat(Data Mapper): Show connections when one node is scrolled out

### DIFF
--- a/libs/data-mapper-v2/src/components/canvas/ReactFlow.tsx
+++ b/libs/data-mapper-v2/src/components/canvas/ReactFlow.tsx
@@ -41,6 +41,7 @@ import { getFunctionNode } from '../../utils/Function.Utils';
 import LoopEdge from '../common/reactflow/edges/LoopEdge';
 import { emptyCanvasRect } from '@microsoft/logic-apps-shared';
 import CanvasNode from '../common/reactflow/CanvasNode';
+import IntermediateConnectedEdge from '../common/reactflow/edges/IntermediateConnectedEdge';
 interface DMReactFlowProps {
   setIsMapStateDirty?: (isMapStateDirty: boolean) => void;
 }
@@ -142,10 +143,10 @@ export const ReactFlowWrapper = ({ setIsMapStateDirty }: DMReactFlowProps) => {
             source: source,
             target: target,
             focusable: true,
+            type: 'intermediateConnectedEdge',
             deletable: true,
             data: {
-              isTemporary: true,
-              scrollNodeId: id,
+              componentId: id,
             },
           };
           newEdgesMap[edgeId] = edge;
@@ -229,7 +230,6 @@ export const ReactFlowWrapper = ({ setIsMapStateDirty }: DMReactFlowProps) => {
 
     if (Object.entries(edgeChanges).length > 0) {
       applyEdgeChanges(Object.values(edgeChanges), edges);
-      console.log(edgeChanges);
     }
   }, [edges, temporaryEdgesMapForCollapsedNodes, temporaryEdgesMapForScrolledNodes]);
 
@@ -249,6 +249,7 @@ export const ReactFlowWrapper = ({ setIsMapStateDirty }: DMReactFlowProps) => {
     () => ({
       connectedEdge: ConnectedEdge,
       loopEdge: LoopEdge,
+      intermediateConnectedEdge: IntermediateConnectedEdge,
     }),
     []
   );

--- a/libs/data-mapper-v2/src/components/canvas/ReactFlow.tsx
+++ b/libs/data-mapper-v2/src/components/canvas/ReactFlow.tsx
@@ -59,6 +59,7 @@ export const ReactFlowWrapper = ({ setIsMapStateDirty }: DMReactFlowProps) => {
     flattenedTargetSchema,
     dataMapConnections,
     sourceStateConnections,
+    nodesForScroll,
   } = useSelector((state: RootState) => state.dataMap.present.curDataMapOperation);
   const currentCanvasRect = useSelector(
     (state: RootState) => state.dataMap.present.curDataMapOperation.loadedMapMetadata?.canvasRect ?? emptyCanvasRect
@@ -313,8 +314,13 @@ export const ReactFlowWrapper = ({ setIsMapStateDirty }: DMReactFlowProps) => {
   );
 
   const nodes = useMemo(
-    () => [...Object.values(sourceNodesMap), ...Object.values(targetNodesMap), ...functionNodesForDragDrop],
-    [sourceNodesMap, targetNodesMap, functionNodesForDragDrop]
+    () => [
+      ...Object.values(sourceNodesMap),
+      ...Object.values(targetNodesMap),
+      ...functionNodesForDragDrop,
+      ...Object.values(nodesForScroll),
+    ],
+    [sourceNodesMap, targetNodesMap, functionNodesForDragDrop, nodesForScroll]
   );
 
   return (

--- a/libs/data-mapper-v2/src/components/canvas/ReactFlow.tsx
+++ b/libs/data-mapper-v2/src/components/canvas/ReactFlow.tsx
@@ -40,6 +40,7 @@ import { getReactFlowNodeId } from '../../utils/Schema.Utils';
 import { getFunctionNode } from '../../utils/Function.Utils';
 import LoopEdge from '../common/reactflow/edges/LoopEdge';
 import { emptyCanvasRect } from '@microsoft/logic-apps-shared';
+import CanvasNode from '../common/reactflow/CanvasNode';
 interface DMReactFlowProps {
   setIsMapStateDirty?: (isMapStateDirty: boolean) => void;
 }
@@ -202,6 +203,7 @@ export const ReactFlowWrapper = ({ setIsMapStateDirty }: DMReactFlowProps) => {
       ({
         schemaNode: SchemaNode,
         functionNode: FunctionNode,
+        canvasNode: CanvasNode,
       }) as NodeTypes,
     []
   );

--- a/libs/data-mapper-v2/src/components/canvas/ReactFlow.tsx
+++ b/libs/data-mapper-v2/src/components/canvas/ReactFlow.tsx
@@ -31,7 +31,7 @@ import { FunctionNode } from '../common/reactflow/FunctionNode';
 import { useDrop } from 'react-dnd';
 import useResizeObserver from 'use-resize-observer';
 import type { Bounds } from '../../core';
-import { convertWholeDataMapToLayoutTree } from '../../utils/ReactFlow.Util';
+import { convertWholeDataMapToLayoutTree, isTargetNode } from '../../utils/ReactFlow.Util';
 import { createEdgeId, splitEdgeId } from '../../utils/Edge.Utils';
 import useAutoLayout from '../../ui/hooks/useAutoLayout';
 import cloneDeep from 'lodash/cloneDeep';
@@ -134,16 +134,18 @@ export const ReactFlowWrapper = ({ setIsMapStateDirty }: DMReactFlowProps) => {
     for (const [id, sourceMap] of connectionMapForSource) {
       for (const edgeId of Object.keys(sourceMap)) {
         const splitNodeId = splitEdgeId(edgeId);
-        if (splitNodeId.length === 3) {
+        if (splitNodeId.length >= 2) {
+          const [source, target] = isTargetNode(splitNodeId[0]) ? [splitNodeId[1], splitNodeId[0]] : [splitNodeId[0], splitNodeId[1]];
+
           const edge: Edge = {
             id: edgeId,
-            source: splitNodeId[0],
-            target: splitNodeId[1],
+            source: source,
+            target: target,
             focusable: true,
             deletable: true,
             data: {
               isTemporary: true,
-              source: id,
+              scrollNodeId: id,
             },
           };
           newEdgesMap[edgeId] = edge;
@@ -227,6 +229,7 @@ export const ReactFlowWrapper = ({ setIsMapStateDirty }: DMReactFlowProps) => {
 
     if (Object.entries(edgeChanges).length > 0) {
       applyEdgeChanges(Object.values(edgeChanges), edges);
+      console.log(edgeChanges);
     }
   }, [edges, temporaryEdgesMapForCollapsedNodes, temporaryEdgesMapForScrolledNodes]);
 

--- a/libs/data-mapper-v2/src/components/common/DropdownTree.tsx
+++ b/libs/data-mapper-v2/src/components/common/DropdownTree.tsx
@@ -41,7 +41,6 @@ export const DropdownTree = ({ items, onItemSelect, onDropdownOpenClose, classNa
   const onFileNameSelect = (item: IFileSysTreeItem) => {
     onItemSelect(item);
     setShowDropdownTree(false);
-    console.log(item.name);
   };
 
   const filterDropdownItem = useCallback((item: IFileSysTreeItem, value: string): IFileSysTreeItem | undefined => {

--- a/libs/data-mapper-v2/src/components/common/reactflow/CanvasNode.ts
+++ b/libs/data-mapper-v2/src/components/common/reactflow/CanvasNode.ts
@@ -1,0 +1,14 @@
+import { useUpdateNodeInternals, type Node, type NodeProps } from '@xyflow/react';
+import { useEffect } from 'react';
+
+const CanvasNode = (props: NodeProps<Node>) => {
+  const { id } = props;
+  const updateNodeInternals = useUpdateNodeInternals();
+
+  useEffect(() => {
+    updateNodeInternals(id);
+  }, [id, updateNodeInternals]);
+  return null;
+};
+
+export default CanvasNode;

--- a/libs/data-mapper-v2/src/components/common/reactflow/CanvasNode.tsx
+++ b/libs/data-mapper-v2/src/components/common/reactflow/CanvasNode.tsx
@@ -1,14 +1,17 @@
+import type { StringIndexed } from '@microsoft/logic-apps-shared';
 import { useUpdateNodeInternals, type Node, type NodeProps } from '@xyflow/react';
 import { useEffect } from 'react';
 
-const CanvasNode = (props: NodeProps<Node>) => {
+type CanvasNodeProps = {};
+
+const CanvasNode = (props: NodeProps<Node<StringIndexed<CanvasNodeProps>, 'canvas'>>) => {
   const { id } = props;
   const updateNodeInternals = useUpdateNodeInternals();
 
   useEffect(() => {
     updateNodeInternals(id);
   }, [id, updateNodeInternals]);
-  return null;
+  return <span style={{ background: 'transparent', display: 'block', border: 'none' }} />;
 };
 
 export default CanvasNode;

--- a/libs/data-mapper-v2/src/components/common/reactflow/CanvasNode.tsx
+++ b/libs/data-mapper-v2/src/components/common/reactflow/CanvasNode.tsx
@@ -1,17 +1,25 @@
+import { mergeClasses } from '@fluentui/react-components';
 import type { StringIndexed } from '@microsoft/logic-apps-shared';
-import { useUpdateNodeInternals, type Node, type NodeProps } from '@xyflow/react';
+import { Handle, Position, useUpdateNodeInternals, type Node, type NodeProps } from '@xyflow/react';
 import { useEffect } from 'react';
+import { useStyles } from './styles';
 
 type CanvasNodeProps = {};
 
 const CanvasNode = (props: NodeProps<Node<StringIndexed<CanvasNodeProps>, 'canvas'>>) => {
   const { id } = props;
+  const styles = useStyles();
   const updateNodeInternals = useUpdateNodeInternals();
 
   useEffect(() => {
     updateNodeInternals(id);
   }, [id, updateNodeInternals]);
-  return <span style={{ background: 'transparent', display: 'block', border: 'none' }} />;
+  return (
+    <div className={mergeClasses('nodrag nopan', styles.temporaryCanvasNodeRoot)}>
+      <Handle type="target" position={Position.Left} className={styles.temporaryCanvasNodeHandle} />
+      <Handle type="source" position={Position.Left} className={styles.temporaryCanvasNodeHandle} />
+    </div>
+  );
 };
 
 export default CanvasNode;

--- a/libs/data-mapper-v2/src/components/common/reactflow/edges/IntermediateConnectedEdge.tsx
+++ b/libs/data-mapper-v2/src/components/common/reactflow/edges/IntermediateConnectedEdge.tsx
@@ -1,0 +1,63 @@
+import { getStraightPath, useNodes, type EdgeProps } from '@xyflow/react';
+import { useHoverEdge } from '../../../../core/state/selectors/selectors';
+import { useCallback, useMemo } from 'react';
+import { colors } from '../styles';
+import { useDispatch, useSelector } from 'react-redux';
+import { setHoverState } from '../../../../core/state/DataMapSlice';
+import { splitEdgeId } from '../../../../utils/Edge.Utils';
+import type { RootState } from '../../../../core/state/Store';
+
+const IntermediateConnectedEdge = (props: EdgeProps) => {
+  const { id, sourceX, sourceY, targetX, targetY, data } = props;
+  const splitIds = useMemo(() => splitEdgeId(id), [id]);
+  const nodes = useNodes();
+  const { temporaryEdgeMappingDirection } = useSelector((state: RootState) => state.dataMap.present.curDataMapOperation);
+
+  const componentId1 = useMemo(() => data && data['componentId'], [data]);
+  const componentId2 = useMemo(() => (splitIds.length >= 2 ? splitIds[0] : undefined), [splitIds]);
+  const componentId3 = useMemo(() => (splitIds.length >= 2 ? splitIds[1] : undefined), [splitIds]);
+  const direction = useMemo(
+    () => componentId1 && temporaryEdgeMappingDirection[componentId1 as string],
+    [componentId1, temporaryEdgeMappingDirection]
+  );
+
+  // Check if both source and target nodes are visible, i.e. present in the map
+  // Or if none of the nodes are present, then the edge shouldn't be visible
+  const oneNodeVisible = useMemo(
+    () => nodes.filter((node) => node.id === componentId1 || node.id === componentId2).length === 1,
+    [nodes, componentId1, componentId2]
+  );
+
+  const dispatch = useDispatch();
+  const isHovered = useHoverEdge(id);
+
+  const [path] = getStraightPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+  });
+
+  const strokeColor = useMemo(() => (isHovered ? colors.edgeActive : colors.edgeConnected), [isHovered]);
+
+  const onMouseEnter = useCallback(() => {
+    dispatch(
+      setHoverState({
+        id: id,
+        type: 'edge',
+      })
+    );
+  }, [dispatch, id]);
+
+  const onMouseLeave = useCallback(() => {
+    dispatch(setHoverState());
+  }, [dispatch]);
+
+  return componentId3 && componentId1 && componentId2 && oneNodeVisible && direction && componentId3.startsWith(direction as string) ? (
+    <g id={`${id}_customEdge`} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      <path fill="none" stroke={strokeColor} strokeWidth={5} className="animated" d={path} />
+    </g>
+  ) : null;
+};
+
+export default IntermediateConnectedEdge;

--- a/libs/data-mapper-v2/src/components/common/reactflow/styles.ts
+++ b/libs/data-mapper-v2/src/components/common/reactflow/styles.ts
@@ -95,4 +95,14 @@ export const useStyles = makeStyles({
     alignItems: 'center',
     marginRight: '3px',
   },
+  temporaryCanvasNodeRoot: {
+    width: '10px',
+    height: '10px',
+    backgroundColor: 'transparent',
+  },
+  temporaryCanvasNodeHandle: {
+    backgroundColor: 'transparent',
+    ...shorthands.border('none'),
+    left: '2px',
+  },
 });

--- a/libs/data-mapper-v2/src/components/schema/tree/RecursiveTree.tsx
+++ b/libs/data-mapper-v2/src/components/schema/tree/RecursiveTree.tsx
@@ -45,10 +45,13 @@ const RecursiveTree = (props: RecursiveTreeProps) => {
       ]
   );
 
+  const nodeId = useMemo(() => getReactFlowNodeId(key, isLeftDirection), [key, isLeftDirection]);
+
   const {
     position: { x, y } = { x: undefined, y: undefined },
   } = useNodePosition({
     key: key,
+    nodeId,
     onScreen: onScreen,
     schemaMap: flattenedScehmaMap,
     isLeftDirection: isLeftDirection,
@@ -57,8 +60,6 @@ const RecursiveTree = (props: RecursiveTreeProps) => {
     treePositionX,
     treePositionY,
   });
-
-  const nodeId = useMemo(() => getReactFlowNodeId(key, isLeftDirection), [key, isLeftDirection]);
 
   const onClick = useCallback(() => {
     dispatch(setSelectedItem(addReactFlowPrefix(key, isLeftDirection ? SchemaType.Source : SchemaType.Target)));

--- a/libs/data-mapper-v2/src/components/schema/tree/RecursiveTree.tsx
+++ b/libs/data-mapper-v2/src/components/schema/tree/RecursiveTree.tsx
@@ -173,7 +173,7 @@ const RecursiveTree = (props: RecursiveTreeProps) => {
     return (
       <TreeItem itemType="leaf" id={key} value={key} ref={nodeRef}>
         <TreeItemLayout
-          data-selectableId={key}
+          data-selectableid={key}
           onClick={onClick}
           onMouseEnter={onMouseOver}
           onMouseLeave={onMouseLeave}
@@ -200,7 +200,7 @@ const RecursiveTree = (props: RecursiveTreeProps) => {
       onOpenChange={onOpenChange}
     >
       <TreeItemLayout
-        data-selectableId={key}
+        data-selectableid={key}
         onClick={onClick}
         onMouseOver={onMouseOver}
         onMouseLeave={onMouseLeave}

--- a/libs/data-mapper-v2/src/components/schema/tree/SchemaTree.tsx
+++ b/libs/data-mapper-v2/src/components/schema/tree/SchemaTree.tsx
@@ -76,7 +76,6 @@ export const SchemaTree = (props: SchemaTreeProps) => {
         const position = positions[i];
         const id = getNodeIdForScroll(allIds, direction);
         if (id && nodesForScroll[id] && (nodesForScroll[id].position.x !== position.x || nodesForScroll[id].position.y !== position.y)) {
-          console.log('updateCanvasNodePosition', { id, position });
           dispatch(updateCanvasNodePosition({ id, position }));
         }
       }

--- a/libs/data-mapper-v2/src/components/schema/tree/SchemaTree.tsx
+++ b/libs/data-mapper-v2/src/components/schema/tree/SchemaTree.tsx
@@ -1,10 +1,14 @@
-import type { SchemaExtended, SchemaNodeExtended } from '@microsoft/logic-apps-shared';
+import { emptyCanvasRect, type SchemaExtended, type SchemaNodeExtended } from '@microsoft/logic-apps-shared';
 import { Tree, mergeClasses } from '@fluentui/react-components';
 import { useStyles } from './styles';
-import { useCallback, useContext, useEffect, useRef } from 'react';
+import { useCallback, useContext, useEffect, useLayoutEffect, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import RecursiveTree from './RecursiveTree';
 import { DataMapperWrappedContext } from '../../../core';
+import { useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from '../../../core/state/Store';
+import { getNodeIdForScroll, type NodeScrollDirection } from '../../../utils';
+import { updateCanvasNodePosition } from 'core/state/DataMapSlice';
 
 export type SchemaTreeProps = {
   isLeftDirection?: boolean;
@@ -22,7 +26,14 @@ export const SchemaTree = (props: SchemaTreeProps) => {
 
   const intl = useIntl();
   const treeRef = useRef<HTMLDivElement | null>(null);
+  const dispatch = useDispatch<AppDispatch>();
   const { scroll } = useContext(DataMapperWrappedContext);
+  const {
+    width: canvasWidth,
+    height: canvasHeight,
+    y: canvasTop,
+  } = useSelector((state: RootState) => state.dataMap.present.curDataMapOperation.loadedMapMetadata?.canvasRect ?? emptyCanvasRect);
+  const { nodesForScroll } = useSelector((state: RootState) => state.dataMap.present.curDataMapOperation);
 
   const treeAriaLabel = intl.formatMessage({
     defaultMessage: 'Schema tree',
@@ -44,6 +55,32 @@ export const SchemaTree = (props: SchemaTreeProps) => {
     },
     [treeRef]
   );
+
+  useLayoutEffect(() => {
+    if (treeRef?.current && canvasWidth > 0 && canvasHeight > 0 && canvasTop !== -1) {
+      const left = 0;
+      const right = canvasWidth;
+      const top = treeRef.current.getBoundingClientRect().y;
+      const bottom = canvasHeight;
+      const allIds = Object.keys(nodesForScroll);
+      const directions: NodeScrollDirection[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+      const positions = [
+        { x: left, y: top },
+        { x: right, y: top },
+        { x: left, y: bottom },
+        { x: right, y: bottom },
+      ];
+
+      for (let i = 0; i < directions.length; ++i) {
+        const direction = directions[i];
+        const position = positions[i];
+        const id = getNodeIdForScroll(allIds, direction);
+        if (id) {
+          dispatch(updateCanvasNodePosition({ id, position }));
+        }
+      }
+    }
+  }, [canvasWidth, canvasHeight, canvasTop, treeRef, nodesForScroll, dispatch]);
 
   useEffect(() => {
     if (treeRef?.current && scroll) {

--- a/libs/data-mapper-v2/src/components/schema/tree/SchemaTree.tsx
+++ b/libs/data-mapper-v2/src/components/schema/tree/SchemaTree.tsx
@@ -8,7 +8,7 @@ import { DataMapperWrappedContext } from '../../../core';
 import { useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from '../../../core/state/Store';
 import { getNodeIdForScroll, type NodeScrollDirection } from '../../../utils';
-import { updateCanvasNodePosition } from 'core/state/DataMapSlice';
+import { updateCanvasNodePosition } from '../../../core/state/DataMapSlice';
 
 export type SchemaTreeProps = {
   isLeftDirection?: boolean;
@@ -60,7 +60,7 @@ export const SchemaTree = (props: SchemaTreeProps) => {
     if (treeRef?.current && canvasWidth > 0 && canvasHeight > 0 && canvasTop !== -1) {
       const left = 0;
       const right = canvasWidth;
-      const top = treeRef.current.getBoundingClientRect().y;
+      const top = 0;
       const bottom = canvasHeight;
       const allIds = Object.keys(nodesForScroll);
       const directions: NodeScrollDirection[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
@@ -75,7 +75,8 @@ export const SchemaTree = (props: SchemaTreeProps) => {
         const direction = directions[i];
         const position = positions[i];
         const id = getNodeIdForScroll(allIds, direction);
-        if (id) {
+        if (id && nodesForScroll[id] && (nodesForScroll[id].position.x !== position.x || nodesForScroll[id].position.y !== position.y)) {
+          console.log('updateCanvasNodePosition', { id, position });
           dispatch(updateCanvasNodePosition({ id, position }));
         }
       }

--- a/libs/data-mapper-v2/src/components/schema/tree/useNodePosition.ts
+++ b/libs/data-mapper-v2/src/components/schema/tree/useNodePosition.ts
@@ -3,6 +3,7 @@ import type { XYPosition } from '@xyflow/react';
 import { emptyCanvasRect, type SchemaNodeExtended } from '@microsoft/logic-apps-shared';
 import { useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from '../../../core/state/Store';
+import { updateTemporaryNodeDirection } from '../../../core/state/DataMapSlice';
 
 type NodePositionProps = {
   key: string;
@@ -54,6 +55,12 @@ const useNodePosition = (props: NodePositionProps) => {
 
     if (x !== undefined && y !== undefined) {
       setPosition({ x, y });
+      dispatch(
+        updateTemporaryNodeDirection({
+          id: nodeId,
+          direction: nodePositionY < treePositionY ? 'top' : nodePositionY > canvasHeight ? 'bottom' : undefined,
+        })
+      );
     } else {
       setPosition(undefined);
     }

--- a/libs/data-mapper-v2/src/components/schema/tree/useNodePosition.ts
+++ b/libs/data-mapper-v2/src/components/schema/tree/useNodePosition.ts
@@ -1,11 +1,12 @@
 import { useState, useLayoutEffect } from 'react';
 import type { XYPosition } from '@xyflow/react';
 import { emptyCanvasRect, type SchemaNodeExtended } from '@microsoft/logic-apps-shared';
-import { useSelector } from 'react-redux';
-import type { RootState } from '../../../core/state/Store';
+import { useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from '../../../core/state/Store';
 
 type NodePositionProps = {
   key: string;
+  nodeId: string;
   schemaMap: Record<string, SchemaNodeExtended>;
   isLeftDirection: boolean;
   nodePositionX?: number;
@@ -16,25 +17,24 @@ type NodePositionProps = {
 };
 
 const useNodePosition = (props: NodePositionProps) => {
-  const { schemaMap, key, isLeftDirection, onScreen, treePositionY, nodePositionY } = props;
+  const { schemaMap, key, isLeftDirection, onScreen, treePositionY, nodePositionY, nodeId } = props;
   const [position, setPosition] = useState<XYPosition>();
+  const dispatch = useDispatch<AppDispatch>();
   const currentCanvasRect = useSelector(
     (state: RootState) => state.dataMap.present.curDataMapOperation.loadedMapMetadata?.canvasRect ?? emptyCanvasRect
   );
 
-  const { y: canvasY, width: canvasWidth } = currentCanvasRect;
+  const { y: canvasY, width: canvasWidth, height: canvasHeight } = currentCanvasRect;
 
   useLayoutEffect(() => {
-    // if(isLeftDirection) {
-    //   console.log('Key: ', key, ' ;treeY: ', treePositionY, ' ;nodeY: ', nodePositionY, ' ;canvasY: ', canvasY, ' ;canvas: ', canvasWidth, ' ;Visible: ', onScreen, '; Map: ', schemaMap[key]);
-    // }
-    // Don't look for the node position if tree, node or canvas isn't on the screen yet
     if (
       treePositionY === undefined ||
       nodePositionY === undefined ||
       canvasY === undefined ||
       canvasY === -1 ||
       canvasWidth === 0 ||
+      canvasHeight === 0 ||
+      canvasHeight === undefined ||
       canvasWidth === undefined ||
       onScreen === undefined
     ) {
@@ -57,7 +57,20 @@ const useNodePosition = (props: NodePositionProps) => {
     } else {
       setPosition(undefined);
     }
-  }, [onScreen, schemaMap, setPosition, canvasY, canvasWidth, nodePositionY, isLeftDirection, key, treePositionY]);
+  }, [
+    onScreen,
+    schemaMap,
+    setPosition,
+    canvasY,
+    canvasWidth,
+    canvasHeight,
+    nodePositionY,
+    isLeftDirection,
+    key,
+    treePositionY,
+    nodeId,
+    dispatch,
+  ]);
 
   return { position };
 };

--- a/libs/data-mapper-v2/src/constants/ReactFlowConstants.ts
+++ b/libs/data-mapper-v2/src/constants/ReactFlowConstants.ts
@@ -4,6 +4,7 @@ export const ReactFlowNodeType = {
   SchemaNode: 'schemaNode',
   FunctionNode: 'functionNode',
   FunctionPlaceholder: 'functionPlaceholder',
+  CanvasNode: 'canvasNode',
 } as const;
 export type ReactFlowNodeType = (typeof ReactFlowNodeType)[keyof typeof ReactFlowNodeType];
 

--- a/libs/data-mapper-v2/src/core/state/DataMapSlice.ts
+++ b/libs/data-mapper-v2/src/core/state/DataMapSlice.ts
@@ -21,6 +21,7 @@ import {
   isSchemaNodeExtended,
   flattenSchemaIntoSortArray,
   getUpdatedStateConnections,
+  getNodesForScroll,
 } from '../../utils/Schema.Utils';
 import type {
   FunctionMetadata,
@@ -92,6 +93,9 @@ export interface DataMapOperationState {
   targetOpenKeys: Record<string, boolean>;
   // Mapping used to store which connection is a loop
   edgeLoopMapping: Record<string, boolean>;
+  // Temporary Nodes for when the scrolling is happening and the tree-nodes are not in view
+  // For each corner of the canvas
+  nodesForScroll: Record<string, Node>;
   // This is used to store the temporary state of the edge for which popover is visible
   edgePopOverId?: string;
   state?: ComponentState;
@@ -119,6 +123,7 @@ const emptyPristineState: DataMapOperationState = {
   sourceStateConnections: {},
   targetStateConnections: {},
   edgeLoopMapping: {},
+  nodesForScroll: getNodesForScroll(),
 };
 
 const initialState: DataMapState = {
@@ -694,6 +699,15 @@ export const dataMapSlice = createSlice({
         canvasRect: action.payload,
       };
     },
+    updateCanvasNodePosition: (state, action: PayloadAction<{ id: string; position: XYPosition }>) => {
+      const node = state.curDataMapOperation.nodesForScroll[action.payload.id];
+      if (node) {
+        state.curDataMapOperation.nodesForScroll = {
+          ...state.curDataMapOperation.nodesForScroll,
+          [action.payload.id]: { ...node, position: action.payload.position },
+        };
+      }
+    },
   },
 });
 
@@ -721,6 +735,7 @@ export const {
   toggleTargetEditState,
   setHoverState,
   updateCanvasDimensions,
+  updateCanvasNodePosition,
 } = dataMapSlice.actions;
 
 export default dataMapSlice.reducer;

--- a/libs/data-mapper-v2/src/core/state/DataMapSlice.ts
+++ b/libs/data-mapper-v2/src/core/state/DataMapSlice.ts
@@ -78,6 +78,9 @@ export interface DataMapOperationState {
   loadedMapMetadata?: MapMetadataV2;
   // Store edge mapping for each edge in the schema to use when the scrolling is happening
   temporaryEdgeMapping: Record<string, Record<string, boolean>>;
+  // Store edge mapping direction for each edge in the schema to use when the scrolling is happening
+  // And node is hidden
+  temporaryEdgeMappingDirection: Record<string, string>;
   // Save the temporary state of edges to be used for rendering when tree node is expanded/collapsed
   // This info is not saved in LML which is why it is stored separately in the store
   sourceStateConnections: Record<string, Record<string, boolean>>;
@@ -127,6 +130,7 @@ const emptyPristineState: DataMapOperationState = {
   edgeLoopMapping: {},
   temporaryEdgeMapping: {},
   nodesForScroll: {},
+  temporaryEdgeMappingDirection: {},
 };
 
 const initialState: DataMapState = {
@@ -733,6 +737,20 @@ export const dataMapSlice = createSlice({
     updateCanvasNodesForScroll: (state, action: PayloadAction<Record<string, Node>>) => {
       state.curDataMapOperation.nodesForScroll = action.payload;
     },
+    updateTemporaryNodeDirection: (
+      state,
+      action: PayloadAction<{
+        id: string;
+        direction: 'top' | 'bottom' | undefined;
+      }>
+    ) => {
+      const { id, direction } = action.payload;
+      if (direction) {
+        state.curDataMapOperation.temporaryEdgeMappingDirection[id] = direction;
+      } else if (state.curDataMapOperation.temporaryEdgeMappingDirection[id]) {
+        delete state.curDataMapOperation.temporaryEdgeMappingDirection[id];
+      }
+    },
   },
 });
 
@@ -761,6 +779,7 @@ export const {
   setHoverState,
   updateCanvasDimensions,
   updateCanvasNodesForScroll,
+  updateTemporaryNodeDirection,
 } = dataMapSlice.actions;
 
 export default dataMapSlice.reducer;

--- a/libs/data-mapper-v2/src/core/state/DataMapSlice.ts
+++ b/libs/data-mapper-v2/src/core/state/DataMapSlice.ts
@@ -21,7 +21,6 @@ import {
   isSchemaNodeExtended,
   flattenSchemaIntoSortArray,
   getUpdatedStateConnections,
-  getNodesForScroll,
   type NodeScrollDirection,
   getNodeIdForScroll,
 } from '../../utils/Schema.Utils';
@@ -127,7 +126,7 @@ const emptyPristineState: DataMapOperationState = {
   targetStateConnections: {},
   edgeLoopMapping: {},
   temporaryEdgeMapping: {},
-  nodesForScroll: getNodesForScroll(),
+  nodesForScroll: {},
 };
 
 const initialState: DataMapState = {
@@ -731,14 +730,8 @@ export const dataMapSlice = createSlice({
         canvasRect: action.payload,
       };
     },
-    updateCanvasNodePosition: (state, action: PayloadAction<{ id: string; position: XYPosition }>) => {
-      const node = state.curDataMapOperation.nodesForScroll[action.payload.id];
-      if (node) {
-        state.curDataMapOperation.nodesForScroll = {
-          ...state.curDataMapOperation.nodesForScroll,
-          [action.payload.id]: { ...node, position: action.payload.position },
-        };
-      }
+    updateCanvasNodesForScroll: (state, action: PayloadAction<Record<string, Node>>) => {
+      state.curDataMapOperation.nodesForScroll = action.payload;
     },
   },
 });
@@ -767,7 +760,7 @@ export const {
   toggleTargetEditState,
   setHoverState,
   updateCanvasDimensions,
-  updateCanvasNodePosition,
+  updateCanvasNodesForScroll,
 } = dataMapSlice.actions;
 
 export default dataMapSlice.reducer;

--- a/libs/data-mapper-v2/src/ui/styles.ts
+++ b/libs/data-mapper-v2/src/ui/styles.ts
@@ -69,6 +69,9 @@ export const useStaticStyles = makeStaticStyles({
   '.react-flow__pane': {
     zIndex: '100 !important',
   },
+  '.react-flow__renderer': {
+    zIndex: '110 !important',
+  },
   '.react-flow__edges': {
     zIndex: '120 !important',
   },

--- a/libs/data-mapper-v2/src/utils/Edge.Utils.ts
+++ b/libs/data-mapper-v2/src/utils/Edge.Utils.ts
@@ -2,6 +2,7 @@ import { LogCategory, LogService } from './Logging.Utils';
 import * as PF from 'pathfinding';
 import type { Node as ReactFlowNode, XYPosition } from '@xyflow/react';
 import { Position } from '@xyflow/react';
+import { guid } from '@microsoft/logic-apps-shared';
 
 interface BoundingBox {
   width: number;
@@ -65,6 +66,8 @@ const getQuadraticCurve = (a: XYPosition, b: XYPosition, c: XYPosition, borderRa
 };
 
 export const createEdgeId = (sourceId: string, targetId: string) => `${sourceId}__edge__${targetId}`;
+export const createTemporaryEdgeId = (sourceId: string, targetId: string) => `${sourceId}__edge__${targetId}__edge__${guid()}`; //When scrolled out
+
 export const splitEdgeId = (edgeId: string) => edgeId.split('__edge__');
 
 const getNextPointFromPosition = (curPoint: XYPosition, position: Position): XYPosition => {

--- a/libs/data-mapper-v2/src/utils/Schema.Utils.ts
+++ b/libs/data-mapper-v2/src/utils/Schema.Utils.ts
@@ -322,14 +322,17 @@ export type NodeScrollDirection = 'top-left' | 'top-right' | 'bottom-left' | 'bo
  */
 export const getNodesForScroll = (): Record<string, Node> => {
   const map: Record<string, Node> = {};
-  const ids = [`top-left${guid()}`, `top-right${guid()}`, `bottom-left${guid()}`, `bottom-right${guid()}`];
+  const ids = [`top-left-${guid()}`, `top-right-${guid()}`, `bottom-left-${guid()}`, `bottom-right-${guid()}`];
   for (const id of ids) {
     map[id] = {
       id,
+      hidden: false,
       selectable: false,
       draggable: false,
-      position: { x: -10, y: -10 },
-      data: {},
+      position: { x: 0, y: 0 },
+      data: {
+        isTemporary: true,
+      },
       type: 'canvasNode',
     };
   }

--- a/libs/data-mapper-v2/src/utils/Schema.Utils.ts
+++ b/libs/data-mapper-v2/src/utils/Schema.Utils.ts
@@ -322,7 +322,7 @@ export type NodeScrollDirection = 'top-left' | 'top-right' | 'bottom-left' | 'bo
  */
 export const getNodesForScroll = (): Record<string, Node> => {
   const map: Record<string, Node> = {};
-  const ids = [`top-left${guid}`, `top-right${guid}`, `bottom-left${guid}`, `bottom-right${guid}`];
+  const ids = [`top-left${guid()}`, `top-right${guid()}`, `bottom-left${guid()}`, `bottom-right${guid()}`];
   for (const id of ids) {
     map[id] = {
       id,

--- a/libs/data-mapper-v2/src/utils/Schema.Utils.ts
+++ b/libs/data-mapper-v2/src/utils/Schema.Utils.ts
@@ -10,8 +10,9 @@ import type {
   SchemaNodeDictionary,
   SchemaNodeExtended,
 } from '@microsoft/logic-apps-shared';
-import { NormalizedDataType, SchemaNodeProperty, SchemaType } from '@microsoft/logic-apps-shared';
+import { guid, NormalizedDataType, SchemaNodeProperty, SchemaType } from '@microsoft/logic-apps-shared';
 import { addReactFlowPrefix } from './ReactFlow.Util';
+import type { Node } from '@xyflow/react';
 
 export const getReactFlowNodeId = (key: string, isLeftDirection: boolean) =>
   addReactFlowPrefix(key, isLeftDirection ? SchemaType.Source : SchemaType.Target);
@@ -311,4 +312,30 @@ export const getUpdatedStateConnections = (
   }
 
   return [sourceStateConnections, targetStateConnections];
+};
+
+export type NodeScrollDirection = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+/**
+ *
+ * @returns Need to return 4 nodes, one each for top-left, top-right, bottom-left, bottom-right
+ */
+export const getNodesForScroll = (): Record<string, Node> => {
+  const map: Record<string, Node> = {};
+  const ids = [`top-left${guid}`, `top-right${guid}`, `bottom-left${guid}`, `bottom-right${guid}`];
+  for (const id of ids) {
+    map[id] = {
+      id,
+      selectable: false,
+      draggable: false,
+      position: { x: -10, y: -10 },
+      data: {},
+      type: 'canvasNode',
+    };
+  }
+  return map;
+};
+
+export const getNodeIdForScroll = (ids: string[], direction: NodeScrollDirection) => {
+  return ids.find((id) => id.startsWith(direction));
 };


### PR DESCRIPTION
## Requirement Checklist

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->

With Connections
![image](https://github.com/user-attachments/assets/6df7e2aa-eb92-46c2-a8e8-268f3c12461d)


One set of Connections scrolled away
![image](https://github.com/user-attachments/assets/7c5142e5-4ee9-46fc-a195-53ad2baf5c43)


All source and target scrolled away
![image](https://github.com/user-attachments/assets/f87dee6a-54b8-407f-a91d-876041beaf36)
