### PR TITLE
fix(designer): Error Being thrown On Extended Text Node

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/utils/initialConfig.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/initialConfig.ts
@@ -25,7 +25,7 @@ export const htmlNodes = [
   HeadingNode,
   ExtentedTextNode,
   LineBreakNode,
-  { replace: TextNode, with: (node: TextNode) => new ExtentedTextNode(node.__text, node.__key) },
+  { replace: TextNode, with: (node: TextNode) => new ExtentedTextNode(node.__text) },
 ];
 
 export const defaultNodes = [AutoLinkNode, LinkNode, TokenNode];


### PR DESCRIPTION
Updating Lexical on this PR https://github.com/Azure/LogicAppsUX/pull/6213 ended up introducing a previously silently failing error on extending nodes. 
Fixes: https://github.com/Azure/LogicAppsUX/issues/6361