### PR TITLE
fix(Designer): Null catch on connection query

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: lts/*
+        node-version: 20.x
     - uses: pnpm/action-setup@v3
       with:
         version: 9.1.3

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/connection.ts
@@ -313,7 +313,7 @@ export abstract class BaseConnectionService implements IConnectionService {
           : this.getAllConnectionsInLocation();
         const allConnections = await connectionsCall;
         const filteredConnections = allConnections.filter((connection) => {
-          return equals(connection.properties.api.id, connectorId);
+          return equals(connection.properties?.api?.id, connectorId);
         });
         return filteredConnections;
       }
@@ -337,7 +337,7 @@ export abstract class BaseConnectionService implements IConnectionService {
     }
 
     return Object.keys(this._connections)
-      .filter((connectionId) => equals(this._connections[connectionId].properties.api.id, connectorId))
+      .filter((connectionId) => equals(this._connections[connectionId].properties?.api?.id, connectorId))
       .map((connectionId) => this._connections[connectionId]);
   }
 


### PR DESCRIPTION
## Main Changes

Added null catches for broken connections.
We had a customer issue and their connection object somehow was missing the entire API object.
The catches added in this PR should filter those connections out since they are unusable without that data.

Cherry picked from main.