### PR TITLE
fix(Designer): Fixed workflow ID path for getting child workflow

### DIFF
--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -224,11 +224,11 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
     return undefined;
   };
 
-  const getChildWorkflowIdFromInputs = (inputs: any): string | undefined => {
-    if (!isNullOrEmpty(inputs)) {
-      const workflow = getObjectPropertyValue(inputs, ['host', 'value', 'workflow']);
+  const getChildWorkflowIdFromInputs = (childWorkflowInputs: any): string | undefined => {
+    if (!isNullOrEmpty(childWorkflowInputs)) {
+      const workflow = getObjectPropertyValue(childWorkflowInputs, ['host.workflow.id']);
       if (!isNullOrEmpty(workflow)) {
-        return workflow.id;
+        return workflow.value;
       }
     }
     return undefined;


### PR DESCRIPTION
## Main Changes

Adjusted workflow id path for getting child workflow.
The workflow id path during binding was changed, and this reference was not updated.