### PR TITLE
feat(designer): No longer escapes characters in token expressions

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
@@ -70,7 +70,7 @@ export const convertValueType = (value: ValueSegment[], type?: string): string |
 const isNonString = (value: string): boolean => {
   try {
     const parsedValue = JSON.parse(value);
-    return Array.isArray(parsedValue) || typeof parsedValue === 'object';
+    return parsedValue === null || Array.isArray(parsedValue) || typeof parsedValue !== 'string';
   } catch {
     return false;
   }

--- a/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
@@ -3,7 +3,7 @@ import { isEmpty } from '../../../dictionary/expandeddictionary';
 import type { ValueSegment } from '../../models/parameter';
 import { createLiteralValueSegment, insertQutationForStringType } from './helper';
 import { convertSegmentsToString } from './parsesegments';
-import { isNumber, isBoolean, escapeString } from '@microsoft/logic-apps-shared';
+import { escapeString } from '@microsoft/logic-apps-shared';
 
 export interface KeyValueItem {
   id: string;
@@ -24,7 +24,7 @@ export const convertKeyValueItemToSegments = (items: KeyValueItem[], keyType?: s
 
   for (let index = 0; index < itemsToConvert.length; index++) {
     const { key, value } = itemsToConvert[index];
-    // todo: we should have some way of handle formatting better
+
     const convertedKeyType = convertValueType(key, keyType);
     const updatedKey = key.map((segment) => {
       return {
@@ -41,6 +41,7 @@ export const convertKeyValueItemToSegments = (items: KeyValueItem[], keyType?: s
       };
     });
 
+    // wrap key and value with quotation marks if they are string type
     insertQutationForStringType(parsedItems, convertedKeyType);
     parsedItems.push(...updatedKey);
     insertQutationForStringType(parsedItems, convertedKeyType);
@@ -60,8 +61,17 @@ export const convertValueType = (value: ValueSegment[], type?: string): string |
     return type;
   }
   const stringSegments = convertSegmentsToString(value).trim();
-  const isExpressionOrObject = (stringSegments.startsWith('@{') || stringSegments.startsWith('{')) && stringSegments.endsWith('}');
-  const isKnownType = isExpressionOrObject || isNumber(stringSegments) || isBoolean(stringSegments) || /^\[.*\]$/.test(stringSegments);
+  if (isNonString(stringSegments)) {
+    return type;
+  }
+  return constants.SWAGGER.TYPE.STRING;
+};
 
-  return isKnownType ? type : constants.SWAGGER.TYPE.STRING;
+const isNonString = (value: string): boolean => {
+  try {
+    const parsedValue = JSON.parse(value);
+    return Array.isArray(parsedValue) || typeof parsedValue === 'object';
+  } catch {
+    return false;
+  }
 };

--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
@@ -411,7 +411,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{"newUnb3_1":"@xpath(xml(triggerBody()), \'string(/*[local-name()=\\"DynamicsSOCSV\\"])\')"}'
+        '{\n  "newUnb3_1": @{xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')}\n}'
       );
     });
 
@@ -485,7 +485,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{"newUnb3_1":"@{xpath(xml(triggerBody()), \'string(/*[local-name()=\\"DynamicsSOCSV\\"])\')}"}'
+        '{\n  "newUnb3_1": "@{xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')}"\n}'
       );
     });
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -891,7 +891,6 @@ export function shouldIncludeSelfForRepetitionReference(manifest: OperationManif
 }
 
 export function loadParameterValue(parameter: InputParameter): ValueSegment[] {
-  console.log(parameter);
   let valueObject: unknown = undefined;
 
   if (parameter.isNotificationUrl) {

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -788,8 +788,8 @@ function toAuthenticationViewModel(value: any): { type: AuthenticationType; auth
           type: value.type,
           authenticationValue: {
             basic: {
-              basicUsername: loadParameterValueFromString(value.username),
-              basicPassword: loadParameterValueFromString(value.password),
+              basicUsername: loadParameterValueFromString(value.username, { parameterType: constants.SWAGGER.TYPE.STRING }),
+              basicPassword: loadParameterValueFromString(value.password, { parameterType: constants.SWAGGER.TYPE.STRING }),
             },
           },
         };
@@ -798,8 +798,8 @@ function toAuthenticationViewModel(value: any): { type: AuthenticationType; auth
           type: value.type,
           authenticationValue: {
             clientCertificate: {
-              clientCertificatePfx: loadParameterValueFromString(value.pfx),
-              clientCertificatePassword: loadParameterValueFromString(value.password),
+              clientCertificatePfx: loadParameterValueFromString(value.pfx, { parameterType: constants.SWAGGER.TYPE.STRING }),
+              clientCertificatePassword: loadParameterValueFromString(value.password, { parameterType: constants.SWAGGER.TYPE.STRING }),
             },
           },
         };
@@ -809,14 +809,14 @@ function toAuthenticationViewModel(value: any): { type: AuthenticationType; auth
           type: value.type,
           authenticationValue: {
             aadOAuth: {
-              oauthTenant: loadParameterValueFromString(value.tenant),
-              oauthAudience: loadParameterValueFromString(value.audience),
-              oauthAuthority: loadParameterValueFromString(value.authority),
-              oauthClientId: loadParameterValueFromString(value.clientId),
+              oauthTenant: loadParameterValueFromString(value.tenant, { parameterType: constants.SWAGGER.TYPE.STRING }),
+              oauthAudience: loadParameterValueFromString(value.audience, { parameterType: constants.SWAGGER.TYPE.STRING }),
+              oauthAuthority: loadParameterValueFromString(value.authority, { parameterType: constants.SWAGGER.TYPE.STRING }),
+              oauthClientId: loadParameterValueFromString(value.clientId, { parameterType: constants.SWAGGER.TYPE.STRING }),
               oauthType: loadOauthType(value),
-              oauthTypeSecret: loadParameterValueFromString(value.secret),
-              oauthTypeCertificatePfx: loadParameterValueFromString(value.pfx),
-              oauthTypeCertificatePassword: loadParameterValueFromString(value.password),
+              oauthTypeSecret: loadParameterValueFromString(value.secret, { parameterType: constants.SWAGGER.TYPE.STRING }),
+              oauthTypeCertificatePfx: loadParameterValueFromString(value.pfx, { parameterType: constants.SWAGGER.TYPE.STRING }),
+              oauthTypeCertificatePassword: loadParameterValueFromString(value.password, { parameterType: constants.SWAGGER.TYPE.STRING }),
             },
           },
         };
@@ -836,7 +836,7 @@ function toAuthenticationViewModel(value: any): { type: AuthenticationType; auth
           type: value.type,
           authenticationValue: {
             msi: {
-              msiAudience: loadParameterValueFromString(value.audience),
+              msiAudience: loadParameterValueFromString(value.audience, { parameterType: constants.SWAGGER.TYPE.STRING }),
               msiIdentity: value.identity,
             },
           },
@@ -3635,6 +3635,7 @@ export function parameterValueToJSONString(parameterValue: ValueSegment[], apply
 
 export function parameterValueWithoutCasting(parameter: ParameterInfo, shouldInterpolateSingleToken = false): any {
   const stringifiedValue = parameterValueToStringWithoutCasting(parameter.value, false, shouldInterpolateSingleToken);
+  console.log(stringifiedValue);
   return getJSONValueFromString(stringifiedValue, parameter.type);
 }
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -3635,7 +3635,6 @@ export function parameterValueToJSONString(parameterValue: ValueSegment[], apply
 
 export function parameterValueWithoutCasting(parameter: ParameterInfo, shouldInterpolateSingleToken = false): any {
   const stringifiedValue = parameterValueToStringWithoutCasting(parameter.value, false, shouldInterpolateSingleToken);
-  console.log(stringifiedValue);
   return getJSONValueFromString(stringifiedValue, parameter.type);
 }
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -3740,13 +3740,14 @@ function parameterValueToStringWithoutCasting(value: ValueSegment[], forValidati
   const shouldInterpolateTokens = (value.length > 1 || shouldInterpolateSingleToken) && value.some(isTokenValueSegment);
 
   return value
-    .map((expression) => {
-      let expressionValue = forValidation ? expression.value || null : unescapeString(expression.value);
-      if (isTokenValueSegment(expression)) {
-        expressionValue = shouldInterpolateTokens ? `@{${expressionValue}}` : `@${expressionValue}`;
+    .map((segment) => {
+      const { value: segmentValue } = segment;
+      if (isTokenValueSegment(segment)) {
+        const token = forValidation ? segmentValue || null : unescapeString(segmentValue);
+        return shouldInterpolateTokens ? `@{${token}}` : `@${token}`;
       }
 
-      return expressionValue;
+      return forValidation ? segmentValue || null : segmentValue;
     })
     .join('');
 }

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -18,6 +18,7 @@ import {
   isNullOrUndefined,
   startsWith,
   UnsupportedException,
+  escapeString,
 } from '@microsoft/logic-apps-shared';
 
 /**
@@ -57,7 +58,7 @@ export class ValueSegmentConvertor {
    * @arg {any} value - The value.
    * @return {ValueSegment[]}
    */
-  public convertToValueSegments(value: any, parameterType: string = constants.SWAGGER.TYPE.ANY): ValueSegment[] {
+  public convertToValueSegments(value: any, parameterType?: string): ValueSegment[] {
     if (isNullOrUndefined(value)) {
       return [createLiteralValueSegment('')];
     }
@@ -107,11 +108,12 @@ export class ValueSegmentConvertor {
     return [this._createLiteralValueSegment(section)];
   }
 
-  private _convertStringToValueSegments(value: string, parameterType: string): ValueSegment[] {
+  private _convertStringToValueSegments(value: string, parameterType?: string): ValueSegment[] {
     if (isTemplateExpression(value)) {
       const expression = ExpressionParser.parseTemplateExpression(value);
       return this._convertTemplateExpressionToValueSegments(expression);
     }
+
     const isSpecialValue = ['true', 'false', 'null'].includes(value) || /^-?\d+$/.test(value);
     const stringValue = parameterType === constants.SWAGGER.TYPE.ANY && isSpecialValue ? `"${value}"` : value;
     return [this._createLiteralValueSegment(stringValue)];
@@ -186,10 +188,11 @@ export class ValueSegmentConvertor {
       return dynamicContentTokenSegment;
     }
     // Note: We need to get the expression value if this is a sub expression resulted from uncasting.
-    const value =
+    const value = escapeString(
       expression.startPosition === 0
         ? expression.expression
-        : expression.expression.substring(expression.startPosition, expression.endPosition);
+        : expression.expression.substring(expression.startPosition, expression.endPosition)
+    );
     return this._createExpressionTokenValueSegment(value, expression);
   }
 

--- a/libs/designer/src/lib/core/utils/validation.ts
+++ b/libs/designer/src/lib/core/utils/validation.ts
@@ -373,7 +373,6 @@ export function validateJSONParameter(parameterMetadata: ParameterInfo, paramete
     try {
       JSON.parse(value);
     } catch (e) {
-      console.log(e);
       if (!parameterHasOnlyTokenBinding(parameterValue)) {
         errors.push(
           intl.formatMessage({

--- a/libs/designer/src/lib/core/utils/validation.ts
+++ b/libs/designer/src/lib/core/utils/validation.ts
@@ -373,6 +373,7 @@ export function validateJSONParameter(parameterMetadata: ParameterInfo, paramete
     try {
       JSON.parse(value);
     } catch (e) {
+      console.log(e);
       if (!parameterHasOnlyTokenBinding(parameterValue)) {
         errors.push(
           intl.formatMessage({
@@ -418,16 +419,10 @@ const validateFloatingActionMenuOutputsEditor = (editorViewModel: FloatingAction
 };
 
 function shouldValidateJSON(expressions: ValueSegment[]): boolean {
-  const shouldValidate = true;
-
-  if (shouldValidate && expressions.length) {
-    const firstSegmentValue = expressions[0].token?.value;
-    if (firstSegmentValue) {
-      return startsWith(firstSegmentValue, '@@') || startsWith(firstSegmentValue, '@{') || !startsWith(firstSegmentValue, '@');
-    }
-  }
-
-  return shouldValidate;
+  const firstSegmentValue = expressions[0]?.token?.value;
+  return firstSegmentValue
+    ? firstSegmentValue.startsWith('@@') || firstSegmentValue.startsWith('@{') || !firstSegmentValue.startsWith('@')
+    : true;
 }
 
 export function parameterHasOnlyTokenBinding(parameterValue: ValueSegment[]): boolean {

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
@@ -1,4 +1,4 @@
-import { escapeString, idDisplayCase, labelCase, canStringBeConverted } from '../stringFunctions';
+import { escapeString, idDisplayCase, labelCase, canStringBeConverted, unescapeString } from '../stringFunctions';
 import { describe, it, expect } from 'vitest';
 describe('label_case', () => {
   it('should replace _ with spaces', () => {
@@ -28,26 +28,6 @@ describe('idDisplayCase', () => {
   });
 });
 
-describe('escapeString', () => {
-  it('should correctly escape backslashes', () => {
-    expect(escapeString('\\')).toEqual('\\\\');
-    expect(escapeString('Test\\Test')).toEqual('Test\\\\Test');
-  });
-
-  it('should correctly escape newline characters', () => {
-    expect(escapeString('\n')).toEqual('\\n');
-    expect(escapeString('Test\nTest')).toEqual('Test\\nTest');
-  });
-
-  it('should correctly escape backslashes and newline characters together', () => {
-    expect(escapeString('\\\n')).toEqual('\\\\\\n');
-    expect(escapeString('Test\\\nTest')).toEqual('Test\\\\\\nTest');
-  });
-
-  it('should handle an empty string', () => {
-    expect(escapeString('')).toEqual('');
-  });
-});
 describe('canStringBeConverted', () => {
   it('should return false for non-string inputs', () => {
     expect(canStringBeConverted(123 as any)).toBe(false);
@@ -87,5 +67,93 @@ describe('canStringBeConverted', () => {
     expect(canStringBeConverted('not an array')).toBe(false);
     expect(canStringBeConverted('{ "key": "value" }')).toBe(false);
     expect(canStringBeConverted('{"a", "b", "c"}')).toBe(false);
+  });
+});
+
+describe('unescapeString', () => {
+  it('unescapes newline characters', () => {
+    const input = 'Hello\\nWorld';
+    const expectedOutput = 'Hello\nWorld';
+    const result = unescapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('unescapes carriage return characters', () => {
+    const input = 'Hello\\rWorld';
+    const expectedOutput = 'Hello\rWorld';
+    const result = unescapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('unescapes tab characters', () => {
+    const input = 'Hello\\tWorld';
+    const expectedOutput = 'Hello\tWorld';
+    const result = unescapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('unescapes vertical tab characters', () => {
+    const input = 'Hello\\vWorld';
+    const expectedOutput = 'Hello\vWorld';
+    const result = unescapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('returns the same string if there are no escape sequences', () => {
+    const input = 'Hello World';
+    const expectedOutput = 'Hello World';
+    const result = unescapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+});
+
+describe('escapeString', () => {
+  it('escapes newline characters', () => {
+    const input = 'Hello\nWorld';
+    const expectedOutput = 'Hello\\nWorld';
+    const result = escapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('escapes carriage return characters', () => {
+    const input = 'Hello\rWorld';
+    const expectedOutput = 'Hello\\rWorld';
+    const result = escapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('escapes tab characters', () => {
+    const input = 'Hello\tWorld';
+    const expectedOutput = 'Hello\\tWorld';
+    const result = escapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('escapes vertical tab characters', () => {
+    const input = 'Hello\vWorld';
+    const expectedOutput = 'Hello\\vWorld';
+    const result = escapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('returns the same string if there are no special characters', () => {
+    const input = 'Hello World';
+    const expectedOutput = 'Hello World';
+    const result = escapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('should correctly escape newline characters', () => {
+    expect(escapeString('\n')).toEqual('\\n');
+    expect(escapeString('Test\nTest')).toEqual('Test\\nTest');
+  });
+
+  it('should correctly escape backslashes and newline characters together', () => {
+    expect(escapeString('\\\n')).toEqual('\\\\n');
+    expect(escapeString('Test\\\nTest')).toEqual('Test\\\\nTest');
+  });
+
+  it('should handle an empty string', () => {
+    expect(escapeString('')).toEqual('');
   });
 });

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -30,10 +30,6 @@ export const splitFileName = (fileName: string) => {
   return [fileName.slice(0, splitFileName), fileName.slice(splitFileName)];
 };
 
-export const escapeString = (s: string): string => {
-  return s.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
-};
-
 export const canStringBeConverted = (s: string): boolean => {
   if (typeof s !== 'string' || s.trim() === '') {
     return false;
@@ -56,4 +52,38 @@ export const createIdCopy = (id: string) => `${id}-copy`;
 
 export const cleanResourceId = (resourceId?: string): string => {
   return resourceId?.startsWith('/') ? resourceId : `/${resourceId}`;
+};
+
+export const unescapeString = (input: string): string => {
+  return input.replace(/\\([nrtv])/g, (_match, char) => {
+    switch (char) {
+      case 'n':
+        return '\n';
+      case 'r':
+        return '\r';
+      case 't':
+        return '\t';
+      case 'v':
+        return '\v';
+      default:
+        return char;
+    }
+  });
+};
+
+export const escapeString = (input: string): string => {
+  return input.replace(/[\n\r\t\v]/g, (char) => {
+    switch (char) {
+      case '\n':
+        return '\\n';
+      case '\r':
+        return '\\r';
+      case '\t':
+        return '\\t';
+      case '\v':
+        return '\\v';
+      default:
+        return char;
+    }
+  });
 };


### PR DESCRIPTION
By default when stringifying expressions we were escaping the characters. However, this is quite confusing to the user, especially when handling something like `array(split(variables('something'), '\n'))` to be created by: 
```
array(split(variables('something'), '
'))
```
This PR was handling "unescaping" the default behavior of tokens before serialization and then re-escaping the characters before deserializing

Fixes: https://github.com/Azure/LogicAppsUX/issues/3496

![unescape](https://github.com/user-attachments/assets/ca48d243-86ce-4d21-9d9e-0bb7db01f7d2)


I've also tested this to work on other editors (dictionary, authentication, etc)

Fixes https://github.com/Azure/LogicAppsUX/issues/6070 where quotes were being added unncessarily
Fixed a bug where authentication editor inputs were not being defaulted to string type