### PR TITLE
fix(designer): Correctly verify parents arrays are in spliton while adding implicit foreach

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -173,7 +173,7 @@ export const initializeOperationMetadata = async (
           repetitionInfo: getRecordEntry(repetitionInfos, id),
         };
       }),
-      clearExisting: !pasteParams ?? true,
+      clearExisting: !pasteParams,
     })
   );
 

--- a/libs/designer/src/lib/core/utils/__test__/loops.spec.ts
+++ b/libs/designer/src/lib/core/utils/__test__/loops.spec.ts
@@ -1,0 +1,278 @@
+import { clone, equals, InitOperationManifestService, TokenType } from '@microsoft/logic-apps-shared';
+import { shouldAddForeach } from '../loops';
+import * as GraphHelper from '../graph';
+import { describe, vi, beforeAll, test, expect } from 'vitest';
+import foreachManifest from '../../../../../../logic-apps-shared/src/designer-client-services/lib/base/manifests/foreach';
+
+describe('Loops Utility', () => {
+  describe('shouldAddForeach', () => {
+    const nodeId = 'nodeId';
+    const parameterId = 'parameterId';
+    const rootState = {
+      operations: {
+        operationInfo: {
+          [nodeId]: { type: 'ApiConnection', operationId: 'operationId', connectorId: 'connectorId' },
+          manual: { type: 'ApiConnection', operationId: 'operationId1', connectorId: 'connectorId1' },
+          For_each: { type: 'foreach', operationId: 'operationId2', connectorId: 'connectorId2' },
+        },
+        inputParameters: {
+          [nodeId]: { parameterGroups: {} },
+          For_each: {
+            parameterGroups: {
+              default: {
+                id: 'default',
+                parameters: [
+                  {
+                    parameterKey: 'inputs.$.foreach',
+                    parameterName: 'foreach',
+                    info: {},
+                    type: 'array',
+                    value: [
+                      {
+                        id: 'F3863BCC-869D-4E93-A4D8-BA2F95A3F114',
+                        type: 'token',
+                        token: {
+                          source: 'body',
+                          name: 'value',
+                          key: 'body.$.value',
+                          tokenType: 'outputs',
+                          title: 'value',
+                          value: "triggerBody()?['value']",
+                        },
+                        value: "triggerBody()?['value']",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+        outputParameters: {
+          manual: {
+            outputs: {
+              'body.$.value.[*].NestedArray': {
+                key: 'body.$.value.[*].NestedArray',
+                type: 'array',
+                name: 'NestedArray',
+                isInsideArray: false,
+                parentArray: 'value',
+                source: 'body',
+                required: false,
+              },
+              'body.$.value.[*].NestedArray.[*].P1': {
+                key: 'body.$.value.[*].NestedArray.[*].P1',
+                type: 'string',
+                name: 'P1',
+                isInsideArray: true,
+                parentArray: 'NestedArray',
+                source: 'body',
+                required: false,
+              },
+            },
+          },
+        },
+        settings: { manual: { splitOn: { isSupported: true, value: { enabled: true, value: "@triggerBody()?['value']" } } } },
+      },
+      workflow: {
+        idReplacements: {},
+        nodesMetadata: {
+          manual: { graphId: 'root', isRoot: true },
+          nodeId: { graphId: 'root', isRoot: false },
+        },
+      },
+    } as any;
+
+    beforeAll(() => {
+      InitOperationManifestService({
+        isSupported: (type: string) => equals(type, 'foreach'),
+        getOperationManifest: () => Promise.resolve(foreachManifest),
+      } as any);
+    });
+
+    test('should correctly return one implicit foreach when token is in an array is added for splitOn enabled', async () => {
+      const token = {
+        key: 'body.$.value.[*].NestedArray.[*].P1',
+        name: 'P1',
+        type: 'string',
+        brandColor: 'brandColor',
+        title: 'P1',
+        value: `item()?['P1']`,
+        outputInfo: { arrayDetails: { parentArray: 'NestedArray' }, required: false, source: 'body', type: TokenType.OUTPUTS },
+      };
+      vi.spyOn(GraphHelper, 'getTriggerNodeId').mockReturnValue('manual');
+      let details = await shouldAddForeach(nodeId, parameterId, token, rootState);
+
+      expect(details).toBeDefined();
+      expect(details.shouldAdd).toBeTruthy();
+      expect(details.arrayDetails).toBeDefined();
+      expect(details.arrayDetails).toEqual([
+        expect.objectContaining({
+          parentArrayKey: 'body.$.value.[*].NestedArray',
+          parentArrayValue: "@triggerBody()?['NestedArray']",
+        }),
+      ]);
+      expect(details.repetitionContext).toEqual({
+        repetitionReferences: [],
+        splitOn: "@triggerBody()?['value']",
+      });
+
+      const tokenNotInArray = {
+        key: 'body.$.value.[*].P2',
+        name: 'P2',
+        type: 'string',
+        brandColor: 'brandColor',
+        title: 'P2',
+        value: `triggerBody()?['P2']`,
+        outputInfo: { required: false, source: 'body', type: TokenType.OUTPUTS },
+      };
+      details = await shouldAddForeach(nodeId, parameterId, tokenNotInArray, rootState);
+      expect(details).toEqual({ shouldAdd: false });
+    });
+
+    test('should correctly return correct implicit foreachs (1 and 2) when token is in an array is added for splitOn disabled', async () => {
+      const token = {
+        key: 'body.$.value.[*].NestedArray.[*].P1',
+        name: 'P1',
+        type: 'string',
+        brandColor: 'brandColor',
+        title: 'P1',
+        value: `item()?['P1']`,
+        outputInfo: { arrayDetails: { parentArray: 'NestedArrray' }, required: false, source: 'body', type: TokenType.OUTPUTS },
+      };
+      const state = clone(rootState);
+      state.operations.settings['manual'].splitOn.value.enabled = false;
+      state.operations.outputParameters['manual'].outputs['body.$.value.[*].NestedArray'].isInsideArray = true;
+
+      vi.spyOn(GraphHelper, 'getTriggerNodeId').mockReturnValue('manual');
+      let details = await shouldAddForeach(nodeId, parameterId, token, state);
+
+      expect(details).toBeDefined();
+      expect(details.shouldAdd).toBeTruthy();
+      expect(details.arrayDetails).toBeDefined();
+      expect(details.arrayDetails).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ parentArrayKey: 'body.$.value.[*].NestedArray', parentArrayValue: "@item()?['NestedArray']" }),
+          expect.objectContaining({ parentArrayKey: 'body.$.value', parentArrayValue: "@triggerBody()['value']" }),
+        ])
+      );
+      expect(details.repetitionContext).toEqual({
+        repetitionReferences: [],
+        splitOn: undefined,
+      });
+
+      const tokenInTopArray = {
+        key: 'body.$.value.[*].P2',
+        name: 'P2',
+        type: 'string',
+        brandColor: 'brandColor',
+        title: 'P2',
+        value: `item()?['P2']`,
+        outputInfo: { arrayDetails: { parentArray: 'value' }, required: false, source: 'body', type: TokenType.OUTPUTS },
+      };
+      details = await shouldAddForeach(nodeId, parameterId, tokenInTopArray, state);
+      expect(details).toBeDefined();
+      expect(details.shouldAdd).toBeTruthy();
+      expect(details.arrayDetails).toBeDefined();
+      expect(details.arrayDetails).toEqual([
+        expect.objectContaining({ parentArrayKey: 'body.$.value', parentArrayValue: "@triggerBody()['value']" }),
+      ]);
+      expect(details.repetitionContext).toEqual({
+        repetitionReferences: [],
+        splitOn: undefined,
+      });
+    });
+
+    test('should not add any implicit foreach for a node already in a loop when token in an array is added for splitOn enabled', async () => {
+      const token = {
+        key: 'body.$.value.[*].NestedArray.[*].P1',
+        name: 'P1',
+        type: 'string',
+        brandColor: 'brandColor',
+        title: 'P1',
+        value: `item()?['P1']`,
+        outputInfo: { arrayDetails: { parentArray: 'NestedArray' }, required: false, source: 'body', type: TokenType.OUTPUTS },
+      };
+      const state = clone(rootState);
+      state.workflow.nodesMetadata = {
+        ...state.workflow.nodesMetadata,
+        [nodeId]: { graphId: 'For_each', isRoot: true, parentNodeId: 'For_each' },
+        For_each: { graphId: 'root', isRoot: false, actionCount: 1 },
+      };
+      state.operations.inputParameters['For_each'].parameterGroups.default.parameters[0].value = [
+        {
+          id: 'F3863BCC-869D-4E93-A4D8-BA2F95A3F114',
+          type: 'token',
+          token: {
+            source: 'body',
+            name: 'NestedArray',
+            key: 'body.$.value.[*].NestedArray',
+            tokenType: 'outputs',
+            title: 'NestedArray',
+            value: "triggerBody()?['NestedArray']",
+          },
+          value: "triggerBody()?['NestedArray']",
+        },
+      ];
+
+      vi.spyOn(GraphHelper, 'getTriggerNodeId').mockReturnValue('manual');
+      const details = await shouldAddForeach(nodeId, parameterId, token, state);
+
+      expect(details).toBeDefined();
+      expect(details.shouldAdd).toBeFalsy();
+      expect(details.arrayDetails).toEqual([]);
+      expect(details.repetitionContext).toEqual({
+        repetitionReferences: [
+          {
+            actionName: 'For_each',
+            actionType: 'foreach',
+            repetitionValue: "@triggerBody()?['NestedArray']",
+            repetitionPath: 'body.$.value.NestedArray',
+          },
+        ],
+        splitOn: "@triggerBody()?['value']",
+      });
+    });
+
+    test('should add only one implicit foreach for a node already in a loop when token in a nested array is added for splitOn disabled', async () => {
+      const token = {
+        key: 'body.$.value.[*].NestedArray.[*].P1',
+        name: 'P1',
+        type: 'string',
+        brandColor: 'brandColor',
+        title: 'P1',
+        value: `item()?['P1']`,
+        outputInfo: { arrayDetails: { parentArray: 'NestedArray' }, required: false, source: 'body', type: TokenType.OUTPUTS },
+      };
+      const state = clone(rootState);
+      state.operations.settings['manual'].splitOn.value.enabled = false;
+      state.operations.outputParameters['manual'].outputs['body.$.value.[*].NestedArray'].isInsideArray = true;
+      state.workflow.nodesMetadata = {
+        ...state.workflow.nodesMetadata,
+        [nodeId]: { graphId: 'For_each', isRoot: true, parentNodeId: 'For_each' },
+        For_each: { graphId: 'root', isRoot: false, actionCount: 1 },
+      };
+      state.operations.settings['manual'].splitOn.value.enabled = false;
+
+      vi.spyOn(GraphHelper, 'getTriggerNodeId').mockReturnValue('manual');
+      const details = await shouldAddForeach(nodeId, parameterId, token, state);
+
+      expect(details).toBeDefined();
+      expect(details.shouldAdd).toBeTruthy();
+      expect(details.arrayDetails).toEqual([
+        expect.objectContaining({ parentArrayKey: 'body.$.value.[*].NestedArray', parentArrayValue: "@items('For_each')?['NestedArray']" }),
+      ]);
+      expect(details.repetitionContext).toEqual({
+        repetitionReferences: [
+          {
+            actionName: 'For_each',
+            actionType: 'foreach',
+            repetitionValue: "@triggerBody()?['value']",
+            repetitionPath: 'body.$.value',
+          },
+        ],
+        splitOn: undefined,
+      });
+    });
+  });
+});

--- a/libs/designer/src/lib/core/utils/loops.ts
+++ b/libs/designer/src/lib/core/utils/loops.ts
@@ -308,13 +308,14 @@ const getArrayDetailsForNestedForeach = (
       return checkArrayInRepetition(actionName, repetitionValue, parentArrayKey, data?.expression, data?.output, areOutputsManifestBased);
     });
 
-    shouldAdd = !isSplitOn && !alreadyInLoop;
+    const shouldAddLoopForCurrentParent = !isSplitOn && !alreadyInLoop;
 
-    if (data?.expression) {
+    if (shouldAddLoopForCurrentParent && data?.expression) {
       arrayDetails.push({ parentArrayKey, parentArrayValue: data.expression });
     }
 
-    parentArrayKey = getParentArrayKey(parentArrayKey);
+    shouldAdd = shouldAdd || shouldAddLoopForCurrentParent;
+    parentArrayKey = data?.token.arrayDetails ? getParentArrayKey(parentArrayKey) : undefined;
     parentArray = data?.token.arrayDetails?.parentArrayName;
   }
 
@@ -333,8 +334,8 @@ const getParentArrayExpression = (
     return undefined;
   }
 
+  const { repetitionReferences } = repetitionContext;
   const sanitizedParentArrayKey = sanitizeKey(parentArrayKey);
-
   const parentArrayOutput = nodeOutputs.outputs[parentArrayKey];
   const parentArrayKeyOfParentArray = getParentArrayKey(parentArrayKey);
 
@@ -343,7 +344,6 @@ const getParentArrayExpression = (
     key: parentArrayKey,
     name: parentArrayName,
     tokenType: TokenType.OUTPUTS,
-    arrayDetails: parentArrayKeyOfParentArray ? { parentArrayKey: parentArrayKeyOfParentArray } : undefined,
     title: parentArrayName as string,
   };
 
@@ -352,12 +352,17 @@ const getParentArrayExpression = (
     parentArrayTokenInfo.name = parentArrayOutput.name;
     parentArrayTokenInfo.title = parentArrayOutput.title;
     parentArrayTokenInfo.source = parentArrayOutput.source;
-    if (parentArrayOutput.parentArray) {
-      parentArrayTokenInfo.arrayDetails = { ...parentArrayTokenInfo.arrayDetails, parentArrayName: parentArrayOutput.parentArray };
+    if (parentArrayOutput.isInsideArray) {
+      parentArrayTokenInfo.arrayDetails = {
+        parentArrayKey: parentArrayKeyOfParentArray ? parentArrayKeyOfParentArray : undefined,
+        parentArrayName: parentArrayOutput.parentArray ? parentArrayOutput.parentArray : undefined,
+      };
     }
+  } else {
+    parentArrayTokenInfo.arrayDetails = parentArrayKeyOfParentArray ? { parentArrayKey: parentArrayKeyOfParentArray } : undefined;
   }
 
-  for (const repetitionReference of repetitionContext.repetitionReferences) {
+  for (const repetitionReference of repetitionReferences) {
     if (
       equals(sanitizedParentArrayKey, repetitionReference.repetitionPath) &&
       ((isNullOrUndefined(tokenOwnerActionName) && isNullOrUndefined(repetitionReference.repetitionStep)) ||
@@ -632,7 +637,7 @@ const isExpressionEqualToNodeSplitOn = (test: string | any[], splitOn: string | 
     return false;
   }
 
-  if (equals(test, splitOn)) {
+  if (equals(sanitizeOperatorsInExpression(test), sanitizeOperatorsInExpression(splitOn))) {
     return true;
   }
 
@@ -824,4 +829,8 @@ const normalizeKeyPath = (path: string | undefined): string | undefined => {
     : path === 'outputs.$.body'
       ? 'body.$'
       : path;
+};
+
+const sanitizeOperatorsInExpression = (expression: string): string => {
+  return expression.replaceAll('?[', '[');
 };


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior
fixes #5425 

## Pending
Tests are pending and will be covered in next iteration
