### PR TITLE
fix(vscode): Extension cleanup

### DIFF
--- a/apps/vs-code-designer/src/app/commands/pickFuncProcess.ts
+++ b/apps/vs-code-designer/src/app/commands/pickFuncProcess.ts
@@ -245,6 +245,13 @@ async function pickChildProcess(taskInfo: IRunningFuncTask): Promise<string> {
   return child ? child.pid.toString() : String(taskInfo.processId);
 }
 
+export async function findChildProcess(processId: number): Promise<string | undefined> {
+  const children: OSAgnosticProcess[] =
+    process.platform === Platform.windows ? await getWindowsChildren(processId) : await getUnixChildren(processId);
+  const child: OSAgnosticProcess | undefined = children.reverse().find((c) => /(dotnet|func)(\.exe|)$/i.test(c.command || ''));
+  return child ? child.pid.toString() : String(processId);
+}
+
 async function getUnixChildren(pid: number): Promise<OSAgnosticProcess[]> {
   const processes: ActualUnixPS[] = await new Promise((resolve, reject): void => {
     unixPsTree(pid, (error: Error | null, result: unixPsTree.PS[]) => {

--- a/apps/vs-code-designer/src/extensionVariables.ts
+++ b/apps/vs-code-designer/src/extensionVariables.ts
@@ -24,6 +24,7 @@ export namespace ext {
   export let context: ExtensionContext;
   export let designTimePort: number;
   export let designChildProcess: cp.ChildProcess | undefined;
+  export let designChildFuncProcessId: string | undefined;
   export let workflowDotNetProcess: cp.ChildProcess | undefined;
   export let workflowNodeProcess: cp.ChildProcess | undefined;
   export let logicAppWorkspace: string;


### PR DESCRIPTION
## Requirement Checklist

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->
Upon Ctrl+Shift+P Reload Window selection or File -> Open Workspace From File..., when a logic app workspace is opened, the func.exe process is not always terminated.

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->
func.exe processes launched by the extension is cleaned up.

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->
This change should prevent users from having any linger func.exe instances which may cause instability when using any logic app extension features.

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
