### PR TITLE
fix(designer): Update identity identification and connection serialization

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/ConsumptionSerializationHelpers.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/ConsumptionSerializationHelpers.ts
@@ -71,6 +71,7 @@ export const convertDesignerWorkflowToConsumptionWorkflow = async (_workflow: an
           connectionId: connection.connection.id,
           connectionName: connection.connectionName,
           id: connection.api.id,
+          connectionProperties: connection.connectionProperties,
         };
       });
       delete workflow.connectionReferences;

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
@@ -95,6 +95,7 @@ const DesignerEditorConsumption = () => {
     workflow: baseWorkflow,
     connectionReferences,
     parameters,
+    identity,
   } = useMemo(() => getDataForConsumption(workflowAndArtifactsData), [workflowAndArtifactsData]);
 
   const [runWorkflow, setRunWorkflow] = useState<any>();
@@ -122,9 +123,9 @@ const DesignerEditorConsumption = () => {
   };
   const canonicalLocation = WorkflowUtility.convertToCanonicalFormat(workflowAndArtifactsData?.location ?? '');
   const services = useMemo(
-    () => getDesignerServices(workflowId, workflow as any, tenantId, objectId, canonicalLocation, language, undefined, queryClient),
+    () => getDesignerServices(workflowId, identity, tenantId, objectId, canonicalLocation, language, undefined, queryClient),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [workflowId, workflow, tenantId, canonicalLocation, designerID, language]
+    [workflowId, identity, tenantId, canonicalLocation, designerID, language]
   );
 
   useEffect(() => {
@@ -228,7 +229,7 @@ const DesignerEditorConsumption = () => {
   };
 
   const getAuthToken = async () => {
-    return `Bearer ${environment.armToken}` ?? '';
+    return `Bearer ${environment.armToken}`;
   };
 
   const handleSwitchView = async () => {
@@ -316,7 +317,7 @@ const DesignerEditorConsumption = () => {
 
 const getDesignerServices = (
   workflowId: string,
-  workflow: any,
+  identity: any,
   tenantId: string | undefined,
   objectId: string | undefined,
   location: string,
@@ -481,7 +482,7 @@ const getDesignerServices = (
 
   const workflowService = {
     getCallbackUrl: (triggerName: string) => listCallbackUrl(workflowId, triggerName, true),
-    getAppIdentity: () => workflow?.identity,
+    getAppIdentity: () => identity,
     isExplicitAuthRequiredForManagedIdentity: () => false,
     getDefinitionSchema: (operationInfos: { type: string; kind?: string }[]) => {
       return operationInfos.some((info) => startsWith(info.type, 'openapiconnection'))
@@ -562,7 +563,7 @@ const getDataForConsumption = (data: any) => {
   const connectionReferences = formatConnectionReferencesForConsumption(connections);
   const parameters: ParametersData = formatWorkflowParametersForConsumption(properties);
 
-  return { workflow, connectionReferences, parameters };
+  return { workflow, connectionReferences, parameters, identity: data?.identity };
 };
 
 const removeProperties = (obj: any = {}, props: string[] = []): Object => {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -36,6 +36,7 @@ import {
   ConnectionReferenceKeyFormat,
   getRecordEntry,
   UserPreferenceService,
+  includes,
 } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
@@ -142,7 +143,7 @@ const getConnectionPropertiesIfRequired = (connection: Connection, connector: Co
 
   const identity = WorkflowService().getAppIdentity?.();
   const userAssignedIdentity =
-    equals(identity?.type, ResourceIdentityType.USER_ASSIGNED) && identity?.userAssignedIdentities
+    includes(identity?.type ?? '', ResourceIdentityType.USER_ASSIGNED) && identity?.userAssignedIdentities
       ? Object.keys(identity?.userAssignedIdentities)[0]
       : undefined;
 


### PR DESCRIPTION
### Main code changes

This pull request enhance the handling of identity and connection properties in the workflow consumption process. 

* Added `identity` to the workflow data returned by `getDataForConsumption` and updated the `getDesignerServices` function to use `identity` instead of `workflow`.

* Added `connectionProperties` to the connection references in the `convertDesignerWorkflowToConsumptionWorkflow` function.


<img width="1225" alt="image" src="https://github.com/user-attachments/assets/aba63716-5743-4a6b-906e-9b29bf6c5d4c">
