### PR TITLE
fix(Designer): Prevent HTML editor from allowing DOM-based XSS

### DIFF
--- a/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
+++ b/libs/designer-ui/src/lib/html/plugins/toolbar/helper/util.ts
@@ -126,14 +126,14 @@ export const getDomFromHtmlEditorString = (htmlEditorString: string, nodeMap: Ma
   // Comments at the start of a DOM are lost when parsing HTML strings, so we wrap the HTML string in a <div>.
   const wrappedHtmlEditorString = `<div>${htmlEditorString}</div>`;
 
-  const purifiedHtmlEditorString = DomPurify.sanitize(encodeURIComponent(wrappedHtmlEditorString), { ADD_TAGS: ['#comment'] });
-  const encodedHtmlEditorString = encodeStringSegmentTokensInDomContext(decodeURIComponent(purifiedHtmlEditorString), nodeMap);
+  const purifiedHtmlEditorString = DomPurify.sanitize(wrappedHtmlEditorString, { ADD_TAGS: ['#comment'] });
+  const encodedHtmlEditorString = encodeStringSegmentTokensInDomContext(purifiedHtmlEditorString, nodeMap);
 
-  const tempElement = document.createElement('div', {});
-  tempElement.innerHTML = encodedHtmlEditorString;
+  const tempElement = document.createElement('div');
+  tempElement.innerHTML = DomPurify.sanitize(encodedHtmlEditorString);
 
   // Unwrap the wrapper <div>.
-  return tempElement.children[0] as HTMLElement;
+  return tempElement.firstElementChild as HTMLElement;
 };
 
 export const isAttributeSupportedByHtmlEditor = (tagName: string, attribute: string): boolean => {


### PR DESCRIPTION
Ensures no untrusted content is ever directly added to the DOM
![xxs](https://github.com/user-attachments/assets/e16a80ed-76ee-4d3b-aace-03b730b52cb5)
