### PR TITLE
fix(designer): Implicit String type conversions

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -116,7 +116,6 @@ import {
   isRecordNotEmpty,
   isBodySegment,
   canStringBeConverted,
-  isStringLiteral,
   splitAtIndex,
   unescapeString,
 } from '@microsoft/logic-apps-shared';
@@ -3563,8 +3562,8 @@ export function parameterValueToString(
             !remappedParameterInfo.suppressCasting &&
             parameterType === 'string' &&
             segment.token?.type !== 'string' &&
-            segment.token?.expression &&
-            isStringLiteral(segment.token.expression);
+            segment.token?.tokenType !== TokenType.FX;
+
           expressionValue = `@${shouldCastToString ? `{${expressionValue}}` : expressionValue}`;
         }
       }


### PR DESCRIPTION
There were a couple issues that PA had run into, where they implemented fixes:
https://github.com/Azure/LogicAppsUX/pull/4733/files
https://github.com/Azure/LogicAppsUX/pull/4977/files

However, in doing so, shouldCastToString ends up always being false or undefined, causing us never to cast. I'm modifying it to prevent the check on expressions where we can expect the user to cast themselves

Fixes https://github.com/Azure/LogicAppsUX/issues/6180