### PR TITLE
fix(designer): Add locale to connections API call for connectors and swagger

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumption.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-types */
 import { environment } from '../../../environments/environment';
 import type { AppDispatch, RootState } from '../../state/store';
 import { setIsChatBotEnabled } from '../../state/workflowLoadingSlice';
@@ -340,6 +339,7 @@ const getDesignerServices = (
     location,
     tenantId,
     httpClient,
+    locale,
   });
 
   const apimService = new BaseApiManagementService({
@@ -567,7 +567,7 @@ const getDataForConsumption = (data: any) => {
   return { workflow, connectionReferences, parameters };
 };
 
-const removeProperties = (obj: any = {}, props: string[] = []): Object => {
+const removeProperties = (obj: any = {}, props: string[] = []): object => {
   return Object.fromEntries(Object.entries(obj).filter(([key]) => !props.includes(key)));
 };
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/connection.ts
@@ -69,8 +69,14 @@ export abstract class BaseConnectionService implements IConnectionService {
     }
 
     try {
-      const { apiVersion, httpClient } = this.options;
-      return httpClient.get<OpenAPIV2.Document>({ uri: connectorId, queryParameters: { 'api-version': apiVersion, export: 'true' } });
+      const { apiVersion, httpClient, locale } = this.options;
+      const headers = locale ? { 'Accept-Language': locale } : undefined;
+
+      return httpClient.get<OpenAPIV2.Document>({
+        uri: connectorId,
+        queryParameters: { 'api-version': apiVersion, export: 'true' },
+        headers,
+      });
     } catch (error: any) {
       throw error?.response?.data?.error?.message ?? error;
     }
@@ -133,8 +139,9 @@ export abstract class BaseConnectionService implements IConnectionService {
   }
 
   protected async _getAzureConnector(connectorId: string): Promise<Connector> {
-    const { apiVersion, httpClient } = this.options;
-    const response = await httpClient.get<Connector>({ uri: connectorId, queryParameters: { 'api-version': apiVersion } });
+    const { apiVersion, httpClient, locale } = this.options;
+    const headers = locale ? { 'Accept-Language': locale } : undefined;
+    const response = await httpClient.get<Connector>({ uri: connectorId, queryParameters: { 'api-version': apiVersion }, headers });
 
     return {
       ...response,


### PR DESCRIPTION
This pull request includes several updates to the `AzureLogicAppsDesigner` and `BaseConnectionService` to enhance localization support and improve code consistency. The most important changes are summarized below:


* Added `locale` parameter to the `getDesignerServices` function to support localization in API requests.
* Updated `_getAzureConnector` and `_getOpenApiDocument` methods to include `Accept-Language` headers in API requests if `locale` is provided.