### PR TITLE
fix(designer): Removing parent object from dynamic inputs when parameter is nested

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -737,14 +737,12 @@ function getSwaggerBasedInputParameters(
     propertyNames,
     getObjectPropertyValue(operationDefinition.inputs, propertyNames)
   );
-  let dynamicInputParameters = loadInputValuesFromDefinition(
+  const dynamicInputParameters = loadInputValuesFromDefinition(
     dynamicInputDefinition as Record<string, any>,
     isNested ? [getDynamicInputParameterFromDynamicParameter(dynamicParameter)] : inputs,
     operationPath,
     basePath as string
   );
-
-  dynamicInputParameters = removeParentObjectInputsIfNotNeeded(dynamicInputParameters);
 
   if (isNested) {
     const parameter = first((inputParameter) => inputParameter.key === key, dynamicInputParameters);
@@ -767,9 +765,9 @@ function getSwaggerBasedInputParameters(
       result.push(inputParameter);
     }
 
-    return result;
+    return removeParentObjectInputsIfNotNeeded(result);
   }
-  return dynamicInputParameters;
+  return removeParentObjectInputsIfNotNeeded(dynamicInputParameters);
 }
 
 // We should remove any reference to dynamic schema if parameter containing dynamic schema is used directly as an input.


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior
Regression was introduced few weeks back due to which nested dynamic schema was also adding the parent object as an input in inputs along with leaf parameters showing extra parameters, did not cause any issue in serialization just UI bug. Fixes #5624 
