### PR TITLE
fix(Designer): Modified connector swagger fetch to have proper casing

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Utilities/resourceUtilities.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Utilities/resourceUtilities.ts
@@ -13,7 +13,7 @@ export const validateResourceId = (resourceId: string): string => {
 export const fetchAppsByQuery = async (query: string): Promise<any[]> => {
   const requestPage = async (value: any[] = [], pageNum = 0, currentSkipToken = ''): Promise<any> => {
     try {
-      const pageSize = 1000;
+      const pageSize = 500;
       const { data } = await axios.post(
         'https://edge.management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01',
         {

--- a/libs/designer/src/lib/core/queries/operation.ts
+++ b/libs/designer/src/lib/core/queries/operation.ts
@@ -34,8 +34,8 @@ export const getSwagger = async (connectorId: string): Promise<OpenAPIV2.Documen
   }
   const queryClient = getReactQueryClient();
   const connectionService = ConnectionService();
-  connectorId = connectorId.toLowerCase();
-  return queryClient.fetchQuery(['swagger', { connectorId }], () => connectionService.getSwaggerFromConnector(connectorId));
+  const queryKeyObject = { connectorId: connectorId.toLowerCase() };
+  return queryClient.fetchQuery(['swagger', queryKeyObject], () => connectionService.getSwaggerFromConnector(connectorId));
 };
 
 export const getOperationManifest = async ({ connectorId, operationId }: OperationInfo): Promise<OperationManifest> => {

--- a/libs/designer/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer/src/lib/core/state/connection/connectionSelector.ts
@@ -57,13 +57,17 @@ export const useConnectors = (connectorIds?: string[]): UseQueryResult<[string, 
   );
 
 export const useSwagger = (connectorId?: string, enabled = true) =>
-  useQuery(['swagger', { connectorId }], async () => ConnectionService().getSwaggerFromConnector(connectorId ?? ''), {
-    enabled: !!connectorId && enabled,
-    cacheTime: 1000 * 60 * 60 * 24,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-  });
+  useQuery(
+    ['swagger', { connectorId: connectorId?.toLowerCase() }],
+    async () => ConnectionService().getSwaggerFromConnector(connectorId ?? ''),
+    {
+      enabled: !!connectorId && enabled,
+      cacheTime: 1000 * 60 * 60 * 24,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    }
+  );
 
 export const useGateways = (subscriptionId: string, connectorName: string): UseQueryResult<Gateway[], unknown> =>
   useQuery(['gateways', { subscriptionId }, { connectorName }], async () => GatewayService().getGateways(subscriptionId, connectorName), {


### PR DESCRIPTION
## Main Changes

Connector ID query is now only keyed as lowercase, the actual fetch is now done with the raw connector id.
We have a user in west-europe that is seeing different swagger responses seemingly due to a casing issue.

This is being merged to v5.2 just for a private slot deployment to confirm the issue.

// I also lowered our standalone page size to 500 since 1000k was failing due to response data size constraints.