### PR TITLE
feat(vscode): Add copy file assemblies for .net 8 projects

### DIFF
--- a/apps/vs-code-designer/src/assets/FunctionProjectTemplate/FunctionsProjNet8
+++ b/apps/vs-code-designer/src/assets/FunctionProjectTemplate/FunctionsProjNet8
@@ -9,6 +9,7 @@
     <LogicAppFolder>LogicApp</LogicAppFolder>
     <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     <SelfContained>false</SelfContained>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
  </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes a small but significant change to the `apps/vs-code-designer/src/assets/FunctionProjectTemplate/FunctionsProjNet8` file. The change ensures that local lock file assemblies are copied during the build process.

* Added the `CopyLocalLockFileAssemblies` property to ensure local lock file assemblies are copied.