### PR TITLE
fix(vscode): Update Microsoft.Azure.Workflows.WebJobs.Extension Version and Correct NuGet Reference

### DIFF
--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestNugetConfig
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestNugetConfig
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
-        <add key="myget.org" value="https://www.myget.org/F/microsoft-azure-logicapp-sdk-test/auth/4d294415-e556-497a-a971-f70226b48814/api/v3/index.json" />
+        <add key="myget.org" value="https://www.myget.org/F/microsoft-azure-logicapp-test-sdk/api/v3/index.json" />
     </packageSources>
 </configuration>

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestProjectFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestProjectFile
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Azure.Workflows.WebJobs.Extension" Version="1.96.*" />
+    <PackageReference Include="Microsoft.Azure.Workflows.WebJobs.Extension" Version="1.94.*" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**Title**: fix(vscode): Update `Microsoft.Azure.Workflows.WebJobs.Extension` Version and Correct NuGet Reference

## Requirement Checklist

* [ ] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes or features)
* [ ] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [ ] Feature
* [x] Other

## Current Behavior

The `.csproj` file currently references the `Microsoft.Azure.Workflows.WebJobs.Extension` package with version `1.96.*`, which needs to be downgraded to `1.94.*` for compatibility. Additionally, the NuGet reference in the `nuget.config` file was outdated and needed to be corrected to point to the most recent version of the `microsoft-azure-logicapp-test-sdk`.

## New Behavior

The `.csproj` file has been updated to reference `Microsoft.Azure.Workflows.WebJobs.Extension` version `1.94.*` instead of `1.96.*`. The `nuget.config` file has also been updated to reference the latest version of the `microsoft-azure-logicapp-test-sdk`.

## Impact of Change

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
