### PR TITLE
meta(Templates): Add Telemetry for Multi-Workflow for Non-Creation Scenarios

### DIFF
--- a/libs/designer/src/lib/core/templates/utils/helper.ts
+++ b/libs/designer/src/lib/core/templates/utils/helper.ts
@@ -16,16 +16,18 @@ export const getQuickViewTabs = (
   dispatch: AppDispatch,
   workflowId: string,
   showCreate: boolean,
-  { templateId, workflowAppName }: Template.TemplateContext
+  { templateId, workflowAppName, isMultiWorkflow }: Template.TemplateContext
 ) => {
   return [
     workflowTab(intl, dispatch, workflowId, showCreate, undefined, {
       templateId,
       workflowAppName,
+      isMultiWorkflow,
     }),
     summaryTab(intl, dispatch, workflowId, showCreate, {
       templateId,
       workflowAppName,
+      isMultiWorkflow,
     }),
   ];
 };

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/quickViewPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/quickViewPanel.tsx
@@ -20,6 +20,7 @@ export const QuickViewPanel = ({ workflowId, clearDetailsOnClose }: { workflowId
   const panelTabs = getQuickViewTabs(intl, dispatch, workflowId, clearDetailsOnClose, {
     templateId: templateName ?? '',
     workflowAppName,
+    isMultiWorkflow: false,
   });
   const [selectedTabId, setSelectedTabId] = useState<string>(panelTabs[0]?.id);
 

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/summaryTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/summaryTab.tsx
@@ -113,7 +113,7 @@ export const summaryTab = (
   dispatch: AppDispatch,
   workflowId: string,
   clearDetailsOnClose: boolean,
-  { templateId, workflowAppName }: Template.TemplateContext
+  { templateId, workflowAppName, isMultiWorkflow }: Template.TemplateContext
 ): TemplatePanelTab => ({
   id: constants.TEMPLATE_PANEL_TAB_NAMES.OVERVIEW,
   title: intl.formatMessage({
@@ -134,7 +134,7 @@ export const summaryTab = (
         level: LogEntryLevel.Verbose,
         area: 'Templates.overviewTab',
         message: 'Template create button clicked',
-        args: [templateId, workflowAppName],
+        args: [templateId, workflowAppName, `isMultiWorkflowTemplate:${isMultiWorkflow}`],
       });
       dispatch(openCreateWorkflowPanelView());
     },

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/workflowTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/workflowTab.tsx
@@ -27,7 +27,7 @@ export const workflowTab = (
   workflowId: string,
   clearDetailsOnClose: boolean,
   onPrimaryButtonClick: (() => void) | undefined,
-  { templateId, workflowAppName }: Template.TemplateContext
+  { templateId, workflowAppName, isMultiWorkflow }: Template.TemplateContext
 ): TemplatePanelTab => ({
   id: constants.TEMPLATE_PANEL_TAB_NAMES.WORKFLOW_VIEW,
   title: intl.formatMessage({
@@ -48,7 +48,7 @@ export const workflowTab = (
         level: LogEntryLevel.Verbose,
         area: 'Templates.overviewTab',
         message: 'Template create button clicked',
-        args: [templateId, workflowAppName],
+        args: [templateId, workflowAppName, `isMultiWorkflowTemplate:${isMultiWorkflow}`],
       });
       dispatch(openCreateWorkflowPanelView());
       onPrimaryButtonClick?.();

--- a/libs/designer/src/lib/ui/panel/templatePanel/templatePanel.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/templatePanel.tsx
@@ -65,8 +65,19 @@ export const TemplatePanel = ({ createWorkflow, onClose, showCreate, workflowId,
         : getQuickViewTabs(intl, dispatch, workflowId as string, showCreate, {
             templateId: templateName ?? 'Unknown',
             workflowAppName,
+            isMultiWorkflow: isMultiWorkflowTemplate,
           }),
-    [isCreatePanelView, createWorkflowPanelTabs, intl, dispatch, workflowId, showCreate, templateName, workflowAppName]
+    [
+      isCreatePanelView,
+      createWorkflowPanelTabs,
+      intl,
+      dispatch,
+      workflowId,
+      showCreate,
+      templateName,
+      workflowAppName,
+      isMultiWorkflowTemplate,
+    ]
   );
 
   const selectedTabProps = selectedTabId ? currentPanelTabs?.find((tab) => tab.id === selectedTabId) : currentPanelTabs[0];

--- a/libs/designer/src/lib/ui/templates/cards/templateCard.tsx
+++ b/libs/designer/src/lib/ui/templates/cards/templateCard.tsx
@@ -20,7 +20,8 @@ import {
 } from '@microsoft/logic-apps-shared';
 import MicrosoftIcon from '../../../common/images/templates/microsoft.svg';
 import { Add16Regular, PeopleCommunity16Regular } from '@fluentui/react-icons';
-import { loadTemplate } from '../../../core/actions/bjsworkflow/templates';
+import { isMultiWorkflowTemplate, loadTemplate } from '../../../core/actions/bjsworkflow/templates';
+import { useMemo } from 'react';
 
 interface TemplateCardProps {
   templateName: string;
@@ -42,6 +43,7 @@ export const TemplateCard = ({ templateName }: TemplateCardProps) => {
     location: state.workflow.location,
   }));
   const templateManifest = templates?.[templateName];
+  const isMultiWorkflow = useMemo(() => templateManifest && isMultiWorkflowTemplate(templateManifest), [templateManifest]);
 
   const intlText = {
     TEMPLATE_LOADING: intl.formatMessage({ defaultMessage: 'Loading....', description: 'Loading text', id: 'cZ60Tk' }),
@@ -67,7 +69,7 @@ export const TemplateCard = ({ templateName }: TemplateCardProps) => {
       level: LogEntryLevel.Verbose,
       area: 'Templates.TemplateCard',
       message: 'Template is selected',
-      args: [templateName, workflowAppName],
+      args: [templateName, workflowAppName, `isMultiWorkflowTemplate:${isMultiWorkflow}`],
     });
     dispatch(changeCurrentTemplateName(templateName));
     dispatch(loadTemplate(templateManifest));
@@ -190,7 +192,7 @@ export const BlankWorkflowTemplateCard = () => {
   const onBlankWorkflowClick = () => {
     LoggerService().log({
       level: LogEntryLevel.Verbose,
-      area: 'Templates.TemplateCard',
+      area: 'Templates.TemplateCard.Blank',
       message: 'Blank workflow is selected',
       args: [workflowAppName],
     });

--- a/libs/designer/src/lib/ui/templates/templateoverview.tsx
+++ b/libs/designer/src/lib/ui/templates/templateoverview.tsx
@@ -63,6 +63,7 @@ export const TemplateOverview = ({ createWorkflow }: { createWorkflow: CreateWor
     {
       templateId: templateName ?? '',
       workflowAppName,
+      isMultiWorkflow: true,
     }
   ).footerContent;
   return (

--- a/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
@@ -54,4 +54,5 @@ export interface Connection {
 export interface TemplateContext {
   templateId: string;
   workflowAppName: string;
+  isMultiWorkflow: boolean;
 }


### PR DESCRIPTION
## Requirement Checklist

* [X] The commit message follows our guidelines

## Type of Change

* [ ] Bug fix
* [ ] Feature
* [X] Other

Currently, we only have "isMultiWrokflowTemplate" upon template creation. In queries such as when users leave in template generation processes, we are unable to tell if it was a multi-workflow scenario. To be able to detect this, adding telemetry for all template telemetry cases.