### PR TITLE
meta(vscode): Add pipeline to test and build private feature vsix

### DIFF
--- a/.github/workflows/private-vsix-build.yml
+++ b/.github/workflows/private-vsix-build.yml
@@ -1,0 +1,86 @@
+name: Private vsix build
+run-name: Private vsix build - [ ${{ github.ref_name || 'branch'  }} ]
+on:
+  workflow_dispatch: # Trigger only manually  workflow_dispatch: # Trigger only manually
+
+env:
+  AI_KEY: 3cf0d6ae-3327-414a-b7c1-12f31ef45eff
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+      # checkout the repo
+      - name: 'Checkout Github Action'
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Set up Node.js version ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9.1.3
+          run_install: |
+            - recursive: true
+              args: [--frozen-lockfile, --strict-peer-dependencies]
+            
+      - run: pnpm turbo run test:lib --cache-dir=.turbo
+      - run: pnpm turbo run test:extension-unit --cache-dir=.turbo
+
+  build:
+    name: Build private vsix
+    runs-on: ubuntu-latest
+
+    steps:
+      # checkout the repo
+      - name: 'Checkout Github Action'
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js version 20
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9.1.3
+          run_install: |
+            - recursive: true
+              args: [--frozen-lockfile, --strict-peer-dependencies]
+
+      - name: 'Set Designer Extension VSIX aiKey in package.json'
+        run: echo "`jq '.aiKey="${{ env.AI_KEY }}"' apps/vs-code-designer/src/package.json`" > apps/vs-code-designer/src/package.json
+
+      - name: Replace Placeholder with Telemetry Key
+        run: sed -i 's/setInGitHubBuild/${{ env.AI_KEY }}/g' apps/vs-code-designer/src/main.ts
+
+      - name: 'Pack VSCode Designer Extension'
+        run: pnpm run vscode:designer:pack
+
+      - name: Archive VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          path: |
+            apps/vs-code-designer/dist/*.vsix
+
+
+ 

--- a/.github/workflows/private-vsix-build.yml
+++ b/.github/workflows/private-vsix-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # Trigger only manually  workflow_dispatch: # Trigger only manually
 
 env:
-  AI_KEY: 3cf0d6ae-3327-414a-b7c1-12f31ef45eff
+  AI_KEY: ${{ vars.AI_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -18,7 +18,7 @@ on:
     - cron: '0 17 * * 4'
 
 env:
-  AI_KEY: 3cf0d6ae-3327-414a-b7c1-12f31ef45eff
+  AI_KEY: ${{ vars.AI_KEY }}
   NX_AI_CON_STR: InstrumentationKey=3cf0d6ae-3327-414a-b7c1-12f31ef45eff;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/
   BUMP_COMMAND: pnpm run bump --release-as ${{ github.event.inputs.release_type || 'minor' }}
 

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionWrapper.tsx
@@ -185,10 +185,16 @@ export const CreateConnectionInternal = (props: {
   const queryClient = useQueryClient();
   const updateNewConnectionInCache = useCallback(
     async (newConnection: Connection) => {
-      return queryClient.setQueryData<Connection[]>(
-        ['connections', connector?.id?.toLowerCase()],
-        (oldConnections: Connection[] | undefined) => [...(oldConnections ?? []), newConnection]
-      );
+      // Update all connections cache (Used for custom connectors)
+      queryClient.setQueryData<Connection[]>(['allConnections'], (oldConnections: Connection[] | undefined) => [
+        ...(oldConnections ?? []),
+        newConnection,
+      ]);
+      // Update connector specific cache (Used for everything else)
+      queryClient.setQueryData<Connection[]>(['connections', connector?.id?.toLowerCase()], (oldConnections: Connection[] | undefined) => [
+        ...(oldConnections ?? []),
+        newConnection,
+      ]);
     },
     [connector?.id, queryClient]
   );


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and testing of a private VSIX (Visual Studio Code extension) package. The workflow is designed to run tests on different Node.js versions and build the VSIX package with specific configurations.

### Why having new pipeline
 The idea is to have a pipeline in which creates a VSIX that closely resembles a release version. This pipeline requires a branch name as input, runs the tests, and builds the VSIX in GitHub. As a result, we will be able to distribute a more solid private vsix


### New GitHub Actions Workflow:
* Added a new workflow named "Private vsix build" that includes two jobs: `test` and `build`. The `test` job runs on multiple Node.js versions (18.x, 20.x, 22.x) and caches the turbo build setup. The `build` job sets up Node.js version 20, replaces placeholders with the telemetry key, and packs the VSCode Designer Extension.