### PR TITLE
fix(Designer): Canvas pans when dragging a node to the edge of the canvas

### DIFF
--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -38,6 +38,7 @@ import { PerformanceDebugTool } from './common/PerformanceDebug/PerformanceDebug
 import { CanvasFinder } from './CanvasFinder';
 import { DesignerContextualMenu } from './common/DesignerContextualMenu/DesignerContextualMenu';
 import { EdgeContextualMenu } from './common/EdgeContextualMenu/EdgeContextualMenu';
+import { DragPanMonitor } from './common/DragPanMonitor/DragPanMonitor';
 
 export interface DesignerProps {
   backgroundProps?: BackgroundProps;
@@ -245,6 +246,7 @@ export const Designer = (props: DesignerProps) => {
           </div>
           <PerformanceDebugTool />
           <CanvasFinder panelLocation={panelLocation} />
+          <DragPanMonitor />
         </ReactFlowProvider>
         <div
           id={'msla-layer-host'}

--- a/libs/designer/src/lib/ui/common/DragPanMonitor/DragPanMonitor.tsx
+++ b/libs/designer/src/lib/ui/common/DragPanMonitor/DragPanMonitor.tsx
@@ -1,0 +1,110 @@
+import { clamp, useThrottledEffect, useWindowDimensions } from '@microsoft/logic-apps-shared';
+import { useOnViewportChange, useReactFlow } from '@xyflow/react';
+import { useLayout } from '../../../core/graphlayout';
+import { DEFAULT_NODE_SIZE } from '../../../core/utils/graph';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDragDropManager } from 'react-dnd';
+
+interface XY {
+  x: number;
+  y: number;
+}
+
+const zoneSize = 160;
+const speed = 40;
+const pollingRate = 16;
+
+export const DragPanMonitor = () => {
+  const [_nodes, _edges, flowSize] = useLayout();
+  const windowDimensions = useWindowDimensions();
+  const [zoom, setZoom] = useState(1);
+
+  useOnViewportChange({ onChange: (v) => setZoom(v.zoom) });
+
+  const translateExtent = useMemo((): {
+    x: { min: number; max: number };
+    y: { min: number; max: number };
+  } => {
+    const padding = 120 * zoom;
+    const [flowWidth, flowHeight] = flowSize;
+
+    return {
+      x: {
+        min: -flowWidth * zoom + DEFAULT_NODE_SIZE.width * zoom + padding,
+        max: windowDimensions.width - DEFAULT_NODE_SIZE.width * zoom - padding,
+      },
+      y: {
+        min: -flowHeight * zoom + DEFAULT_NODE_SIZE.height * zoom + padding,
+        max: windowDimensions.height - DEFAULT_NODE_SIZE.height * zoom - padding,
+      },
+    };
+  }, [zoom, flowSize, windowDimensions]);
+
+  /////
+
+  const [dragPos, setDragPos] = useState<XY | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  const dragDropManager = useDragDropManager();
+  useEffect(() => {
+    const monitor = dragDropManager.getMonitor();
+    monitor.subscribeToOffsetChange(() => setDragPos(monitor.getClientOffset()));
+    monitor.subscribeToStateChange(() => setDragging(monitor.isDragging()));
+  }, [dragDropManager]);
+
+  const { getViewport, setViewport } = useReactFlow();
+  const panCanvas = useCallback(
+    (pan: XY) => {
+      const v = getViewport();
+      v.x += pan.x;
+      v.y += pan.y;
+      v.x = clamp(v.x, translateExtent.x.min, translateExtent.x.max);
+      v.y = clamp(v.y, translateExtent.y.min, translateExtent.y.max);
+      setViewport(v);
+    },
+    [translateExtent, getViewport, setViewport]
+  );
+
+  const handleDragPos = useCallback(
+    ({ x, y }: XY) => {
+      const screen = { width: window.innerWidth, height: window.innerHeight };
+      const pan = { x: 0, y: 0 };
+      if (x < zoneSize) {
+        const ratio = 1 - x / zoneSize;
+        pan.x = speed * ratio;
+      }
+      if (x > screen.width - zoneSize) {
+        const ratio = 1 - (screen.width - x) / zoneSize;
+        pan.x = -speed * ratio;
+      }
+      if (y < zoneSize) {
+        const ratio = 1 - y / zoneSize;
+        pan.y = speed * ratio;
+      }
+      if (y > screen.height - zoneSize) {
+        const ratio = 1 - (screen.height - y) / zoneSize;
+        pan.y = -speed * ratio;
+      }
+
+      if (pan.x !== 0 || pan.y !== 0) {
+        panCanvas(pan);
+      }
+    },
+    [panCanvas]
+  );
+
+  const [retrigger, setRetrigger] = useState(0);
+  useThrottledEffect(
+    () => {
+      if (!dragging || !dragPos) {
+        return;
+      }
+      setRetrigger(retrigger + 1);
+      handleDragPos(dragPos);
+    },
+    [dragPos, retrigger, handleDragPos],
+    pollingRate
+  );
+
+  return null;
+};


### PR DESCRIPTION
## Main Changes

Dragging a node to the edge of the canvas now pans in that direction.
This variable based on how close to the edge you are.
This also is clamped so you can't accidentally pan way off into no-man's-land.

Fixes https://github.com/Azure/LogicAppsUX/issues/6037

![node_drag_pan](https://github.com/user-attachments/assets/1139c757-1f26-4915-b542-d10b9396c1b2)
