### PR TITLE
fix(designer): Standalone Consumption Code view to pass in rest of workflow data

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/WorkflowAndArtifacts.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/WorkflowAndArtifacts.tsx
@@ -613,10 +613,21 @@ export const validateWorkflowStandard = async (
   }
 };
 
-export const validateWorkflowConsumption = async (siteResourceId: string, location: string, workflow: any): Promise<any> => {
+export const validateWorkflowConsumption = async (
+  siteResourceId: string,
+  location: string,
+  outdatedWorkflow: any,
+  workflow: any
+): Promise<any> => {
   const { subscriptionId, resourceGroup, topResourceName } = new ArmParser(siteResourceId);
   const logicApp = {
-    properties: { definition: workflow.definition, parameters: workflow.parameters, connectionReferences: workflow.connectionReferences },
+    ...outdatedWorkflow,
+    properties: {
+      ...outdatedWorkflow?.properties,
+      definition: workflow.definition,
+      parameters: workflow.parameters,
+      connectionReferences: workflow.connectionReferences,
+    },
   };
   const response = await axios.post(
     `${baseUrl}/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Logic/locations/${location}/workflows/${topResourceName}/validate?api-version=2016-10-01`,

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
@@ -205,7 +205,7 @@ const DesignerEditorConsumption = () => {
   const saveWorkflowFromCode = async (clearDirtyState: () => void) => {
     try {
       const codeToConvert = JSON.parse(codeEditorRef.current?.getValue() ?? '');
-      await validateWorkflowConsumption(workflowId, canonicalLocation, codeToConvert);
+      await validateWorkflowConsumption(workflowId, canonicalLocation, workflowAndArtifactsData, codeToConvert);
       saveWorkflowConsumption(workflowAndArtifactsData, codeToConvert, clearDirtyState);
     } catch (error: any) {
       if (error.status !== 404) {
@@ -228,7 +228,7 @@ const DesignerEditorConsumption = () => {
   };
 
   const getAuthToken = async () => {
-    return `Bearer ${environment.armToken}` ?? '';
+    return `Bearer ${environment.armToken}`;
   };
 
   const handleSwitchView = async () => {
@@ -237,10 +237,12 @@ const DesignerEditorConsumption = () => {
     } else {
       try {
         const codeToConvert = JSON.parse(codeEditorRef.current?.getValue() ?? '');
-        await validateWorkflowConsumption(workflowId, canonicalLocation, codeToConvert);
-        setDefinition(codeToConvert.definition);
-        setWorkflowDefinitionId(guid());
-        setDesignerView(true);
+        if (workflowAndArtifactsData) {
+          await validateWorkflowConsumption(workflowId, canonicalLocation, workflowAndArtifactsData, codeToConvert);
+          setDefinition(codeToConvert.definition);
+          setWorkflowDefinitionId(guid());
+          setDesignerView(true);
+        }
       } catch (error: any) {
         if (error.status !== 404) {
           alert(`Error converting code to workflow ${error}`);


### PR DESCRIPTION
Previously we were only sending data from the code view, but now we are just replacing the definition with the code view data