### PR TITLE
fix(Designer): Fixed issue with loop pager index resetting, fixed operations reloading in loops

### DIFF
--- a/libs/designer/src/lib/core/queries/connections.ts
+++ b/libs/designer/src/lib/core/queries/connections.ts
@@ -102,7 +102,7 @@ export const getUniqueConnectionName = async (connectorId: string, existingKeys:
 export const useConnectionResource = (_connectionId: string) => {
   const connectionId = cleanResourceId(_connectionId)?.toLowerCase();
   return useQuery(['connection', connectionId], () => ConnectionService().getConnection(connectionId) ?? null, {
-    enabled: !!connectionId,
+    enabled: !!_connectionId,
     refetchOnMount: false,
   });
 };

--- a/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -74,7 +74,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
   const runInstance = useRunInstance();
   const runData = useRunData(id);
   const parentRunId = useParentRunId(id);
-  const parenRunData = useRunData(parentRunId ?? '');
+  const parentRunData = useRunData(parentRunId ?? '');
   const nodesMetaData = useNodesMetadata();
   const repetitionName = getRepetitionName(parentRunIndex, id, nodesMetaData, operationsInfo);
   const isSecureInputsOutputs = useSecureInputsOutputs(id);
@@ -84,7 +84,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
   const nodeSelectCallbackOverride = useNodeSelectAdditionalCallback();
 
   const getRunRepetition = () => {
-    if (parenRunData?.status === constants.FLOW_STATUS.SKIPPED) {
+    if (parentRunData?.status === constants.FLOW_STATUS.SKIPPED) {
       return {
         properties: {
           status: constants.FLOW_STATUS.SKIPPED,
@@ -100,18 +100,12 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
     return RunService().getRepetition({ nodeId: id, runId: runInstance?.id }, repetitionName);
   };
 
-  const {
-    refetch,
-    isFetching: isRepetitionLoading,
-    data: repetitionData,
-  } = useQuery<any>(
-    ['runInstance', { nodeId: id, runId: runInstance?.id, repetitionName, parentStatus: parenRunData?.status }],
+  const { isFetching: isRepetitionLoading, data: repetitionData } = useQuery<any>(
+    ['runInstance', { nodeId: id, runId: runInstance?.id, repetitionName, parentStatus: parentRunData?.status, parentRunIndex }],
     getRunRepetition,
     {
       refetchOnWindowFocus: false,
-      initialData: null,
-      refetchIntervalInBackground: true,
-      enabled: parentRunIndex !== undefined && isMonitoringView,
+      enabled: isMonitoringView && parentRunIndex !== undefined,
     }
   );
 
@@ -120,12 +114,6 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
       dispatch(setRepetitionRunData({ nodeId: id, runData: repetitionData.properties as any }));
     }
   }, [dispatch, id, repetitionData, runInstance?.id]);
-
-  useEffect(() => {
-    if (parentRunIndex !== undefined && isMonitoringView) {
-      refetch();
-    }
-  }, [dispatch, parentRunIndex, isMonitoringView, refetch, repetitionName, parenRunData?.status]);
 
   const dependencies = useTokenDependencies(id);
 

--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -1,12 +1,12 @@
 import constants from '../../../common/constants';
 import type { AppDispatch } from '../../../core';
-import { useActionMetadata, useRunInstance } from '../../../core/state/workflow/workflowSelectors';
+import { useActionMetadata, useNodeMetadata, useRunInstance } from '../../../core/state/workflow/workflowSelectors';
 import { setRunIndex } from '../../../core/state/workflow/workflowSlice';
 import { getForeachItemsCount } from './helper';
 import { RunService, FindPreviousAndNextPage, isNullOrUndefined, type LogicAppsV2 } from '@microsoft/logic-apps-shared';
 import type { PageChangeEventArgs, PageChangeEventHandler } from '@microsoft/designer-ui';
 import { Pager } from '@microsoft/designer-ui';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';
 
@@ -17,12 +17,13 @@ export interface LoopsPagerProps {
 }
 
 export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) => {
-  const [currentPage, setCurrentPage] = useState(1);
   const [failedRepetitions, setFailedRepetitions] = useState<number[]>([]);
   const runInstance = useRunInstance();
   const dispatch = useDispatch<AppDispatch>();
-  const node = useActionMetadata(scopeId);
-  const normalizedType = node?.type.toLowerCase();
+  const actionMetadata = useActionMetadata(scopeId);
+  const normalizedType = actionMetadata?.type.toLowerCase();
+  const nodeMetadata = useNodeMetadata(scopeId);
+  const currentPage = useMemo(() => nodeMetadata?.runIndex ?? 0, [nodeMetadata]);
 
   const forEachItemsCount = getForeachItemsCount(metadata?.runData);
 
@@ -75,24 +76,21 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
 
   const onPagerChange: PageChangeEventHandler = (page: PageChangeEventArgs) => {
     dispatch(setRunIndex({ page: page.value - 1, nodeId: scopeId }));
-    setCurrentPage(page.value);
   };
 
   const onClickNextFailed: PageChangeEventHandler = (page: PageChangeEventArgs) => {
     const { nextFailedRepetition } = findPreviousAndNextFailed(page.value - 1);
     dispatch(setRunIndex({ page: nextFailedRepetition, nodeId: scopeId }));
-    setCurrentPage(nextFailedRepetition + 1);
   };
 
   const onClickPreviousFailed: PageChangeEventHandler = (page: PageChangeEventArgs) => {
     const { prevFailedRepetition } = findPreviousAndNextFailed(page.value - 1);
     dispatch(setRunIndex({ page: prevFailedRepetition, nodeId: scopeId }));
-    setCurrentPage(prevFailedRepetition + 1);
   };
 
-  if (currentPage > forEachItemsCount) {
-    onPagerChange({ value: forEachItemsCount });
-  }
+  // if (currentPage > forEachItemsCount + 1) {
+  //   onPagerChange({ value: forEachItemsCount + 1 });
+  // }
 
   const failedIterationProps =
     failedRepetitions.length > 0
@@ -106,7 +104,7 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
 
   return isLoading ? null : (
     <Pager
-      current={currentPage}
+      current={currentPage + 1}
       onChange={onPagerChange}
       max={forEachItemsCount}
       maxLength={forEachItemsCount.toString().length + 1}


### PR DESCRIPTION
## Main Changes

- Loop pager component index now only uses the index from the redux store
  - This fixes the issue of the pager component index being reset when rerendering on scroll
- Nodes within monitoring view loops now only fetch their data once
  - If you moved a node offscreen then back, or paged away then back, it would refetch the run data
  - This has been fixed and now only fetches once, then just uses the cached data when needed

Fixes https://github.com/Azure/LogicAppsUX/issues/5530