### PR TITLE
fix(designer): Accessibility - Set right aria label for concurrency control inputs

### DIFF
--- a/libs/designer/src/lib/ui/settings/sections/general.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/general.tsx
@@ -242,7 +242,7 @@ export const General = ({
             concurrencySubLabel,
             /* isSubLabelToggle*/ true
           ),
-          ariaLabel: concurrencyTitle,
+          ariaLabel: concurrencySubLabel,
         },
         visible: concurrency?.isSupported,
       },
@@ -257,7 +257,7 @@ export const General = ({
           onValueChange: onConcurrencyRunValueChange,
           sliderLabel: degreeOfParallelism,
           readOnly,
-          ariaLabel: concurrencyTitle,
+          ariaLabel: degreeOfParallelism,
         },
         visible: concurrency?.isSupported && concurrency?.value?.enabled,
       },


### PR DESCRIPTION
This pull request includes changes to the `libs/designer/src/lib/ui/settings/sections/general.tsx` file to improve accessibility by updating the `ariaLabel` properties for better clarity.

Accessibility improvements:

* Updated `ariaLabel` from `concurrencyTitle` to `concurrencySubLabel` to provide a more accurate description.
* Updated `ariaLabel` from `concurrencyTitle` to `degreeOfParallelism` to ensure the label matches the slider's function.

Fixes #6096 