### PR TITLE
fix(Designer): Connection objects can now have ids without the starting slash

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -302,7 +302,7 @@ const DesignerEditor = () => {
   };
 
   const getAuthToken = async () => {
-    return `Bearer ${environment.armToken}` ?? '';
+    return environment?.armToken ? `Bearer ${environment.armToken}` : '';
   };
 
   return (

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -71,6 +71,7 @@ import {
   equals,
   getRecordEntry,
   parseErrorMessage,
+  cleanResourceId,
 } from '@microsoft/logic-apps-shared';
 import type { InputParameter, OutputParameter, LogicAppsV2, OperationManifest } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
@@ -191,7 +192,7 @@ export const initializeOperationMetadata = async (
 };
 
 const initializeConnectorsForReferences = async (references: ConnectionReferences): Promise<ConnectorWithParsedSwagger[]> => {
-  const connectorIds = uniqueArray(Object.keys(references || {}).map((key) => references[key].api.id));
+  const connectorIds = uniqueArray(Object.keys(references || {}).map((key) => cleanResourceId(references[key].api.id)));
   const connectorPromises: Promise<ConnectorWithParsedSwagger | undefined>[] = [];
 
   for (const connectorId of connectorIds) {

--- a/libs/designer/src/lib/core/queries/connections.ts
+++ b/libs/designer/src/lib/core/queries/connections.ts
@@ -1,5 +1,5 @@
 import { getReactQueryClient } from '../ReactQueryProvider';
-import { ConnectionService, SwaggerParser, equals } from '@microsoft/logic-apps-shared';
+import { ConnectionService, SwaggerParser, equals, cleanResourceId } from '@microsoft/logic-apps-shared';
 import type { Connection, Connector } from '@microsoft/logic-apps-shared';
 import { useMemo } from 'react';
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -85,7 +85,9 @@ export const getConnectionsForConnector = async (connectorId: string) => {
   });
 };
 
-export const getConnection = async (connectionId: string, connectorId: string, fetchResourceIfNeeded = false) => {
+export const getConnection = async (_connectionId: string, _connectorId: string, fetchResourceIfNeeded = false) => {
+  const connectionId = cleanResourceId(_connectionId);
+  const connectorId = cleanResourceId(_connectorId);
   const connections = await getConnectionsForConnector(connectorId);
   const connection = connections?.find((connection) => equals(connection.id, connectionId));
   return (!connection && fetchResourceIfNeeded ? getConnectionFromResource(connectionId) : connection) ?? null;

--- a/libs/designer/src/lib/core/queries/connections.ts
+++ b/libs/designer/src/lib/core/queries/connections.ts
@@ -99,8 +99,9 @@ export const getUniqueConnectionName = async (connectorId: string, existingKeys:
   return ConnectionService().getUniqueConnectionName(connectorId, [...connectionNames, ...existingKeys], connectorName as string);
 };
 
-export const useConnectionResource = (connectionId: string) => {
-  return useQuery(['connection', connectionId?.toLowerCase()], () => ConnectionService().getConnection(connectionId) ?? null, {
+export const useConnectionResource = (_connectionId: string) => {
+  const connectionId = cleanResourceId(_connectionId)?.toLowerCase();
+  return useQuery(['connection', connectionId], () => ConnectionService().getConnection(connectionId) ?? null, {
     enabled: !!connectionId,
     refetchOnMount: false,
   });

--- a/libs/designer/src/lib/core/utils/swagger/operation.ts
+++ b/libs/designer/src/lib/core/utils/swagger/operation.ts
@@ -46,6 +46,7 @@ import {
   removeConnectionPrefix,
   startsWith,
   unmap,
+  cleanResourceId,
 } from '@microsoft/logic-apps-shared';
 import type { LAOperation, LogicAppsV2, OperationInfo, OutputParameter, SwaggerParser } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
@@ -288,7 +289,8 @@ const getOperationInfo = async (
       if (!reference || !reference.api || !reference.api.id) {
         throw new Error(`Incomplete information for operation '${nodeId}'`);
       }
-      const connectorId = reference.api.id;
+      const connectorId = cleanResourceId(reference.api.id);
+
       const { parsedSwagger } = await getConnectorWithSwagger(connectorId);
       if (!parsedSwagger) {
         throw new Error(`Could not fetch swagger for connector - ${connectorId}`);

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/connectionEntry.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/connectionEntry.tsx
@@ -10,7 +10,7 @@ import {
   ErrorCircle24Filled,
   PlugDisconnected24Filled,
 } from '@fluentui/react-icons';
-import { HostService, getConnectionErrors } from '@microsoft/logic-apps-shared';
+import { HostService, cleanResourceId, getConnectionErrors } from '@microsoft/logic-apps-shared';
 import { useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
@@ -26,8 +26,8 @@ interface ConnectionEntryProps {
 
 export const ConnectionEntry = ({ connectorId, refId, connectionReference, iconUri, disconnectedNodeIds = [] }: ConnectionEntryProps) => {
   const dispatch = useDispatch();
-
-  const connection = useConnectionById(connectionReference?.connection?.id, connectorId);
+  const connectionId = cleanResourceId(connectionReference?.connection?.id);
+  const connection = useConnectionById(connectionId, connectorId);
   const nodeIds = useMemo(() => connectionReference?.nodes || disconnectedNodeIds, [connectionReference?.nodes, disconnectedNodeIds]);
 
   const disconnected = useMemo(() => disconnectedNodeIds.length > 0, [disconnectedNodeIds.length]);

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/connectionTable.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/connectionTable.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
 } from '@fluentui/react-components';
 import type { Connection } from '@microsoft/logic-apps-shared';
-import { getIdLeaf, LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
+import { cleanResourceId, getIdLeaf, LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
 import { useCallback, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { ConnectionTableDetailsButton } from './connectionTableDetailsButton';
@@ -40,7 +40,7 @@ export const ConnectionTable = (props: ConnectionTableProps): JSX.Element => {
   const initiallySelectedConnectionId = useRef(currentConnectionId);
 
   const isSelectedConnection = (connection: ConnectionWithFlattenedProperties): boolean => {
-    return connection.id === initiallySelectedConnectionId.current;
+    return cleanResourceId(connection.id) === cleanResourceId(initiallySelectedConnectionId.current);
   };
 
   // We need to flatten the connection to allow the detail list access to nested props

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -54,6 +54,6 @@ export const canStringBeConverted = (s: string): boolean => {
 
 export const createIdCopy = (id: string) => `${id}-copy`;
 
-export const cleanResourceId = (resourceId: string): string => {
-  return resourceId.startsWith('/') ? resourceId : `/${resourceId}`;
+export const cleanResourceId = (resourceId?: string): string => {
+  return resourceId?.startsWith('/') ? resourceId : `/${resourceId}`;
 };

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -53,3 +53,7 @@ export const canStringBeConverted = (s: string): boolean => {
 };
 
 export const createIdCopy = (id: string) => `${id}-copy`;
+
+export const cleanResourceId = (resourceId: string): string => {
+  return resourceId.startsWith('/') ? resourceId : `/${resourceId}`;
+};


### PR DESCRIPTION
## Main Changes

In old designer, if a connection api id or a connection id did not have a `/` at the start of the id it would load the matching operations with no issue. In new designer this situation would cause the operation load to fail.

This PR just adds the `/` into the ids if they are missing in a few places


### Old
![image](https://github.com/user-attachments/assets/d8ac6d86-c119-47d7-95c8-89a0114557c2)

### New
![image](https://github.com/user-attachments/assets/c62401b5-a972-4957-8620-803e6a7616c2)


Fixes https://github.com/Azure/LogicAppsUX/issues/5436