### PR TITLE
fix(designer): Update undo/redo compression to use pako instead of zlib library

### DIFF
--- a/libs/designer/package.json
+++ b/libs/designer/package.json
@@ -20,6 +20,7 @@
     "lodash.frompairs": "4.0.1",
     "lodash.merge": "4.6.2",
     "monaco-editor": "0.44.0",
+    "pako": "2.1.0",
     "react-dnd": "16.0.1",
     "react-dnd-accessible-backend": "1.0.1",
     "react-dnd-html5-backend": "16.0.1",
@@ -38,6 +39,7 @@
     "@formatjs/intl": "^2.10.1",
     "@types/lodash.frompairs": "^4.0.9",
     "@types/lodash.merge": "^4.6.9",
+    "@types/pako": "^2.0.3",
     "@types/to-title-case": "^1.0.2"
   },
   "engines": {

--- a/libs/designer/src/lib/__test__/redux-test-helper.tsx
+++ b/libs/designer/src/lib/__test__/redux-test-helper.tsx
@@ -3,18 +3,21 @@ import designerOptionsReducer from '../core/state/designerOptions/designerOption
 import designerViewReducer from '../core/state/designerView/designerViewSlice';
 import operationMetadataReducer from '../core/state/operation/operationMetadataSlice';
 import panelReducer from '../core/state/panel/panelSlice';
+import panelV2Reducer from '../core/state/panelV2/panelSlice';
 import customCodeReducer from '../core/state/customcode/customcodeSlice';
 import settingsReducer from '../core/state/setting/settingSlice';
 import staticResultsSchemasReducer from '../core/state/staticresultschema/staticresultsSlice';
 import tokens from '../core/state/tokens/tokensSlice';
 import workflowReducer from '../core/state/workflow/workflowSlice';
 import workflowParametersReducer from '../core/state/workflowparameters/workflowparametersSlice';
+import undoRedoReducer from '../core/state/undoRedo/undoRedoSlice';
 import type { AppStore, RootState } from '../core/store';
 import { configureStore } from '@reduxjs/toolkit';
 import { type RenderOptions } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import ReactTestRenderer from 'react-test-renderer';
+import { storeStateHistoryMiddleware } from '../core/utils/middleware';
 
 // This type interface extends the default options for render from RTL, as well
 // as allows the user to specify other things such as initialState, store.
@@ -33,6 +36,7 @@ export function renderWithRedux(
         workflow: workflowReducer,
         operations: operationMetadataReducer,
         panel: panelReducer,
+        panelV2: panelV2Reducer,
         connections: connectionsReducer,
         settings: settingsReducer,
         designerOptions: designerOptionsReducer,
@@ -41,11 +45,12 @@ export function renderWithRedux(
         workflowParameters: workflowParametersReducer,
         staticResults: staticResultsSchemasReducer,
         customCode: customCodeReducer,
+        undoRedo: undoRedoReducer,
       },
       middleware: (getDefaultMiddleware) =>
         getDefaultMiddleware({
           serializableCheck: false,
-        }),
+        }).concat(storeStateHistoryMiddleware),
       preloadedState,
     }),
   }: ExtendedRenderOptions = {}

--- a/libs/designer/src/lib/core/actions/bjsworkflow/undoRedo.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/undoRedo.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { deflateSync, inflateSync } from 'zlib';
+import { deflate, inflate } from 'pako';
 import CONSTANTS from '../../../common/constants';
 import { setStateAfterUndoRedo } from '../../state/global';
 import { saveStateToHistory, updateStateHistoryOnRedoClick, updateStateHistoryOnUndoClick } from '../../state/undoRedo/undoRedoSlice';
@@ -68,8 +68,8 @@ export const getCompressedStateFromRootState = (rootState: RootState) => {
     workflow: rootState.workflow,
     workflowParameters: rootState.workflowParameters,
   };
-  return deflateSync(JSON.stringify(partialRootState)).toString('base64');
+  return deflate(JSON.stringify(partialRootState));
 };
 
-export const getRootStateFromCompressedState = (compressedState: string) =>
-  JSON.parse(inflateSync(Buffer.from(compressedState, 'base64')).toString()) as UndoRedoPartialRootState;
+export const getRootStateFromCompressedState = (compressedState: Uint8Array) =>
+  JSON.parse(inflate(compressedState, { to: 'string' })) as UndoRedoPartialRootState;

--- a/libs/designer/src/lib/core/state/__test__/undoRedoSlice.spec.ts
+++ b/libs/designer/src/lib/core/state/__test__/undoRedoSlice.spec.ts
@@ -3,13 +3,19 @@ import reducer, { saveStateToHistory, updateStateHistoryOnRedoClick, updateState
 import { StateHistory } from '../undoRedo/undoRedoTypes';
 
 describe('undo redo slice reducers', () => {
+  const mockCompressedState1 = new Uint8Array([140, 27]);
+  const mockCompressedState2 = new Uint8Array([120, 59]);
+  const mockCompressedState3 = new Uint8Array([12, 1]);
+  const mockCompressedState4 = new Uint8Array([63, 150]);
+  const mockCompressedState5 = new Uint8Array([32, 47]);
+
   it('should save state to history based on limit', () => {
     let mockInitialState: StateHistory = {
       past: [],
       future: [],
     };
 
-    const getMockPayload = (mockState: string) => {
+    const getMockPayload = (mockState: Uint8Array) => {
       return {
         compressedState: mockState,
         limit: 2,
@@ -17,51 +23,51 @@ describe('undo redo slice reducers', () => {
     };
 
     // Adds the first state to past array
-    let state = reducer(mockInitialState, saveStateToHistory(getMockPayload('state1')));
-    expect(state.past).toEqual(['state1']);
+    let state = reducer(mockInitialState, saveStateToHistory(getMockPayload(mockCompressedState1)));
+    expect(state.past).toEqual([mockCompressedState1]);
     expect(state.future).toEqual([]);
 
     // Appends second state to past array
-    state = reducer(state, saveStateToHistory(getMockPayload('state2')));
-    expect(state.past).toEqual(['state1', 'state2']);
+    state = reducer(state, saveStateToHistory(getMockPayload(mockCompressedState2)));
+    expect(state.past).toEqual([mockCompressedState1, mockCompressedState2]);
     expect(state.future).toEqual([]);
 
     // Removes first state (oldest) and adds third state to past array
-    state = reducer(state, saveStateToHistory(getMockPayload('state3')));
-    expect(state.past).toEqual(['state2', 'state3']);
+    state = reducer(state, saveStateToHistory(getMockPayload(mockCompressedState3)));
+    expect(state.past).toEqual([mockCompressedState2, mockCompressedState3]);
     expect(state.future).toEqual([]);
 
     // Future array should go back to empty when a new state is saved
     mockInitialState = {
-      past: ['state2', 'state3'],
-      future: ['state4'],
+      past: [mockCompressedState2, mockCompressedState3],
+      future: [mockCompressedState4],
     };
-    state = reducer(mockInitialState, saveStateToHistory(getMockPayload('state5')));
-    expect(state.past).toEqual(['state3', 'state5']);
+    state = reducer(mockInitialState, saveStateToHistory(getMockPayload(mockCompressedState5)));
+    expect(state.past).toEqual([mockCompressedState3, mockCompressedState5]);
     expect(state.future).toEqual([]);
   });
 
   it('should update state history on undo click', () => {
     const mockInitialState = {
-      past: ['state1', 'state2'],
-      future: ['state3'],
+      past: [mockCompressedState1, mockCompressedState2],
+      future: [mockCompressedState3],
     };
 
     // Current state gets put into future and latest past state gets removed to be used for current state
-    let state = reducer(mockInitialState, updateStateHistoryOnUndoClick('currentState'));
-    expect(state.past).toEqual(['state1']);
-    expect(state.future).toEqual(['currentState', 'state3']);
+    let state = reducer(mockInitialState, updateStateHistoryOnUndoClick(mockCompressedState4));
+    expect(state.past).toEqual([mockCompressedState1]);
+    expect(state.future).toEqual([mockCompressedState4, mockCompressedState3]);
   });
 
   it('should update state history on redo click', () => {
     const mockInitialState = {
-      past: ['state1', 'state2'],
-      future: ['state3'],
+      past: [mockCompressedState1, mockCompressedState2],
+      future: [mockCompressedState3],
     };
 
     // Current state gets put into past and first future state gets removed to be used for current state
-    let state = reducer(mockInitialState, updateStateHistoryOnRedoClick('currentState'));
-    expect(state.past).toEqual(['state1', 'state2', 'currentState']);
+    let state = reducer(mockInitialState, updateStateHistoryOnRedoClick(mockCompressedState4));
+    expect(state.past).toEqual([mockCompressedState1, mockCompressedState2, mockCompressedState4]);
     expect(state.future).toEqual([]);
   });
 });

--- a/libs/designer/src/lib/core/state/undoRedo/undoRedoSlice.ts
+++ b/libs/designer/src/lib/core/state/undoRedo/undoRedoSlice.ts
@@ -11,7 +11,7 @@ export const undoRedoSlice = createSlice({
   name: 'undoRedo',
   initialState,
   reducers: {
-    saveStateToHistory: (state, action: PayloadAction<{ compressedState: string; limit: number }>) => {
+    saveStateToHistory: (state, action: PayloadAction<{ compressedState: Uint8Array; limit: number }>) => {
       if (action.payload.limit < 1) {
         return;
       }
@@ -21,11 +21,11 @@ export const undoRedoSlice = createSlice({
       ];
       state.future = [];
     },
-    updateStateHistoryOnUndoClick: (state, action: PayloadAction<string>) => {
+    updateStateHistoryOnUndoClick: (state, action: PayloadAction<Uint8Array>) => {
       state.past = state.past.slice(0, state.past.length - 1);
       state.future = [action.payload, ...state.future];
     },
-    updateStateHistoryOnRedoClick: (state, action: PayloadAction<string>) => {
+    updateStateHistoryOnRedoClick: (state, action: PayloadAction<Uint8Array>) => {
       state.future = state.future.slice(1);
       state.past = [...state.past, action.payload];
     },

--- a/libs/designer/src/lib/core/state/undoRedo/undoRedoTypes.ts
+++ b/libs/designer/src/lib/core/state/undoRedo/undoRedoTypes.ts
@@ -15,8 +15,8 @@ import {
 } from '../workflow/workflowSlice';
 
 export interface StateHistory {
-  past: string[];
-  future: string[];
+  past: Uint8Array[];
+  future: Uint8Array[];
 }
 
 // Omitted slices: designerView, designerOptions, dev, undoRedo

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -858,6 +858,9 @@ importers:
       monaco-editor:
         specifier: 0.44.0
         version: 0.44.0
+      pako:
+        specifier: 2.1.0
+        version: 2.1.0
       react:
         specifier: ^16.4.0 || ^17.0.0 || ^18.0.0
         version: 18.2.0
@@ -913,6 +916,9 @@ importers:
       '@types/lodash.merge':
         specifier: ^4.6.9
         version: 4.6.9
+      '@types/pako':
+        specifier: ^2.0.3
+        version: 2.0.3
       '@types/to-title-case':
         specifier: ^1.0.2
         version: 1.0.2
@@ -5243,6 +5249,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/pako@2.0.3':
+    resolution: {integrity: sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -9408,6 +9417,9 @@ packages:
 
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
@@ -18880,6 +18892,8 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/pako@2.0.3': {}
+
   '@types/parse-json@4.0.2': {}
 
   '@types/pathfinding@0.0.9': {}
@@ -24144,6 +24158,8 @@ snapshots:
       semver: 7.6.0
 
   pako@1.0.11: {}
+
+  pako@2.1.0: {}
 
   param-case@3.0.4:
     dependencies:


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior
Undo/redo is using zlib compression library. 

## New Behavior
Updating undo/redo to use pako library instead as suggested.

## Impact of Change
No feature impact, just changing compression library. Undo/redo isn't live yet.

* [ ] **This is a breaking change.**
