### PR TITLE
fix(vscode): Resolve Hyphen Handling, Mock Generator Formatting, and Add Missing Reference Errors in Templates

### DIFF
--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFile
@@ -55,13 +55,14 @@ namespace <%= LogicAppName %>.Tests
         {
             // Set the path for workflow-related input files in the workspace and build the full paths to the required JSON files.
             this.rootPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, @"..\..\..\..\.."));
-            this.workflowDefinitionPath = Path.Combine(rootPath, "<%= LogicAppName %>", "<%= WorkflowName %>", "workflow.json");
-            this.connectionsPath = Path.Combine(rootPath, "<%= LogicAppName %>", "connections.json");
-            this.parametersPath = Path.Combine(rootPath, "<%= LogicAppName %>", "parameters.json");
-            this.localSettingsPath = Path.Combine(rootPath, "<%= LogicAppName %>", "local.settings.json");
+            this.workflowDefinitionPath = Path.Combine(this.rootPath, "<%= LogicAppName %>", "<%= WorkflowName %>", "workflow.json");
+            this.connectionsPath = Path.Combine(this.rootPath, "<%= LogicAppName %>", "connections.json");
+            this.parametersPath = Path.Combine(this.rootPath, "<%= LogicAppName %>", "parameters.json");
+            this.localSettingsPath = Path.Combine(this.rootPath, "<%= LogicAppName %>", "local.settings.json");
+
 
             // Load the mock data 
-            var mockDataPath = Path.Combine(rootPath, "Tests", "<%= LogicAppName %>", "<%= WorkflowName %>", "<%= UnitTestName %>", "<%= UnitTestName %>-mock.json");
+            var mockDataPath = Path.Combine(this.rootPath, "Tests", "<%= LogicAppName %>", "<%= WorkflowName %>", "<%= UnitTestName %>", "<%= UnitTestName %>-mock.json");
             var mockData = JObject.Parse(File.ReadAllText(mockDataPath));
             this.triggerMock = mockData["triggerMocks"]?.ToObject<Dictionary<string, TriggerMock>>()?.Values.FirstOrDefault();
             this.actionMocks = mockData["actionMocks"].ToObject<Dictionary<string, ActionMock>>();
@@ -75,9 +76,9 @@ namespace <%= LogicAppName %>.Tests
         public async Task <%= WorkflowName %>_<%= UnitTestName %>_ExecuteWorkflow_SUCCESS()
         {
             // PREPARE Mock
-            // var actionMocks = this.actionMocks;
-            // actionMocks["<actionName>"] = new ActionMock(
-            //     "<actionName>",
+            var actionMocks = this.actionMocks;
+            // actionMocks["actionName"] = new ActionMock(
+            //     "actionName",
             //     TestWorkflowStatus.Succeeded,
             //     onGetActionOutputsCallback: this.MockActionOutputCallback
             // );
@@ -99,8 +100,9 @@ namespace <%= LogicAppName %>.Tests
         }
 
         #region Mock generator helpers
-         /// <summary>
-        /// The callback method to dynamically generate mocked data for the action named '<actionName>'.
+
+        /// <summary>
+        /// The callback method to dynamically generate mocked data for the action named 'actionName'.
         /// You can modify this method to return different mock outputs based on the test scenario.
         /// </summary>
         /// <param name="context">The test execution context that contains information about the current test run.</param>
@@ -115,8 +117,8 @@ namespace <%= LogicAppName %>.Tests
             //     }
             // }");
 
-            // Sample mock data 2: Modify the existing mocked data dynamically for <actionName>.
-            // var mockDataToModify = this.actionMocks["<actionName>"];
+            // Sample mock data 2: Modify the existing mocked data dynamically for 'actionName'.
+            // var mockDataToModify = this.actionMocks["actionName"];
             // mockDataToModify.Outputs["body"]["<property1Name>"] = "<your-test-string-value>";
             // return mockDataToModify.Outputs;
             return new JObject();

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFile
@@ -77,8 +77,8 @@ namespace <%= LogicAppName %>.Tests
         {
             // PREPARE Mock
             var actionMocks = this.actionMocks;
-            // actionMocks["actionName"] = new ActionMock(
-            //     "actionName",
+            // actionMocks["<actionName>"] = new ActionMock(
+            //     "<actionName>",
             //     TestWorkflowStatus.Succeeded,
             //     onGetActionOutputsCallback: this.MockActionOutputCallback
             // );
@@ -117,8 +117,8 @@ namespace <%= LogicAppName %>.Tests
             //     }
             // }");
 
-            // Sample mock data 2: Modify the existing mocked data dynamically for 'actionName'.
-            // var mockDataToModify = this.actionMocks["actionName"];
+            // Sample mock data 2: Modify the existing mocked data dynamically for '<actionName>'.
+            // var mockDataToModify = this.actionMocks["<actionName>"];
             // mockDataToModify.Outputs["body"]["<property1Name>"] = "<your-test-string-value>";
             // return mockDataToModify.Outputs;
             return new JObject();

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestProjectFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestProjectFile
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?> 
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestProjectFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestProjectFile
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?> 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,5 +11,6 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Workflows.WebJobs.Extension" Version="1.96.*" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Requirement Checklist

### Work Items
[Add `coverlet.collector` to package reference in generated `csproj`](https://msazure.visualstudio.com/One/_workitems/edit/30156094)
[Implement consistent handling of hyphens in `unitTestName` and `WorkflowName` inputs](https://msazure.visualstudio.com/One/_workitems/edit/30192393)
[Compile error - rootPath missing `this` reference](https://msazure.visualstudio.com/One/_workitems/edit/30199593)
[Formatting issue in mock generator helper doc comments](https://msazure.visualstudio.com/One/_workitems/edit/30199679)
[Uncomment `var actionMocks` in `PREPARE Mock` section](https://msazure.visualstudio.com/One/_workitems/edit/30199718)

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes or features)

## Type of Change

* [x] Bug fix
* [x] Feature


### Issues Addressed:
- **[Bug][Frontend]** [Add `coverlet.collector` to package reference in generated `csproj`](#) to improve code coverage collection capabilities.
- **[Bug][Frontend]** [Handle hyphens in `unitTestName` and `WorkflowName` inputs by replacing hyphens (`-`) with underscores (`_`) in generated `.cs` files](#), improving readability, maintainability, and compatibility with C# naming conventions.
- **[Bug][Frontend]** [Formatting issues in mock generator helper doc comments](#):
  - Newline needed after the region block.
  - Extra space in the summary block.
  - `<actionName>` syntax causing compilation errors.
- **[Bug][Frontend]** [Compile error - missing `this` reference for `rootPath`](#), which caused a compile-time error.
- **[Bug][Frontend]** [Commented-out `var actionMocks` in `PREPARE Mock` section](#), affecting test completeness.

## New Behavior

### Feature: Enhanced Naming Convention Consistency
1. **User Input Handling**:
   - Users can input names with hyphens (`-`) in fields like `unitTestName` and `WorkflowName`.
   - Hyphens are preserved in file and folder names to respect user input preferences.

2. **Code-Level Replacement**:
   - In generated `.cs` files, hyphens in `unitTestName` and `WorkflowName` inputs are replaced with underscores (`_`) to comply with C# naming conventions for methods and class names.
   - Example transformation:
      ```csharp
      public async Task <%= WorkflowName %>-<%= UnitTestName %>_ExecuteWorkflow_SUCCESS()
      ```
      becomes:
      ```csharp
      public async Task <%= WorkflowName %>_<%= UnitTestName %>_ExecuteWorkflow_SUCCESS()
      ```
   - Internal references to `unitTestName` and `WorkflowName` now follow consistent naming conventions, enhancing readability and reducing potential errors.

3. **File and Folder Naming**:
   - File names and folder structures retain hyphens, ensuring the user’s preferred naming conventions are respected.
   - Example: A file `test-order-new-successful.cs` and a folder `la-sample-workflow` retain their hyphenated format.

### Bug Fixes
1. **Compile Error (`rootPath`)**:
   - Added `this` reference to `rootPath` where required, resolving the missing reference compile error.

2. **Formatting Issues in Mock Generator Helper**:
   - Resolved doc comment issues in the mock generator helper:
     - Newline added after the region block.
     - Removed extra space from the summary block.
     - Changed `<actionName>` to `actionName`, avoiding compilation errors due to angle brackets.

3. **Uncommented `var actionMocks` in PREPARE Mock Section**:
   - Uncommented `var actionMocks` in the `PREPARE Mock` section, restoring intended functionality for the unit tests.

## Impact of Change

* [ ] **This is a breaking change.**

### Impact Analysis
These changes standardize naming conventions and improve code maintainability, reducing potential compile-time errors due to naming inconsistencies. The updates will positively impact downstream consumers by maintaining input-based naming preferences while ensuring that C# conventions are upheld within the code. No breaking changes are expected from this update.