### PR TITLE
feat(designer): Handle high content size in monitoring view 

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/run.ts
@@ -12,6 +12,8 @@ import {
   UnsupportedException,
   isNullOrUndefined,
 } from '../../../utils/src';
+import { LoggerService } from '../logger';
+import { LogEntryLevel } from '../logging/logEntry';
 
 export interface ConsumptionRunServiceOptions {
   apiVersion: string;
@@ -41,14 +43,16 @@ export class ConsumptionRunService implements IRunService {
     const { uri, contentSize } = contentLink;
     const { httpClient } = this.options;
 
-    // 2^18
-    if (contentSize > 262144) {
-      return undefined;
-    }
-
     if (!uri) {
       throw new Error();
     }
+
+    LoggerService().log({
+      level: LogEntryLevel.Verbose,
+      area: 'getContent consumption run service',
+      message: `Content size: ${contentSize}`,
+      args: [`size: ${contentSize}`],
+    });
 
     try {
       const response = await httpClient.get<any>({

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
@@ -13,6 +13,8 @@ import {
   isNullOrUndefined,
 } from '../../../utils/src';
 import { isHybridLogicApp } from './hybrid';
+import { LogEntryLevel } from '../logging/logEntry';
+import { LoggerService } from '../logger';
 
 export interface RunServiceOptions {
   apiVersion: string;
@@ -42,14 +44,16 @@ export class StandardRunService implements IRunService {
     const { uri, contentSize } = contentLink;
     const { httpClient } = this.options;
 
-    // 2^18
-    if (contentSize > 262144) {
-      return undefined;
-    }
-
     if (!uri) {
       throw new Error();
     }
+
+    LoggerService().log({
+      level: LogEntryLevel.Verbose,
+      area: 'getContent standard run service',
+      message: `Content size: ${contentSize}`,
+      args: [`size: ${contentSize}`],
+    });
 
     try {
       const response = await httpClient.get<any>({


### PR DESCRIPTION
This pull request introduces logging enhancements and removes a content size check within the `ConsumptionRunService` and `StandardRunService` classes. These changes aim to improve the traceability and debugging capabilities of the services.

* Included a logging statement to log the content size in the `ConsumptionRunService` and `StandardRunService` class. 
* Removed the content size check that returned `undefined` if the size exceeded 262144 bytes.

Fixes: #5658 