### PR TITLE
chore(designer): Bump data mapper v2 version

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -23,6 +23,10 @@
             "type": "json"
         },
         {
+            "filename": "libs/data-mapper-v2/package.json",
+            "type": "json"
+        },
+        {
             "filename": "libs/logic-apps-shared/package.json",
             "type": "json"
         },


### PR DESCRIPTION
This pull request includes a small change to the `.versionrc` file. The change adds a new entry for the `libs/data-mapper-v2/package.json` file to the versioning configuration.

* [`.versionrc`](diffhunk://#diff-5530fb07101d34a455c1f664800f0f8d4f6424ce779af3f5c99d9517e3e7539dR25-R28): Added a new entry for `libs/data-mapper-v2/package.json` to the versioning configuration.