### PR TITLE
fix(designer): Fixed fluent drawer stutter

### DIFF
--- a/libs/designer-ui/src/lib/styles.less
+++ b/libs/designer-ui/src/lib/styles.less
@@ -84,6 +84,7 @@
   flex: 1;
   margin: 0 auto;
   min-width: 100%;
+	overflow: hidden;
 
   @media only screen and (max-width: calc(@card-max-width + 40)) {
     width: 100%;
@@ -93,6 +94,15 @@
   img {
     vertical-align: baseline;
   }
+
+	/*
+		Weird new fluent bug where this generated css is causing weird
+		behavior when opening / closing panels.
+		This does not have any other effect.
+	*/
+	&>div {
+		--fui-Drawer--size: 0px;
+	}
 }
 
 .msla-theme-dark {


### PR DESCRIPTION
## Main Changes

Fixed fluent drawer stutter caused by some generated CSS on the fluent component.
Also fixed an issue where we were rendering component shadows outside of our application bounds, just added `overflow: hidden` to our base component.

## Error behavior
![old_drawer_stutter](https://github.com/user-attachments/assets/a692e406-c032-4c8f-8c29-267774f9accd)

## Fixed behavior
![fixed_drawer_stutter](https://github.com/user-attachments/assets/fc0e042f-7cc9-4051-825e-71daba9a97b2)
