### PR TITLE
fix(Designer): hotfix/5.35 - Expression fix

### DIFF
--- a/e2e/designer/tokens/escapeExpressionTokens.spec.ts
+++ b/e2e/designer/tokens/escapeExpressionTokens.spec.ts
@@ -1,0 +1,46 @@
+import test, { expect } from '@playwright/test';
+import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+
+test.describe(
+  'Escape Expression Tokens Tests',
+  {
+    tag: '@mock',
+  },
+  async () => {
+    test('Expressions should be able to use escape characters and serialize', async ({ page }) => {
+      await page.goto('/');
+      await GoToMockWorkflow(page, 'Panel');
+      await page.getByLabel('HTTP operation, HTTP connector').click();
+      await page.getByTitle('Enter request content').getByRole('paragraph').click();
+      await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-expression"]').click();
+      const viewLine = page.locator('.view-line').first();
+      await viewLine.click();
+      // full expression not typed out because Monaco automatically fills closing brackets and single quotes
+      await viewLine.pressSequentially("array(split(variables('ArrayVariable'), '\n");
+      await page.getByRole('tab', { name: 'Dynamic content' }).click();
+      await page.getByRole('button', { name: 'Add', exact: true }).click();
+      await page.getByRole('tab', { name: 'Code view' }).click();
+      await expect(page.getByRole('code')).toContainText(
+        '{ "type": "Http", "inputs": { "uri": "http://test.com", "method": "GET", "body": "@{variables(\'ArrayVariable\')}@{array(split(variables (\'ArrayVariable\'), \'\\r\\n\'))}" }, "runAfter": { "Filter_array": [ "SUCCEEDED" ] }, "runtimeConfiguration": { "contentTransfer": { "transferMode": "Chunked" } }}'
+      );
+    });
+
+    test('Expressions should be able to use escaped escape characters and serialize as the same', async ({ page }) => {
+      await page.goto('/');
+      await GoToMockWorkflow(page, 'Panel');
+      await page.getByLabel('HTTP operation, HTTP connector').click();
+      await page.getByTitle('Enter request content').getByRole('paragraph').click();
+      await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-expression"]').click();
+      const viewLine = page.locator('.view-line').first();
+      await viewLine.click();
+      // full expression not typed out because Monaco automatically fills closing brackets and single quotes
+      await viewLine.pressSequentially("array(split(variables('ArrayVariable'), '\\n");
+      await page.getByRole('tab', { name: 'Dynamic content' }).click();
+      await page.getByRole('button', { name: 'Add', exact: true }).click();
+      await page.getByRole('tab', { name: 'Code view' }).click();
+      await expect(page.getByRole('code')).toContainText(
+        '{ "type": "Http", "inputs": { "uri": "http://test.com", "method": "GET", "body": "@{variables(\'ArrayVariable\')}@{array(split(variables (\'ArrayVariable\'), \'\\n\'))}" }, "runAfter": { "Filter_array": [ "SUCCEEDED" ] }, "runtimeConfiguration": { "contentTransfer": { "transferMode": "Chunked" } }}'
+      );
+    });
+  }
+);

--- a/e2e/designer/tokens/tokenRemoval.spec.ts
+++ b/e2e/designer/tokens/tokenRemoval.spec.ts
@@ -1,6 +1,6 @@
 import test, { expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
-import { getSerializedWorkflowFromState } from './utils/designerFunctions';
+import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+import { getSerializedWorkflowFromState } from '../utils/designerFunctions';
 
 test.describe(
   'Token Removal Tests',

--- a/libs/designer-ui/src/lib/editor/base/plugins/OpenTokenPicker.tsx
+++ b/libs/designer-ui/src/lib/editor/base/plugins/OpenTokenPicker.tsx
@@ -1,5 +1,5 @@
 import { TokenPickerMode } from '../../../tokenpicker';
-import { UPDATE_TOKENPICKER_EXPRESSION } from '../../../tokenpicker/plugins/TokenPickerHandler';
+import { INITIALIZE_TOKENPICKER_EXPRESSION } from '../../../tokenpicker/plugins/InitializeTokenPickerExpressionHandler';
 import { TokenType } from '../../models/parameter';
 import { findChildNode } from '../utils/helper';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
@@ -24,7 +24,7 @@ export default function OpenTokenPicker({ openTokenPicker }: OpenTokenPickerProp
         if (node?.token?.tokenType === TokenType.FX) {
           openTokenPicker(TokenPickerMode.EXPRESSION);
           setTimeout(() => {
-            editor.dispatchCommand(UPDATE_TOKENPICKER_EXPRESSION, payload);
+            editor.dispatchCommand(INITIALIZE_TOKENPICKER_EXPRESSION, payload);
           }, 50);
         }
         return true;

--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -6,7 +6,7 @@ import type { ExpressionEditorEvent } from '../expressioneditor';
 import { ExpressionEditor } from '../expressioneditor';
 import { PanelSize } from '../panel/panelUtil';
 import type { TokenGroup } from '@microsoft/logic-apps-shared';
-import TokenPickerHandler from './plugins/TokenPickerHandler';
+import TokenPickerHandler from './plugins/InitializeTokenPickerExpressionHandler';
 import UpdateTokenNode from './plugins/UpdateTokenNode';
 import { TokenPickerFooter } from './tokenpickerfooter';
 import { TokenPickerHeader } from './tokenpickerheader';
@@ -22,7 +22,7 @@ import { useIntl } from 'react-intl';
 import { Button } from '@fluentui/react-components';
 import copilotLogo from './images/copilotLogo.svg';
 import { Nl2fExpressionAssistant } from './nl2fExpressionAssistant';
-import { isCopilotServiceEnabled } from '@microsoft/logic-apps-shared';
+import { escapeString, isCopilotServiceEnabled } from '@microsoft/logic-apps-shared';
 
 export const TokenPickerMode = {
   TOKEN: 'token',
@@ -164,16 +164,17 @@ export function TokenPicker({
     }
   }, [anchorKey, editor, windowDimensions.height]);
 
-  const handleUpdateExpressionToken = (s: string, n: NodeKey) => {
-    setExpression({ value: s, selectionStart: 0, selectionEnd: 0 });
+  const handleInitializeExpression = (s: string, n: NodeKey) => {
+    const escapedString = escapeString(s, /*requireSingleQuotesWrap*/ true);
+    setExpression({ value: escapedString, selectionStart: 0, selectionEnd: 0 });
     setSelectedMode(TokenPickerMode.EXPRESSION);
     setExpressionToBeUpdated(n);
 
     setTimeout(() => {
       expressionEditorRef.current?.setSelection({
-        startLineNumber: s.length + 1,
+        startLineNumber: escapedString.length + 1,
         startColumn: 1,
-        endLineNumber: s.length + 1,
+        endLineNumber: escapedString.length + 1,
         endColumn: 1,
       });
       expressionEditorRef.current?.focus();
@@ -415,7 +416,7 @@ export function TokenPicker({
           </div>
         </div>
       </Callout>
-      {tokenClickedCallback ? null : <TokenPickerHandler handleUpdateExpressionToken={handleUpdateExpressionToken} />}
+      {tokenClickedCallback ? null : <TokenPickerHandler handleInitializeExpression={handleInitializeExpression} />}
       {tokenClickedCallback ? null : <UpdateTokenNode />}
     </>
   );

--- a/libs/designer-ui/src/lib/tokenpicker/plugins/InitializeTokenPickerExpressionHandler.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/plugins/InitializeTokenPickerExpressionHandler.tsx
@@ -5,22 +5,22 @@ import type { LexicalCommand, NodeKey } from 'lexical';
 import { $getRoot, COMMAND_PRIORITY_EDITOR, createCommand } from 'lexical';
 import { useEffect } from 'react';
 
-export const UPDATE_TOKENPICKER_EXPRESSION: LexicalCommand<string> = createCommand();
+export const INITIALIZE_TOKENPICKER_EXPRESSION: LexicalCommand<string> = createCommand();
 
 interface TokenPickerHandlerProps {
-  handleUpdateExpressionToken?: (s: string, n: NodeKey) => void;
+  handleInitializeExpression?: (s: string, n: NodeKey) => void;
 }
 
-export default function TokenPickerHandler({ handleUpdateExpressionToken }: TokenPickerHandlerProps): null {
+export default function TokenPickerHandler({ handleInitializeExpression }: TokenPickerHandlerProps): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
     return editor.registerCommand<string>(
-      UPDATE_TOKENPICKER_EXPRESSION,
+      INITIALIZE_TOKENPICKER_EXPRESSION,
       (payload: string) => {
         const node = findChildNode($getRoot(), payload, TokenType.FX);
         if (node?.token?.tokenType === TokenType.FX) {
-          handleUpdateExpressionToken?.(node?.value ?? '', payload);
+          handleInitializeExpression?.(node?.value ?? '', payload);
         } else {
           editor.focus();
         }
@@ -28,6 +28,6 @@ export default function TokenPickerHandler({ handleUpdateExpressionToken }: Toke
       },
       COMMAND_PRIORITY_EDITOR
     );
-  }, [editor, handleUpdateExpressionToken]);
+  }, [editor, handleInitializeExpression]);
   return null;
 }

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
@@ -18,6 +18,7 @@ import {
   ScannerException,
   guid,
   isCopilotServiceEnabled,
+  unescapeString,
 } from '@microsoft/logic-apps-shared';
 import type { Expression, TokenGroup, Token as TokenGroupToken } from '@microsoft/logic-apps-shared';
 import type { LexicalEditor, NodeKey } from 'lexical';
@@ -112,9 +113,12 @@ export function TokenPickerFooter({
 
   const onUpdateOrAddClicked = () => {
     let currExpression: Expression | null = null;
+    const unescapedExpressionValue = unescapeString(expression.value);
     try {
-      currExpression = ExpressionParser.parseExpression(expression.value);
+      console.log(unescapedExpressionValue);
+      currExpression = ExpressionParser.parseExpression(unescapedExpressionValue);
     } catch (ex) {
+      console.log(ex);
       if (ex instanceof ScannerException && (ex as any).message === ExpressionExceptionCode.MISUSED_DOUBLE_QUOTES) {
         // if the expression contains misused double quotes, we'll show a different error message
         setExpressionEditorError(invalidExpressionQuotations);
@@ -149,18 +153,18 @@ export function TokenPickerFooter({
         icon: FxIcon,
         title: getExpressionTokenTitle(currExpression),
         key: guid(),
-        value: expression.value,
+        value: unescapedExpressionValue,
       };
 
       // if the expression is already in the expression editor, we'll update the token node
       if (expressionToBeUpdated) {
         editor?.dispatchCommand(UPDATE_TOKEN_NODE, {
-          updatedValue: expression.value,
+          updatedValue: unescapedExpressionValue,
           updatedTitle: token.title,
           updatedData: {
             id: guid(),
             type: ValueSegmentType.TOKEN,
-            value: expression.value,
+            value: unescapedExpressionValue,
             token,
           },
           nodeKey: expressionToBeUpdated,
@@ -174,7 +178,7 @@ export function TokenPickerFooter({
           title: token.title,
           icon: token.icon,
           value: token.value,
-          data: { id: guid(), type: ValueSegmentType.TOKEN, value: expression.value, token },
+          data: { id: guid(), type: ValueSegmentType.TOKEN, value: unescapedExpressionValue, token },
         });
       }
     }

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -117,7 +117,6 @@ import {
   isBodySegment,
   canStringBeConverted,
   splitAtIndex,
-  unescapeString,
 } from '@microsoft/logic-apps-shared';
 import type {
   AuthProps,
@@ -3791,14 +3790,13 @@ function parameterValueToStringWithoutCasting(value: ValueSegment[], forValidati
   const shouldInterpolateTokens = (value.length > 1 || shouldInterpolateSingleToken) && value.some(isTokenValueSegment);
 
   return value
-    .map((segment) => {
-      const { value: segmentValue } = segment;
-      if (isTokenValueSegment(segment)) {
-        const token = forValidation ? segmentValue || null : unescapeString(segmentValue);
-        return shouldInterpolateTokens ? `@{${token}}` : `@${token}`;
+    .map((expression) => {
+      let expressionValue = forValidation ? expression.value || null : expression.value;
+      if (isTokenValueSegment(expression)) {
+        expressionValue = shouldInterpolateTokens ? `@{${expressionValue}}` : `@${expressionValue}`;
       }
 
-      return forValidation ? segmentValue || null : segmentValue;
+      return expressionValue;
     })
     .join('');
 }

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -18,7 +18,6 @@ import {
   isNullOrUndefined,
   startsWith,
   UnsupportedException,
-  escapeString,
 } from '@microsoft/logic-apps-shared';
 
 /**
@@ -188,11 +187,10 @@ export class ValueSegmentConvertor {
       return dynamicContentTokenSegment;
     }
     // Note: We need to get the expression value if this is a sub expression resulted from uncasting.
-    const value = escapeString(
+    const value =
       expression.startPosition === 0
         ? expression.expression
-        : expression.expression.substring(expression.startPosition, expression.endPosition)
-    );
+        : expression.expression.substring(expression.startPosition, expression.endPosition);
     return this._createExpressionTokenValueSegment(value, expression);
   }
 

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
@@ -156,4 +156,46 @@ describe('escapeString', () => {
   it('should handle an empty string', () => {
     expect(escapeString('')).toEqual('');
   });
+
+  it('does not escape characters if requireSingleQuotesWrap is true and there are no surrounding single quotes', () => {
+    const input = 'Test\nTest';
+    const result = escapeString(input, true);
+    expect(result).toBe(input); // No change, since it's not surrounded by single quotes
+  });
+
+  it('escapes characters if requireSingleQuotesWrap is true and the string is surrounded by single quotes', () => {
+    const input = "'Test\nTest'";
+    const expectedOutput = "'Test\\nTest'";
+    const result = escapeString(input, true);
+    expect(result).toBe(expectedOutput); // Should escape \n
+  });
+
+  it('escapes characters even if the string contains multiple lines when requireSingleQuotesWrap is true and surrounded by single quotes', () => {
+    const input = "'Test\nAnotherLine\nTest'";
+    const expectedOutput = `'Test
+AnotherLine
+Test'`;
+    const result = escapeString(input, true);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('does not escape characters if requireSingleQuotesWrap is true and string is not surrounded by single quotes', () => {
+    const input = 'Test\nTest';
+    const result = escapeString(input, true);
+    expect(result).toBe(input); // No change, since it's not surrounded by single quotes
+  });
+
+  it('escapes characters when requireSingleQuotesWrap is false regardless of surrounding quotes', () => {
+    const input = "'Test\nTest'";
+    const expectedOutput = "'Test\\nTest'";
+    const result = escapeString(input, false);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('escapes characters when requireSingleQuotesWrap is undefined regardless of surrounding quotes', () => {
+    const input = "'Test\nTest'";
+    const expectedOutput = "'Test\\nTest'";
+    const result = escapeString(input);
+    expect(result).toBe(expectedOutput);
+  });
 });

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -43,7 +43,7 @@ export const canStringBeConverted = (s: string): boolean => {
   try {
     const parsed = JSON.parse(s);
     return Array.isArray(parsed);
-  } catch (e) {
+  } catch (_e) {
     return false;
   }
 };
@@ -71,8 +71,12 @@ export const unescapeString = (input: string): string => {
   });
 };
 
-export const escapeString = (input: string): string => {
-  return input.replace(/[\n\r\t\v]/g, (char) => {
+export const escapeString = (input: string, requireSingleQuotesWrap?: boolean): string => {
+  if (requireSingleQuotesWrap && !/'.*[\n\r\t\v].*'/.test(input)) {
+    return input;
+  }
+
+  return input?.replace(/[\n\r\t\v]/g, (char) => {
     switch (char) {
       case '\n':
         return '\\n';


### PR DESCRIPTION
Previously we were escaping expressions on deserialization and unescaping expression on serialization. Now instead, this is done strictly on the ui-layer where before the tokenpicker expression editor is opened, the expression gets escaped; then when the token gets added/updated, the expression gets unescaped.

Fixes https://github.com/Azure/LogicAppsUX/issues/6515
Fixes https://github.com/Azure/LogicAppsUX/issues/6529

Cherry-picked from: https://github.com/Azure/LogicAppsUX/pull/6539