### PR TITLE
feat(vscode): Add unit test for installing binaries and fix return values

### DIFF
--- a/apps/vs-code-designer/src/app/commands/nodeJs/validateNodeJsInstalled.ts
+++ b/apps/vs-code-designer/src/app/commands/nodeJs/validateNodeJsInstalled.ts
@@ -69,7 +69,7 @@ export async function isNodeJsInstalled(): Promise<boolean> {
   try {
     await executeCommand(undefined, undefined, getNodeJsCommand(), '--version');
     return true;
-  } catch (error) {
+  } catch {
     return false;
   }
 }

--- a/apps/vs-code-designer/src/app/utils/__test__/azure.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/azure.test.ts
@@ -1,7 +1,16 @@
-import { describe, it, expect } from 'vitest';
 import { getResourceGroupFromId } from '../azure';
+import { describe, it, expect, vi, Mock, beforeEach } from 'vitest';
+import { getStorageConnectionString } from '../azure';
+import type { IStorageAccountWizardContext } from '@microsoft/vscode-azext-azureutils';
+import type { StorageAccount, StorageAccountListKeysResult, StorageManagementClient } from '@azure/arm-storage';
+import { createStorageClient } from '../azureClients';
+import { nonNullProp, nonNullValue } from '@microsoft/vscode-azext-utils';
 
 describe('azure', () => {
+  vi.mock('../azureClients', () => ({
+    createStorageClient: vi.fn(),
+  }));
+
   describe('getResourceGroupFromId', () => {
     it('should return the resource group from a valid storage account ID', () => {
       const id = '/subscriptions/123/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount';
@@ -12,6 +21,100 @@ describe('azure', () => {
     it('should throw an error for an invalid storage account ID', () => {
       const id = '/invalid/resource/id';
       expect(() => getResourceGroupFromId(id)).toThrow('Invalid Azure Resource Id');
+    });
+  });
+
+  describe('getStorageConnectionString', () => {
+    let mockClient: StorageManagementClient;
+
+    beforeEach(() => {
+      mockClient = {
+        storageAccounts: {
+          listKeys: vi.fn().mockResolvedValue({
+            keys: [{ value: 'mockKey' }],
+          } as StorageAccountListKeysResult),
+        },
+      } as unknown as StorageManagementClient;
+
+      (nonNullProp as Mock).mockImplementation((obj, prop) => {
+        if (!obj[prop]) {
+          throw new Error();
+        }
+        return obj[prop];
+      });
+
+      (nonNullValue as Mock).mockImplementation((value) => {
+        if (!value) {
+          throw new Error();
+        }
+        return value;
+      });
+    });
+
+    it('should return the storage connection string for a valid context', async () => {
+      const mockContext: IStorageAccountWizardContext = {
+        storageAccount: {
+          id: '/subscriptions/123/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount',
+          name: 'myStorageAccount',
+        } as StorageAccount,
+        environment: {
+          storageEndpointSuffix: '.core.windows.net',
+        },
+      } as IStorageAccountWizardContext;
+
+      (createStorageClient as Mock).mockResolvedValue(mockClient);
+      (nonNullValue as Mock).mockImplementation((value) => value);
+
+      const result = await getStorageConnectionString(mockContext);
+
+      expect(result).toEqual({
+        name: 'myStorageAccount',
+        connectionString: 'DefaultEndpointsProtocol=https;AccountName=myStorageAccount;AccountKey=mockKey;EndpointSuffix=core.windows.net',
+      });
+    });
+
+    it('should throw an error if storage account ID is invalid', async () => {
+      const mockContext: IStorageAccountWizardContext = {
+        storageAccount: {
+          id: '/invalid/resource/id',
+          name: 'myStorageAccount',
+        } as StorageAccount,
+        environment: {
+          storageEndpointSuffix: '.core.windows.net',
+        },
+      } as IStorageAccountWizardContext;
+
+      (createStorageClient as Mock).mockResolvedValue(mockClient);
+      (nonNullValue as Mock).mockImplementation((value) => value);
+
+      await expect(getStorageConnectionString(mockContext)).rejects.toThrow('Invalid Azure Resource Id');
+    });
+
+    it('should throw an error if context does not have storageAccount', async () => {
+      const mockContext: IStorageAccountWizardContext = {
+        environment: {
+          storageEndpointSuffix: '.core.windows.net',
+        },
+      } as IStorageAccountWizardContext;
+
+      (createStorageClient as Mock).mockResolvedValue(mockClient);
+
+      await expect(getStorageConnectionString(mockContext)).rejects.toThrow();
+    });
+
+    it('should throw an error if storageAccount does not have a name', async () => {
+      const mockContext: IStorageAccountWizardContext = {
+        storageAccount: {
+          id: '/subscriptions/123/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount',
+        } as StorageAccount,
+        environment: {
+          storageEndpointSuffix: '.core.windows.net',
+        },
+      } as IStorageAccountWizardContext;
+
+      (createStorageClient as Mock).mockResolvedValue(mockClient);
+
+      await expect(getStorageConnectionString(mockContext)).rejects.toThrow();
     });
   });
 });

--- a/apps/vs-code-designer/src/app/utils/__test__/azure.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/azure.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { getResourceGroupFromId } from '../azure';
+
+describe('azure', () => {
+  describe('getResourceGroupFromId', () => {
+    it('should return the resource group from a valid storage account ID', () => {
+      const id = '/subscriptions/123/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount';
+      const result = getResourceGroupFromId(id);
+      expect(result).toBe('myResourceGroup');
+    });
+
+    it('should throw an error for an invalid storage account ID', () => {
+      const id = '/invalid/resource/id';
+      expect(() => getResourceGroupFromId(id)).toThrow('Invalid Azure Resource Id');
+    });
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import axios from 'axios';
+import * as vscode from 'vscode';
+import * as semver from 'semver';
+import {
+  downloadAndExtractDependency,
+  binariesExist,
+  getLatestDotNetVersion,
+  getLatestFunctionCoreToolsVersion,
+  getLatestNodeJsVersion,
+  getNodeJsBinariesReleaseUrl,
+  getFunctionCoreToolsBinariesReleaseUrl,
+  getDotNetBinariesReleaseUrl,
+  getCpuArchitecture,
+  getDependencyTimeout,
+  installBinaries,
+  useBinariesDependencies,
+} from '../binaries';
+import { ext } from '../../../extensionVariables';
+import { DependencyVersion, Platform, dotnetDependencyName, funcPackageName } from '../../../constants';
+import { executeCommand } from '../funcCoreTools/cpUtils';
+import { getNpmCommand } from '../nodeJs/nodeJsVersion';
+import { getGlobalSetting, getWorkspaceSetting, updateGlobalSetting } from '../vsCodeConfig/settings';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+
+// vi.mock('fs');
+// vi.mock('path');
+// vi.mock('os');
+// vi.mock('axios');
+// vi.mock('vscode');
+// vi.mock('semver');
+// vi.mock('../../../extensionVariables');
+// vi.mock('../funcCoreTools/cpUtils');
+// vi.mock('../nodeJs/nodeJsVersion');
+vi.mock('../../../onboarding');
+vi.mock('../vsCodeConfig/settings');
+
+describe('binaries', () => {
+  //   describe('downloadAndExtractDependency', () => {
+  //     it('should download and extract dependency', async () => {
+  //       const context = {} as IActionContext;
+  //       const downloadUrl = 'https://example.com/dependency.zip';
+  //       const targetFolder = 'targetFolder';
+  //       const dependencyName = 'dependency';
+  //       const folderName = 'folderName';
+  //       const dotNetVersion = '6.0';
+
+  //       (axios as any).mockResolvedValue({
+  //         data: {
+  //           pipe: vi.fn().mockImplementation((writer) => {
+  //             writer.emit('finish');
+  //           }),
+  //         },
+  //       });
+
+  //       await downloadAndExtractDependency(context, downloadUrl, targetFolder, dependencyName, folderName, dotNetVersion);
+
+  //       expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+  //       expect(fs.chmodSync).toHaveBeenCalledWith(expect.any(String), 0o777);
+  //       expect(executeCommand).toHaveBeenCalledWith(ext.outputChannel, undefined, 'echo', `Downloading dependency from: ${downloadUrl}`);
+  //     });
+  //   });
+
+  //   describe('binariesExist', () => {
+  //     it('should return true if binaries exist', () => {
+  //       (fs.existsSync as any).mockReturnValue(true);
+  //       (getGlobalSetting as any).mockReturnValue('binariesLocation');
+
+  //       const result = binariesExist('dependencyName');
+
+  //       expect(result).toBe(true);
+  //     });
+
+  //     it('should return false if binaries do not exist', () => {
+  //       (fs.existsSync as any).mockReturnValue(false);
+  //       (getGlobalSetting as any).mockReturnValue('binariesLocation');
+
+  //       const result = binariesExist('dependencyName');
+
+  //       expect(result).toBe(false);
+  //     });
+  //   });
+
+  //   describe('getLatestDotNetVersion', () => {
+  //     it('should return the latest .NET version', async () => {
+  //       const context = {} as IActionContext;
+  //       const majorVersion = '6';
+  //       const response = [{ tag_name: 'v6.0.0' }];
+
+  //       (axios.get as any).mockResolvedValue({ data: response });
+
+  //       const result = await getLatestDotNetVersion(context, majorVersion);
+
+  //       expect(result).toBe('6.0.0');
+  //     });
+  //   });
+
+  //   describe('getLatestFunctionCoreToolsVersion', () => {
+  //     it('should return the latest Function Core Tools version', async () => {
+  //       const context = {} as IActionContext;
+  //       const majorVersion = '3';
+  //       const response = { tag_name: 'v3.0.0' };
+
+  //       (axios.get as any).mockResolvedValue({ data: response });
+
+  //       const result = await getLatestFunctionCoreToolsVersion(context, majorVersion);
+
+  //       expect(result).toBe('3.0.0');
+  //     });
+  //   });
+
+  //   describe('getLatestNodeJsVersion', () => {
+  //     it('should return the latest Node.js version', async () => {
+  //       const context = {} as IActionContext;
+  //       const majorVersion = '14';
+  //       const response = [{ tag_name: 'v14.0.0' }];
+
+  //       (axios.get as any).mockResolvedValue({ data: response });
+
+  //       const result = await getLatestNodeJsVersion(context, majorVersion);
+
+  //       expect(result).toBe('14.0.0');
+  //     });
+  //   });
+
+  describe('getNodeJsBinariesReleaseUrl', () => {
+    const version = '14.0.0';
+    const arch = 'x64';
+
+    it('should return the correct Node.js binaries release URL for windows', () => {
+      const osPlatform = 'win';
+
+      const result = getNodeJsBinariesReleaseUrl(version, osPlatform, arch);
+      console.log(result);
+
+      expect(result).toStrictEqual('https://nodejs.org/dist/v14.0.0/node-v14.0.0-win-x64.zip');
+    });
+    it('should return the correct Node.js binaries release URL for non windows', () => {
+      const osPlatform = 'darwin';
+      const result = getNodeJsBinariesReleaseUrl(version, osPlatform, arch);
+
+      expect(result).toStrictEqual('https://nodejs.org/dist/v14.0.0/node-v14.0.0-darwin-x64.tar.gz');
+    });
+  });
+
+  describe('getFunctionCoreToolsBinariesReleaseUrl', () => {
+    it('should return the correct Function Core Tools binaries release URL', () => {
+      const version = '3.0.0';
+      const osPlatform = 'win-x64';
+      const arch = 'x64';
+      const result = getFunctionCoreToolsBinariesReleaseUrl(version, osPlatform, arch);
+
+      expect(result).toStrictEqual(
+        `https://github.com/Azure/azure-functions-core-tools/releases/download/${version}/Azure.Functions.Cli.${osPlatform}-${arch}.${version}.zip`
+      );
+    });
+  });
+
+  describe('getDotNetBinariesReleaseUrl', () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+      });
+    });
+
+    it('should return the correct .NET binaries release URL for windows', () => {
+      vi.stubGlobal('process', {
+        ...process,
+        platform: Platform.windows,
+      });
+      const result = getDotNetBinariesReleaseUrl();
+
+      expect(result).toBe('https://dot.net/v1/dotnet-install.ps1');
+    });
+
+    it('should return the correct .NET binaries release URL for non windows', () => {
+      vi.stubGlobal('process', {
+        ...process,
+        platform: Platform.mac,
+      });
+      const result = getDotNetBinariesReleaseUrl();
+
+      expect(result).toBe('https://dot.net/v1/dotnet-install.sh');
+    });
+  });
+
+  describe('getCpuArchitecture', () => {
+    const originalArch = process.arch;
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      Object.defineProperty(process, 'arch', {
+        value: originalArch,
+      });
+    });
+
+    it('should return the correct CPU architecture', () => {
+      vi.stubGlobal('process', {
+        ...process,
+        arch: 'x64',
+      });
+      const result = getCpuArchitecture();
+
+      expect(result).toBe('x64');
+    });
+
+    it('should throw an error for unsupported CPU architecture', () => {
+      (process as any).arch = vi.stubGlobal('process', {
+        ...process,
+        arch: 'unsupported',
+      });
+      expect(() => getCpuArchitecture()).toThrowError('Unsupported CPU architecture: unsupported');
+    });
+  });
+
+  describe('getDependencyTimeout', () => {
+    it('should return the dependency timeout value', () => {
+      (getWorkspaceSetting as any).mockReturnValue(60);
+
+      const result = getDependencyTimeout();
+
+      expect(result).toBe(60);
+    });
+
+    it('should throw an error for invalid timeout value', () => {
+      (getWorkspaceSetting as any).mockReturnValue('invalid');
+
+      expect(() => getDependencyTimeout()).toThrowError('The setting "invalid" must be a number, but instead found "invalid".');
+    });
+  });
+
+  describe('installBinaries', () => {
+    const context = {
+      telemetry: {
+        properties: {},
+      },
+    } as IActionContext;
+    it('should install binaries', async () => {
+      (getGlobalSetting as any).mockReturnValue(true);
+
+      await installBinaries(context);
+
+      expect(context.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting).toBe('true');
+    });
+
+    it('should not install binaries', async () => {
+      (getGlobalSetting as any).mockReturnValue(false);
+
+      await installBinaries(context);
+
+      expect(context.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting).toBe('false');
+    });
+  });
+
+  describe('useBinariesDependencies', () => {
+    it('should return true if binaries dependencies are used', () => {
+      (getGlobalSetting as any).mockReturnValue(true);
+
+      const result = useBinariesDependencies();
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if binaries dependencies are not used', () => {
+      (getGlobalSetting as any).mockReturnValue(false);
+
+      const result = useBinariesDependencies();
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
@@ -136,6 +136,7 @@ describe('binaries', () => {
   describe('getLatestFunctionCoreToolsVersion', () => {
     let context: IActionContext;
     let majorVersion;
+
     beforeEach(() => {
       context = {
         telemetry: {
@@ -179,6 +180,14 @@ describe('binaries', () => {
 
       expect(result).toBe(DependencyVersion.funcCoreTools);
       expect(showErrorMessage).toHaveBeenCalled();
+      expect(context.telemetry.properties.getLatestFunctionCoreToolsVersion).toBe('fallback');
+    });
+
+    it('should return the fallback Function Core Tools version when no major version is sent', async () => {
+      (isNodeJsInstalled as Mock).mockResolvedValue(false);
+      const result = await getLatestFunctionCoreToolsVersion(context);
+
+      expect(result).toBe(DependencyVersion.funcCoreTools);
       expect(context.telemetry.properties.getLatestFunctionCoreToolsVersion).toBe('fallback');
     });
   });

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -33,7 +33,7 @@ import * as semver from 'semver';
 import * as vscode from 'vscode';
 
 import AdmZip = require('adm-zip');
-import { HTTP_METHODS, isNullOrUndefined } from '@microsoft/logic-apps-shared';
+import { isNullOrUndefined } from '@microsoft/logic-apps-shared';
 
 /**
  * Download and Extracts dependency zip.
@@ -63,15 +63,9 @@ export async function downloadAndExtractDependency(
   const dependencyFileExtension = getCompressionFileExtension(downloadUrl);
   const dependencyFilePath = path.join(tempFolderPath, `${dependencyName}${dependencyFileExtension}`);
 
-  const downloadPromise = axios({
-    method: HTTP_METHODS.GET,
-    url: downloadUrl,
-    responseType: 'stream',
-  });
-
   executeCommand(ext.outputChannel, undefined, 'echo', `Downloading dependency from: ${downloadUrl}`);
 
-  downloadPromise.then((response) => {
+  axios.get(downloadUrl, { responseType: 'stream' }).then((response) => {
     executeCommand(ext.outputChannel, undefined, 'echo', `Creating temporary folder... ${tempFolderPath}`);
     fs.mkdirSync(tempFolderPath, { recursive: true });
     fs.chmodSync(tempFolderPath, 0o777);

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -216,11 +216,11 @@ export async function getLatestNodeJsVersion(context: IActionContext, majorVersi
 }
 
 export function getNodeJsBinariesReleaseUrl(version: string, osPlatform: string, arch: string): string {
-  if (osPlatform !== 'win') {
-    return `https://nodejs.org/dist/v${version}/node-v${version}-${osPlatform}-${arch}.tar.gz`;
+  if (osPlatform === 'win') {
+    return `https://nodejs.org/dist/v${version}/node-v${version}-${osPlatform}-${arch}.zip`;
   }
 
-  return `https://nodejs.org/dist/v${version}/node-v${version}-${osPlatform}-${arch}.zip`;
+  return `https://nodejs.org/dist/v${version}/node-v${version}-${osPlatform}-${arch}.tar.gz`;
 }
 
 export function getFunctionCoreToolsBinariesReleaseUrl(version: string, osPlatform: string, arch: string): string {

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -195,16 +195,16 @@ export async function getLatestNodeJsVersion(context: IActionContext, majorVersi
   context.telemetry.properties.nodeMajorVersion = majorVersion;
 
   if (majorVersion) {
-    await readJsonFromUrl('https://api.github.com/repos/nodejs/node/releases')
+    return await readJsonFromUrl('https://api.github.com/repos/nodejs/node/releases')
       .then((response: IGitHubReleaseInfo[]) => {
         context.telemetry.properties.latestVersionSource = 'github';
-        response.forEach((releaseInfo: IGitHubReleaseInfo) => {
+        for (const releaseInfo of response) {
           const releaseVersion = semver.valid(semver.coerce(releaseInfo.tag_name));
           context.telemetry.properties.latestGithubVersion = releaseInfo.tag_name;
           if (checkMajorVersion(releaseVersion, majorVersion)) {
             return releaseVersion;
           }
-        });
+        }
       })
       .catch((error) => {
         throw Error(localize('errorNewestNodeJsVersion', `Error getting latest Node JS version: ${error}`));

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -119,7 +119,7 @@ export async function downloadAndExtractDependency(
   });
 }
 
-export async function getLatestFunctionCoreToolsVersion(context: IActionContext, majorVersion: string): Promise<string> {
+export async function getLatestFunctionCoreToolsVersion(context: IActionContext, majorVersion?: string): Promise<string> {
   context.telemetry.properties.funcCoreTools = majorVersion;
 
   // Use npm to find newest func core tools version

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -31,7 +31,7 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('axios');
-// vi.mock('vscode');
+
 vi.mock('vscode', () => ({
   window: {},
 }));

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -22,5 +22,7 @@ vi.mock('@microsoft/vscode-azext-utils', () => {
     AzureWizardPromptStep: vi.fn().mockImplementation(() => {
       return {};
     }),
+    nonNullProp: vi.fn(),
+    nonNullValue: vi.fn(),
   };
 });

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -10,7 +10,6 @@ vi.mock('@microsoft/vscode-azext-azureutils', () => ({
 }));
 
 vi.mock('@microsoft/vscode-azext-azureauth', () => ({
-  // Mock any methods or exports used by your code from `@microsoft/vscode-azext-azureauth`
   getSessionFromVSCode: vi.fn(() => Promise.resolve({})), // example of a mocked function
 }));
 
@@ -26,3 +25,13 @@ vi.mock('@microsoft/vscode-azext-utils', () => {
     nonNullValue: vi.fn(),
   };
 });
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock('axios');
+// vi.mock('vscode');
+vi.mock('vscode', () => ({
+  window: {},
+}));

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -28,6 +28,9 @@ vi.mock('@microsoft/vscode-azext-utils', () => {
 
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  chmodSync: vi.fn(),
+  createWriteStream: vi.fn(),
 }));
 
 vi.mock('axios');


### PR DESCRIPTION
This pull request includes several changes to improve error handling, add unit tests, and refactor the codebase for better readability and maintainability. The most important changes include updating error handling in the `binaries.ts` file, adding unit tests for Azure-related functions, and refactoring the `downloadAndExtractDependency` function.

* Updated error handling in `getLatestFunctionCoreToolsVersion`, `getLatestDotNetVersion`, and `getLatestNodeJsVersion` functions to log errors to telemetry and use fallback versions. 

* Added unit tests for `getResourceGroupFromId` and `getStorageConnectionString` functions in `azure.test.ts` to ensure proper functionality and error handling.

* Refactored `downloadAndExtractDependency` function to directly use `axios.get` instead of a separate download promise.
* Removed unnecessary import of `HTTP_METHODS` from `binaries.ts`.

* Simplified error handling in `isNodeJsInstalled` function by removing the error parameter in the catch block.
* Added mocks for `fs`, `axios`, and `vscode` in the test setup file to support new unit tests.


#### Coverage screenshot
<img width="2543" alt="Screenshot 2025-01-14 at 2 43 03 PM" src="https://github.com/user-attachments/assets/424b086a-a084-4459-90cd-31dcd949a1a3" />
