### PR TITLE
docs(vscode): Add Logic Apps (Standard – Hybrid) announcement to vscode readme

### DIFF
--- a/apps/vs-code-designer/src/README.md
+++ b/apps/vs-code-designer/src/README.md
@@ -4,6 +4,10 @@ In Visual Studio Code, you can use the Azure Logic Apps (Standard) extension to 
 
 > Sign up today for your free Azure account and receive 12 months of free popular services, $200 free credit and 25+ always free services 👉 [Start Free](https://azure.microsoft.com/free/open-source).
 
+## Azure Logic Apps - Introducing the Logic Apps Hybrid Deployment Model (preview)
+
+Starting with version 4.107.2, the Azure Logic Apps (Standard) extension for Visual Studio Code introduces Logic Apps Hybrid Deployment Model, a new feature that empowers our customers with additional flexibility and control. This new offering allows you to build and deploy workflows that run on customer-managed infrastructure, providing you with the option to run Logic Apps on-premises, in a private cloud, or even in a third-party public cloud. For more information, see [Introducing the Logic Apps Hybrid Deployment Model (Public Preview)](https://go.microsoft.com/fwlink/?linkid=2293544).
+
 ## Azure Logic Apps - Automatic Regeneration of Connection ACL keys
 
 Starting with version 4.57.0, the Azure Logic Apps (Standard) extension for Visual Studio Code will automatically regenerate  the keys required to allow the extension to access Azure Managed Connections. This will allow the same Azure Managed Connection to be used for projects for longer than 7 days without any user intervention. For more information, see [Regeneration Azure Managed Connection ACL for Local Development](https://go.microsoft.com/fwlink/?linkid=2283427).


### PR DESCRIPTION
This pull request includes an update to the `README.md` file for the Azure Logic Apps (Standard) extension in Visual Studio Code. The update introduces a new feature and provides relevant information and links.

New feature introduction:

* [`apps/vs-code-designer/src/README.md`](diffhunk://#diff-69c5b43bdf2eb0abae618f74af3299bd2be0f3184c8ebdbebdf45aa44e84f8fdR7-R10): Added a section about the Logic Apps Hybrid Deployment Model, which allows workflows to run on customer-managed infrastructure, including on-premises, private clouds, or third-party public clouds.