### PR TITLE
feat(Designer): Moved manual tab indexing to be behind a host option

### DIFF
--- a/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
+++ b/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
@@ -34,6 +34,7 @@ export interface WorkflowLoadingState {
     stringOverrides?: Record<string, string>; // string overrides for localization
     maxStateHistorySize?: number; // maximum number of states to save in history for undo/redo
     collapseGraphsByDefault?: boolean; // collapse scope by default
+    manualTabIndexing?: boolean; // enable manual tab indexing
   };
   showPerformanceDebug?: boolean;
 }

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -48,6 +48,7 @@ export interface DesignerOptionsState {
     maxStateHistorySize?: number; // maximum number of states to save in history for undo/redo (default is 0)
     hideContentTransferSettings?: boolean; // hide content transfer settings in the designer
     collapseGraphsByDefault?: boolean; // collapse scope by default
+    manualTabIndexing?: boolean; // enable manual tab indexes
   };
   nodeSelectAdditionalCallback?: (nodeId: string) => any;
   showConnectionsPanel?: boolean;

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -48,6 +48,7 @@ export const initialDesignerOptionsState: DesignerOptionsState = {
     maxStateHistorySize: CONSTANTS.DEFAULT_MAX_STATE_HISTORY_SIZE,
     hideContentTransferSettings: false,
     collapseGraphsByDefault: false,
+    manualTabIndexing: false,
   },
 };
 


### PR DESCRIPTION
## Main Changes

Our manual tab indexing is causing some unintended side effects with tab navigation outside of the canvas.
This PR moves the manual tab indexing behind a host option just while we try to find a proper solution for the issues we're experiencing.
Our tab flow is currently broken so this puts us in a semi-functional state.