### PR TITLE
fix(designer): revert No longer escapes characters in token expressions

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
@@ -3,7 +3,7 @@ import { isEmpty } from '../../../dictionary/expandeddictionary';
 import type { ValueSegment } from '../../models/parameter';
 import { createLiteralValueSegment, insertQutationForStringType } from './helper';
 import { convertSegmentsToString } from './parsesegments';
-import { escapeString } from '@microsoft/logic-apps-shared';
+import { isNumber, isBoolean, escapeString } from '@microsoft/logic-apps-shared';
 
 export interface KeyValueItem {
   id: string;
@@ -24,7 +24,7 @@ export const convertKeyValueItemToSegments = (items: KeyValueItem[], keyType?: s
 
   for (let index = 0; index < itemsToConvert.length; index++) {
     const { key, value } = itemsToConvert[index];
-
+    // todo: we should have some way of handle formatting better
     const convertedKeyType = convertValueType(key, keyType);
     const updatedKey = key.map((segment) => {
       return {
@@ -41,7 +41,6 @@ export const convertKeyValueItemToSegments = (items: KeyValueItem[], keyType?: s
       };
     });
 
-    // wrap key and value with quotation marks if they are string type
     insertQutationForStringType(parsedItems, convertedKeyType);
     parsedItems.push(...updatedKey);
     insertQutationForStringType(parsedItems, convertedKeyType);
@@ -61,17 +60,8 @@ export const convertValueType = (value: ValueSegment[], type?: string): string |
     return type;
   }
   const stringSegments = convertSegmentsToString(value).trim();
-  if (isNonString(stringSegments)) {
-    return type;
-  }
-  return constants.SWAGGER.TYPE.STRING;
-};
+  const isExpressionOrObject = (stringSegments.startsWith('@{') || stringSegments.startsWith('{')) && stringSegments.endsWith('}');
+  const isKnownType = isExpressionOrObject || isNumber(stringSegments) || isBoolean(stringSegments) || /^\[.*\]$/.test(stringSegments);
 
-const isNonString = (value: string): boolean => {
-  try {
-    const parsedValue = JSON.parse(value);
-    return parsedValue === null || Array.isArray(parsedValue) || typeof parsedValue !== 'string';
-  } catch {
-    return false;
-  }
+  return isKnownType ? type : constants.SWAGGER.TYPE.STRING;
 };

--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
@@ -411,7 +411,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{\n  "newUnb3_1": @{xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')}\n}'
+        '{"newUnb3_1":"@xpath(xml(triggerBody()), \'string(/*[local-name()=\\"DynamicsSOCSV\\"])\')"}'
       );
     });
 
@@ -485,7 +485,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{\n  "newUnb3_1": "@{xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')}"\n}'
+        '{"newUnb3_1":"@{xpath(xml(triggerBody()), \'string(/*[local-name()=\\"DynamicsSOCSV\\"])\')}"}'
       );
     });
 

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -18,7 +18,6 @@ import {
   isNullOrUndefined,
   startsWith,
   UnsupportedException,
-  escapeString,
 } from '@microsoft/logic-apps-shared';
 
 /**
@@ -58,7 +57,7 @@ export class ValueSegmentConvertor {
    * @arg {any} value - The value.
    * @return {ValueSegment[]}
    */
-  public convertToValueSegments(value: any, parameterType?: string): ValueSegment[] {
+  public convertToValueSegments(value: any, parameterType: string = constants.SWAGGER.TYPE.ANY): ValueSegment[] {
     if (isNullOrUndefined(value)) {
       return [createLiteralValueSegment('')];
     }
@@ -108,12 +107,11 @@ export class ValueSegmentConvertor {
     return [this._createLiteralValueSegment(section)];
   }
 
-  private _convertStringToValueSegments(value: string, parameterType?: string): ValueSegment[] {
+  private _convertStringToValueSegments(value: string, parameterType: string): ValueSegment[] {
     if (isTemplateExpression(value)) {
       const expression = ExpressionParser.parseTemplateExpression(value);
       return this._convertTemplateExpressionToValueSegments(expression);
     }
-
     const isSpecialValue = ['true', 'false', 'null'].includes(value) || /^-?\d+$/.test(value);
     const stringValue = parameterType === constants.SWAGGER.TYPE.ANY && isSpecialValue ? `"${value}"` : value;
     return [this._createLiteralValueSegment(stringValue)];
@@ -188,11 +186,10 @@ export class ValueSegmentConvertor {
       return dynamicContentTokenSegment;
     }
     // Note: We need to get the expression value if this is a sub expression resulted from uncasting.
-    const value = escapeString(
+    const value =
       expression.startPosition === 0
         ? expression.expression
-        : expression.expression.substring(expression.startPosition, expression.endPosition)
-    );
+        : expression.expression.substring(expression.startPosition, expression.endPosition);
     return this._createExpressionTokenValueSegment(value, expression);
   }
 

--- a/libs/designer/src/lib/core/utils/validation.ts
+++ b/libs/designer/src/lib/core/utils/validation.ts
@@ -429,10 +429,16 @@ const validateFloatingActionMenuOutputsEditor = (editorViewModel: FloatingAction
 };
 
 function shouldValidateJSON(expressions: ValueSegment[]): boolean {
-  const firstSegmentValue = expressions[0]?.token?.value;
-  return firstSegmentValue
-    ? firstSegmentValue.startsWith('@@') || firstSegmentValue.startsWith('@{') || !firstSegmentValue.startsWith('@')
-    : true;
+  const shouldValidate = true;
+
+  if (shouldValidate && expressions.length) {
+    const firstSegmentValue = expressions[0].token?.value;
+    if (firstSegmentValue) {
+      return startsWith(firstSegmentValue, '@@') || startsWith(firstSegmentValue, '@{') || !startsWith(firstSegmentValue, '@');
+    }
+  }
+
+  return shouldValidate;
 }
 
 export function parameterHasOnlyTokenBinding(parameterValue: ValueSegment[]): boolean {

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
@@ -1,4 +1,4 @@
-import { escapeString, idDisplayCase, labelCase, canStringBeConverted, unescapeString } from '../stringFunctions';
+import { escapeString, idDisplayCase, labelCase, canStringBeConverted } from '../stringFunctions';
 import { describe, it, expect } from 'vitest';
 describe('label_case', () => {
   it('should replace _ with spaces', () => {
@@ -28,6 +28,26 @@ describe('idDisplayCase', () => {
   });
 });
 
+describe('escapeString', () => {
+  it('should correctly escape backslashes', () => {
+    expect(escapeString('\\')).toEqual('\\\\');
+    expect(escapeString('Test\\Test')).toEqual('Test\\\\Test');
+  });
+
+  it('should correctly escape newline characters', () => {
+    expect(escapeString('\n')).toEqual('\\n');
+    expect(escapeString('Test\nTest')).toEqual('Test\\nTest');
+  });
+
+  it('should correctly escape backslashes and newline characters together', () => {
+    expect(escapeString('\\\n')).toEqual('\\\\\\n');
+    expect(escapeString('Test\\\nTest')).toEqual('Test\\\\\\nTest');
+  });
+
+  it('should handle an empty string', () => {
+    expect(escapeString('')).toEqual('');
+  });
+});
 describe('canStringBeConverted', () => {
   it('should return false for non-string inputs', () => {
     expect(canStringBeConverted(123 as any)).toBe(false);
@@ -67,93 +87,5 @@ describe('canStringBeConverted', () => {
     expect(canStringBeConverted('not an array')).toBe(false);
     expect(canStringBeConverted('{ "key": "value" }')).toBe(false);
     expect(canStringBeConverted('{"a", "b", "c"}')).toBe(false);
-  });
-});
-
-describe('unescapeString', () => {
-  it('unescapes newline characters', () => {
-    const input = 'Hello\\nWorld';
-    const expectedOutput = 'Hello\nWorld';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it('unescapes carriage return characters', () => {
-    const input = 'Hello\\rWorld';
-    const expectedOutput = 'Hello\rWorld';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it('unescapes tab characters', () => {
-    const input = 'Hello\\tWorld';
-    const expectedOutput = 'Hello\tWorld';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it('unescapes vertical tab characters', () => {
-    const input = 'Hello\\vWorld';
-    const expectedOutput = 'Hello\vWorld';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it('returns the same string if there are no escape sequences', () => {
-    const input = 'Hello World';
-    const expectedOutput = 'Hello World';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-});
-
-describe('escapeString', () => {
-  it('escapes newline characters', () => {
-    const input = 'Hello\nWorld';
-    const expectedOutput = 'Hello\\nWorld';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it('escapes carriage return characters', () => {
-    const input = 'Hello\rWorld';
-    const expectedOutput = 'Hello\\rWorld';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it('escapes tab characters', () => {
-    const input = 'Hello\tWorld';
-    const expectedOutput = 'Hello\\tWorld';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it('escapes vertical tab characters', () => {
-    const input = 'Hello\vWorld';
-    const expectedOutput = 'Hello\\vWorld';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it('returns the same string if there are no special characters', () => {
-    const input = 'Hello World';
-    const expectedOutput = 'Hello World';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it('should correctly escape newline characters', () => {
-    expect(escapeString('\n')).toEqual('\\n');
-    expect(escapeString('Test\nTest')).toEqual('Test\\nTest');
-  });
-
-  it('should correctly escape backslashes and newline characters together', () => {
-    expect(escapeString('\\\n')).toEqual('\\\\n');
-    expect(escapeString('Test\\\nTest')).toEqual('Test\\\\nTest');
-  });
-
-  it('should handle an empty string', () => {
-    expect(escapeString('')).toEqual('');
   });
 });

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -30,6 +30,10 @@ export const splitFileName = (fileName: string) => {
   return [fileName.slice(0, splitFileName), fileName.slice(splitFileName)];
 };
 
+export const escapeString = (s: string): string => {
+  return s.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
+};
+
 export const canStringBeConverted = (s: string): boolean => {
   if (typeof s !== 'string' || s.trim() === '') {
     return false;
@@ -52,38 +56,4 @@ export const createIdCopy = (id: string) => `${id}-copy`;
 
 export const cleanResourceId = (resourceId?: string): string => {
   return resourceId?.startsWith('/') ? resourceId : `/${resourceId}`;
-};
-
-export const unescapeString = (input: string): string => {
-  return input.replace(/\\([nrtv])/g, (_match, char) => {
-    switch (char) {
-      case 'n':
-        return '\n';
-      case 'r':
-        return '\r';
-      case 't':
-        return '\t';
-      case 'v':
-        return '\v';
-      default:
-        return char;
-    }
-  });
-};
-
-export const escapeString = (input: string): string => {
-  return input.replace(/[\n\r\t\v]/g, (char) => {
-    switch (char) {
-      case '\n':
-        return '\\n';
-      case '\r':
-        return '\\r';
-      case '\t':
-        return '\\t';
-      case '\v':
-        return '\\v';
-      default:
-        return char;
-    }
-  });
 };


### PR DESCRIPTION
…ions (#6131)"

This reverts commit a3f6e31c76e630f32c3fac7bb60f1690f6cc0fca.

## Type of Change

* [ ] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
