### PR TITLE
fix(designer): Use Default swagger Host when api host is not set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ CHANGELOG.MD
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+vite.config.ts.timestamp*

--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -37,6 +37,7 @@ import { CustomTokenField, isCustomEditor } from './customTokenField';
 import { Label } from '../../label';
 import { EditorLanguage, equals, getPropertyValue, replaceWhiteSpaceWithUnderscore } from '@microsoft/logic-apps-shared';
 import { MixedInputEditor } from '../../mixedinputeditor/mixedinputeditor';
+import { useMemo } from 'react';
 
 export interface SettingTokenFieldProps extends SettingProps {
   id?: string;
@@ -114,8 +115,8 @@ export const TokenField = ({
   getTokenPicker,
   suppressCastingForSerialize,
 }: TokenFieldProps) => {
-  const dropdownOptions = getDropdownOptionsFromOptions(editorOptions);
-  const labelForAutomationId = replaceWhiteSpaceWithUnderscore(label);
+  const dropdownOptions = useMemo(() => getDropdownOptionsFromOptions(editorOptions), [editorOptions]);
+  const labelForAutomationId = useMemo(() => replaceWhiteSpaceWithUnderscore(label), [label]);
 
   switch (editor?.toLowerCase()) {
     case constants.PARAMETER.EDITOR.ARRAY:

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/appService.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/appService.ts
@@ -65,11 +65,12 @@ export class BaseAppServiceService implements IAppServiceService {
     const schema = { type: 'object', properties: {} as any, required: [] as string[] };
 
     if (isInput) {
-      const baseUrl = swagger.api.host
-        ? swagger.api.schemes?.length
-          ? `${swagger.api.schemes.at(-1)}://${swagger.api.host}`
-          : `http://${swagger.api.host}`
-        : 'NotFound';
+      const element = document.createElement('a');
+      element.href = swaggerUrl;
+
+      const scheme = swagger.api.schemes?.at(-1) || 'http';
+      const host = swagger.api.host || element.host;
+      const baseUrl = `${scheme}://${host}`;
       schema.properties = {
         method: { type: 'string', default: operation.method, 'x-ms-visibility': 'hideInUI', title: 'Method' },
         uri: {


### PR DESCRIPTION
Fixes https://github.com/Azure/LogicAppsUX/issues/6046

![Screenshot 2024-11-11 154023](https://github.com/user-attachments/assets/37ffef29-ebf8-442e-9efb-1500782bf69b)
