### PR TITLE
fix(Designer): Custom connection cache is now updated properly

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
@@ -185,10 +185,16 @@ export const CreateConnectionInternal = (props: {
   const queryClient = useQueryClient();
   const updateNewConnectionInCache = useCallback(
     async (newConnection: Connection) => {
-      return queryClient.setQueryData<Connection[]>(
-        ['connections', connector?.id?.toLowerCase()],
-        (oldConnections: Connection[] | undefined) => [...(oldConnections ?? []), newConnection]
-      );
+      // Update all connections cache (Used for custom connectors)
+      queryClient.setQueryData<Connection[]>(['allConnections'], (oldConnections: Connection[] | undefined) => [
+        ...(oldConnections ?? []),
+        newConnection,
+      ]);
+      // Update connector specific cache (Used for everything else)
+      queryClient.setQueryData<Connection[]>(['connections', connector?.id?.toLowerCase()], (oldConnections: Connection[] | undefined) => [
+        ...(oldConnections ?? []),
+        newConnection,
+      ]);
     },
     [connector?.id, queryClient]
   );


### PR DESCRIPTION
## Main Changes

Custom connection cache is now updated properly when creating a new custom connector connection.
We hold custom connectors in a different query cache initially so when creating we also need to add it to another cache.

Fixes: https://github.com/Azure/LogicAppsUX/issues/6117