### PR TITLE
fix(designer): Fixing the recursive call in dynamic data load

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -320,7 +320,7 @@ export async function getDynamicInputsFromSchema(
   }
 
   if (!schemaProperties.length) {
-    dynamicInputs = [dynamicParameter];
+    dynamicInputs = [getDynamicInputParameterFromDynamicParameter(dynamicParameter)];
   }
 
   if (OperationManifestService().isSupported(operationInfo.type, operationInfo.kind)) {
@@ -734,7 +734,7 @@ function getSwaggerBasedInputParameters(
   );
   let dynamicInputParameters = loadInputValuesFromDefinition(
     dynamicInputDefinition as Record<string, any>,
-    isNested ? [dynamicParameter] : inputs,
+    isNested ? [getDynamicInputParameterFromDynamicParameter(dynamicParameter)] : inputs,
     operationPath,
     basePath as string
   );
@@ -765,6 +765,20 @@ function getSwaggerBasedInputParameters(
     return result;
   }
   return dynamicInputParameters;
+}
+
+// We should remove any reference to dynamic schema if parameter containing dynamic schema is used directly as an input.
+function getDynamicInputParameterFromDynamicParameter(dynamicParameter: InputParameter): InputParameter {
+  const result = {
+    ...dynamicParameter,
+    isDynamic: true,
+    dynamicParameterReference: dynamicParameter.key,
+    in: dynamicParameter.in,
+    required: (dynamicParameter.schema?.required as any) ?? dynamicParameter.required ?? false,
+  };
+  
+  delete result.dynamicSchema;
+  return result;
 }
 
 function _getKeyPrefixFromParameter(parameterKey: string): string {

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1866,7 +1866,7 @@ function getDependenciesToUpdate(
   return dependenciesToUpdate;
 }
 
-export async function updateDynamicDataInNode(
+export const updateDynamicDataInNode = async (
   nodeId: string,
   isTrigger: boolean,
   operationInfo: NodeOperation,
@@ -1875,7 +1875,7 @@ export async function updateDynamicDataInNode(
   dispatch: Dispatch,
   getState: () => RootState,
   operationDefinition?: any
-): Promise<void> {
+): Promise<void> => {
   await loadDynamicData(nodeId, isTrigger, operationInfo, connectionReference, dependencies, dispatch, getState, operationDefinition);
 
   const { operations, workflowParameters } = getState();
@@ -1910,7 +1910,7 @@ export async function updateDynamicDataInNode(
   if (parameterDynamicValues.length > 0) {
     dispatch(updateNodeParameters({ nodeId, parameters: parameterDynamicValues }));
   }
-}
+};
 
 async function loadDynamicData(
   nodeId: string,
@@ -2933,7 +2933,7 @@ function getClosestRepetitionReference(repetitionContext: RepetitionContext): Re
   return undefined;
 }
 
-export function updateTokenMetadataInParameters(nodeId: string, parameters: ParameterInfo[], rootState: RootState): void {
+export const updateTokenMetadataInParameters = (nodeId: string, parameters: ParameterInfo[], rootState: RootState): void => {
   const {
     workflow: { operations, nodesMetadata },
     operations: { operationMetadata, outputParameters, settings },
@@ -2994,7 +2994,7 @@ export function updateTokenMetadataInParameters(nodeId: string, parameters: Para
       );
     }
   }
-}
+};
 
 export const flattenAndUpdateViewModel = (
   repetitionContext: RepetitionContext,


### PR DESCRIPTION
Issue: When dynamic schema could not be fetched or returns empty parameters we always return the current dynamic schema parameter as the sole input, while doing so other dynamic data was not removed which caused the recursive call for dynamic schema [feature added in april]