### PR TITLE
fix(Designer): Fixed token-picker fullscreen issue

### DIFF
--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -318,13 +318,14 @@ export function TokenPicker({
           style={
             fullScreen
               ? {
-                  height: Math.max(windowDimensions.height - 100, Math.min(windowDimensions.height, 550)),
+                  maxHeight: windowDimensions.height - 16,
+                  height: windowDimensions.height - 16,
                   width: Math.max(
                     windowDimensions.width - (Number.parseInt(PanelSize.Medium, 10) + 40),
                     Math.min(windowDimensions.width - 16, 400)
                   ),
                 }
-              : { maxHeight: Math.min(windowDimensions.height, 550), width: Math.min(windowDimensions.width - 16, 400) }
+              : { maxHeight: Math.min(windowDimensions.height - 16, 550), width: Math.min(windowDimensions.width - 16, 400) }
           }
           ref={containerRef}
         >

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickersection.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickersection.tsx
@@ -1,4 +1,4 @@
-import { getWindowDimensions, TokenPickerMode } from '..';
+import { TokenPickerMode } from '..';
 import type { ValueSegment } from '../../editor';
 import type { ExpressionEditorEvent } from '../../expressioneditor';
 import type { TokenGroup } from '../models/token';
@@ -32,9 +32,7 @@ export const TokenPickerSection = ({
   tokenGroup,
   expressionGroup,
   searchQuery,
-  fullScreen,
   noDynamicContent,
-  expressionEditorCurrentHeight,
   ...tokenPickerBaseProps
 }: TokenPickerSectionProps): JSX.Element => {
   const [dynamicTokenLength, setDynamicTokenLength] = useState(new Array<number>(tokenGroup.length));
@@ -49,26 +47,8 @@ export const TokenPickerSection = ({
     }
   }, [dynamicTokenLength, expressionTokenLength, searchQuery, selectedMode]);
 
-  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
-
-  useEffect(() => {
-    function handleResize() {
-      setWindowDimensions(getWindowDimensions());
-    }
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
   return (
-    <div
-      className="msla-token-picker-sections"
-      style={{
-        maxHeight: fullScreen
-          ? windowDimensions.height - (expressionEditorCurrentHeight + 287)
-          : Math.min(windowDimensions.height - (expressionEditorCurrentHeight + 197), 540),
-      }}
-    >
+    <div className="msla-token-picker-sections">
       {searchQuery && noItems ? <TokenPickerNoMatches /> : null}
       {noDynamicContent && (selectedMode === TokenPickerMode.TOKEN_EXPRESSION || selectedMode === TokenPickerMode.TOKEN) ? (
         <TokenPickerNoDynamicContent />


### PR DESCRIPTION
## Main Changes

Fixed issue with making token-picker fullscreen
Fixed issue with token picker being slightly off the bottom of the screen
Cleaned up unnecessary size logic

// This is a cherry-pick into 4.71

### Before
![image](https://github.com/user-attachments/assets/563025a8-3a70-4ae2-9c3d-38735db4c042)

### After
![image](https://github.com/user-attachments/assets/a79fd8ee-f883-437a-b7ec-aed4e41cc1ac)