### PR TITLE
fix(vscode): Handle extension initialization when there aren't logic apps projects

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createCodeless/createCodeless.ts
+++ b/apps/vs-code-designer/src/app/commands/createCodeless/createCodeless.ts
@@ -10,7 +10,7 @@ import { getWorkspaceSetting } from '../../utils/vsCodeConfig/settings';
 import { verifyInitForVSCode } from '../../utils/vsCodeConfig/verifyInitForVSCode';
 import { getContainingWorkspace, getWorkspaceFolder } from '../../utils/workspace';
 import { WorkflowStateTypeStep } from './createCodelessSteps/WorkflowStateTypeStep';
-import { isString } from '@microsoft/logic-apps-shared';
+import { isNullOrUndefined, isString } from '@microsoft/logic-apps-shared';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzureWizard } from '@microsoft/vscode-azext-utils';
 import type { IFunctionWizardContext, FuncVersion } from '@microsoft/vscode-extension-logic-apps';
@@ -32,7 +32,11 @@ export async function createCodeless(
   workspacePath = isString(workspacePath) ? workspacePath : undefined;
   if (workspacePath === undefined) {
     workspaceFolder = await getWorkspaceFolder(context);
-    workspacePath = isString(workspaceFolder) ? workspaceFolder : workspaceFolder.uri.fsPath;
+    workspacePath = isNullOrUndefined(workspaceFolder)
+      ? undefined
+      : isString(workspaceFolder)
+        ? workspaceFolder
+        : workspaceFolder.uri.fsPath;
   } else {
     workspaceFolder = getContainingWorkspace(workspacePath);
   }

--- a/apps/vs-code-designer/src/app/commands/dataMapper/dataMapper.ts
+++ b/apps/vs-code-designer/src/app/commands/dataMapper/dataMapper.ts
@@ -18,7 +18,8 @@ export const createNewDataMapCmd = async (context: IActionContext) => {
       context,
       localize('openLogicAppsProject', 'You must have a logic apps project open to use the Data Mapper.')
     );
-    const projectPath: string | undefined = await verifyAndPromptToCreateProject(context, workspaceFolder.uri.fsPath);
+    const projectPath: string | undefined =
+      !isNullOrUndefined(workspaceFolder) && (await verifyAndPromptToCreateProject(context, workspaceFolder?.uri?.fsPath));
     if (!projectPath) {
       return;
     }
@@ -35,7 +36,8 @@ export const loadDataMapFileCmd = async (context: IActionContext, uri: Uri) => {
       context,
       localize('openLogicAppsProject', 'You must have a logic apps project open to use the Data Mapper.')
     );
-    const projectPath: string | undefined = await verifyAndPromptToCreateProject(context, workspaceFolder.uri.fsPath);
+    const projectPath: string | undefined =
+      !isNullOrUndefined(workspaceFolder) && (await verifyAndPromptToCreateProject(context, workspaceFolder?.uri?.fsPath));
     if (!projectPath) {
       return;
     }

--- a/apps/vs-code-designer/src/app/commands/workflows/configureWebhookRedirectEndpoint/configureWebhookRedirectEndpoint.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/configureWebhookRedirectEndpoint/configureWebhookRedirectEndpoint.ts
@@ -22,7 +22,7 @@ export async function configureWebhookRedirectEndpoint(context: IActionContext, 
     workspaceFolder = await getWorkspaceFolder(context);
   }
 
-  const workspacePath = workspaceFolder.uri.fsPath;
+  const workspacePath = workspaceFolder?.uri?.fsPath;
   const projectPath = (await tryGetLogicAppProjectRoot(context, workspacePath)) || workspacePath;
   const localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName));
   const redirectEndpoint: string = localSettings.Values[webhookRedirectHostUri] || '';

--- a/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
@@ -20,7 +20,7 @@ import { ext } from '../../../extensionVariables';
 import { DependencyVersion, Platform } from '../../../constants';
 import { executeCommand } from '../funcCoreTools/cpUtils';
 import { getNpmCommand } from '../nodeJs/nodeJsVersion';
-import { getGlobalSetting, getWorkspaceSetting, updateGlobalSetting } from '../vsCodeConfig/settings';
+import { getGlobalSetting, getWorkspaceSetting } from '../vsCodeConfig/settings';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { isNodeJsInstalled } from '../../commands/nodeJs/validateNodeJsInstalled';
 

--- a/apps/vs-code-designer/src/app/utils/__test__/workspace.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/workspace.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import * as vscode from 'vscode';
+import * as workspaceUtils from '../workspace';
+import { promptOpenProject, tryGetLogicAppProjectRoot } from '../verifyIsProject';
+
+vi.mock('../verifyIsProject');
+
+describe('workspaceUtils.getWorkspaceFolder', () => {
+  const originalWorkspace = { ...vscode.workspace };
+
+  const mockContext: any = {
+    telemetry: { properties: {}, measurements: {} },
+    errorHandling: { issueProperties: {} },
+    ui: {
+      showQuickPick: vi.fn(),
+      showOpenDialog: vi.fn(),
+      onDidFinishPrompt: vi.fn(),
+      showInputBox: vi.fn(),
+      showWarningMessage: vi.fn(),
+    },
+  };
+
+  const mockFolder = (fsPath: string): vscode.WorkspaceFolder => ({ uri: { fsPath } }) as vscode.WorkspaceFolder;
+
+  beforeEach(() => {
+    // Reset workspace state and mocks before each test
+    vi.restoreAllMocks();
+    (vscode.workspace as any).workspaceFolders = undefined;
+    (vscode.workspace as any).workspaceFile = undefined;
+  });
+
+  afterEach(() => {
+    // Restore original workspace
+    Object.assign(vscode, { workspace: originalWorkspace });
+  });
+
+  it('should prompt to open project if no workspace folders are open', async () => {
+    const folder1 = mockFolder('/path/one');
+    (vscode.workspace as any).workspaceFolders = [];
+
+    const promptOpenProjectSpy = vi.fn(() => {
+      (vscode.workspace as any).workspaceFolders = [folder1];
+    });
+
+    (promptOpenProject as Mock).mockImplementation(promptOpenProjectSpy);
+
+    await workspaceUtils.getWorkspaceFolder(mockContext);
+    expect(promptOpenProjectSpy).toHaveBeenCalled();
+  });
+
+  it('should prompt to open project if workspace folders are undefined', async () => {
+    const folder1 = mockFolder('/path/one');
+    (vscode.workspace as any).workspaceFolders = undefined;
+
+    const promptOpenProjectSpy = vi.fn(() => {
+      (vscode.workspace as any).workspaceFolders = [folder1];
+    });
+
+    (promptOpenProject as Mock).mockImplementation(promptOpenProjectSpy);
+
+    await workspaceUtils.getWorkspaceFolder(mockContext);
+    expect(promptOpenProjectSpy).toHaveBeenCalled();
+  });
+
+  it('should return the only workspace folder if there is only one', async () => {
+    const folder1 = mockFolder('/path/one');
+    (vscode.workspace as any).workspaceFolders = [folder1];
+
+    const promptOpenProjectSpy = vi.fn(() => {
+      (vscode.workspace as any).workspaceFolders = [folder1];
+    });
+
+    (promptOpenProject as Mock).mockImplementation(promptOpenProjectSpy);
+
+    const result = await workspaceUtils.getWorkspaceFolder(mockContext);
+    expect(result).toEqual(folder1);
+    expect(promptOpenProjectSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return the only workspace folder if there is only one after prompting', async () => {
+    const folder1 = mockFolder('/path/one');
+    (vscode.workspace as any).workspaceFolders = undefined;
+
+    const promptOpenProjectSpy = vi.fn(() => {
+      (vscode.workspace as any).workspaceFolders = [folder1];
+    });
+
+    (promptOpenProject as Mock).mockImplementation(promptOpenProjectSpy);
+
+    const result = await workspaceUtils.getWorkspaceFolder(mockContext);
+    expect(result).toEqual(folder1);
+  });
+
+  it('should return undefined if no logic app project is found among multiple folders', async () => {
+    const folder1 = mockFolder('/path/one');
+    const folder2 = mockFolder('/path/two');
+    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+
+    const tryGetLogicAppProjectRootSpy = vi.fn(() => {
+      return undefined;
+    });
+    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
+
+    const result = await workspaceUtils.getWorkspaceFolder(mockContext);
+    expect(tryGetLogicAppProjectRootSpy).toHaveBeenCalledTimes(2);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the only logic app project if there is only one', async () => {
+    const folder1 = mockFolder('/logic/path');
+    const folder2 = mockFolder('/nonlogic/path');
+    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+
+    // For folder1 return a valid project root, for folder2 return undefined.
+    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => {
+      return folder.uri.fsPath === '/logic/path' ? folder.uri.fsPath : undefined;
+    });
+    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
+
+    const result = await workspaceUtils.getWorkspaceFolder(mockContext);
+
+    expect(result).toBe('/logic/path');
+    expect(tryGetLogicAppProjectRootSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return the first logic app project if skipPromptOnMultipleFolders is true', async () => {
+    const folder1 = mockFolder('/logic/path1');
+    const folder2 = mockFolder('/logic/path2');
+    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+
+    // Both folders return a valid project root.
+    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => {
+      return folder.uri.fsPath;
+    });
+    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
+
+    const result = await workspaceUtils.getWorkspaceFolder(mockContext, undefined, true);
+    // Expect the first folder (or its project root) to be returned.
+    expect(result).toBe('/logic/path1');
+    expect(tryGetLogicAppProjectRootSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should prompt the user to select a logic app project if there are multiple', async () => {
+    const folder1 = mockFolder('/logic/path1');
+    const folder2 = mockFolder('/logic/path2');
+    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+    // Both folders are logic app projects.
+    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => {
+      return folder.uri.fsPath;
+    });
+    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
+
+    const quickPickSpy = vi.spyOn(mockContext.ui, 'showQuickPick').mockResolvedValue({ data: folder2 });
+
+    const result = await workspaceUtils.getWorkspaceFolder(mockContext);
+    expect(quickPickSpy).toHaveBeenCalled();
+    expect(result).toBe(folder2);
+  });
+
+  it('should throw UserCancelledError if user cancels the prompt', async () => {
+    const folder1 = mockFolder('/logic/path1');
+    const folder2 = mockFolder('/logic/path2');
+    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+
+    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => {
+      return folder.uri.fsPath;
+    });
+    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
+    vi.spyOn(mockContext.ui, 'showQuickPick').mockResolvedValue(undefined);
+
+    await expect(workspaceUtils.getWorkspaceFolder(mockContext)).rejects.toThrowError();
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
+++ b/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
@@ -5,7 +5,7 @@
 import { extensionBundleId, hostFileName, extensionCommand } from '../../constants';
 import { localize } from '../../localize';
 import { getWorkspaceSetting, updateWorkspaceSetting } from './vsCodeConfig/settings';
-import { isString } from '@microsoft/logic-apps-shared';
+import { isNullOrUndefined, isString } from '@microsoft/logic-apps-shared';
 import type { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as path from 'path';
@@ -57,7 +57,10 @@ export async function isLogicAppProject(folderPath: string): Promise<boolean> {
  * Checks root folder and subFolders one level down
  * If any logic app projects are found return true.
  */
-export async function isLogicAppProjectInRoot(workspaceFolder: WorkspaceFolder | string): Promise<boolean | undefined> {
+export async function isLogicAppProjectInRoot(workspaceFolder: WorkspaceFolder | string | undefined): Promise<boolean | undefined> {
+  if (isNullOrUndefined(workspaceFolder)) {
+    return false;
+  }
   const subpath: string | undefined = getWorkspaceSetting(projectSubpathKey, workspaceFolder);
   const folderPath = isString(workspaceFolder) ? workspaceFolder : workspaceFolder.uri.fsPath;
   if (!subpath) {
@@ -93,9 +96,12 @@ export async function isLogicAppProjectInRoot(workspaceFolder: WorkspaceFolder |
  */
 export async function tryGetLogicAppProjectRoot(
   context: IActionContext,
-  workspaceFolder: WorkspaceFolder | string,
+  workspaceFolder: WorkspaceFolder | string | undefined,
   suppressPrompt = false
 ): Promise<string | undefined> {
+  if (isNullOrUndefined(workspaceFolder)) {
+    return undefined;
+  }
   let subpath: string | undefined = getWorkspaceSetting(projectSubpathKey, workspaceFolder);
   const folderPath = isString(workspaceFolder) ? workspaceFolder : workspaceFolder.uri.fsPath;
   if (!subpath) {

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -106,7 +106,7 @@ export async function getWorkspaceFolder(
   context: IActionContext,
   message?: string,
   skipPromptOnMultipleFolders?: boolean
-): Promise<vscode.WorkspaceFolder> {
+): Promise<vscode.WorkspaceFolder | undefined> {
   const promptMessage: string = message ?? localize('noWorkspaceWarning', 'You must have a project open to create a workflow.');
   let folder: vscode.WorkspaceFolder | undefined;
   if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
@@ -122,6 +122,10 @@ export async function getWorkspaceFolder(
       if (projectRoot) {
         logicAppsWorkspaces.push(projectRoot);
       }
+    }
+
+    if (logicAppsWorkspaces.length === 0) {
+      return undefined;
     }
 
     if (logicAppsWorkspaces.length === 1) {

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -106,7 +106,7 @@ export async function getWorkspaceFolder(
   context: IActionContext,
   message?: string,
   skipPromptOnMultipleFolders?: boolean
-): Promise<vscode.WorkspaceFolder | undefined> {
+): Promise<vscode.WorkspaceFolder | string | undefined> {
   const promptMessage: string = message ?? localize('noWorkspaceWarning', 'You must have a project open to create a workflow.');
   let folder: vscode.WorkspaceFolder | undefined;
   if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -37,4 +37,7 @@ vi.mock('axios');
 
 vi.mock('vscode', () => ({
   window: {},
+  workspace: {
+    workspaceFolders: [],
+  },
 }));


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

Current behavior pops the following error `Cannot read properties of undefined (reading 'uri')` when the vscode extension is initialized in a workspace that doesn't have any Logic App projects in it.

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

New behavior will handle properly the initialization of the vscode extension for workspaces in which there are no Logic App projects in it

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

I added unit test for this. This will help us control this scenario in the future and if there are any updates on the logic. 


## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->

Fixing scenarios in which the workspaces don't have Logic Apps projects in it 
https://github.com/Azure/LogicAppsUX/issues/6274#issuecomment-2623119932

<img width="1242" alt="Screenshot 2025-02-03 at 10 26 19 AM" src="https://github.com/user-attachments/assets/5bb67720-a309-4412-9f8e-47edfe538219" />

