### PR TITLE
fix(designer): Render copied tooltip properly

### DIFF
--- a/e2e/designer/mock-copypastescope.spec.ts
+++ b/e2e/designer/mock-copypastescope.spec.ts
@@ -15,6 +15,8 @@ test(
     });
     await page.getByTestId('msla-copy-menu-option').click();
 
+    await expect(page.getByRole('tooltip', { name: 'Copied!' })).toBeVisible();
+    await expect(page.getByTestId('msla-tooltip-location-condition')).toBeVisible();
     await page.getByTestId('msla-plus-button-initialize_variable-condition').click();
     await page.getByTestId('msla-paste-button-initialize_variable-condition').click();
     await page.waitForTimeout(1000);

--- a/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -336,7 +336,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
           isLoadingDynamicData={isLoadingDynamicData}
           nodeIndex={nodeIndex}
         />
-        {showCopyCallout ? <CopyTooltip targetRef={ref} hideTooltip={clearCopyTooltip} /> : null}
+        {showCopyCallout ? <CopyTooltip id={id} targetRef={ref} hideTooltip={clearCopyTooltip} /> : null}
         <Handle className="node-handle bottom" type="source" position={sourcePosition} isConnectable={false} />
       </div>
       {showLeafComponents ? (

--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -334,7 +334,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
             setFocus={shouldFocus}
             nodeIndex={nodeIndex}
           />
-          {showCopyCallout ? <CopyTooltip targetRef={rootRef} hideTooltip={clearCopyCallout} /> : null}
+          {showCopyCallout ? <CopyTooltip id={scopeId} targetRef={rootRef} hideTooltip={clearCopyCallout} /> : null}
           {normalizedType === constants.NODE.TYPE.FOREACH && isMonitoringView ? renderLoopsPager : null}
           <Handle className="node-handle bottom" type="source" position={sourcePosition} isConnectable={false} />
         </div>

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/CopyTooltip.tsx
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/CopyTooltip.tsx
@@ -30,7 +30,11 @@ export const CopyTooltip = ({ targetRef: ref, location, hideTooltip, id }: CopyT
       relationship="description"
       visible={true}
     >
-      <div ref={locationRef} style={{ position: 'absolute', top: location?.y ?? 0, left: location?.x ?? 0 }} />
+      <div
+        data-testid="msla-tooltip-location"
+        ref={locationRef}
+        style={{ width: '1px', height: '1px', position: 'absolute', top: location?.y ?? 0, left: location?.x ?? 0 }}
+      />
     </Tooltip>
   );
 };

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/CopyTooltip.tsx
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/CopyTooltip.tsx
@@ -1,16 +1,16 @@
-/* eslint-disable react/display-name */
 import { Tooltip } from '@fluentui/react-components';
 import { useOnViewportChange } from '@xyflow/react';
-import { useMemo, useRef } from 'react';
+import { useRef } from 'react';
 import { useIntl } from 'react-intl';
 
 export interface CopyTooltipProps {
   targetRef?: React.RefObject<HTMLElement>;
   location?: { x: number; y: number };
   hideTooltip: () => void;
+  id: string;
 }
 
-export const CopyTooltip = ({ targetRef: ref, location, hideTooltip }: CopyTooltipProps) => {
+export const CopyTooltip = ({ targetRef: ref, location, hideTooltip, id }: CopyTooltipProps) => {
   useOnViewportChange({ onStart: () => hideTooltip() });
 
   const intl = useIntl();
@@ -22,21 +22,15 @@ export const CopyTooltip = ({ targetRef: ref, location, hideTooltip }: CopyToolt
 
   const locationRef = useRef<HTMLDivElement>(null);
 
-  const TooltipComponent = useMemo(
-    () => () => (
-      <Tooltip
-        positioning={{ target: (ref ?? locationRef)?.current, position: 'below', align: 'start' }}
-        content={copiedText}
-        relationship="description"
-        visible={true}
-      />
-    ),
-    [copiedText, ref]
-  );
-
   return (
-    <div ref={locationRef} style={{ position: 'absolute', top: location?.y ?? 0, left: location?.x ?? 0 }}>
-      <TooltipComponent />
-    </div>
+    <Tooltip
+      key={id}
+      positioning={{ target: (ref ?? locationRef)?.current ?? undefined, position: 'below', align: 'start' }}
+      content={copiedText}
+      relationship="description"
+      visible={true}
+    >
+      <div ref={locationRef} style={{ position: 'absolute', top: location?.y ?? 0, left: location?.x ?? 0 }} />
+    </Tooltip>
   );
 };

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/CopyTooltip.tsx
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/CopyTooltip.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from '@fluentui/react-components';
+import { replaceWhiteSpaceWithUnderscore } from '@microsoft/logic-apps-shared';
 import { useOnViewportChange } from '@xyflow/react';
 import { useRef } from 'react';
 import { useIntl } from 'react-intl';
@@ -31,7 +32,8 @@ export const CopyTooltip = ({ targetRef: ref, location, hideTooltip, id }: CopyT
       visible={true}
     >
       <div
-        data-testid="msla-tooltip-location"
+        data-testid={`msla-tooltip-location-${replaceWhiteSpaceWithUnderscore(id)}`}
+        data-automation-id={`msla-tooltip-location-${replaceWhiteSpaceWithUnderscore(id)}`}
         ref={locationRef}
         style={{ width: '1px', height: '1px', position: 'absolute', top: location?.y ?? 0, left: location?.x ?? 0 }}
       />

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/DesignerContextualMenu.tsx
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/DesignerContextualMenu.tsx
@@ -185,7 +185,7 @@ export const DesignerContextualMenu = () => {
         title={title}
         setOpen={(o) => setOpen(o)}
       />
-      {showCopyCallout ? <CopyTooltip location={menuData?.location} hideTooltip={clearCopyCallout} /> : null}
+      {showCopyCallout ? <CopyTooltip id={nodeId} location={menuData?.location} hideTooltip={clearCopyCallout} /> : null}
     </>
   );
 };

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/CopyTooltip.spec.tsx
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/CopyTooltip.spec.tsx
@@ -53,7 +53,7 @@ describe('CopyTooltip', () => {
 
     // Get the tooltip div and the location div
     const tooltipDiv = screen.getByRole('tooltip');
-    const tooltipLocationDiv = screen.getByTestId('msla-tooltip-location');
+    const tooltipLocationDiv = screen.getByTestId('msla-tooltip-location-test_id');
 
     // Assert that the tooltip and location div are rendered correctly
     expect(tooltipDiv).toBeInTheDocument();
@@ -69,7 +69,7 @@ describe('CopyTooltip', () => {
     const { baseElement } = renderComponent({ location });
 
     // Get the tooltip location div
-    const tooltipLocationDiv = screen.getByTestId('msla-tooltip-location');
+    const tooltipLocationDiv = screen.getByTestId('msla-tooltip-location-test_id');
 
     // Assert that the location div are rendered correctly
     expect(tooltipLocationDiv).toBeInTheDocument();

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/CopyTooltip.spec.tsx
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/CopyTooltip.spec.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+import { CopyTooltip, CopyTooltipProps } from '../CopyTooltip';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
+import React from 'react';
+
+vi.mock('@xyflow/react', () => ({
+  useOnViewportChange: vi.fn(),
+}));
+
+vi.mock('react-intl', async () => {
+  const actualIntl = await vi.importActual('react-intl');
+  return {
+    ...actualIntl,
+    useIntl: () => ({
+      formatMessage: vi.fn(() => 'Copied!'),
+    }),
+  };
+});
+
+describe('CopyTooltip', () => {
+  const hideTooltipMock = vi.fn();
+
+  beforeAll(() => {
+    const portalRoot = document.createElement('div');
+    portalRoot.setAttribute('id', 'root');
+    document.body.appendChild(portalRoot);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderComponent = (props: Partial<CopyTooltipProps> = {}) => {
+    const defaultProps: CopyTooltipProps = {
+      hideTooltip: hideTooltipMock,
+      id: 'test-id',
+      ...props,
+    };
+
+    return render(<CopyTooltip {...defaultProps} />);
+  };
+
+  it('should display the tooltip on hover', () => {
+    const copiedText = 'Copied!';
+    const location = { x: 100, y: 100 };
+
+    // Render the Tooltip component
+    const { baseElement } = renderComponent({ location });
+    expect(baseElement).toMatchSnapshot();
+
+    // Get the tooltip div and the location div
+    const tooltipDiv = screen.getByRole('tooltip');
+    const tooltipLocationDiv = screen.getByTestId('msla-tooltip-location');
+
+    // Assert that the tooltip and location div are rendered correctly
+    expect(tooltipDiv).toBeInTheDocument();
+    expect(screen.getByText(copiedText)).toBeVisible();
+    expect(tooltipLocationDiv).toBeInTheDocument();
+    expect(tooltipLocationDiv).toHaveStyle({ position: 'absolute', top: '100px', left: '100px' });
+  });
+
+  // it('should render the tooltip with the correct content', () => {
+  //   const { asFragment } = renderComponent();
+  //   expect(asFragment()).toMatchSnapshot();
+
+  //   // expect(screen.getByText('Copied!')).toBeInTheDocument();
+  // });
+
+  // it('should render the tooltip with the correct content', () => {
+  //   const { asFragment } = renderComponent();
+  //   expect(asFragment()).toMatchSnapshot();
+
+  //   expect(screen.getByText('Copied!')).toBeInTheDocument();
+  // });
+
+  // it('should call hideTooltip on viewport change', () => {
+  //   renderComponent();
+  //   expect(useOnViewportChange).toHaveBeenCalledWith({ onStart: hideTooltipMock });
+  // });
+
+  // it('should position the tooltip based on the provided location', () => {
+  //   const location = { x: 100, y: 200 };
+  //   renderComponent({ location });
+
+  //   const tooltipDiv = screen.getByRole('tooltip').parentElement;
+  //   expect(tooltipDiv).toHaveStyle({ position: 'absolute', top: '200px', left: '100px' });
+  // });
+
+  // it('should use the targetRef if provided', () => {
+  //   const targetRef = { current: document.createElement('div') } as React.RefObject<HTMLElement>;
+  //   renderComponent({ targetRef });
+
+  //   expect(screen.getByRole('tooltip').parentElement).toBe(targetRef.current);
+  // });
+
+  // it('should default to locationRef if targetRef is not provided', () => {
+  //   renderComponent();
+
+  //   const tooltipDiv = screen.getByRole('tooltip').parentElement;
+  //   expect(tooltipDiv).toHaveStyle({ position: 'absolute', top: '0px', left: '0px' });
+  // });
+
+  // // it('should call hideTooltip on viewport change', () => {
+  // //   const copyTooltip = renderComponent();
+  // //   expect(copyTooltip).toMatchSnapshot();
+
+  // //   expect(useOnViewportChange).toHaveBeenCalledWith({ onStart: hideTooltipMock });
+  // // });
+
+  // it('should position the tooltip based on the provided location', () => {
+  //   const location = { x: 100, y: 200 };
+  //   const { asFragment } = renderComponent({location});
+  //   expect(asFragment()).toMatchSnapshot();
+
+  //   const tooltipDiv = screen.getByRole('tooltip');
+  //   console.log('charlie', tooltipDiv);
+  //   expect(tooltipDiv).toHaveStyle({ position: 'absolute', top: '200px', left: '100px' });
+  // });
+
+  // // it('should use the targetRef if provided', () => {
+  // //   const targetRef = { current: document.createElement('div') } as React.RefObject<HTMLElement>;
+  // //   renderComponent({ targetRef });
+
+  // //   expect(screen.getByRole('tooltip').parentElement).toBe(targetRef.current);
+  // // });
+
+  // // it('should default to locationRef if targetRef is not provided', () => {
+  // //   renderComponent();
+
+  // //   const tooltipDiv = screen.getByRole('tooltip').parentElement;
+  // //   expect(tooltipDiv).toHaveStyle({ position: 'absolute', top: '0px', left: '0px' });
+  // // });
+});

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/__snapshots__/CopyTooltip.spec.tsx.snap
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/__snapshots__/CopyTooltip.spec.tsx.snap
@@ -1,38 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CopyTooltip > should display the tooltip on hover 1`] = `
-<body>
-  <div
-    id="portal-root"
-  />
-  <div>
-    <div
-      aria-describedby="tooltip-r0"
-      data-testid="msla-tooltip-location"
-      style="width: 1px; height: 1px; position: absolute; top: 100px; left: 100px;"
-    />
-    <span
-      hidden=""
-    />
-  </div>
-  <div
-    class="___1uxlrft_djprso0 f1euv43f f15twtuk f1vgc2s3 f1e31b4d f494woh"
-    data-portal-node="true"
-    dir="ltr"
-  >
-    <div
-      class="fui-Tooltip__content ___1iilip3_omhya70 ftgm304 f1ewtqcl f132xexn f158kwzp fk6fouc fy9rknc fwrc4pm fokg9q4 ft85np5 f9ggezi f1bzqsji fxugw4r f19n0e5 fxeb0a7"
-      id="tooltip-r0"
-      role="tooltip"
-      style="position: fixed; left: 0px; top: 0px; margin: 0px;"
-    >
-      Copied!
-    </div>
-  </div>
-</body>
-`;
-
-exports[`CopyTooltip > should display the tooltip on hover 2`] = `
+exports[`CopyTooltip > should position the tooltip based on the provided location 1`] = `
 <body>
   <div
     id="root"
@@ -55,6 +23,38 @@ exports[`CopyTooltip > should display the tooltip on hover 2`] = `
     <div
       class="fui-Tooltip__content ___1iilip3_omhya70 ftgm304 f1ewtqcl f132xexn f158kwzp fk6fouc fy9rknc fwrc4pm fokg9q4 ft85np5 f9ggezi f1bzqsji fxugw4r f19n0e5 fxeb0a7"
       id="tooltip-r1"
+      role="tooltip"
+      style="position: fixed; left: 0px; top: 0px; margin: 0px;"
+    >
+      Copied!
+    </div>
+  </div>
+</body>
+`;
+
+exports[`CopyTooltip > should render the tooltip with the correct content 1`] = `
+<body>
+  <div
+    id="root"
+  />
+  <div>
+    <div
+      aria-describedby="tooltip-r0"
+      data-testid="msla-tooltip-location"
+      style="width: 1px; height: 1px; position: absolute; top: 100px; left: 100px;"
+    />
+    <span
+      hidden=""
+    />
+  </div>
+  <div
+    class="___1uxlrft_djprso0 f1euv43f f15twtuk f1vgc2s3 f1e31b4d f494woh"
+    data-portal-node="true"
+    dir="ltr"
+  >
+    <div
+      class="fui-Tooltip__content ___1iilip3_omhya70 ftgm304 f1ewtqcl f132xexn f158kwzp fk6fouc fy9rknc fwrc4pm fokg9q4 ft85np5 f9ggezi f1bzqsji fxugw4r f19n0e5 fxeb0a7"
+      id="tooltip-r0"
       role="tooltip"
       style="position: fixed; left: 0px; top: 0px; margin: 0px;"
     >

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/__snapshots__/CopyTooltip.spec.tsx.snap
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/__snapshots__/CopyTooltip.spec.tsx.snap
@@ -1,0 +1,65 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CopyTooltip > should display the tooltip on hover 1`] = `
+<body>
+  <div
+    id="portal-root"
+  />
+  <div>
+    <div
+      aria-describedby="tooltip-r0"
+      data-testid="msla-tooltip-location"
+      style="width: 1px; height: 1px; position: absolute; top: 100px; left: 100px;"
+    />
+    <span
+      hidden=""
+    />
+  </div>
+  <div
+    class="___1uxlrft_djprso0 f1euv43f f15twtuk f1vgc2s3 f1e31b4d f494woh"
+    data-portal-node="true"
+    dir="ltr"
+  >
+    <div
+      class="fui-Tooltip__content ___1iilip3_omhya70 ftgm304 f1ewtqcl f132xexn f158kwzp fk6fouc fy9rknc fwrc4pm fokg9q4 ft85np5 f9ggezi f1bzqsji fxugw4r f19n0e5 fxeb0a7"
+      id="tooltip-r0"
+      role="tooltip"
+      style="position: fixed; left: 0px; top: 0px; margin: 0px;"
+    >
+      Copied!
+    </div>
+  </div>
+</body>
+`;
+
+exports[`CopyTooltip > should display the tooltip on hover 2`] = `
+<body>
+  <div
+    id="root"
+  />
+  <div>
+    <div
+      aria-describedby="tooltip-r1"
+      data-testid="msla-tooltip-location"
+      style="width: 1px; height: 1px; position: absolute; top: 100px; left: 100px;"
+    />
+    <span
+      hidden=""
+    />
+  </div>
+  <div
+    class="___1uxlrft_djprso0 f1euv43f f15twtuk f1vgc2s3 f1e31b4d f494woh"
+    data-portal-node="true"
+    dir="ltr"
+  >
+    <div
+      class="fui-Tooltip__content ___1iilip3_omhya70 ftgm304 f1ewtqcl f132xexn f158kwzp fk6fouc fy9rknc fwrc4pm fokg9q4 ft85np5 f9ggezi f1bzqsji fxugw4r f19n0e5 fxeb0a7"
+      id="tooltip-r1"
+      role="tooltip"
+      style="position: fixed; left: 0px; top: 0px; margin: 0px;"
+    >
+      Copied!
+    </div>
+  </div>
+</body>
+`;

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/__snapshots__/CopyTooltip.spec.tsx.snap
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/__snapshots__/CopyTooltip.spec.tsx.snap
@@ -8,7 +8,8 @@ exports[`CopyTooltip > should position the tooltip based on the provided locatio
   <div>
     <div
       aria-describedby="tooltip-r1"
-      data-testid="msla-tooltip-location"
+      data-automation-id="msla-tooltip-location-test_id"
+      data-testid="msla-tooltip-location-test_id"
       style="width: 1px; height: 1px; position: absolute; top: 100px; left: 100px;"
     />
     <span
@@ -40,7 +41,8 @@ exports[`CopyTooltip > should render the tooltip with the correct content 1`] = 
   <div>
     <div
       aria-describedby="tooltip-r0"
-      data-testid="msla-tooltip-location"
+      data-automation-id="msla-tooltip-location-test_id"
+      data-testid="msla-tooltip-location-test_id"
       style="width: 1px; height: 1px; position: absolute; top: 100px; left: 100px;"
     />
     <span


### PR DESCRIPTION
## Type of Change

* [X] Bug fix

Fixes - #6076 

## Current Behavior

Tooltip wasn't rendering properly in vscode as well as in portal. The tooltip was getting rendered at the top left corner of the screen instead of the target element.

## New Behavior

Tooltip is now rendering in a location related to the target element. In both cases when using the contextual menu and when using `Ctrl`+`C`

## Impact of Change

Cosmetic change non functionality affected 

## Test Plan

Unit tests - Added to the CopyTooltip component
<img width="2545" alt="Screenshot 2025-01-24 at 11 45 58 AM" src="https://github.com/user-attachments/assets/464e3d31-3ed7-4194-bd7c-2ec82b02a110" />
E2E - Updated e2e tests


## Screenshots or Videos (if applicable)

### New behavior VSCode

https://github.com/user-attachments/assets/04a9f16d-00fe-4807-aaaa-2419e1a4b8e9

### New behavior standalone
https://github.com/user-attachments/assets/3c483780-bef5-4452-929a-ee1f373246ab


