### PR TITLE
fix(vscode): Simplify .sln File Generation with Reload Window Button

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -162,12 +162,16 @@ async function generateCodefulUnitTest(
     if (!(await fs.pathExists(csprojFilePath))) {
       ext.outputChannel.appendLog(localize('creatingCsproj', 'Creating .csproj file at: {0}', csprojFilePath));
       await createCsprojFile(csprojFilePath, logicAppName);
+      const action = 'Reload Window';
+      vscode.window
+        .showInformationMessage('Reload Required: Please reload the VS Code window to enable test discovery in the Test Explorer', action)
+        .then((selectedAction) => {
+          if (selectedAction === action) {
+            vscode.commands.executeCommand('workbench.action.reloadWindow');
+          }
+        });
     }
     await createNugetConfigFile(nugetConfigFilePath);
-
-    vscode.window.showInformationMessage(
-      localize('info.generateCodefulUnitTest', 'Generated unit test "{0}" in "{1}"', unitTestName, unitTestFolderPath)
-    );
 
     // Check if testsDirectory is already part of the workspace
     const workspaceFolders = vscode.workspace.workspaceFolders || [];


### PR DESCRIPTION
## [Work Item: [Bug]: Investigate Solution File in Workspaces in General for Logic Apps](https://msazure.visualstudio.com/One/_workitems/edit/30080110)

## Summary

This PR addresses an issue where the C# Dev Kit extension does not generate a `.sln` file automatically under certain conditions. The proposed fix introduces a new "Reload Window" button to simplify the user's experience. Additionally, the localized message to the user (`localize('info.generateCodefulUnitTest', 'Generated unit test "{0}" in "{1}"', unitTestName, unitTestFolderPath)`) has been removed as it is no longer necessary.

## Requirement Checklist

* [x] The commit message follows our guidelines.
* [x] Tests for the changes have been added (for bug fixes or features).

## Type of Change

* [x] Bug fix  
* [ ] Feature  
* [ ] Other  

## Current Behavior

The `.sln` file generation is not triggered automatically under the following conditions:
- Opening a folder with multiple C# projects.
- Opening a C# project directly without an existing `.sln` file.
- Opening a multi-root workspace containing C# files across multiple folders.

For our use case (opening a C# project without an existing `.sln`), `.sln` file generation fails because:
- The "Create Unit Test from Run" feature is active only during debugging mode.
- The VS Code Workspace API does not refresh fully during debugging, preventing the C# Dev Kit from detecting the project and generating the `.sln` file.

## New Behavior

To mitigate this issue, this PR introduces the following:
- **"Reload Window" Button:** A user-friendly button that reloads the workspace, ensuring the `.sln` file is generated correctly.
- **Improved User Flow:** Simplifies the process for users by removing manual workspace reloading.
- **Removal of Localized Message:** The localized message `localize('info.generateCodefulUnitTest', 'Generated unit test "{0}" in "{1}"', unitTestName, unitTestFolderPath)` has been removed since it is no longer necessary.

### Tested Scenarios

1. **Happy Path:**  
   - Generated a unit test in an empty folder.  
   - Verified the workflow completes without any issues.  

2. **No Existing Tests Folder:**  
   - Generated a unit test in a workspace without a `Tests` folder.  
   - Verified the folder is created, and the window reloads smoothly.  

3. **Existing `.csproj` in Tests Folder:**  
   - Verified that the reload popup does not appear unnecessarily when the folder already contains a `.csproj`.

## Impact of Change

* [ ] **This is a breaking change.**

### Non-breaking improvements include:
- Enhanced user experience by reducing manual steps.
- Better handling of multi-root workspaces and direct project openings.

## Screenshots or Videos (if applicable)

### "Reload Window" Button:
![image](https://github.com/user-attachments/assets/1ebaf290-f037-4faa-bf21-da86eae33595)
