### PR TITLE
meta(vscdoe): Add parameter to template pipeline

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -90,3 +90,5 @@ extends:
               - template: .azure-pipelines/templates/package.yml@LogicAppsUX
               - template: .azure-pipelines/templates/sign.yml@LogicAppsUX
               - template: .azure-pipelines/templates/stage-artifacts.yml@LogicAppsUX
+                parameters:
+                  publishVersion: ${{ parameters.publishVersion }}

--- a/.azure-pipelines/templates/stage-artifacts.yml
+++ b/.azure-pipelines/templates/stage-artifacts.yml
@@ -1,3 +1,7 @@
+parameters:
+  - name: publishVersion
+    type: string
+
 steps:
   - task: CopyFiles@2
     displayName: "\U0001F449 Copy packages and vsix to staging directory"


### PR DESCRIPTION
This pull request includes changes to the Azure Pipelines configuration to add a new parameter for publishing versions. The most important changes include modifying the `extends:` section in the main pipeline file and adding a new parameter definition in the `stage-artifacts.yml` template.

Pipeline configuration updates:

* Modified the `extends:` section to include a new `parameters` block for `publishVersion`.
* Added a new parameter definition for `publishVersion` to allow version specification during the artifact staging process.