### PR TITLE
fix(designer-ui): Optimize file picker partitioning and fix overflow

### DIFF
--- a/libs/designer-ui/src/lib/picker/__test__/helpers.test.ts
+++ b/libs/designer-ui/src/lib/picker/__test__/helpers.test.ts
@@ -1,56 +1,10 @@
-/*!
- * Copyright (C) Microsoft Corporation. All rights reserved.
- */
-
-import { filterAndSortItems, getTreeItemDisplayName, getTreeItemId } from '../helpers';
+import { filterAndSortItems } from '../helpers';
 import { PickerItemType } from '../types';
 import type { TreeDynamicValue } from '@microsoft/logic-apps-shared';
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test, vi } from 'vitest';
-
-type TreeDynamicValueWithExtraFields = TreeDynamicValue & Record<string, unknown>;
+import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
 
 describe('lib/picker/helpers', () => {
-  const getMockItemWithoutUsefulData = (): TreeDynamicValueWithExtraFields => ({
-    displayName: '',
-    isParent: false,
-    value: {},
-  });
-
-  const getMockLogicAppsItem = (): TreeDynamicValueWithExtraFields => ({
-    value: {
-      Id: '%252f_cts%252fWorkflow%2bHistory',
-      Name: 'Workflow History Folder',
-      DisplayName: 'Workflow History',
-      Path: '/_cts/Workflow History',
-      LastModified: '0001-01-01T00:00:00',
-      Size: 0,
-      MediaType: null,
-      IsFolder: true,
-      ETag: null,
-      FileLocator: null,
-      LastModifiedBy: null,
-    },
-
-    // Below top-level fields are normally generated from top-level `value` field as part of `getLegacyDynamicTreeItems`.
-    displayName: 'Workflow His...',
-    isParent: true,
-  });
-
-  const getMockPowerAutomateItem = (): TreeDynamicValueWithExtraFields => ({
-    displayName: 'Deep Folder Test 2',
-    fullyQualifiedDisplayName: '/Code & Config/Deep Folder Test 1/Deep Folder Test 2',
-    isParent: true,
-    nodeType: 'Parent',
-    selectionState: {
-      id: 'b!0000000000000-0000000000000000000000000000_000000000000000000000.0000000000000000000000000000000000',
-    },
-    selectedItemProperties: {
-      id: 'b!0000000000000-0000000000000000000000000000_000000000000000000000.0000000000000000000000000000000000',
-    },
-    value: 'b!0000000000000-0000000000000000000000000000_000000000000000000000.0000000000000000000000000000000000',
-  });
-
   describe('filterAndSortItems', () => {
     it('should handle undefined array', () => {
       expect(filterAndSortItems(undefined, PickerItemType.FILE, [])).toEqual([]);
@@ -90,28 +44,6 @@ describe('lib/picker/helpers', () => {
       ];
 
       expect(filterAndSortItems(items, PickerItemType.FILE, [])).toEqual([items[2], items[1], items[4], items[3], items[0]]);
-    });
-  });
-
-  describe('getTreeItemDisplayName', () => {
-    it.each<[string, TreeDynamicValue & Record<Exclude<string, keyof TreeDynamicValue>, unknown>]>([
-      ['', getMockItemWithoutUsefulData()],
-      ['Workflow History', { ...getMockLogicAppsItem(), displayName: '' }],
-      ['Workflow His...', getMockLogicAppsItem()],
-      ['/Code & Config/Deep Folder Test 1/Deep Folder Test 2', { ...getMockPowerAutomateItem(), displayName: '' }],
-      ['Deep Folder Test 2', getMockPowerAutomateItem()],
-    ])('should extract the display name %s', (expected, itemAsObject) => {
-      expect(getTreeItemDisplayName(itemAsObject)).toEqual(expected);
-    });
-  });
-
-  describe('getTreeItemId', () => {
-    it.each<[string, TreeDynamicValue & Record<Exclude<string, keyof TreeDynamicValue>, unknown>]>([
-      ['', getMockItemWithoutUsefulData()],
-      ['%252f_cts%252fWorkflow%2bHistory', getMockLogicAppsItem()],
-      ['b!0000000000000-0000000000000000000000000000_000000000000000000000.0000000000000000000000000000000000', getMockPowerAutomateItem()],
-    ])('should extract the ID %s', (expected, itemAsObject) => {
-      expect(getTreeItemId(itemAsObject)).toEqual(expected);
     });
   });
 });

--- a/libs/designer-ui/src/lib/picker/__test__/helpers.test.ts
+++ b/libs/designer-ui/src/lib/picker/__test__/helpers.test.ts
@@ -1,10 +1,56 @@
-import { filterAndSortItems } from '../helpers';
+/*!
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ */
+
+import { filterAndSortItems, getTreeItemDisplayName, getTreeItemId } from '../helpers';
 import { PickerItemType } from '../types';
 import type { TreeDynamicValue } from '@microsoft/logic-apps-shared';
 
-import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test, vi } from 'vitest';
+
+type TreeDynamicValueWithExtraFields = TreeDynamicValue & Record<string, unknown>;
 
 describe('lib/picker/helpers', () => {
+  const getMockItemWithoutUsefulData = (): TreeDynamicValueWithExtraFields => ({
+    displayName: '',
+    isParent: false,
+    value: {},
+  });
+
+  const getMockLogicAppsItem = (): TreeDynamicValueWithExtraFields => ({
+    value: {
+      Id: '%252f_cts%252fWorkflow%2bHistory',
+      Name: 'Workflow History Folder',
+      DisplayName: 'Workflow History',
+      Path: '/_cts/Workflow History',
+      LastModified: '0001-01-01T00:00:00',
+      Size: 0,
+      MediaType: null,
+      IsFolder: true,
+      ETag: null,
+      FileLocator: null,
+      LastModifiedBy: null,
+    },
+
+    // Below top-level fields are normally generated from top-level `value` field as part of `getLegacyDynamicTreeItems`.
+    displayName: 'Workflow His...',
+    isParent: true,
+  });
+
+  const getMockPowerAutomateItem = (): TreeDynamicValueWithExtraFields => ({
+    displayName: 'Deep Folder Test 2',
+    fullyQualifiedDisplayName: '/Code & Config/Deep Folder Test 1/Deep Folder Test 2',
+    isParent: true,
+    nodeType: 'Parent',
+    selectionState: {
+      id: 'b!0000000000000-0000000000000000000000000000_000000000000000000000.0000000000000000000000000000000000',
+    },
+    selectedItemProperties: {
+      id: 'b!0000000000000-0000000000000000000000000000_000000000000000000000.0000000000000000000000000000000000',
+    },
+    value: 'b!0000000000000-0000000000000000000000000000_000000000000000000000.0000000000000000000000000000000000',
+  });
+
   describe('filterAndSortItems', () => {
     it('should handle undefined array', () => {
       expect(filterAndSortItems(undefined, PickerItemType.FILE, [])).toEqual([]);
@@ -44,6 +90,28 @@ describe('lib/picker/helpers', () => {
       ];
 
       expect(filterAndSortItems(items, PickerItemType.FILE, [])).toEqual([items[2], items[1], items[4], items[3], items[0]]);
+    });
+  });
+
+  describe('getTreeItemDisplayName', () => {
+    it.each<[string, TreeDynamicValue & Record<Exclude<string, keyof TreeDynamicValue>, unknown>]>([
+      ['', getMockItemWithoutUsefulData()],
+      ['Workflow History', { ...getMockLogicAppsItem(), displayName: '' }],
+      ['Workflow His...', getMockLogicAppsItem()],
+      ['/Code & Config/Deep Folder Test 1/Deep Folder Test 2', { ...getMockPowerAutomateItem(), displayName: '' }],
+      ['Deep Folder Test 2', getMockPowerAutomateItem()],
+    ])('should extract the display name %s', (expected, itemAsObject) => {
+      expect(getTreeItemDisplayName(itemAsObject)).toEqual(expected);
+    });
+  });
+
+  describe('getTreeItemId', () => {
+    it.each<[string, TreeDynamicValue & Record<Exclude<string, keyof TreeDynamicValue>, unknown>]>([
+      ['', getMockItemWithoutUsefulData()],
+      ['%252f_cts%252fWorkflow%2bHistory', getMockLogicAppsItem()],
+      ['b!0000000000000-0000000000000000000000000000_000000000000000000000.0000000000000000000000000000000000', getMockPowerAutomateItem()],
+    ])('should extract the ID %s', (expected, itemAsObject) => {
+      expect(getTreeItemId(itemAsObject)).toEqual(expected);
     });
   });
 });

--- a/libs/designer-ui/src/lib/picker/__test__/helpers.test.ts
+++ b/libs/designer-ui/src/lib/picker/__test__/helpers.test.ts
@@ -16,8 +16,8 @@ describe('lib/picker/helpers', () => {
 
     it('should filter based on `type` parameter', () => {
       const items: TreeDynamicValue[] = [
-        { displayName: 'My Folder', isParent: true, value: {} },
-        { displayName: 'My File', isParent: false, value: {} },
+        { displayName: 'My Folder', id: '', isParent: true, value: {} },
+        { displayName: 'My File', id: '', isParent: false, value: {} },
       ];
 
       expect(filterAndSortItems(items, PickerItemType.FOLDER, [])).toEqual([items[0]]);
@@ -26,9 +26,9 @@ describe('lib/picker/helpers', () => {
 
     it('should filter based on `mediaTypeFilters` parameter', () => {
       const items: TreeDynamicValue[] = [
-        { displayName: 'My Folder', mediaType: 'directory', isParent: true, value: {} },
-        { displayName: 'My JSON', mediaType: 'application/json', isParent: false, value: {} },
-        { displayName: 'My Binary', mediaType: 'application/octet-stream', isParent: false, value: {} },
+        { displayName: 'My Folder', mediaType: 'directory', id: '', isParent: true, value: {} },
+        { displayName: 'My JSON', mediaType: 'application/json', id: '', isParent: false, value: {} },
+        { displayName: 'My Binary', mediaType: 'application/octet-stream', id: '', isParent: false, value: {} },
       ];
 
       expect(filterAndSortItems(items, PickerItemType.FILE, ['application/json'])).toEqual([items[0], items[1]]);
@@ -36,11 +36,11 @@ describe('lib/picker/helpers', () => {
 
     it('should sort results', () => {
       const items: TreeDynamicValue[] = [
-        { displayName: 'CCC File', isParent: false, value: {} },
-        { displayName: 'BBB Folder', isParent: true, value: {} },
-        { displayName: 'AAA Folder', isParent: true, value: {} },
-        { displayName: 'BBB File', isParent: false, value: {} },
-        { displayName: 'AAA File', isParent: false, value: {} },
+        { displayName: 'CCC File', id: '', isParent: false, value: {} },
+        { displayName: 'BBB Folder', id: '', isParent: true, value: {} },
+        { displayName: 'AAA Folder', id: '', isParent: true, value: {} },
+        { displayName: 'BBB File', id: '', isParent: false, value: {} },
+        { displayName: 'AAA File', id: '', isParent: false, value: {} },
       ];
 
       expect(filterAndSortItems(items, PickerItemType.FILE, [])).toEqual([items[2], items[1], items[4], items[3], items[0]]);

--- a/libs/designer-ui/src/lib/picker/filepickerEditor.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickerEditor.tsx
@@ -75,7 +75,7 @@ export const FilePickerEditor = ({
     setTitleSegments([
       ...titleSegments,
       {
-        key: selectedItem.value?.Id || displayValue,
+        key: selectedItem.id || displayValue,
         onSelect: () => onFolderNavigated(selectedItem),
         text: displayValue,
       },

--- a/libs/designer-ui/src/lib/picker/filepickerPopover.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickerPopover.tsx
@@ -1,5 +1,6 @@
 import { FilePickerPopoverHeader } from './filepickerPopoverHeader';
 import { FilePickerPopoverItem } from './filepickerPopoverItem';
+import { getTreeItemId } from './helpers';
 import type { FilePickerBreadcrumb } from './types';
 import { MenuList, PopoverSurface, Spinner } from '@fluentui/react-components';
 import type { TreeDynamicValue } from '@microsoft/logic-apps-shared';
@@ -60,7 +61,7 @@ export const FilePickerPopover: React.FC<FilePickerProps> = (props) => {
             file={file}
             handleFolderNavigation={handleFolderNavigation}
             handleItemSelected={handleItemSelected}
-            key={`FilePickerPopover.item.${file.value.Id}`}
+            key={`FilePickerPopover.item.${getTreeItemId(file)}`}
           />
         ))}
       </MenuList>

--- a/libs/designer-ui/src/lib/picker/filepickerPopover.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickerPopover.tsx
@@ -1,6 +1,5 @@
 import { FilePickerPopoverHeader } from './filepickerPopoverHeader';
 import { FilePickerPopoverItem } from './filepickerPopoverItem';
-import { getTreeItemId } from './helpers';
 import type { FilePickerBreadcrumb } from './types';
 import { MenuList, PopoverSurface, Spinner } from '@fluentui/react-components';
 import type { TreeDynamicValue } from '@microsoft/logic-apps-shared';
@@ -61,7 +60,7 @@ export const FilePickerPopover: React.FC<FilePickerProps> = (props) => {
             file={file}
             handleFolderNavigation={handleFolderNavigation}
             handleItemSelected={handleItemSelected}
-            key={`FilePickerPopover.item.${getTreeItemId(file)}`}
+            key={`FilePickerPopover.item.${file.id}`}
           />
         ))}
       </MenuList>

--- a/libs/designer-ui/src/lib/picker/filepickerPopoverHeader.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickerPopoverHeader.tsx
@@ -6,6 +6,7 @@ import {
   BreadcrumbDivider,
   BreadcrumbItem,
   Button,
+  makeStyles,
   Menu,
   MenuItem,
   MenuList,
@@ -21,10 +22,13 @@ import {
   useRestoreFocusTarget,
 } from '@fluentui/react-components';
 import { MoreHorizontalRegular } from '@fluentui/react-icons';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 const MAX_PRIORITY = 999;
+const MIN_ITEMS_TO_SHOW = 2;
+const NO_OVERFLOW_LIMIT = 999;
+const OVERFLOW_START_INDEX = 1;
 
 interface FilePickerPopoverHeaderProps {
   currentPathSegments: FilePickerBreadcrumb[];
@@ -42,21 +46,33 @@ const OverflowGroupDivider: React.FC<{
   );
 };
 
+const useStyles = makeStyles({
+  breadcrumb: {
+    overflowX: 'hidden',
+  },
+  breadcrumbButton: {
+    justifyContent: 'flex-start',
+  },
+});
+
 const FilePickerPopoverHeaderItem: React.FC<{ index: number; item: FilePickerBreadcrumb; isLast: boolean }> = (props) => {
   const { index, item, isLast } = props;
+
+  const classNames = useStyles();
 
   const firstButtonFocusAttributes = useRestoreFocusTarget();
   const focusAttributes = index === 0 ? firstButtonFocusAttributes : {};
 
   const itemId = item.key;
   const groupId = index;
+  const groupIdString = `${groupId}`;
 
   return (
     <React.Fragment key={`FilePicker.breadcrumb.${itemId}`}>
-      <OverflowItem groupId={`${groupId}`} id={itemId} priority={index === 0 ? MAX_PRIORITY : index}>
+      <OverflowItem groupId={groupIdString} id={itemId} priority={index === 0 ? MAX_PRIORITY : index}>
         <BreadcrumbItem>
-          <BreadcrumbButton current={isLast} onClick={item.onSelect} {...focusAttributes}>
-            {item.text}
+          <BreadcrumbButton className={classNames.breadcrumbButton} current={isLast} onClick={item.onSelect} {...focusAttributes}>
+            <span>{item.text}</span>
           </BreadcrumbButton>
         </BreadcrumbItem>
       </OverflowItem>
@@ -65,21 +81,18 @@ const FilePickerPopoverHeaderItem: React.FC<{ index: number; item: FilePickerBre
   );
 };
 
-const FilePickerPopoverBreadcrumbs: React.FC<FilePickerPopoverHeaderProps> = (props) => {
-  const { currentPathSegments } = props;
-
+const FilePickerPopoverOverflowMenu: React.FC<{ items: FilePickerBreadcrumb[] }> = (props) => {
   const intl = useIntl();
 
-  const { ref } = useOverflowMenu<HTMLButtonElement>();
+  const { items } = props;
+  const { isOverflowing, overflowCount, ref } = useOverflowMenu<HTMLButtonElement>();
 
-  const { startDisplayedItems, overflowItems, endDisplayedItems }: PartitionBreadcrumbItems<FilePickerBreadcrumb> =
-    partitionBreadcrumbItems({
-      items: currentPathSegments,
-      maxDisplayedItems: 2,
-    });
+  if (!isOverflowing) {
+    return null;
+  }
 
-  const overflowItemsLength = overflowItems?.length ?? 0;
-  const endDisplayedItemsStartIndex = startDisplayedItems.length + overflowItemsLength;
+  const overflowItems = items.slice(OVERFLOW_START_INDEX, OVERFLOW_START_INDEX + overflowCount);
+  const overflowItemsLength = overflowItems.length;
 
   const moreTooltipMessage = intl.formatMessage({
     defaultMessage: 'More…',
@@ -111,47 +124,73 @@ const FilePickerPopoverBreadcrumbs: React.FC<FilePickerPopoverHeaderProps> = (pr
 
   return (
     <>
+      <BreadcrumbItem>
+        <Menu>
+          <MenuTrigger disableButtonEnhancement={true}>
+            <Tooltip content={moreTooltipMessage} relationship="label" withArrow={true}>
+              <Button
+                appearance="subtle"
+                aria-label={overflowItemsLength === 1 ? moreItemsSingularMessage : moreItemsPluralMessage}
+                icon={<MoreHorizontalRegular />}
+                ref={ref}
+                role="button"
+              />
+            </Tooltip>
+          </MenuTrigger>
+          <MenuPopover>
+            <MenuList>
+              {overflowItems.map((item) => (
+                <MenuItem id={item.key} key={item.key} onClick={item.onSelect} persistOnClick={true}>
+                  {item.text}
+                </MenuItem>
+              ))}
+            </MenuList>
+          </MenuPopover>
+        </Menu>
+      </BreadcrumbItem>
+      <BreadcrumbDivider />
+    </>
+  );
+};
+
+const FilePickerPopoverBreadcrumbs: React.FC<FilePickerPopoverHeaderProps> = (props) => {
+  const { currentPathSegments } = props;
+
+  const partitionedBreadcrumbItems: PartitionBreadcrumbItems<FilePickerBreadcrumb> = useMemo(
+    () =>
+      partitionBreadcrumbItems({
+        items: currentPathSegments,
+        maxDisplayedItems: NO_OVERFLOW_LIMIT,
+        overflowIndex: OVERFLOW_START_INDEX,
+      }),
+    [currentPathSegments]
+  );
+
+  const { startDisplayedItems, endDisplayedItems = [] } = partitionedBreadcrumbItems;
+
+  const startBasePriority = 200;
+  const endBasePriority = 100;
+
+  const mergedDisplayedItems = [...startDisplayedItems, ...endDisplayedItems];
+  const lastItemKey = mergedDisplayedItems[mergedDisplayedItems.length - 1]?.key;
+
+  return (
+    <>
       {startDisplayedItems.map((segment, index) => (
         <FilePickerPopoverHeaderItem
           key={`FilePicker.breadcrumb.${segment.key}`}
-          index={index}
+          index={startBasePriority + index}
           item={segment}
-          isLast={index === currentPathSegments.length - 1}
+          isLast={segment.key === lastItemKey}
         />
       ))}
-      {overflowItems ? (
-        <>
-          <Menu>
-            <MenuTrigger disableButtonEnhancement={true}>
-              <Tooltip content={moreTooltipMessage} relationship="label" withArrow={true}>
-                <Button
-                  appearance="subtle"
-                  aria-label={overflowItemsLength === 1 ? moreItemsSingularMessage : moreItemsPluralMessage}
-                  icon={<MoreHorizontalRegular />}
-                  ref={ref}
-                  role="button"
-                />
-              </Tooltip>
-            </MenuTrigger>
-            <MenuPopover>
-              <MenuList>
-                {overflowItems.map((item) => (
-                  <MenuItem id={item.key} key={item.key} onClick={item.onSelect} persistOnClick={true}>
-                    {item.text}
-                  </MenuItem>
-                ))}
-              </MenuList>
-            </MenuPopover>
-          </Menu>
-          <BreadcrumbDivider />
-        </>
-      ) : null}
-      {endDisplayedItems?.map((segment, index) => (
+      <FilePickerPopoverOverflowMenu items={mergedDisplayedItems} />
+      {endDisplayedItems.map((segment, index) => (
         <FilePickerPopoverHeaderItem
           key={`FilePicker.breadcrumb.${segment.key}`}
-          index={endDisplayedItemsStartIndex + index}
+          index={endBasePriority + index}
           item={segment}
-          isLast={endDisplayedItemsStartIndex + index === currentPathSegments.length - 1}
+          isLast={segment.key === lastItemKey}
         />
       ))}
     </>
@@ -159,11 +198,12 @@ const FilePickerPopoverBreadcrumbs: React.FC<FilePickerPopoverHeaderProps> = (pr
 };
 
 export const FilePickerPopoverHeader: React.FC<FilePickerPopoverHeaderProps> = (props) => {
+  const classNames = useStyles();
   const focusAttributes = useArrowNavigationGroup({ axis: 'horizontal' });
 
   return (
-    <Overflow minimumVisible={2}>
-      <Breadcrumb {...focusAttributes}>
+    <Overflow minimumVisible={MIN_ITEMS_TO_SHOW}>
+      <Breadcrumb {...focusAttributes} className={classNames.breadcrumb}>
         <FilePickerPopoverBreadcrumbs {...props} />
       </Breadcrumb>
     </Overflow>

--- a/libs/designer-ui/src/lib/picker/filepickerPopoverHeader.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickerPopoverHeader.tsx
@@ -94,6 +94,10 @@ const FilePickerPopoverOverflowMenu: React.FC<{ items: FilePickerBreadcrumb[] }>
   const overflowItems = items.slice(OVERFLOW_START_INDEX, OVERFLOW_START_INDEX + overflowCount);
   const overflowItemsLength = overflowItems.length;
 
+  if (overflowItemsLength === 0) {
+    return null;
+  }
+
   const moreTooltipMessage = intl.formatMessage({
     defaultMessage: 'More…',
     id: 'TDfQzn',

--- a/libs/designer-ui/src/lib/picker/filepickerPopoverItem.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickerPopoverItem.tsx
@@ -3,6 +3,7 @@ import { ChevronRight12Regular, Document28Regular, Folder28Regular } from '@flue
 import type { TreeDynamicValue } from '@microsoft/logic-apps-shared';
 import type React from 'react';
 import { useIntl } from 'react-intl';
+import { getTreeItemDisplayName, getTreeItemId } from './helpers';
 
 export interface FilePickerPopoverItemProps {
   file: TreeDynamicValue;
@@ -12,7 +13,10 @@ export interface FilePickerPopoverItemProps {
 
 export const FilePickerPopoverItem: React.FC<FilePickerPopoverItemProps> = (props) => {
   const { file, handleFolderNavigation, handleItemSelected } = props;
-  const { displayName, isParent, value } = file;
+  const { isParent } = file;
+
+  const fileDisplayName = getTreeItemDisplayName(file);
+  const fileId = getTreeItemId(file);
 
   const intl = useIntl();
   const navMessage = intl.formatMessage(
@@ -22,15 +26,15 @@ export const FilePickerPopoverItem: React.FC<FilePickerPopoverItemProps> = (prop
       description: 'a label that shows which folder the user will be able to dig deeper into',
     },
     {
-      folderName: displayName,
+      folderName: fileDisplayName,
     }
   );
 
   if (isParent) {
     return (
-      <MenuSplitGroup className="msla-filepicker-item-split" key={`FilePicker.folder.${value.Id}`}>
+      <MenuSplitGroup className="msla-filepicker-item-split" key={`FilePicker.folder.${fileId}`}>
         <MenuItem className="msla-filepicker-item" icon={<Folder28Regular />} onClick={() => handleItemSelected(file)}>
-          {displayName}
+          {fileDisplayName}
         </MenuItem>
         <Tooltip content={navMessage} relationship="label">
           <MenuItem className="msla-filepicker-item-split-chevron" onClick={() => handleFolderNavigation(file)} persistOnClick={true}>
@@ -45,10 +49,10 @@ export const FilePickerPopoverItem: React.FC<FilePickerPopoverItemProps> = (prop
     <MenuItem
       className="msla-filepicker-item"
       icon={<Document28Regular />}
-      key={`FilePicker.item.${value.Id}`}
+      key={`FilePicker.item.${fileId}`}
       onClick={() => handleItemSelected(file)}
     >
-      {displayName}
+      {fileDisplayName}
     </MenuItem>
   );
 };

--- a/libs/designer-ui/src/lib/picker/filepickerPopoverItem.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickerPopoverItem.tsx
@@ -3,7 +3,6 @@ import { ChevronRight12Regular, Document28Regular, Folder28Regular } from '@flue
 import type { TreeDynamicValue } from '@microsoft/logic-apps-shared';
 import type React from 'react';
 import { useIntl } from 'react-intl';
-import { getTreeItemDisplayName, getTreeItemId } from './helpers';
 
 export interface FilePickerPopoverItemProps {
   file: TreeDynamicValue;
@@ -13,10 +12,7 @@ export interface FilePickerPopoverItemProps {
 
 export const FilePickerPopoverItem: React.FC<FilePickerPopoverItemProps> = (props) => {
   const { file, handleFolderNavigation, handleItemSelected } = props;
-  const { isParent } = file;
-
-  const fileDisplayName = getTreeItemDisplayName(file);
-  const fileId = getTreeItemId(file);
+  const { displayName, id, isParent } = file;
 
   const intl = useIntl();
   const navMessage = intl.formatMessage(
@@ -26,15 +22,15 @@ export const FilePickerPopoverItem: React.FC<FilePickerPopoverItemProps> = (prop
       description: 'a label that shows which folder the user will be able to dig deeper into',
     },
     {
-      folderName: fileDisplayName,
+      folderName: displayName,
     }
   );
 
   if (isParent) {
     return (
-      <MenuSplitGroup className="msla-filepicker-item-split" key={`FilePicker.folder.${fileId}`}>
+      <MenuSplitGroup className="msla-filepicker-item-split" key={`FilePicker.folder.${id}`}>
         <MenuItem className="msla-filepicker-item" icon={<Folder28Regular />} onClick={() => handleItemSelected(file)}>
-          {fileDisplayName}
+          {displayName}
         </MenuItem>
         <Tooltip content={navMessage} relationship="label">
           <MenuItem className="msla-filepicker-item-split-chevron" onClick={() => handleFolderNavigation(file)} persistOnClick={true}>
@@ -49,10 +45,10 @@ export const FilePickerPopoverItem: React.FC<FilePickerPopoverItemProps> = (prop
     <MenuItem
       className="msla-filepicker-item"
       icon={<Document28Regular />}
-      key={`FilePicker.item.${fileId}`}
+      key={`FilePicker.item.${id}`}
       onClick={() => handleItemSelected(file)}
     >
-      {fileDisplayName}
+      {displayName}
     </MenuItem>
   );
 };

--- a/libs/designer-ui/src/lib/picker/helpers.ts
+++ b/libs/designer-ui/src/lib/picker/helpers.ts
@@ -1,5 +1,5 @@
 import type { TreeDynamicValue } from '@microsoft/logic-apps-shared';
-import { equals, isEmptyString, isString } from '@microsoft/logic-apps-shared';
+import { equals } from '@microsoft/logic-apps-shared';
 import { PickerItemType } from './types';
 
 export const filterAndSortItems = (
@@ -26,16 +26,6 @@ export const filterAndSortItems = (
     if (!a.isParent && b.isParent) {
       return 1;
     }
-    return getTreeItemDisplayName(a).localeCompare(getTreeItemDisplayName(b));
+    return a.displayName.localeCompare(b.displayName);
   });
-};
-
-export const getTreeItemDisplayName = (item: TreeDynamicValue): string => {
-  const possibleValues = [item.displayName, item.value?.DisplayName, item.fullyQualifiedDisplayName];
-  return possibleValues.find((v) => isString(v) && !isEmptyString(v)) || '';
-};
-
-export const getTreeItemId = (item: TreeDynamicValue): string => {
-  const possibleValues = [item.value?.Id, item.value, item.fullyQualifiedDisplayName];
-  return possibleValues.find((v) => isString(v) && !isEmptyString(v)) || '';
 };

--- a/libs/designer-ui/src/lib/picker/helpers.ts
+++ b/libs/designer-ui/src/lib/picker/helpers.ts
@@ -1,5 +1,5 @@
 import type { TreeDynamicValue } from '@microsoft/logic-apps-shared';
-import { equals } from '@microsoft/logic-apps-shared';
+import { equals, isEmptyString, isString } from '@microsoft/logic-apps-shared';
 import { PickerItemType } from './types';
 
 export const filterAndSortItems = (
@@ -26,6 +26,16 @@ export const filterAndSortItems = (
     if (!a.isParent && b.isParent) {
       return 1;
     }
-    return a.displayName.localeCompare(b.displayName);
+    return getTreeItemDisplayName(a).localeCompare(getTreeItemDisplayName(b));
   });
+};
+
+export const getTreeItemDisplayName = (item: TreeDynamicValue): string => {
+  const possibleValues = [item.displayName, item.value?.DisplayName, item.fullyQualifiedDisplayName];
+  return possibleValues.find((v) => isString(v) && !isEmptyString(v)) || '';
+};
+
+export const getTreeItemId = (item: TreeDynamicValue): string => {
+  const possibleValues = [item.value?.Id, item.value, item.fullyQualifiedDisplayName];
+  return possibleValues.find((v) => isString(v) && !isEmptyString(v)) || '';
 };

--- a/libs/designer/src/lib/core/queries/connector.ts
+++ b/libs/designer/src/lib/core/queries/connector.ts
@@ -18,6 +18,9 @@ import {
   isNullOrUndefined,
   LoggerService,
   LogEntryLevel,
+  isObject,
+  isString,
+  guid,
 } from '@microsoft/logic-apps-shared';
 
 export const getLegacyDynamicValues = async (
@@ -215,11 +218,11 @@ export const getLegacyDynamicTreeItems = async (
     collectionData = typeof possibleCollectionData === Types.Object ? getFirstArrayProperty(possibleCollectionData) : [];
   }
 
-  return collectionData.map((value: any) => {
+  return collectionData.map((value: any): TreeDynamicValue => {
     return {
       value,
       displayName: (getPropertyValue(value, titlePath as string) ?? '').toString(),
-      id: value.Id,
+      id: getDynamicTreeValueIdFromCollectionDataValue(value),
       isParent: !!getPropertyValue(value, folderPropertyPath as string),
       mediaType: mediaPropertyPath ? getPropertyValue(value, mediaPropertyPath) : undefined,
     };
@@ -267,4 +270,13 @@ const getFirstArrayProperty = (value: any): any[] => {
   }
 
   return [];
+};
+
+const getDynamicTreeValueIdFromCollectionDataValue = (value: any): string => {
+  const valueId = value && isObject(value) && 'Id' in value && value.Id;
+  if (isString(valueId) && valueId.length > 0) {
+    return valueId;
+  }
+
+  return guid();
 };

--- a/libs/designer/src/lib/core/queries/connector.ts
+++ b/libs/designer/src/lib/core/queries/connector.ts
@@ -219,6 +219,7 @@ export const getLegacyDynamicTreeItems = async (
     return {
       value,
       displayName: (getPropertyValue(value, titlePath as string) ?? '').toString(),
+      id: value.Id,
       isParent: !!getPropertyValue(value, folderPropertyPath as string),
       mediaType: mediaPropertyPath ? getPropertyValue(value, mediaPropertyPath) : undefined,
     };

--- a/libs/logic-apps-shared/src/designer-client-services/lib/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/connector.ts
@@ -10,9 +10,10 @@ export interface ListDynamicValue {
 }
 
 export interface TreeDynamicValue {
-  value: any;
+  value: unknown;
   displayName: string;
   fullyQualifiedDisplayName?: string;
+  id?: string;
   isParent: boolean;
   mediaType?: string;
 }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/connector.ts
@@ -13,7 +13,7 @@ export interface TreeDynamicValue {
   value: unknown;
   displayName: string;
   fullyQualifiedDisplayName?: string;
-  id?: string;
+  id: string;
   isParent: boolean;
   mediaType?: string;
 }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/connector.ts
@@ -12,6 +12,7 @@ export interface ListDynamicValue {
 export interface TreeDynamicValue {
   value: any;
   displayName: string;
+  fullyQualifiedDisplayName?: string;
   isParent: boolean;
   mediaType?: string;
 }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/connector.ts
@@ -138,6 +138,7 @@ export class ConsumptionConnectorService extends BaseConnectorService {
     return (values || []).map((item: any) => ({
       value: item,
       displayName: item.displayName,
+      id: item.Id,
       isParent: item.isParent ?? equals(item.nodeType, 'parent'),
     }));
   }


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Issues with file picker:

- In Power Automate, the '...' breadcrumb sometimes does not show at all. **This is due to a bug in `react-breadcrumb` which was fixed in v9.0.4, while Power Automate currently uses v9.0.3. https://github.com/microsoft/fluentui/pull/30005**
- In Azure Logic Apps, browsing to a folder that would show the '...' breadcrumb can crash the page. (Mitigated with #5576)
- Following the mitigation for the above issue, only the first and last breadcrumb will ever show in the file picker header, even if there is room to show more.
- Long file names can render outside of the header container.

![image](https://github.com/user-attachments/assets/1644bdfd-439b-45bc-b79a-e3a7a4bc2d83)

![image](https://github.com/user-attachments/assets/d1556a5d-bc95-4d10-923b-09dfc98128b1)

## New Behavior

![image](https://github.com/user-attachments/assets/0e2baf95-b851-4f0d-85b8-e4e170b69d48)
***Note:** I wanted to get `text-overflow: ellipsis` working on the header, but doing so requires adding `overflow: hidden` to the individual breadcrumb `li` element, which breaks `useOverflowMenu` calculations. Therefore, the only option is to just cut the text off.*

![image](https://github.com/user-attachments/assets/33ff5c48-b5ff-4a42-b175-6968cdfda66f)

![e2e-picker](https://github.com/user-attachments/assets/0b3fd0cf-a7f2-40c3-b5ec-d3b31fe9ca88)