### PR TITLE
feat(Designer): Added host option to collapse all graph nodes by default

### DIFF
--- a/apps/Standalone/src/designer/app/SettingsSections/contextSettings.tsx
+++ b/apps/Standalone/src/designer/app/SettingsSections/contextSettings.tsx
@@ -76,6 +76,11 @@ const ContextSettings = () => {
         onChange={(_, checked) => dispatch(setHostOptions({ displayRuntimeInfo: !!checked }))}
       />
       <Checkbox
+        label="Collapse Graphs"
+        checked={hostOptions.collapseGraphsByDefault}
+        onChange={(_, checked) => dispatch(setHostOptions({ collapseGraphsByDefault: !!checked }))}
+      />
+      <Checkbox
         label="Suppress default node click"
         checked={suppressDefaultNodeSelect}
         onChange={(_, checked) => dispatch(setSuppressDefaultNodeSelect(!!checked))}

--- a/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
+++ b/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
@@ -32,6 +32,7 @@ export interface WorkflowLoadingState {
     displayRuntimeInfo: boolean; // show info about where the action is run(i.e. InApp/Shared/Custom)
     stringOverrides?: Record<string, string>; // string overrides for localization
     maxStateHistorySize?: number; // maximum number of states to save in history for undo/redo
+    collapseGraphsByDefault?: boolean; // collapse scope by default
   };
   showPerformanceDebug?: boolean;
 }
@@ -57,6 +58,7 @@ const initialState: WorkflowLoadingState = {
   hostOptions: {
     displayRuntimeInfo: true,
     maxStateHistorySize: 0,
+    collapseGraphsByDefault: false,
   },
   showPerformanceDebug: false,
 };

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -46,6 +46,7 @@ export interface DesignerOptionsState {
     stringOverrides?: Record<string, string>; // string overrides for localization
     maxStateHistorySize?: number; // maximum number of states to save in history for undo/redo (default is 0)
     hideContentTransferSettings?: boolean; // hide content transfer settings in the designer
+    collapseGraphsByDefault?: boolean; // collapse scope by default
   };
   nodeSelectAdditionalCallback?: (nodeId: string) => any;
   showConnectionsPanel?: boolean;

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -46,6 +46,7 @@ export const initialDesignerOptionsState: DesignerOptionsState = {
     recurrenceInterval: undefined,
     maxStateHistorySize: CONSTANTS.DEFAULT_MAX_STATE_HISTORY_SIZE,
     hideContentTransferSettings: false,
+    collapseGraphsByDefault: false,
   },
 };
 

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -288,7 +288,18 @@ export const workflowSlice = createSlice({
         !!node?.children?.length && stack.push(...node.children);
       }
     },
-    setCollapsedGraphIds: (state: WorkflowState, action: PayloadAction<string>) => {
+    setCollapsedGraphIds: (state: WorkflowState, action: PayloadAction<string[]>) => {
+      const idArray = action.payload;
+      const idRecord = idArray.reduce(
+        (acc, id) => {
+          acc[id] = true;
+          return acc;
+        },
+        {} as Record<string, boolean>
+      );
+      state.collapsedGraphIds = idRecord;
+    },
+    collapseGraphsToShowNode: (state: WorkflowState, action: PayloadAction<string>) => {
       state.collapsedGraphIds = getParentsUncollapseFromGraphState(state, action.payload);
     },
     toggleCollapsedGraphId: (state: WorkflowState, action: PayloadAction<string>) => {
@@ -547,6 +558,7 @@ export const {
   clearFocusNode,
   setFocusNode,
   setCollapsedGraphIds,
+  collapseGraphsToShowNode,
   replaceId,
   setRunIndex,
   setRepetitionRunData,

--- a/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeSearchPanel/nodeSearchPanel.tsx
@@ -2,7 +2,7 @@ import { useHostOptions } from '../../../core/state/designerOptions/designerOpti
 import { useOperationVisuals } from '../../../core/state/operation/operationSelector';
 import { changePanelNode } from '../../../core/state/panel/panelSlice';
 import { useNodeDisplayName, useNodeIds } from '../../../core/state/workflow/workflowSelectors';
-import { setCollapsedGraphIds, setFocusNode } from '../../../core/state/workflow/workflowSlice';
+import { collapseGraphsToShowNode, setFocusNode } from '../../../core/state/workflow/workflowSlice';
 import { SearchBox, FocusTrapZone } from '@fluentui/react';
 import { Button } from '@fluentui/react-components';
 import { bundleIcon, Dismiss24Filled, Dismiss24Regular } from '@fluentui/react-icons';
@@ -35,7 +35,7 @@ const NodeSearchCard = ({ node, displayRuntimeInfo }: { node: string; displayRun
         operationActionData={{ id: node, title: displayName, isTrigger: false, brandColor, iconUri }}
         showImage={true}
         onClick={(_: string) => {
-          dispatch(setCollapsedGraphIds(node));
+          dispatch(collapseGraphsToShowNode(node));
           dispatch(setFocusNode(node));
           dispatch(changePanelNode(node));
         }}


### PR DESCRIPTION
## Main Changes

Added host option to collapse all graph nodes by default
Renamed existing redux action to be clearer

With the host option enabled the initial load is much faster, but we are essentially just delaying some of the elk/react flow graph initialization to when the graphs are expanded for the first time.  All "data" for the workflow is still being loaded at startup. (ie. if someone loads the flow and immediately saves, all the data will still be there)

Fixes https://github.com/Azure/LogicAppsUX/issues/4995