### PR TITLE
chore(designer): Revert dynamic data aliasing changes in v4.86

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.spec.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.spec.ts
@@ -1,4 +1,3 @@
-import { InitOperationManifestService } from '@microsoft/logic-apps-shared';
 import { getInputParametersFromManifest } from '../initialize';
 import {
   mockGetMyOffice365ProfileOpenApiManifest,
@@ -8,15 +7,6 @@ import {
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
 describe('bjsworkflow initialize', () => {
   describe('getInputParametersFromManifest', () => {
-    beforeAll(() => {
-      InitOperationManifestService({
-        isSupported: () => true,
-        isAliasingSupported: () => true,
-        getOperationInfo: () => Promise.resolve({} as any),
-        getOperationManifest: () => Promise.resolve({} as any),
-      });
-    });
-
     test('works for an OpenAPI operation with input parameters and values', () => {
       const stepDefinition = {
         runAfter: {},
@@ -42,7 +32,6 @@ describe('bjsworkflow initialize', () => {
 
       const inputParameters = getInputParametersFromManifest(
         'Send_an_email',
-        { type: 'OpenApiConnection', operationId: 'SendEmailV2', connectorId: '/providers/Microsoft.PowerApps/apis/shared_office365' },
         mockSendAnOfficeOutlookEmailOpenApiManifest,
         undefined /* presetParameterValues */,
         undefined /* customSwagger */,
@@ -83,11 +72,6 @@ describe('bjsworkflow initialize', () => {
 
       const inputParameters = getInputParametersFromManifest(
         'Post_an_adaptive_card',
-        {
-          type: 'OpenApiConnectionWebhook',
-          operationId: 'PostCardAndWaitForResponse',
-          connectorId: '/providers/Microsoft.PowerApps/apis/shared_teams',
-        },
         mockPostTeamsAdaptiveCardOpenApiManifest,
         undefined /* presetParameterValues */,
         undefined /* customSwagger */,
@@ -120,11 +104,6 @@ describe('bjsworkflow initialize', () => {
 
       const inputParameters = getInputParametersFromManifest(
         'Get_my_profile',
-        {
-          type: 'OpenApiConnection',
-          operationId: 'MyProfile_V2',
-          connectorId: '/providers/Microsoft.PowerApps/apis/shared_office365users',
-        },
         mockGetMyOffice365ProfileOpenApiManifest,
         undefined /* presetParameterValues */,
         undefined /* customSwagger */,

--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -134,12 +134,7 @@ export const initializeOperationDetails = async (
 
     const iconUri = getIconUriFromManifest(manifest);
     const brandColor = getBrandColorFromManifest(manifest);
-    const { inputs: nodeInputs, dependencies: inputDependencies } = getInputParametersFromManifest(
-      nodeId,
-      operationInfo,
-      manifest,
-      presetParameterValues
-    );
+    const { inputs: nodeInputs, dependencies: inputDependencies } = getInputParametersFromManifest(nodeId, manifest, presetParameterValues);
     const customCodeParameter = getParameterFromName(nodeInputs, Constants.DEFAULT_CUSTOM_CODE_INPUT);
     if (customCodeParameter && isCustomCode(customCodeParameter?.editor, customCodeParameter?.editorOptions?.language)) {
       initializeCustomCodeDataInInputs(customCodeParameter, nodeId, dispatch);
@@ -149,11 +144,11 @@ export const initializeOperationDetails = async (
       manifest,
       isTrigger,
       nodeInputs,
-      operationInfo,
       dispatch,
-      operationSupportsSplitOn(isTrigger) ? getSplitOnValue(manifest, undefined, undefined, undefined) : undefined
+      operationSupportsSplitOn(isTrigger) ? getSplitOnValue(manifest, undefined, undefined, undefined) : undefined,
+      operationInfo
     );
-    parsedManifest = new ManifestParser(manifest, operationManifestService.isAliasingSupported(type, kind));
+    parsedManifest = new ManifestParser(manifest);
 
     const nodeDependencies = { inputs: inputDependencies, outputs: outputDependencies };
     const settings = getOperationSettings(
@@ -174,9 +169,9 @@ export const initializeOperationDetails = async (
         manifest,
         isTrigger,
         nodeInputs,
-        operationInfo,
         dispatch,
-        settings.splitOn?.value?.value
+        settings.splitOn?.value?.value,
+        operationInfo
       ).outputs;
     }
 
@@ -283,19 +278,15 @@ export const initializeOperationDetails = async (
 };
 
 export const initializeSwitchCaseFromManifest = async (id: string, manifest: OperationManifest, dispatch: Dispatch): Promise<void> => {
-  const { inputs: nodeInputs, dependencies: inputDependencies } = getInputParametersFromManifest(
-    id,
-    { type: '', kind: '', connectorId: '', operationId: '' },
-    manifest
-  );
+  const { inputs: nodeInputs, dependencies: inputDependencies } = getInputParametersFromManifest(id, manifest);
   const { outputs: nodeOutputs, dependencies: outputDependencies } = getOutputParametersFromManifest(
     id,
     manifest,
     false,
     nodeInputs,
-    { type: '', kind: '', connectorId: '', operationId: '' },
     dispatch,
-    /* splitOnValue */ undefined
+    /* splitOnValue */ undefined,
+    /* operationInfo */ undefined
   );
   const nodeDependencies = { inputs: inputDependencies, outputs: outputDependencies };
   const initData = {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -233,7 +233,7 @@ export const initializeOperationDetailsForManifest = async (
     dispatch(initializeOperationInfo({ id: nodeId, ...nodeOperationInfo }));
 
     const { connectorId, operationId } = nodeOperationInfo;
-    const parsedManifest = new ManifestParser(manifest, OperationManifestService().isAliasingSupported(operation.type, operation.kind));
+    const parsedManifest = new ManifestParser(manifest);
     const schema = staticResultService.getOperationResultSchema(connectorId, operationId, parsedManifest);
     schema.then((schema) => {
       if (schema) {
@@ -244,7 +244,6 @@ export const initializeOperationDetailsForManifest = async (
     const customSwagger = await getCustomSwaggerIfNeeded(manifest.properties, operation);
     const { inputs: nodeInputs, dependencies: inputDependencies } = getInputParametersFromManifest(
       nodeId,
-      nodeOperationInfo,
       manifest,
       /* presetParameterValues */ undefined,
       customSwagger,
@@ -266,9 +265,9 @@ export const initializeOperationDetailsForManifest = async (
       manifest,
       isTrigger,
       nodeInputs,
-      nodeOperationInfo,
       dispatch,
-      operationSupportsSplitOn(isTrigger) ? getSplitOnValue(manifest, undefined, undefined, operation) : undefined
+      operationSupportsSplitOn(isTrigger) ? getSplitOnValue(manifest, undefined, undefined, operation) : undefined,
+      operationInfo
     );
     const nodeDependencies = { inputs: inputDependencies, outputs: outputDependencies };
 
@@ -322,7 +321,6 @@ const processChildGraphAndItsInputs = (
           for (const subNodeKey of Object.keys(subOperation)) {
             const { inputs: subNodeInputs, dependencies: subNodeInputDependencies } = getInputParametersFromManifest(
               subNodeKey,
-              { type: '', kind: '', connectorId: '', operationId: '' },
               subManifest,
               /* presetParameterValues */ undefined,
               /* customSwagger */ undefined,

--- a/libs/designer/src/lib/core/utils/outputs.ts
+++ b/libs/designer/src/lib/core/utils/outputs.ts
@@ -479,9 +479,7 @@ export const loadDynamicOutputsInNode = async (
             /* idReplacements */ undefined,
             workflowParameters
           );
-          let schemaOutputs = outputSchema
-            ? getDynamicOutputsFromSchema(outputSchema, info.parameter as OutputParameter, operationInfo)
-            : {};
+          let schemaOutputs = outputSchema ? getDynamicOutputsFromSchema(outputSchema, info.parameter as OutputParameter) : {};
 
           if (settings.splitOn?.value?.enabled) {
             schemaOutputs = updateOutputsForBatchingTrigger(schemaOutputs, settings.splitOn?.value?.value);

--- a/libs/designer/src/lib/core/utils/parameters/__test__/dynamicdata.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/dynamicdata.spec.ts
@@ -6,7 +6,6 @@ describe('DynamicData', () => {
   describe('getDynamicInputsFromSchema', () => {
     const manifestService: any = {
       isSupported: () => true,
-      isAliasingSupported: () => false,
       getOperationManifest() {
         return Promise.resolve({ properties: { inputsLocationSwapMap: [] } } as any);
       },
@@ -134,41 +133,6 @@ describe('DynamicData', () => {
         expect.arrayContaining([
           expect.objectContaining({ key: 'inputs.$.dynamicData.details' }),
           expect.objectContaining({ key: 'inputs.$.dynamicData.id' }),
-        ])
-      );
-    });
-
-    test('should return only leaf parameters in dynamic schema with aliasing parameters for the property values are present in definition', async () => {
-      InitOperationManifestService(manifestService);
-      const dynamicSchemaWithAliases = {
-        type: 'object',
-        properties: {
-          details: {
-            type: 'object',
-            properties: {
-              name: { type: 'string', 'x-ms-alias': 'inputs/dynamicData/name' },
-              code: { type: 'number', 'x-ms-alias': 'inputs/dynamicData/code' },
-            },
-          },
-          id: { type: 'string' },
-        },
-      };
-
-      const dynamicInputs = await getDynamicInputsFromSchema(
-        dynamicSchemaWithAliases,
-        { ...dynamicParameter, alias: 'inputs/dynamicData' },
-        { connectorId: '/connectionProviders/test', operationId: 'test', type: 'ApiManagement' },
-        ['inputs.$.operationId'],
-        { inputs: { operationId: 'SomeValue', dynamicData: { id: 'abc', details: { name: 'test', code: 123 } } } }
-      );
-
-      expect(dynamicInputs).toBeDefined();
-      expect(dynamicInputs.length).toEqual(3);
-      expect(dynamicInputs).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ key: 'inputs.$.dynamicData.details.name', value: 'test' }),
-          expect.objectContaining({ key: 'inputs.$.dynamicData.details.code', value: 123 }),
-          expect.objectContaining({ key: 'inputs.$.dynamicData.id', value: 'abc' }),
         ])
       );
     });

--- a/libs/designer/src/lib/core/utils/parameters/__test__/dynamicdata.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/dynamicdata.spec.ts
@@ -1,4 +1,4 @@
-import { getDynamicInputsFromSchema, getDynamicOutputsFromSchema } from '../dynamicdata';
+import { getDynamicInputsFromSchema } from '../dynamicdata';
 import { InitOperationManifestService } from '@microsoft/logic-apps-shared';
 import { expect, describe, test } from 'vitest';
 
@@ -134,90 +134,6 @@ describe('DynamicData', () => {
           expect.objectContaining({ key: 'inputs.$.dynamicData.details' }),
           expect.objectContaining({ key: 'inputs.$.dynamicData.id' }),
         ])
-      );
-    });
-  });
-
-  describe('getDynamicOutputsFromSchema', () => {
-    const manifestService: any = {
-      isSupported: () => true,
-      isAliasingSupported: () => false,
-      getOperationManifest() {
-        return Promise.resolve({ properties: { inputsLocationSwapMap: [] } } as any);
-      },
-    };
-    const dynamicSchema = {
-      type: 'object',
-      properties: {
-        body: {
-          type: 'object',
-          properties: {
-            value: {
-              type: 'array',
-              'x-ms-property-name-alias': 'body/value',
-            },
-          },
-          'x-ms-property-name-alias': 'body',
-        },
-      },
-    };
-    const dynamicParameter = {
-      key: 'outputs.$.body',
-      name: 'body',
-      type: 'object',
-      schema: {
-        type: 'object',
-        properties: {
-          value: {
-            type: 'array',
-            'x-ms-property-name-alias': 'body/value',
-          },
-        },
-        'x-ms-property-name-alias': 'body',
-      },
-      alias: 'body',
-    };
-
-    test('should not apply aliases to dynamicOutputs when aliasing is disabled', async () => {
-      InitOperationManifestService(manifestService);
-
-      const dynamicOutputs = await getDynamicOutputsFromSchema(dynamicSchema, dynamicParameter, {
-        connectorId: '/connectionProviders/test',
-        operationId: 'test',
-        type: 'ApiManagement',
-      });
-
-      expect(dynamicOutputs).toBeDefined();
-
-      const objectOutput = dynamicOutputs['body.$.body.body.value'];
-      expect(objectOutput).toBeDefined();
-      expect(objectOutput).toEqual(
-        expect.objectContaining({ key: 'body.$.body.body.value', name: 'body.body.value', title: 'value', alias: undefined, type: 'array' })
-      );
-    });
-
-    test('should apply aliases to dynamicOutputs when aliasing is enabled', async () => {
-      manifestService.isAliasingSupported = () => true;
-      InitOperationManifestService(manifestService);
-
-      const dynamicOutputs = await getDynamicOutputsFromSchema(dynamicSchema, dynamicParameter, {
-        connectorId: '/connectionProviders/testOpenAPI',
-        operationId: 'testOpenAPI',
-        type: 'OpenApiConnection',
-      });
-
-      expect(dynamicOutputs).toBeDefined();
-
-      const objectOutput = dynamicOutputs['body.$.body.body.body/value'];
-      expect(objectOutput).toBeDefined();
-      expect(objectOutput).toEqual(
-        expect.objectContaining({
-          key: 'body.$.body.body.body/value',
-          name: 'body/value',
-          title: 'body/value',
-          alias: 'body/value',
-          type: 'array',
-        })
       );
     });
   });

--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -229,11 +229,7 @@ export async function getDynamicSchema(
   }
 }
 
-export function getDynamicOutputsFromSchema(
-  schema: OpenAPIV2.SchemaObject,
-  dynamicParameter: OutputParameter,
-  operationInfo: NodeOperation
-): OutputParameters {
+export function getDynamicOutputsFromSchema(schema: OpenAPIV2.SchemaObject, dynamicParameter: OutputParameter): OutputParameters {
   const { key, name, parentArray, required, source } = dynamicParameter;
   const keyPrefix = _getKeyPrefixFromParameter(key);
   const processorOptions: SchemaProcessorOptions = {
@@ -245,7 +241,6 @@ export function getDynamicOutputsFromSchema(
     includeParentObject: true,
     parentProperty: parentArray ? { arrayName: parentArray, isArray: true } : undefined,
     dataKeyPrefix: '$',
-    useAliasedIndexing: OperationManifestService().isAliasingSupported(operationInfo.type, operationInfo.kind),
   };
 
   const schemaProperties = new SchemaProcessor(processorOptions).getSchemaProperties(schema);

--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -277,11 +277,10 @@ export async function getDynamicInputsFromSchema(
       visibility: dynamicParameter.visibility,
     },
     required: dynamicParameter.required || schemaHasRequiredParameters,
-    useAliasedIndexing: OperationManifestService().isAliasingSupported(operationInfo.type, operationInfo.kind),
+    useAliasedIndexing: true,
     excludeAdvanced: false,
     excludeInternal: false,
     includeParentObject: true,
-    isInputSchema: true,
   };
   const schemaProperties = new SchemaProcessor(processorOptions).getSchemaProperties(schema);
   let dynamicInputs: InputParameter[] = schemaProperties.map((schemaProperty) => ({
@@ -292,14 +291,13 @@ export async function getDynamicInputsFromSchema(
     required: (schemaProperty.schema?.required as any) ?? schemaProperty.required ?? false,
   }));
 
-  // TODO: This code should be removed once keys are correctly stamped for aliasing inputs since in normal parsing this does not happen.
   // We are recieving some swagger parameters with keys in the following format, ex:
   //     body.$.body/content.body/content/appId
   // We need to reformat to the below string:
   //     body.$.content.appId
   for (const inputParameter of dynamicInputs) {
-    const { key: _key, in: _in } = inputParameter;
-    if (isOpenApiParameter(inputParameter) && _in && _key !== `${_in}.$`) {
+    if (isOpenApiParameter(inputParameter) && inputParameter?.in) {
+      const { key: _key, in: _in } = inputParameter;
       // _key = body.$.body/content.body/content/appId
       const path = replaceSubsegmentSeparator(_key.split('.').pop() ?? '');
       // path = body.content.appId

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/operationmanifest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/operationmanifest.ts
@@ -245,10 +245,6 @@ export abstract class BaseOperationManifestService implements IOperationManifest
       : supportedBaseManifestTypes.indexOf(normalizedOperationType) > -1;
   }
 
-  isAliasingSupported(): boolean {
-    return false;
-  }
-
   abstract getOperationInfo(definition: any, isTrigger: boolean): Promise<OperationInfo>;
 
   abstract getOperationManifest(_connectorId: string, _operationId: string): Promise<OperationManifest>;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/operationmanifest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/operationmanifest.ts
@@ -14,14 +14,6 @@ export interface IOperationManifestService {
   isSupported(operationType?: string, operationKind?: string): boolean;
 
   /**
-   * Checks if the operation type has aliasing supported.
-   * @arg [string] operationType - The operation type.
-   * @arg [string] operationKind - The operation kind.
-   * @return {boolean}
-   */
-  isAliasingSupported(operationType?: string, operationKind?: string): boolean;
-
-  /**
    * Gets the operation info.
    * @arg {any} definition - The operation definition.
    * @arg {boolean} isTrigger - Flag to determine if the definition is of a trigger operation.

--- a/libs/logic-apps-shared/src/parsers/lib/common/schemaprocessor.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/common/schemaprocessor.ts
@@ -329,7 +329,7 @@ export class SchemaProcessor {
       const description = schema.description;
       const $enum = getEnum(schema, this.options.required);
       schemaProperties.push({
-        alias: this.options.useAliasedIndexing ? schema[SwaggerConstants.ExtensionProperties.Alias] : undefined,
+        alias: schema[SwaggerConstants.ExtensionProperties.Alias],
         default: schema.default,
         description,
         dynamicValues,
@@ -512,7 +512,7 @@ export class SchemaProcessor {
     const type = (schema.type as string) || SwaggerConstants.Types.Any;
     const visibility = this._getVisibility(schema);
     const groupName = this._getGroupName(schema);
-    const alias = this.options.useAliasedIndexing ? schema[SwaggerConstants.ExtensionProperties.Alias] : undefined;
+    const alias = schema[SwaggerConstants.ExtensionProperties.Alias];
 
     // Exclude read-only parameters from input schema, i.e., objects in Swagger body parameters.
     if (isInputSchema && this._isReadOnlyParameter(schema)) {

--- a/libs/logic-apps-shared/src/parsers/lib/manifest/__test__/parser.spec.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/manifest/__test__/parser.spec.ts
@@ -6,20 +6,15 @@ import { createItem, getEmails, onNewEmail } from './data/manifests';
 import { equals } from '../../../../utils/src';
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
 describe('Operation manifest parser tests', () => {
-  const aliasingSupported = true;
-  const aliasingNotSupported = false;
   describe('Input Parameters', () => {
     it('should return empty object when there is no inputs.', () => {
-      const parser = new ManifestParser(
-        {
-          properties: {
-            iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
-            brandColor: '#0072c6',
-            description: 'This operation gets emails from a folder.',
-          },
+      const parser = new ManifestParser({
+        properties: {
+          iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
+          brandColor: '#0072c6',
+          description: 'This operation gets emails from a folder.',
         },
-        aliasingNotSupported
-      );
+      });
 
       const inputParameters = parser.getInputParameters(/* includeParentObject */ false, /* expandArrayPropertiesDepth */ 0);
 
@@ -27,18 +22,15 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should return optional inputs when inputs is optional.', () => {
-      const parser = new ManifestParser(
-        {
-          properties: {
-            iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
-            brandColor: '#0072c6',
-            description: 'This operation gets emails from a folder.',
-            isInputsOptional: true,
-            inputs: {},
-          },
+      const parser = new ManifestParser({
+        properties: {
+          iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
+          brandColor: '#0072c6',
+          description: 'This operation gets emails from a folder.',
+          isInputsOptional: true,
+          inputs: {},
         },
-        aliasingNotSupported
-      );
+      });
 
       const inputParameters = parser.getInputParameters(/* includeParentObject */ false, /* expandArrayPropertiesDepth */ 0);
 
@@ -47,7 +39,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should parse primitive inputs which are children of objects correctly', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const inputParameters = parser.getInputParameters(/* includeParentObject */ false, /* expandArrayPropertiesDepth */ 0);
 
@@ -61,7 +53,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should generate enum for boolean parameters', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const inputParameters = parser.getInputParameters(/* includeParentObject */ false, /* expandArrayPropertiesDepth */ 0);
 
@@ -75,7 +67,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should determine when inputs are required', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const inputParameters = parser.getInputParameters(/* includeParentObject */ false, /* expandArrayPropertiesDepth */ 0);
 
@@ -85,7 +77,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should determine when inputs are not required', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const inputParameters = parser.getInputParameters(/* includeParentObject */ false, /* expandArrayPropertiesDepth */ 0);
 
@@ -95,13 +87,13 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should not mark an input required when any ancestor is not required', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
       const inputParameters = parser.getInputParameters(/* includeParentObject */ false, /* expandArrayPropertiesDepth */ 0);
       expect(getInputByName(inputParameters, 'emailMessage/Object/P1')?.required).toBeFalsy();
     });
 
     it('should parse internal array parameters when selected', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const allInputParameters = parser.getInputParameters(/* includeParentObject */ true, /* expandArrayPropertiesDepth */ 100);
 
@@ -112,7 +104,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should parse internal primitive array parameters when selected', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const allInputParameters = parser.getInputParameters(/* includeParentObject */ true, /* expandArrayPropertiesDepth */ 100);
 
@@ -121,7 +113,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should pass through dynamic values', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const allInputParameters = parser.getInputParameters(/* includeParentObject */ true, /* expandArrayPropertiesDepth */ 100);
 
@@ -149,7 +141,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should pass through dynamic schema', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const allInputParameters = parser.getInputParameters(/* includeParentObject */ true, /* expandArrayPropertiesDepth */ 100);
 
@@ -169,7 +161,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should update dynamic extension parameters to reference aliases', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const allInputParameters = parser.getInputParameters(/* includeParentObject */ true, /* expandArrayPropertiesDepth */ 100);
 
@@ -181,16 +173,13 @@ describe('Operation manifest parser tests', () => {
 
   describe('Output Parameters', () => {
     it('should return empty object when there is no outputs.', () => {
-      const parser = new ManifestParser(
-        {
-          properties: {
-            iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
-            brandColor: '#0072c6',
-            description: 'This operation gets emails from a folder.',
-          },
+      const parser = new ManifestParser({
+        properties: {
+          iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
+          brandColor: '#0072c6',
+          description: 'This operation gets emails from a folder.',
         },
-        aliasingNotSupported
-      );
+      });
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -198,19 +187,16 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should return optional outputs when outputs is optional.', () => {
-      const parser = new ManifestParser(
-        {
-          properties: {
-            iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
-            brandColor: '#0072c6',
-            description: 'This operation gets emails from a folder.',
-            isOutputsOptional: true,
-            outputs: {},
-            includeRootOutputs: true,
-          },
+      const parser = new ManifestParser({
+        properties: {
+          iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
+          brandColor: '#0072c6',
+          description: 'This operation gets emails from a folder.',
+          isOutputsOptional: true,
+          outputs: {},
+          includeRootOutputs: true,
         },
-        aliasingNotSupported
-      );
+      });
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -220,19 +206,16 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should return optional outputs when outputs is optional.', () => {
-      const parser = new ManifestParser(
-        {
-          properties: {
-            iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
-            brandColor: '#0072c6',
-            description: 'This operation gets emails from a folder.',
-            isOutputsOptional: true,
-            outputs: {},
-            includeRootOutputs: true,
-          },
+      const parser = new ManifestParser({
+        properties: {
+          iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
+          brandColor: '#0072c6',
+          description: 'This operation gets emails from a folder.',
+          isOutputsOptional: true,
+          outputs: {},
+          includeRootOutputs: true,
         },
-        aliasingNotSupported
-      );
+      });
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -242,47 +225,44 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should not return alternative outputs if no runtime outputs are provided', () => {
-      const parser = new ManifestParser(
-        {
-          properties: {
-            iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
-            brandColor: '#0072c6',
-            description: 'This operation gets emails from a folder.',
-            isOutputsOptional: true,
-            outputs: {
-              type: 'object',
-              properties: {
-                defaultProp: {
-                  type: 'string',
-                },
+      const parser = new ManifestParser({
+        properties: {
+          iconUri: 'https://connectoricons-prod.azureedge.net/office365/icon_1.0.1008.1183.png',
+          brandColor: '#0072c6',
+          description: 'This operation gets emails from a folder.',
+          isOutputsOptional: true,
+          outputs: {
+            type: 'object',
+            properties: {
+              defaultProp: {
+                type: 'string',
               },
             },
-            includeRootOutputs: true,
-            alternativeOutputs: {
-              keyPath: ['statusCode'],
-              schemas: {
-                200: {
-                  type: 'object',
-                  properties: {
-                    altSuccessProp: {
-                      type: 'string',
-                    },
-                  },
-                },
-              },
-              defaultSchema: {
+          },
+          includeRootOutputs: true,
+          alternativeOutputs: {
+            keyPath: ['statusCode'],
+            schemas: {
+              200: {
                 type: 'object',
                 properties: {
-                  altDefaultProp: {
+                  altSuccessProp: {
                     type: 'string',
                   },
                 },
               },
             },
+            defaultSchema: {
+              type: 'object',
+              properties: {
+                altDefaultProp: {
+                  type: 'string',
+                },
+              },
+            },
           },
         },
-        aliasingNotSupported
-      );
+      });
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ false, /* expandArrayOutputsDepth */ 1);
 
@@ -291,7 +271,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should parse primitive outputs which are children of arrays correctly', () => {
-      const parser = new ManifestParser(getEmails, aliasingSupported);
+      const parser = new ManifestParser(getEmails);
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -306,7 +286,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should tell when an output is advanced', () => {
-      const parser = new ManifestParser(getEmails, aliasingSupported);
+      const parser = new ManifestParser(getEmails);
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -316,7 +296,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should consider descendents of advanced parameters advanced', () => {
-      const parser = new ManifestParser(getEmails, aliasingSupported);
+      const parser = new ManifestParser(getEmails);
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -326,7 +306,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should parse array outputs', () => {
-      const parser = new ManifestParser(getEmails, aliasingSupported);
+      const parser = new ManifestParser(getEmails);
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -337,7 +317,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should determine the parent array', () => {
-      const parser = new ManifestParser(onNewEmail, aliasingSupported);
+      const parser = new ManifestParser(onNewEmail);
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -352,7 +332,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should pass through dynamic schema', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -372,7 +352,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should update dynamic extension parameters to reference aliases', () => {
-      const parser = new ManifestParser(createItem, aliasingSupported);
+      const parser = new ManifestParser(createItem);
 
       const allOutputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -383,7 +363,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should set title for primitive array children', () => {
-      const parser = new ManifestParser(onNewEmail, aliasingSupported);
+      const parser = new ManifestParser(onNewEmail);
 
       const allOutputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 
@@ -393,7 +373,7 @@ describe('Operation manifest parser tests', () => {
     });
 
     it('should not surface internal outputs', () => {
-      const parser = new ManifestParser(onNewEmail, aliasingSupported);
+      const parser = new ManifestParser(onNewEmail);
 
       const outputParameters = parser.getOutputParameters(/* includeParentObject */ true, /* expandArrayOutputsDepth */ 1);
 

--- a/libs/logic-apps-shared/src/parsers/lib/manifest/parser.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/manifest/parser.ts
@@ -38,11 +38,9 @@ export function getSplitOnArrayAliasMetadata(schema: SchemaObject, required: boo
 
 export class ManifestParser {
   private _operationManifest: OperationManifest;
-  private _isAliasingSupported: boolean;
 
-  constructor(operationManifest: OperationManifest, isAliasingSupported: boolean) {
+  constructor(operationManifest: OperationManifest) {
     this._operationManifest = operationManifest;
-    this._isAliasingSupported = isAliasingSupported;
   }
 
   /**
@@ -74,7 +72,7 @@ export class ManifestParser {
       keyPrefix: 'inputs.$',
       excludeAdvanced: false,
       excludeInternal: false,
-      useAliasedIndexing: this._isAliasingSupported,
+      useAliasedIndexing: true,
     };
 
     const inputParams = {
@@ -123,7 +121,7 @@ export class ManifestParser {
       isInputSchema: false,
       excludeAdvanced: false,
       excludeInternal: true,
-      useAliasedIndexing: this._isAliasingSupported,
+      useAliasedIndexing: true,
       outputKey: SwaggerConstants.OutputKeys.Outputs,
     };
 


### PR DESCRIPTION
Our proposed fix (#5661) for the aliasing issues in Power Automate was not approved, so additional work is required before we can take aliasing changes.

This cherry-pick PR is mostly the same as #5621 but for v4.86. Looks like LA is using v4.85 and v4.88 but not v4.86 so this should not affect LA portal.

> This is a hotfix PR containing two reverts:
> 
> * #5537 (254a51ad644576335ea3422130cce4f79c32b06c)
> * #5360 (2e27773cd24e5a67fd33a1656a789b3ec0d8c10a)
> 
> Unfortunately, the change to aliasing has broken us in other ways that were not fixed by our initial hotfix for v4.74.1. Therefore, we are reverting that hotfix, as well as the initial dynamic data aliasing change, until we can figure out how to fix the scenario entirely.

Also reverting unit test changes made for the above PRs (#5565).