### PR TITLE
fix(Designer): Patch the gap in aliasing flag for dynamic outputs

### DIFF
--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -486,7 +486,9 @@ export const loadDynamicOutputsInNode = async (
             /* idReplacements */ undefined,
             workflowParameters
           );
-          let schemaOutputs = outputSchema ? getDynamicOutputsFromSchema(outputSchema, info.parameter as OutputParameter) : {};
+          let schemaOutputs = outputSchema
+            ? getDynamicOutputsFromSchema(outputSchema, info.parameter as OutputParameter, operationInfo)
+            : {};
 
           if (settings.splitOn?.value?.enabled) {
             schemaOutputs = updateOutputsForBatchingTrigger(schemaOutputs, settings.splitOn?.value?.value);

--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -229,7 +229,11 @@ export async function getDynamicSchema(
   }
 }
 
-export function getDynamicOutputsFromSchema(schema: OpenAPIV2.SchemaObject, dynamicParameter: OutputParameter): OutputParameters {
+export function getDynamicOutputsFromSchema(
+  schema: OpenAPIV2.SchemaObject,
+  dynamicParameter: OutputParameter,
+  operationInfo: NodeOperation
+): OutputParameters {
   const { key, name, parentArray, required, source } = dynamicParameter;
   const keyPrefix = _getKeyPrefixFromParameter(key);
   const processorOptions: SchemaProcessorOptions = {
@@ -241,6 +245,7 @@ export function getDynamicOutputsFromSchema(schema: OpenAPIV2.SchemaObject, dyna
     includeParentObject: true,
     parentProperty: parentArray ? { arrayName: parentArray, isArray: true } : undefined,
     dataKeyPrefix: '$',
+    useAliasedIndexing: OperationManifestService().isAliasingSupported(operationInfo.type, operationInfo.kind),
   };
 
   const schemaProperties = new SchemaProcessor(processorOptions).getSchemaProperties(schema);


### PR DESCRIPTION
## Requirement Checklist

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

In OpenAPI flows, the output token are generated in a format that breaks the runtime:
@outputs('Get_items')?['body']?['body/value']

## New Behavior

This PR covers a missing case of passing the alias-allowing flag for dynamic outputs, the tokens are now generated as expected (@outputs('Get_items')?['body/value']).

## Impact of Change

Addressing gap for OpenAPI that was introduced in a recent check-in, not affecting non-OpenAPI formats.
