### PR TITLE
fix(vscode): Correct toPascalCase regex

### DIFF
--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -96,5 +96,5 @@ export const escapeString = (input: string): string => {
  * @returns {string} - The PascalCase version of the string.
  */
 export function toPascalCase(str: string): string {
-  return str.replace(/(^\w|_\w)/g, (match) => match.replace('_', '').toUpperCase());
+  return str.replace(/(?:_+|^)(\w)/g, (match, p1) => p1.toUpperCase());
 }


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Current regex fails on test string "_example_string" with leading underscores

## New Behavior

New regex accounts for leading underscores

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Addressed in existing unit tests

## Screenshots or Videos (if applicable)

N/A
