### PR TITLE
feat(Designer): Adding section names to token search

### DIFF
--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickersection/tokenpickeroption.tsx
@@ -71,7 +71,6 @@ export const TokenPickerOptions = ({
       tokens = fuse.search(query).map((token) => token.item);
       setFilteredTokens(tokens);
     }
-    console.log('### Section tokens:', searchableTokens);
     setTokenLength((prevTokens) => {
       const newTokens = prevTokens;
       newTokens[index] = tokens?.length ?? searchableTokens.length;


### PR DESCRIPTION
## Main Changes

You can now search for tokens by the section names.  This works with action names (with renaming), variables, etc.

![image](https://github.com/user-attachments/assets/6d2ecfef-c06e-4fcd-b768-e21d50e8282b)

Fixes https://github.com/Azure/LogicAppsUX/issues/6038