### PR TITLE
fix(Designer): Null catch on connection query

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/connection.ts
@@ -313,7 +313,7 @@ export abstract class BaseConnectionService implements IConnectionService {
           : this.getAllConnectionsInLocation();
         const allConnections = await connectionsCall;
         const filteredConnections = allConnections.filter((connection) => {
-          return equals(connection.properties.api.id, connectorId);
+          return equals(connection.properties?.api?.id, connectorId);
         });
         return filteredConnections;
       }
@@ -337,7 +337,7 @@ export abstract class BaseConnectionService implements IConnectionService {
     }
 
     return Object.keys(this._connections)
-      .filter((connectionId) => equals(this._connections[connectionId].properties.api.id, connectorId))
+      .filter((connectionId) => equals(this._connections[connectionId].properties?.api?.id, connectorId))
       .map((connectionId) => this._connections[connectionId]);
   }
 


### PR DESCRIPTION
## Main Changes

Added null catches for broken connections.
We had a customer issue and their connection object somehow was missing the entire `API` object.
The catches added in this PR should filter those connections out since they are unusable without that data. 