### PR TITLE
fix(vscode): Fix decision on amount of sessions

### DIFF
--- a/apps/vs-code-designer/src/app/utils/credentials.ts
+++ b/apps/vs-code-designer/src/app/utils/credentials.ts
@@ -22,7 +22,7 @@ export const getAccountCredentials = async (tenantId?: string): Promise<any | un
     currentLoggedInSessions = azureAccount.sessions;
   }
 
-  if (currentLoggedInSessions.length > 1) {
+  if (currentLoggedInSessions.length > 0) {
     return getCredentialsForSessions(currentLoggedInSessions, tenantId);
   }
 


### PR DESCRIPTION
This pull request includes a small change to the `apps/vs-code-designer/src/app/utils/credentials.ts` file. The change modifies a condition to check for any logged-in sessions instead of more than one session.

*  Changed the condition from `currentLoggedInSessions.length > 1` to `currentLoggedInSessions.length > 0` to ensure the function handles any number of logged-in sessions.