### PR TITLE
fix(designer-ui): Force `maxDisplayedItems: 2` to mitigate file picker render loop

### DIFF
--- a/libs/designer-ui/src/lib/picker/filepickerPopoverHeader.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickerPopoverHeader.tsx
@@ -70,12 +70,12 @@ const FilePickerPopoverBreadcrumbs: React.FC<FilePickerPopoverHeaderProps> = (pr
 
   const intl = useIntl();
 
-  const { isOverflowing, overflowCount, ref } = useOverflowMenu<HTMLButtonElement>();
+  const { ref } = useOverflowMenu<HTMLButtonElement>();
 
   const { startDisplayedItems, overflowItems, endDisplayedItems }: PartitionBreadcrumbItems<FilePickerBreadcrumb> =
     partitionBreadcrumbItems({
       items: currentPathSegments,
-      maxDisplayedItems: currentPathSegments.length - (isOverflowing ? overflowCount : 0),
+      maxDisplayedItems: 2,
     });
 
   const overflowItemsLength = overflowItems?.length ?? 0;


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

In certain cases (Azure Portal), file picker's Fluent overflow component can cause a render loop due to the length of `overflowItems` (as calculated by Fluent's `partitionBreadcrumbItems` method) switching between 0 and 1 constantly, provoked by `maxDisplayedItems` being updated based on `overflowItems`'s length.

## New Behavior

`maxDisplayedItems` is hardcoded to 2, so that it cannot cause `overflowItems` to be updated accidentally.

## Screenshots or Videos (if applicable)

### Root

![image](https://github.com/user-attachments/assets/f8807928-b6b4-4982-8a31-58ce416bde73)

### 1 level deep

![image](https://github.com/user-attachments/assets/5ac77b1c-8bb1-43af-8afe-ee6008e0d7d7)

### 2 levels deep

![image](https://github.com/user-attachments/assets/e3f36e1c-307e-4212-b19f-b969cfb2fbc2)

### 3+ levels deep

![image](https://github.com/user-attachments/assets/c125e790-21f3-4723-9761-07716510bbdb)

## Follow-ups

- This may be a bug in Fluent, or may be a bug in how the component is coded
- In Power Automate, it seems that the overflow component simply does not render even in subfolders:
    <br>![image](https://github.com/user-attachments/assets/98b28138-8e54-4a9d-a1b3-8b40a7395884)