### PR TITLE
chore(designer): Add log service for errors

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -36,6 +36,8 @@ import {
   ConnectionReferenceKeyFormat,
   getRecordEntry,
   UserPreferenceService,
+  LoggerService,
+  LogEntryLevel,
 } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
@@ -260,7 +262,14 @@ export const getConnectionMappingForNode = (
       }
     }
     return Promise.resolve(undefined);
-  } catch (exception) {
+  } catch (error) {
+    const errorMessage = `Failed to get connection mapping for node: ${error}`;
+    LoggerService().log({
+      level: LogEntryLevel.Error,
+      area: 'getConnectionMappingForNode',
+      message: errorMessage,
+      error: error instanceof Error ? error : undefined,
+    });
     return Promise.resolve(undefined);
     // log exception
   }
@@ -310,8 +319,14 @@ export async function getManifestBasedConnectionMapping(
     }
 
     return connectionReferenceKey ? { [nodeId]: connectionReferenceKey } : undefined;
-  } catch (exception) {
-    // log exception
+  } catch (error) {
+    const errorMessage = `Failed to get manifest based connection mapping: ${error}`;
+    LoggerService().log({
+      level: LogEntryLevel.Error,
+      area: 'getManifestBasedConnectionMapping',
+      message: errorMessage,
+      error: error instanceof Error ? error : undefined,
+    });
     return Promise.resolve(undefined);
   }
 }

--- a/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
+++ b/libs/designer/src/lib/core/parsers/ParseReduxAction.ts
@@ -87,8 +87,8 @@ export const initializeGraphState = createAsyncThunk<
             await initializeDynamicDataInNodes(getState, dispatch);
 
             LoggerService().endTrace(traceId, { status: Status.Success });
-          } catch (e) {
-            LoggerService().endTrace(traceId, { status: Status.Failure });
+          } catch (error) {
+            LoggerService().endTrace(traceId, { status: Status.Failure, data: error instanceof Error ? error : undefined });
           }
         });
       };


### PR DESCRIPTION
This pull request includes several changes to improve error handling and logging in designer. The most important changes include adding the `LoggerService` and `LogEntryLevel` imports, enhancing error logging in specific functions, and updating the error handling in the `initializeGraphState` function.


* Added `LoggerService` and `LogEntryLevel` imports to support logging.
* Enhanced error logging in the `getConnectionMappingForNode` function to include detailed error messages and log the error using `LoggerService`.
* Enhanced error logging in the `getManifestBasedConnectionMapping` function to include detailed error messages and log the error using `LoggerService`.
* Updated error handling in the `initializeGraphState` function to log the error data using `LoggerService` when the status is `Failure`.