### PR TITLE
fix(designer): Don't render info bubble in operation search if there is no description

### DIFF
--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/index.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchCard/index.tsx
@@ -84,7 +84,7 @@ export const OperationSearchCard = (props: OperationSearchCardProps) => {
         </>
       )}
 
-      <InfoDot ariaDescribedBy={buttonId} description={description} innerAriaHidden="true" />
+      {description ? <InfoDot ariaDescribedBy={buttonId} description={description} innerAriaHidden="true" /> : null}
     </button>
   );
 };


### PR DESCRIPTION
![CleanShot 2024-11-14 at 08 56 49@2x](https://github.com/user-attachments/assets/f44c1531-4eea-4d62-8407-722b341432be)
