### PR TITLE
fix(Designer): Fixing issue with managed identity connection creation (4.105)

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/formInputs/legacyManagedIdentityPicker.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/formInputs/legacyManagedIdentityPicker.tsx
@@ -1,6 +1,6 @@
 import { Dropdown, type IDropdownOption } from '@fluentui/react';
 import { getIdentityDropdownOptions, type ManagedIdentity } from '@microsoft/logic-apps-shared';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 interface LegacyManagedIdentityDropdownProps {
@@ -13,6 +13,9 @@ const LegacyManagedIdentityDropdown = (props: LegacyManagedIdentityDropdownProps
   const { identity, onChange, disabled } = props;
   const intl = useIntl();
   const dropdownOptions = useMemo(() => getIdentityDropdownOptions(identity, intl), [identity, intl]);
+
+  // Even though the component has the default value, we need to call onChange to update the parent component
+  useEffect(() => onChange(null, dropdownOptions?.[0]), [onChange, dropdownOptions]);
 
   const noIdentitiesAvailable = useMemo(() => dropdownOptions.length === 0, [dropdownOptions]);
   const noIdentityText = intl.formatMessage({


### PR DESCRIPTION
## Main Changes

Fixed issue where the legacy managed identity dropdown would show the first option as selected, but not actually have it selected. If you only had one managed identity this would prevent you from creating the connection.

