### PR TITLE
fix(Designer): Fixed custom connector browse with extra capabilities

### DIFF
--- a/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
@@ -51,7 +51,7 @@ export const BrowseView = (props: BrowseViewProps) => {
 
       if (filters['actionType'] && (allApiIdsWithActions.data.length > 0 || allApiIdsWithTriggers.data.length > 0)) {
         const capabilities = connector.properties?.capabilities ?? [];
-        const ignoreCapabilities = capabilities.length === 0;
+        const ignoreCapabilities = !capabilities.includes('triggers') && !capabilities.includes('actions');
         const connectorId = cleanConnectorId(connector.id);
         const supportsActions = (ignoreCapabilities || capabilities.includes('actions')) && allApiIdsWithActions.data.includes(connectorId);
         const supportsTriggers =


### PR DESCRIPTION
## Main Changes

If custom connectors had extra capabilities, our filtering was removing them from browse view.
This has now been fixed and we ignore the capabilities check only if it does not include both 'triggers' and 'actions'
