### PR TITLE
fix(designer): Reduce children for nodes that only have children

### DIFF
--- a/libs/designer/src/lib/core/state/workflow/__test__/workflowSelectors.spec.ts
+++ b/libs/designer/src/lib/core/state/workflow/__test__/workflowSelectors.spec.ts
@@ -45,7 +45,7 @@ describe('workflowSelectors', () => {
     operations: {},
     nodesMetadata: {},
     collapsedGraphIds: {
-      'node-1': false,
+      'node-1': true,
     },
     edgeIdsBySource: {},
     idReplacements: {},
@@ -60,25 +60,32 @@ describe('workflowSelectors', () => {
     },
   };
 
-  it('getParentsUncollapseFromGraphState', () => {
-    const collapsedGraphIdsWoParent = getParentsUncollapseFromGraphState(operationInfo, 'node-2');
-    expect(collapsedGraphIdsWoParent).toEqual({
-      'node-1': false,
-      'node-root': false,
-    });
-    const collapsedGraphIdsWithParent = getParentsUncollapseFromGraphState(operationInfo, 'node-3');
-    expect(collapsedGraphIdsWithParent).toEqual({
-      'node-2': false,
-      'node-1': false,
-      'node-root': false,
+  describe('getParentsUncollapseFromGraphState', () => {
+    it('Should return node-1 as true since node-2 is not children from node-1', () => {
+      const collapsedGraphIdsParent = getParentsUncollapseFromGraphState(operationInfo, 'node-2');
+      expect(collapsedGraphIdsParent).toEqual({
+        'node-1': true,
+      });
     });
 
-    const collapsedGraphIdsWithParent2 = getParentsUncollapseFromGraphState(operationInfo, 'node-5');
-    expect(collapsedGraphIdsWithParent2).toEqual({
-      'node-1': false,
-      'node-2': false,
-      'node-4': false,
-      'node-root': false,
+    it('Should return node-2 as false since node-3 is children from node-2', () => {
+      operationInfo.collapsedGraphIds['node-2'] = true;
+      const collapsedGraphIdsParent = getParentsUncollapseFromGraphState(operationInfo, 'node-3');
+      expect(collapsedGraphIdsParent).toEqual({
+        'node-1': true,
+        'node-2': false,
+      });
+    });
+
+    it('Should return node-2 and node-4 as false since node-5 is children from both', () => {
+      operationInfo.collapsedGraphIds['node-2'] = true;
+      operationInfo.collapsedGraphIds['node-4'] = true;
+      const collapsedGraphIdsParent = getParentsUncollapseFromGraphState(operationInfo, 'node-5');
+      expect(collapsedGraphIdsParent).toEqual({
+        'node-1': true,
+        'node-2': false,
+        'node-4': false,
+      });
     });
   });
 });

--- a/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
@@ -60,7 +60,8 @@ const reduceCollapsed =
     return nodes.reduce((acc: any, child: WorkflowNode) => {
       const shouldFilter = condition(child);
       if (!shouldFilter) {
-        acc.push({ ...child, ...{ children: reduceCollapsed(condition)(child.children ?? []) } });
+        const reducedChildren = child.children ? { children: reduceCollapsed(condition)(child.children) } : {};
+        acc.push({ ...child, ...reducedChildren });
         return acc;
       }
 
@@ -183,7 +184,7 @@ export const getParentsUncollapseFromGraphState = (state: WorkflowState, actionI
   if (state.graph) {
     const nodeParents = getWorkflowGraphPath(state.graph, actionId);
     nodeParents.forEach((nodeId) => {
-      if (nodeId !== actionId) {
+      if (nodeId !== actionId && collapsedGraphIds[nodeId]) {
         collapsedGraphIds[nodeId] = false;
       }
     });

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -255,7 +255,6 @@ export const workflowSlice = createSlice({
       });
     },
     setFocusNode: (state: WorkflowState, action: PayloadAction<string>) => {
-      state.collapsedGraphIds = getParentsUncollapseFromGraphState(state, action.payload);
       state.focusedCanvasNodeId = action.payload;
     },
     clearFocusNode: (state: WorkflowState) => {
@@ -289,6 +288,12 @@ export const workflowSlice = createSlice({
     },
     setCollapsedGraphIds: (state: WorkflowState, action: PayloadAction<Record<string, boolean>>) => {
       state.collapsedGraphIds = action.payload;
+    },
+    setCollapsedGraphIdsFromNodeId: (state: WorkflowState, action: PayloadAction<string>) => {
+      state.collapsedGraphIds = getParentsUncollapseFromGraphState(state, action.payload);
+    },
+    clearCollapsedGraphIds: (state: WorkflowState) => {
+      state.collapsedGraphIds = {};
     },
     toggleCollapsedGraphId: (state: WorkflowState, action: PayloadAction<string>) => {
       if (getRecordEntry(state.collapsedGraphIds, action.payload) === true) {
@@ -548,6 +553,8 @@ export const {
   removeEdgeFromRunAfter,
   clearFocusNode,
   setFocusNode,
+  setCollapsedGraphIdsFromNodeId,
+  clearCollapsedGraphIds,
   replaceId,
   setRunIndex,
   setRepetitionRunData,

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -289,12 +289,6 @@ export const workflowSlice = createSlice({
     setCollapsedGraphIds: (state: WorkflowState, action: PayloadAction<string>) => {
       state.collapsedGraphIds = getParentsUncollapseFromGraphState(state, action.payload);
     },
-    setCollapsedGraphIdsFromNodeId: (state: WorkflowState, action: PayloadAction<string>) => {
-      state.collapsedGraphIds = getParentsUncollapseFromGraphState(state, action.payload);
-    },
-    clearCollapsedGraphIds: (state: WorkflowState) => {
-      state.collapsedGraphIds = {};
-    },
     toggleCollapsedGraphId: (state: WorkflowState, action: PayloadAction<string>) => {
       if (getRecordEntry(state.collapsedGraphIds, action.payload) === true) {
         delete state.collapsedGraphIds[action.payload];

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -286,14 +286,8 @@ export const workflowSlice = createSlice({
         !!node?.children?.length && stack.push(...node.children);
       }
     },
-    setCollapsedGraphIds: (state: WorkflowState, action: PayloadAction<Record<string, boolean>>) => {
-      state.collapsedGraphIds = action.payload;
-    },
-    setCollapsedGraphIdsFromNodeId: (state: WorkflowState, action: PayloadAction<string>) => {
+    setCollapsedGraphIds: (state: WorkflowState, action: PayloadAction<string>) => {
       state.collapsedGraphIds = getParentsUncollapseFromGraphState(state, action.payload);
-    },
-    clearCollapsedGraphIds: (state: WorkflowState) => {
-      state.collapsedGraphIds = {};
     },
     toggleCollapsedGraphId: (state: WorkflowState, action: PayloadAction<string>) => {
       if (getRecordEntry(state.collapsedGraphIds, action.payload) === true) {
@@ -543,7 +537,6 @@ export const {
   deleteSwitchCase,
   updateNodeSizes,
   setNodeDescription,
-  setCollapsedGraphIds,
   toggleCollapsedGraphId,
   addSwitchCase,
   discardAllChanges,
@@ -553,8 +546,7 @@ export const {
   removeEdgeFromRunAfter,
   clearFocusNode,
   setFocusNode,
-  setCollapsedGraphIdsFromNodeId,
-  clearCollapsedGraphIds,
+  setCollapsedGraphIds,
   replaceId,
   setRunIndex,
   setRepetitionRunData,

--- a/libs/designer/src/lib/ui/CanvasFinder.tsx
+++ b/libs/designer/src/lib/ui/CanvasFinder.tsx
@@ -5,7 +5,7 @@ import { useInternalNode, useNodes, useReactFlow } from '@xyflow/react';
 
 import { useIsPanelCollapsed } from '../core/state/panel/panelSelectors';
 import { useIsGraphEmpty } from '../core/state/workflow/workflowSelectors';
-import { clearFocusNode } from '../core/state/workflow/workflowSlice';
+import { clearCollapsedGraphIds, clearFocusNode } from '../core/state/workflow/workflowSlice';
 import { DEFAULT_NODE_SIZE } from '../core/utils/graph';
 import type { RootState, AppDispatch } from '../core';
 
@@ -74,6 +74,7 @@ export const CanvasFinder = (props: CanvasFinderProps) => {
     });
 
     dispatch(clearFocusNode());
+    dispatch(clearCollapsedGraphIds());
   }, [focusNode, isPanelCollapsed, setCenter, getZoom, dispatch, panelLocation]);
 
   useEffect(() => {

--- a/libs/designer/src/lib/ui/CanvasFinder.tsx
+++ b/libs/designer/src/lib/ui/CanvasFinder.tsx
@@ -5,7 +5,7 @@ import { useInternalNode, useNodes, useReactFlow } from '@xyflow/react';
 
 import { useIsPanelCollapsed } from '../core/state/panel/panelSelectors';
 import { useIsGraphEmpty } from '../core/state/workflow/workflowSelectors';
-import { clearCollapsedGraphIds, clearFocusNode } from '../core/state/workflow/workflowSlice';
+import { clearFocusNode } from '../core/state/workflow/workflowSlice';
 import { DEFAULT_NODE_SIZE } from '../core/utils/graph';
 import type { RootState, AppDispatch } from '../core';
 
@@ -74,7 +74,6 @@ export const CanvasFinder = (props: CanvasFinderProps) => {
     });
 
     dispatch(clearFocusNode());
-    dispatch(clearCollapsedGraphIds());
   }, [focusNode, isPanelCollapsed, setCenter, getZoom, dispatch, panelLocation]);
 
   useEffect(() => {

--- a/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
@@ -2,7 +2,7 @@ import { useHostOptions } from '../../../core/state/designerOptions/designerOpti
 import { useOperationVisuals } from '../../../core/state/operation/operationSelector';
 import { changePanelNode } from '../../../core/state/panel/panelSlice';
 import { useNodeDisplayName, useNodeIds } from '../../../core/state/workflow/workflowSelectors';
-import { setCollapsedGraphIdsFromNodeId, setFocusNode } from '../../../core/state/workflow/workflowSlice';
+import { setCollapsedGraphIds, setFocusNode } from '../../../core/state/workflow/workflowSlice';
 import { SearchBox, FocusTrapZone } from '@fluentui/react';
 import { Button } from '@fluentui/react-components';
 import { bundleIcon, Dismiss24Filled, Dismiss24Regular } from '@fluentui/react-icons';
@@ -35,7 +35,7 @@ const NodeSearchCard = ({ node, displayRuntimeInfo }: { node: string; displayRun
         operationActionData={{ id: node, title: displayName, isTrigger: false, brandColor, iconUri }}
         showImage={true}
         onClick={(_: string) => {
-          dispatch(setCollapsedGraphIdsFromNodeId(node));
+          dispatch(setCollapsedGraphIds(node));
           dispatch(setFocusNode(node));
           dispatch(changePanelNode(node));
         }}

--- a/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
@@ -2,7 +2,7 @@ import { useHostOptions } from '../../../core/state/designerOptions/designerOpti
 import { useOperationVisuals } from '../../../core/state/operation/operationSelector';
 import { changePanelNode } from '../../../core/state/panel/panelSlice';
 import { useNodeDisplayName, useNodeIds } from '../../../core/state/workflow/workflowSelectors';
-import { setFocusNode } from '../../../core/state/workflow/workflowSlice';
+import { setCollapsedGraphIdsFromNodeId, setFocusNode } from '../../../core/state/workflow/workflowSlice';
 import { SearchBox, FocusTrapZone } from '@fluentui/react';
 import { Button } from '@fluentui/react-components';
 import { bundleIcon, Dismiss24Filled, Dismiss24Regular } from '@fluentui/react-icons';
@@ -35,6 +35,7 @@ const NodeSearchCard = ({ node, displayRuntimeInfo }: { node: string; displayRun
         operationActionData={{ id: node, title: displayName, isTrigger: false, brandColor, iconUri }}
         showImage={true}
         onClick={(_: string) => {
+          dispatch(setCollapsedGraphIdsFromNodeId(node));
           dispatch(setFocusNode(node));
           dispatch(changePanelNode(node));
         }}


### PR DESCRIPTION
This pull request includes several changes to the workflow state management and related tests in the `libs/designer` directory. The changes focus on improving the handling of collapsed graph IDs and simplifying the related code.


* Modified the `reduceCollapsed` function to handle children more efficiently by using a conditional spread operator. Updated `getParentsUncollapseFromGraphState` to only uncollapse nodes that are currently collapsed. 
* Refactored the `setCollapsedGraphIds` action to directly use `getParentsUncollapseFromGraphState`. Removed the `clearCollapsedGraphIds` action and simplified the export list accordingly. 


*  Updated tests to reflect the changes in how collapsed graph IDs are handled. Replaced individual test cases with a `describe` block for better organization and added more descriptive test names. 


*  Removed the dispatch call for `clearCollapsedGraphIds` as it is no longer needed. 
*  Updated the import and usage of `setCollapsedGraphIds` to match the new implementation. 