### PR TITLE
fix(vscode): Remove warning preview messages to non preview features

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createNewCodeProject.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createNewCodeProject.ts
@@ -2,17 +2,10 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import {
-  extensionCommand,
-  funcVersionSetting,
-  projectLanguageSetting,
-  projectOpenBehaviorSetting,
-  projectTemplateKeySetting,
-} from '../../../constants';
+import { funcVersionSetting, projectLanguageSetting, projectOpenBehaviorSetting, projectTemplateKeySetting } from '../../../constants';
 import { localize } from '../../../localize';
 import { createArtifactsFolder } from '../../utils/codeless/artifacts';
 import { addLocalFuncTelemetry, tryGetLocalFuncVersion, tryParseFuncVersion } from '../../utils/funcCoreTools/funcVersion';
-import { showPreviewWarning } from '../../utils/taskUtils';
 import { getGlobalSetting, getWorkspaceSetting } from '../../utils/vsCodeConfig/settings';
 import { OpenBehaviorStep } from '../createNewProject/OpenBehaviorStep';
 import { FolderListStep } from '../createNewProject/createProjectSteps/FolderListStep';
@@ -59,7 +52,6 @@ export async function createNewCodeProjectFromCommand(
 
 export async function createNewCodeProjectInternal(context: IActionContext, options: ICreateFunctionOptions): Promise<void> {
   addLocalFuncTelemetry(context);
-  showPreviewWarning(extensionCommand.createNewCodeProject); //Show warning if command is set to preview
 
   const language: ProjectLanguage | string = (options.language as ProjectLanguage) || getGlobalSetting(projectLanguageSetting);
   const version: string = options.version || getGlobalSetting(funcVersionSetting) || (await tryGetLocalFuncVersion()) || latestGAVersion;

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -9,7 +9,6 @@ import {
   workflowResourceGroupNameKey,
   workflowSubscriptionIdKey,
   localSettingsFileName,
-  extensionCommand,
   COMMON_ERRORS,
 } from '../../../constants';
 import { ext } from '../../../extensionVariables';
@@ -19,7 +18,7 @@ import { getConnectionsJson } from '../../utils/codeless/connection';
 import { getAuthorizationToken, getCloudHost } from '../../utils/codeless/getAuthorizationToken';
 import { isConnectionsParameterized } from '../../utils/codeless/parameterizer';
 import { addLocalFuncTelemetry } from '../../utils/funcCoreTools/funcVersion';
-import { showPreviewWarning, unzipLogicAppArtifacts } from '../../utils/taskUtils';
+import { unzipLogicAppArtifacts } from '../../utils/taskUtils';
 import { tryGetLogicAppProjectRoot } from '../../utils/verifyIsProject';
 import { getWorkspaceFolder } from '../../utils/workspace';
 import { parameterizeConnections } from '../parameterizeConnections';
@@ -42,7 +41,6 @@ export async function generateDeploymentScripts(context: IActionContext): Promis
     ext.outputChannel.appendLog(localize('initScriptGen', 'Initiating script generation...'));
 
     addLocalFuncTelemetry(context);
-    showPreviewWarning(extensionCommand.generateDeploymentScripts);
     const workspaceFolder = await getWorkspaceFolder(context);
     const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
     const projectRoot = vscode.Uri.file(projectPath);


### PR DESCRIPTION
This pull request includes changes to the `apps/vs-code-designer` project, focusing on code cleanup and removal of preview warnings. The most important changes include the consolidation of import statements and the removal of `showPreviewWarning` calls from specific functions.

Code cleanup:

* Consolidated import statements by removing unnecessary `extensionCommand` and `showPreviewWarning` imports.
* Removed the `extensionCommand` import as it is no longer needed.
