### PR TITLE
fix(Designer): Fixed issue with `suppressDefaultNodeSelectFunctionality`

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -183,6 +183,11 @@ export const PanelContainer = ({
 
   const minWidth = pinnedNode ? Number.parseInt(PanelSize.DualView, 10) : undefined;
 
+  if (suppressDefaultNodeSelectFunctionality) {
+    // Used in cases like BPT where we do not want to show the panel during node selection
+    return null;
+  }
+
   return (
     <OverlayDrawer
       aria-label={panelLabel}


### PR DESCRIPTION
## Main Changes

When the `suppressDefaultNodeSelectFunctionality` designer option is enabled we just hide the node details panel.
This was old behavior that got changed/removed during the panel refactor PA did.
The `suppressDefaultNodeSelectFunctionality` option is used in BPT to avoid opening the panel during our token selection over in BPT and this was noticed as broken upon updating.