### PR TITLE
fix(designer): Correctly add inactive class for subgraph cards

### DIFF
--- a/libs/designer/src/lib/ui/CustomNodes/GraphContainerNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/GraphContainerNode.tsx
@@ -1,10 +1,10 @@
 import { useMonitoringView, useReadOnly } from '../../core/state/designerOptions/designerOptionsSelectors';
 import { useIsNodeSelectedInOperationPanel } from '../../core/state/panel/panelSelectors';
-import { useActionMetadata, useIsLeafNode, useNodeMetadata, useRunData } from '../../core/state/workflow/workflowSelectors';
+import { useActionMetadata, useIsLeafNode, useNodeMetadata, useParentRunId, useRunData } from '../../core/state/workflow/workflowSelectors';
 import { DropZone } from '../connections/dropzone';
 import { css } from '@fluentui/react';
 import { GraphContainer } from '@microsoft/designer-ui';
-import { SUBGRAPH_TYPES, useNodeSize, useNodeLeafIndex, isNullOrUndefined } from '@microsoft/logic-apps-shared';
+import { SUBGRAPH_TYPES, useNodeSize, useNodeLeafIndex, isNullOrUndefined, removeIdTag } from '@microsoft/logic-apps-shared';
 import { memo } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 
@@ -19,7 +19,9 @@ const GraphContainerNode = ({ targetPosition = Position.Top, sourcePosition = Po
   const showLeafComponents = !readOnly && actionMetadata?.type && isLeaf;
   const isSubgraphContainer = nodeMetadata?.subgraphType !== undefined;
   const hasFooter = nodeMetadata?.subgraphType === SUBGRAPH_TYPES.UNTIL_DO;
-  const runData = useRunData(id);
+  const graphContainerId = isSubgraphContainer ? removeIdTag(id) : id;
+  const parentRunId = useParentRunId(graphContainerId);
+  const runData = useRunData(isSubgraphContainer ? (parentRunId ?? '') : graphContainerId);
 
   const nodeSize = useNodeSize(id);
 

--- a/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
@@ -15,6 +15,7 @@ import {
   useNewSwitchCaseId,
   useNodeDisplayName,
   useNodeMetadata,
+  useParentRunId,
   useRunData,
   useWorkflowNode,
 } from '../../core/state/workflow/workflowSelectors';
@@ -29,8 +30,7 @@ import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const SubgraphCardNode = ({ data, targetPosition = Position.Top, sourcePosition = Position.Bottom, id }: NodeProps) => {
+const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Position.Bottom, id }: NodeProps) => {
   const subgraphId = removeIdTag(id);
   const node = useActionMetadata(subgraphId);
 
@@ -47,8 +47,8 @@ const SubgraphCardNode = ({ data, targetPosition = Position.Top, sourcePosition 
   const operationInfo = useOperationInfo(graphId);
   const isMonitoringView = useMonitoringView();
   const normalizedType = node?.type.toLowerCase();
-  const runData = useRunData(id);
-
+  const parentRunId = useParentRunId(subgraphId);
+  const parentRunData = useRunData(parentRunId ?? '');
   const title = useNodeDisplayName(subgraphId);
 
   const isAddCase = metadata?.subgraphType === SUBGRAPH_TYPES.SWITCH_ADD_CASE;
@@ -140,7 +140,7 @@ const SubgraphCardNode = ({ data, targetPosition = Position.Top, sourcePosition 
             <>
               <SubgraphCard
                 id={subgraphId}
-                active={isMonitoringView ? !isNullOrUndefined(runData?.status) : true}
+                active={isMonitoringView ? !isNullOrUndefined(parentRunData?.status) : true}
                 parentId={metadata?.graphId}
                 subgraphType={metadata.subgraphType}
                 title={title}


### PR DESCRIPTION
This pull request introduces several updates to the `GraphContainerNode` and `SubgraphCardNode` components in the `libs/designer/src/lib/ui/CustomNodes` directory. The changes include the addition of new selectors and modifications to the way run data is retrieved and used.

### Updates to `GraphContainerNode` and `SubgraphCardNode` components:

* Added `useParentRunId` and `removeIdTag` imports. Modified the logic to use `removeIdTag` for `graphContainerId` and `useParentRunId` to get `parentRunId`. Updated `runData` to conditionally use `parentRunId` or `graphContainerId`. 
* Added `useParentRunId` import. Removed unused `data` parameter from `SubgraphCardNode` component. Updated `runData` logic to use `parentRunId` and `parentRunData`. Modified `SubgraphCard` component to use `parentRunData?.status` for the `active` prop. 


#### Screenshots


##### Before
<img width="1219" alt="Screenshot 2025-01-15 at 3 49 17 PM" src="https://github.com/user-attachments/assets/ca2b4948-55fb-4219-b9d8-fce3982ddd44" />


##### After

<img width="1563" alt="Screenshot 2025-01-15 at 4 05 23 PM" src="https://github.com/user-attachments/assets/7dba0e65-4fb6-47fc-8df0-021c84a20a3a" />
