### PR TITLE
fix(designer): Remove encoding in parameter name

### DIFF
--- a/libs/logic-apps-shared/src/parsers/lib/swagger/parameterprocessor.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/swagger/parameterprocessor.ts
@@ -246,7 +246,7 @@ export class ParametersProcessor {
     const encode = parameter[Constants.ExtensionProperties.Encode];
     const format = parameter.format;
     const $in = parameter.in;
-    const name = encodePropertySegment(parameter.name);
+    const name = parameter.name;
     const recommended = parameter[Constants.ExtensionProperties.SchedulerRecommendation];
     const required = !!parameter.required;
     const summary = parameter[Constants.ExtensionProperties.Summary];


### PR DESCRIPTION
This pull request includes a small change to the `ParametersProcessor` class in the `libs/logic-apps-shared/src/parsers/lib/swagger/parameterprocessor.ts` file. The change removes the encoding of the `name` property of a parameter.

* Removed the `encodePropertySegment` function call for the `name` property, leaving the `name` property as is.

### Screenshots
- Before
![Screenshot 2024-11-18 at 12 44 51 PM](https://github.com/user-attachments/assets/b26644ca-4ff7-490e-a667-299c55be7907)


- After
![Screenshot 2024-11-18 at 12 34 32 PM](https://github.com/user-attachments/assets/d516740a-5b97-4fa6-89d6-4d1664875b2e)

