### PR TITLE
chore(meta): Cherry-pick fix(designer): Parameters panel re-rendering on undo/redo should be after setting root state on undo/redo click

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/undoRedo.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/undoRedo.ts
@@ -61,15 +61,15 @@ export const onUndoClick = createAsyncThunk('onUndoClick', async (_, { dispatch,
   const previousDecompressedState = getRootStateFromCompressedState(previousStateHistoryItem.compressedState);
   const currentCompressedRootState = getCompressedStateFromRootState(currentRootState);
 
+  // Change current state to previous state
+  dispatch(setStateAfterUndoRedo(previousDecompressedState));
+
   // Store current state to state history
   dispatch(
     updateStateHistoryOnUndoClick({
       compressedState: currentCompressedRootState,
     })
   );
-
-  // Change current state to previous state
-  dispatch(setStateAfterUndoRedo(previousDecompressedState));
 
   // If the updates were panel related, change panel node and tab to the changed ones
   const panelNode = previousStateHistoryItem.editedPanelNode;
@@ -99,15 +99,15 @@ export const onRedoClick = createAsyncThunk('onRedoClick', async (_, { dispatch,
   const nextDecompressedState = getRootStateFromCompressedState(nextStateHistoryItem.compressedState);
   const currentCompressedRootState = getCompressedStateFromRootState(currentRootState);
 
+  // Change current state to next state
+  dispatch(setStateAfterUndoRedo(nextDecompressedState));
+
   // Store current state to state history
   dispatch(
     updateStateHistoryOnRedoClick({
       compressedState: currentCompressedRootState,
     })
   );
-
-  // Change current state to next state
-  dispatch(setStateAfterUndoRedo(nextDecompressedState));
 
   // If the updates were panel related, change panel node and tab to the changed ones
   const panelNode = undoRedoState.currentEditedPanelNode;

--- a/libs/designer/src/lib/core/utils/undoredo.ts
+++ b/libs/designer/src/lib/core/utils/undoredo.ts
@@ -6,6 +6,7 @@ import { updateParameterAndDependencies, type UpdateParameterAndDependenciesPayl
 import constants from '../../common/constants';
 import { updateStaticResults } from '../state/operation/operationMetadataSlice';
 import type { AnyAction } from '@reduxjs/toolkit';
+import { LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
 
 export const getCompressedStateFromRootState = (rootState: RootState): Uint8Array => {
   const partialRootState: UndoRedoPartialRootState = {
@@ -19,7 +20,23 @@ export const getCompressedStateFromRootState = (rootState: RootState): Uint8Arra
     workflow: rootState.workflow,
     workflowParameters: rootState.workflowParameters,
   };
-  return deflate(JSON.stringify(partialRootState));
+
+  const stringifiedPartialRootState = JSON.stringify(partialRootState);
+  const compressedState = deflate(stringifiedPartialRootState);
+
+  LoggerService().log({
+    level: LogEntryLevel.Verbose,
+    area: 'getCompressedStateFromRootState',
+    message: 'Compression size',
+    args: [
+      {
+        partialRootStateSize: Buffer.from(stringifiedPartialRootState).byteLength,
+        compressedStateSize: Buffer.from(compressedState).byteLength,
+      },
+    ],
+  });
+
+  return compressedState;
 };
 
 export const getRootStateFromCompressedState = (compressedState: Uint8Array): UndoRedoPartialRootState =>


### PR DESCRIPTION
Cherry-pick: Parameters panel re-rendering on undo/redo should be after setting root state on undo/redo click (#5795)

* Update state history after setting root state on undo/redo click

* Add log for decompressed and compressed state sizes

---------

## Requirement Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->
On undo/redo click, we update the state history item index (which is used to re-render parameters panel) before setting the root state. This causes the parameters panel to not re-render immediately on undo/redo click.

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->
We now set the root state on undo/redo click first, then update state history on undo/redo click to update state history item index after, which would trigger re-rendering of parameters panel as expected.

Also added a log to track compressed vs decompressed size.

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
