### PR TITLE
fix(designer): Setting split on supported and calculations correctly for stateless workflow

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -640,6 +640,7 @@ const getDesignerServices = (
     getCallbackUrl: (triggerName: string) => listCallbackUrl(workflowIdWithHostRuntime, triggerName),
     getAppIdentity: () => workflowApp.identity as any,
     isExplicitAuthRequiredForManagedIdentity: () => true,
+    isSplitOnSupported: () => !!isStateful,
     resubmitWorkflow: async (runId, actionsToResubmit) => {
       const options = {
         uri: `${workflowIdWithHostRuntime}/runs/${runId}/resubmit?api-version=2018-11-01`,

--- a/apps/Standalone/src/designer/app/SettingsSections/contextSettings.tsx
+++ b/apps/Standalone/src/designer/app/SettingsSections/contextSettings.tsx
@@ -76,11 +76,6 @@ const ContextSettings = () => {
         onChange={(_, checked) => dispatch(setHostOptions({ displayRuntimeInfo: !!checked }))}
       />
       <Checkbox
-        label="Force Enable Split-On"
-        checked={hostOptions.forceEnableSplitOn}
-        onChange={(_, checked) => dispatch(setHostOptions({ forceEnableSplitOn: !!checked }))}
-      />
-      <Checkbox
         label="Suppress default node click"
         checked={suppressDefaultNodeSelect}
         onChange={(_, checked) => dispatch(setSuppressDefaultNodeSelect(!!checked))}

--- a/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
+++ b/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
@@ -30,7 +30,6 @@ export interface WorkflowLoadingState {
   suppressDefaultNodeSelect?: boolean;
   hostOptions: {
     displayRuntimeInfo: boolean; // show info about where the action is run(i.e. InApp/Shared/Custom)
-    forceEnableSplitOn?: boolean; // force enable split on for all actions
     stringOverrides?: Record<string, string>; // string overrides for localization
   };
   showPerformanceDebug?: boolean;

--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -59,6 +59,7 @@ import type {
 import type { Dispatch } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { batch } from 'react-redux';
+import { operationSupportsSplitOn } from '../../utils/outputs';
 
 type AddOperationPayload = {
   operation: DiscoveryOperation<DiscoveryResultTypes> | undefined;
@@ -144,7 +145,7 @@ export const initializeOperationDetails = async (
       isTrigger,
       nodeInputs,
       operationInfo,
-      isTrigger ? getSplitOnValue(manifest, undefined, undefined, undefined) : undefined,
+      operationSupportsSplitOn(isTrigger) ? getSplitOnValue(manifest, undefined, undefined, undefined) : undefined,
       nodeId
     );
     parsedManifest = new ManifestParser(manifest, operationManifestService.isAliasingSupported(type, kind));
@@ -153,14 +154,13 @@ export const initializeOperationDetails = async (
     const settings = getOperationSettings(
       isTrigger,
       operationInfo,
-      nodeOutputs,
       manifest,
       /* swagger */ undefined,
       /* operation */ undefined,
-      state.workflow.workflowKind,
-      state.designerOptions.hostOptions.forceEnableSplitOn
+      state.workflow.workflowKind
     );
 
+    // TODO: This seems redundant now since in line: 143 outputs are already updated with a splitOnExpression. Should remove it.
     // We should update the outputs when splitOn is enabled.
     let updatedOutputs = nodeOutputs;
     if (isTrigger && settings.splitOn?.value?.value) {
@@ -208,12 +208,10 @@ export const initializeOperationDetails = async (
     const settings = getOperationSettings(
       isTrigger,
       operationInfo,
-      nodeOutputs,
       /* manifest */ undefined,
       parsedSwagger,
       /* operation */ undefined,
-      state.workflow.workflowKind,
-      state.designerOptions.hostOptions.forceEnableSplitOn
+      state.workflow.workflowKind
     );
 
     // We should update the outputs when splitOn is enabled.

--- a/libs/designer/src/lib/core/actions/bjsworkflow/copypaste.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/copypaste.ts
@@ -227,7 +227,6 @@ export const pasteScopeOperation = createAsyncThunk(
     const connectionReference = (getState() as RootState).connections.connectionReferences;
     const workflowParameters = state.workflowParameters.definitions;
     const workflowKind = state.workflow.workflowKind;
-    const enforceSplitOn = state.designerOptions.hostOptions.forceEnableSplitOn ?? false;
     const operations = state.workflow.operations;
     const nodeMap: Record<string, string> = {};
     for (const id of Object.keys(operations)) {
@@ -248,7 +247,6 @@ export const pasteScopeOperation = createAsyncThunk(
         workflowParameters,
         {},
         workflowKind,
-        enforceSplitOn,
         dispatch,
         { ...pasteParams, existingOutputTokens: upstreamOutputTokens, rootTriggerId: triggerId }
       ),

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -74,6 +74,7 @@ import {
 } from '@microsoft/logic-apps-shared';
 import type { InputParameter, OutputParameter, LogicAppsV2, OperationManifest } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
+import { operationSupportsSplitOn } from '../../utils/outputs';
 
 export interface NodeDataWithOperationMetadata extends NodeData {
   manifest?: OperationManifest;
@@ -108,7 +109,6 @@ export const initializeOperationMetadata = async (
   workflowParameters: Record<string, WorkflowParameter>,
   customCode: CustomCodeFileNameMapping,
   workflowKind: WorkflowKind,
-  forceEnableSplitOn: boolean,
   dispatch: Dispatch,
   pasteParams?: PasteScopeAdditionalParams
 ): Promise<void> => {
@@ -130,13 +130,9 @@ export const initializeOperationMetadata = async (
       triggerNodeId = operationId;
     }
     if (operationManifestService.isSupported(operation.type, operation.kind)) {
-      promises.push(
-        initializeOperationDetailsForManifest(operationId, operation, customCode, !!isTrigger, workflowKind, forceEnableSplitOn, dispatch)
-      );
+      promises.push(initializeOperationDetailsForManifest(operationId, operation, customCode, !!isTrigger, workflowKind, dispatch));
     } else {
-      promises.push(
-        initializeOperationDetailsForSwagger(operationId, operation, references, !!isTrigger, workflowKind, forceEnableSplitOn, dispatch)
-      );
+      promises.push(initializeOperationDetailsForSwagger(operationId, operation, references, !!isTrigger, workflowKind, dispatch));
     }
   }
 
@@ -218,7 +214,6 @@ export const initializeOperationDetailsForManifest = async (
   customCode: CustomCodeFileNameMapping,
   isTrigger: boolean,
   workflowKind: WorkflowKind,
-  forceEnableSplitOn: boolean,
   dispatch: Dispatch
 ): Promise<NodeDataWithOperationMetadata[] | undefined> => {
   const operation = { ..._operation };
@@ -269,21 +264,12 @@ export const initializeOperationDetailsForManifest = async (
       isTrigger,
       nodeInputs,
       nodeOperationInfo,
-      isTrigger ? getSplitOnValue(manifest, undefined, undefined, operation) : undefined,
+      operationSupportsSplitOn(isTrigger) ? getSplitOnValue(manifest, undefined, undefined, operation) : undefined,
       nodeId
     );
     const nodeDependencies = { inputs: inputDependencies, outputs: outputDependencies };
 
-    const settings = getOperationSettings(
-      isTrigger,
-      nodeOperationInfo,
-      nodeOutputs,
-      manifest,
-      undefined /* swagger */,
-      operation,
-      workflowKind,
-      forceEnableSplitOn
-    );
+    const settings = getOperationSettings(isTrigger, nodeOperationInfo, manifest, undefined /* swagger */, operation, workflowKind);
 
     const childGraphInputs = processChildGraphAndItsInputs(manifest, operation);
 

--- a/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/settings.ts
@@ -1,7 +1,7 @@
 import Constants from '../../../common/constants';
-import type { NodeOperation, NodeOutputs } from '../../state/operation/operationMetadataSlice';
+import type { NodeOperation } from '../../state/operation/operationMetadataSlice';
 import { WorkflowKind } from '../../state/workflow/workflowInterfaces';
-import { getSplitOnOptions } from '../../utils/outputs';
+import { operationSupportsSplitOn } from '../../utils/outputs';
 import { getTokenExpressionValue } from '../../utils/parameters/helper';
 import { TokenType } from '@microsoft/designer-ui';
 import type {
@@ -114,7 +114,6 @@ export interface Settings {
  * Gets the operation options for the specified node based on the definition of the operation in a reload, or from swagger information.
  * @arg {string} isTrigger - Specifies if this is trigger operation node.
  * @arg {NodeOperation} operationInfo - The operation information about the node.
- * @arg {NodeOutputs} nodeOutputs - All outputs of the node.
  * @arg {OperationManifest} [manifest] - The operation manifest if node type supports.
  * @arg {SwaggerParser} [swagger] - The swagger if the node type supports.
  * @arg {LogicAppsV2.OperationDefinition} [operation] - The JSON from the definition for the given operation.
@@ -123,12 +122,10 @@ export interface Settings {
 export const getOperationSettings = (
   isTrigger: boolean,
   operationInfo: NodeOperation,
-  nodeOutputs: NodeOutputs,
   manifest?: OperationManifest,
   swagger?: SwaggerParser,
   operation?: LogicAppsV2.OperationDefinition,
-  workflowKind?: WorkflowKind,
-  forceEnableSplitOn?: boolean
+  workflowKind?: WorkflowKind
 ): Settings => {
   const { operationId, type: nodeType } = operationInfo;
   return {
@@ -157,8 +154,8 @@ export const getOperationSettings = (
       value: getDisableAutomaticDecompression(isTrigger, nodeType, manifest, operation),
     },
     splitOn: {
-      isSupported: isSplitOnSupported(isTrigger, nodeOutputs, manifest, swagger, operationId, operation, workflowKind, forceEnableSplitOn),
-      value: getSplitOn(manifest, swagger, operationId, operation, workflowKind, forceEnableSplitOn),
+      isSupported: isSplitOnSupported(isTrigger, manifest, swagger, operationId, operation),
+      value: getSplitOn(manifest, swagger, operationId, operation),
     },
     retryPolicy: {
       isSupported: isRetryPolicySupported(isTrigger, operationInfo.type, manifest),
@@ -519,11 +516,9 @@ const getSplitOn = (
   manifest?: OperationManifest,
   swagger?: SwaggerParser,
   operationId?: string,
-  definition?: LogicAppsV2.OperationDefinition,
-  workflowKind?: WorkflowKind,
-  forceEnableSplitOn?: boolean
+  definition?: LogicAppsV2.OperationDefinition
 ): SimpleSetting<string> => {
-  if (workflowKind === WorkflowKind.STATELESS && !forceEnableSplitOn) {
+  if (!operationSupportsSplitOn(/* isTrigger */ true)) {
     return { enabled: false };
   }
   const splitOnValue = getSplitOnValue(manifest, swagger, operationId, definition);
@@ -531,6 +526,18 @@ const getSplitOn = (
     enabled: !!splitOnValue,
     value: splitOnValue,
   };
+};
+
+const isBatchTrigger = (manifest?: OperationManifest, swagger?: SwaggerParser, operationId?: string): boolean => {
+  if (manifest) {
+    return equals(manifest.properties.trigger, Constants.BATCH_TRIGGER);
+  }
+
+  if (swagger && operationId) {
+    return equals(swagger.getOperations()?.[operationId]?.triggerType, Constants.BATCH_TRIGGER);
+  }
+
+  return false;
 };
 
 export const getSplitOnValue = (
@@ -582,19 +589,16 @@ export const getSplitOnValue = (
 
 const isSplitOnSupported = (
   isTrigger: boolean,
-  nodeOutputs: NodeOutputs,
   manifest?: OperationManifest,
   swagger?: SwaggerParser,
   operationId?: string,
-  definition?: LogicAppsV2.OperationDefinition,
-  workflowKind?: WorkflowKind,
-  forceEnableSplitOn?: boolean
+  definition?: LogicAppsV2.OperationDefinition
 ): boolean => {
-  if (workflowKind === WorkflowKind.STATELESS && !forceEnableSplitOn) {
+  if (!operationSupportsSplitOn(isTrigger)) {
     return false;
   }
   const existingSplitOn = getSplitOn(manifest, swagger, operationId, definition);
-  return isTrigger && (getSplitOnOptions(nodeOutputs, !!manifest).length > 0 || existingSplitOn.enabled);
+  return isBatchTrigger(manifest, swagger, operationId) || existingSplitOn.enabled;
 };
 
 const getTimeout = (

--- a/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
+++ b/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
@@ -26,7 +26,7 @@ export const initializeGraphState = createAsyncThunk<
   { state: RootState }
 >('parser/deserialize', async (graphState: { workflowDefinition: Workflow; runInstance: any }, thunkAPI): Promise<InitWorkflowPayload> => {
   const { workflowDefinition, runInstance } = graphState;
-  const { workflow, designerOptions } = thunkAPI.getState() as RootState;
+  const { workflow } = thunkAPI.getState() as RootState;
   const spec = workflow.workflowSpec;
 
   if (spec === undefined) {
@@ -63,7 +63,6 @@ export const initializeGraphState = createAsyncThunk<
               parameters ?? {},
               customCodeWithData,
               workflow.workflowKind,
-              designerOptions.hostOptions.forceEnableSplitOn ?? false,
               thunkAPI.dispatch
             ),
             getConnectionsApiAndMapping(deserializedWorkflow, thunkAPI.dispatch),

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -40,7 +40,6 @@ export interface DesignerOptionsState {
     suppressCastingForSerialize?: boolean; // suppress casting for serialize
     recurrenceInterval?: LogicApps.Recurrence;
     maxWaitingRuns?: MaximumWaitingRunsMetadata; // min and max of Maximum Waiting Runs Concurrency Setting
-    forceEnableSplitOn?: boolean; // force enable split on (by default it is disabled on stateless workflows)
     hideUTFExpressions?: boolean; // hide UTF expressions in template functions
     stringOverrides?: Record<string, string>; // string overrides for localization
   };

--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -162,7 +162,6 @@ export const addForeachToNode = createAsyncThunk(
         customCodeWithData,
         /* isTrigger */ false,
         state.workflow.workflowKind,
-        state.designerOptions.hostOptions.forceEnableSplitOn ?? false,
         dispatch
       )) as NodeDataWithOperationMetadata[];
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1933,8 +1933,6 @@ async function loadDynamicData(
       rootState.operations.inputParameters[nodeId],
       rootState.operations.settings[nodeId],
       rootState.workflowParameters.definitions,
-      rootState.workflow.workflowKind,
-      rootState.designerOptions.hostOptions.forceEnableSplitOn ?? false,
       dispatch
     );
   }

--- a/libs/designer/src/lib/core/utils/swagger/operation.ts
+++ b/libs/designer/src/lib/core/utils/swagger/operation.ts
@@ -65,7 +65,6 @@ export const initializeOperationDetailsForSwagger = async (
   references: ConnectionReferences,
   isTrigger: boolean,
   workflowKind: WorkflowKind,
-  forceEnableSplitOn: boolean,
   dispatch: Dispatch
 ): Promise<NodeDataWithOperationMetadata[] | undefined> => {
   try {
@@ -99,16 +98,7 @@ export const initializeOperationDetailsForSwagger = async (
         isTrigger ? (operation as LogicAppsV2.TriggerDefinition).splitOn : undefined
       );
       const nodeDependencies = { inputs: inputDependencies, outputs: outputDependencies };
-      const settings = getOperationSettings(
-        isTrigger,
-        nodeOperationInfo,
-        nodeOutputs,
-        /* manifest */ undefined,
-        parsedSwagger,
-        operation,
-        workflowKind,
-        forceEnableSplitOn
-      );
+      const settings = getOperationSettings(isTrigger, nodeOperationInfo, /* manifest */ undefined, parsedSwagger, operation, workflowKind);
 
       return [
         {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/workflow.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/workflow.ts
@@ -43,6 +43,11 @@ export interface IWorkflowService {
   isExplicitAuthRequiredForManagedIdentity?(): boolean;
 
   /**
+   * Checks if workflow supports split on in triggers.
+   */
+  isSplitOnSupported?(): boolean;
+
+  /**
    * Gets definition schema version from current operation types.
    */
   getDefinitionSchema?(operationInfos: { type: string; kind?: string }[]): string;


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Fixes #5420 

## Impact of Change

As part of changes have removed the hostOption - forceEnableSplitOn... I have added a method in WorkflowService for the host to implement if spliton is supported in an app.. if not specified this is always set to true. Only change is needed in LA portal for this to be implemented to we can set it to false for stateless workflow

* [x] **This is a breaking change.**
