### PR TITLE
fix(Designer): Fixed HTTP+Swagger retry policy serialization issue

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -156,6 +156,8 @@ export const serializeWorkflow = async (rootState: RootState, options?: Serializ
     parameters,
   };
 
+  console.log('### serializedWorkflow', serializedWorkflow);
+
   const workflowService = WorkflowService();
   if (workflowService && workflowService.getDefinitionWithDynamicInputs) {
     serializedWorkflow.definition = workflowService.getDefinitionWithDynamicInputs(
@@ -321,7 +323,10 @@ const serializeManifestBasedOperation = async (rootState: RootState, operationId
 
   const retryPolicy = getRetryPolicy(nodeSettings);
   if (retryPolicy) {
-    inputs.retryPolicy = retryPolicy;
+    if (!inputs.inputs) {
+      inputs.inputs = {};
+    }
+    inputs.inputs.retryPolicy = retryPolicy;
   }
 
   const inputsLocation = manifest.properties.inputsLocation ?? ['inputs'];

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -156,8 +156,6 @@ export const serializeWorkflow = async (rootState: RootState, options?: Serializ
     parameters,
   };
 
-  console.log('### serializedWorkflow', serializedWorkflow);
-
   const workflowService = WorkflowService();
   if (workflowService && workflowService.getDefinitionWithDynamicInputs) {
     serializedWorkflow.definition = workflowService.getDefinitionWithDynamicInputs(

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/http.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/http.ts
@@ -286,7 +286,10 @@ export const httpWithSwaggerManifest = {
       },
       required: ['inputs', 'metadata'],
     },
-    inputsLocationSwapMap: [{ source: ['inputs', 'operationDetails'], target: ['inputs'] }],
+    inputsLocationSwapMap: [
+      { source: ['inputs', 'operationDetails'], target: ['inputs'] },
+      { source: ['retryPolicy'], target: ['inputs', 'retryPolicy'] },
+    ],
     inputsLocation: [],
     isInputsOptional: false,
     autoCast: true,


### PR DESCRIPTION
## Main Changes

Our HTTP+Swagger action had it's inputs location set to the action root, so the retry policy was being loaded into the action root when it should be in the "actions".  This has been added to the action's swap map so the retry policy ends up in the right place.
The swapmap execution has also been moved to after the retry policy being set, so that the retry policy can be altered.

Fixes https://github.com/Azure/LogicAppsUX/issues/5824