### PR TITLE
fix(designer): Loop pager visibility in do-until action

### DIFF
--- a/__mocks__/runs/LoopsPager/SuccessRun.json
+++ b/__mocks__/runs/LoopsPager/SuccessRun.json
@@ -1,0 +1,161 @@
+{
+    "properties": {
+        "waitEndTime": "2025-02-04T17:44:56.6396086Z",
+        "startTime": "2025-02-04T17:44:56.6396086Z",
+        "endTime": "2025-02-04T17:45:09.6484667Z",
+        "status": "Succeeded",
+        "correlation": {
+            "clientTrackingId": "08584629157889890322247822477CU00"
+        },
+        "workflow": {
+            "properties": {
+                "createdTime": "2025-02-04T17:43:03.1167222Z",
+                "changedTime": "2025-02-04T17:44:47.7981262Z",
+                "version": "08584629157982535659",
+                "definition": {
+                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "resourceGroup": {
+                            "type": "String"
+                        },
+                        "subscriptionId": {
+                            "type": "String"
+                        },
+                        "resourceName": {
+                            "type": "String"
+                        }
+                    },
+                    "triggers": {
+                        "When_a_HTTP_request_is_received": {
+                            "type": "Request",
+                            "kind": "Http"
+                        }
+                    },
+                    "actions": {
+                        "Initialize_variable": {
+                            "runAfter": {},
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "one",
+                                        "type": "integer",
+                                        "value": 1
+                                    }
+                                ]
+                            }
+                        },
+                        "Until": {
+                            "actions": {
+                                "Increment_variable": {
+                                    "type": "IncrementVariable",
+                                    "inputs": {
+                                        "name": "one",
+                                        "value": 1
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "expression": "@equals(variables('one'),10)",
+                            "limit": {
+                                "count": 60,
+                                "timeout": "PT1H"
+                            },
+                            "type": "Until"
+                        }
+                    },
+                    "outputs": {}
+                },
+                "parameters": {
+                    "resourceGroup": {
+                        "type": "String",
+                        "value": "cleanupservice"
+                    },
+                    "subscriptionId": {
+                        "type": "String",
+                        "value": "dasdmasda"
+                    },
+                    "resourceName": {
+                        "type": "String",
+                        "value": "sadasdas"
+                    }
+                },
+                "endpointsConfiguration": {},
+                "runtimeConfiguration": {
+                    "lifetime": {
+                        "unit": "Day",
+                        "count": 90
+                    },
+                    "operationOptions": "None"
+                }
+            },
+            "id": "/workflows/WhileLoop/versions/08584629157982535659",
+            "name": "08584629157982535659",
+            "type": "workflows/versions"
+        },
+        "trigger": {
+            "name": "When_a_HTTP_request_is_received",
+            "outputsLink": {
+                "uri": "testLink",
+                "contentSize": 4375
+            },
+            "startTime": "2025-02-04T17:44:56.5051872Z",
+            "endTime": "2025-02-04T17:44:56.5051872Z",
+            "originHistoryName": "08584629157889890322247822477CU00",
+            "correlation": {
+                "clientTrackingId": "08584629157889890322247822477CU00"
+            },
+            "status": "Succeeded"
+        },
+        "actions": {
+            "Increment_variable": {
+                "repetitionCount": 9,
+                "canResubmit": false,
+                "startTime": "2025-02-04T17:45:09.4431018Z",
+                "endTime": "2025-02-04T17:45:09.5877863Z",
+                "correlation": {
+                    "actionTrackingId": "b8d5d722-10eb-42fd-b9f7-fcd5d592d33a",
+                    "clientTrackingId": "08584629157889890322247822477CU00"
+                },
+                "status": "Succeeded",
+                "code": "NotSpecified"
+            },
+            "Initialize_variable": {
+                "inputsLink": {
+                    "uri": "testLink",
+                    "contentSize": 57
+                },
+                "canResubmit": true,
+                "startTime": "2025-02-04T17:44:58.9789633Z",
+                "endTime": "2025-02-04T17:44:59.9031445Z",
+                "correlation": {
+                    "actionTrackingId": "a34d3b47-b795-44fb-bbb6-1eeed5cb5d0d",
+                    "clientTrackingId": "08584629157889890322247822477CU00"
+                },
+                "status": "Succeeded",
+                "code": "NotSpecified"
+            },
+            "Until": {
+                "iterationCount": 9,
+                "canResubmit": false,
+                "startTime": "2025-02-04T17:45:00.0222385Z",
+                "endTime": "2025-02-04T17:45:09.6183066Z",
+                "correlation": {
+                    "actionTrackingId": "cb252e8f-e114-45bf-899c-b9e9abb02db5",
+                    "clientTrackingId": "08584629157889890322247822477CU00"
+                },
+                "status": "Succeeded",
+                "code": "NotSpecified"
+            }
+        },
+        "outputs": {}
+    },
+    "id": "/workflows/WhileLoop/runs/08584629157889890322247822477CU00",
+    "name": "08584629157889890322247822477CU00",
+    "type": "workflows/runs"
+}

--- a/__mocks__/workflows/LoopsPager.json
+++ b/__mocks__/workflows/LoopsPager.json
@@ -1,0 +1,51 @@
+{
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "actions": {
+        "Initialize_variable": {
+          "type": "InitializeVariable",
+          "inputs": {
+            "variables": [
+              {
+                "name": "one",
+                "type": "integer",
+                "value": 1
+              }
+            ]
+          },
+          "runAfter": {}
+        },
+        "Until": {
+          "type": "Until",
+          "expression": "@equals(variables('one'),10)",
+          "limit": {
+            "count": 60,
+            "timeout": "PT1H"
+          },
+          "actions": {
+            "Increment_variable": {
+              "type": "IncrementVariable",
+              "inputs": {
+                "name": "one",
+                "value": 1
+              }
+            }
+          },
+          "runAfter": {
+            "Initialize_variable": [
+              "SUCCEEDED"
+            ]
+          }
+        }
+      },
+      "contentVersion": "1.0.0.0",
+      "outputs": {},
+      "triggers": {
+        "When_a_HTTP_request_is_received": {
+          "type": "Request",
+          "kind": "Http"
+        }
+      }
+    },
+    "kind": "Stateful"
+  }

--- a/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
@@ -56,6 +56,7 @@ const fileOptions = [
   { key: 'divider_5', text: '-', itemType: DropdownMenuItemType.Divider },
   { key: 'MonitoringViewHeader', text: 'Monitoring view scenarios', itemType: DropdownMenuItemType.Header },
   { key: 'MonitoringViewConditional.json', text: 'Monitoring view conditional' },
+  { key: 'LoopsPager.json', text: 'Loops pager' },
 ];
 
 export const LocalLogicAppSelector: React.FC = () => {

--- a/e2e/designer/monitoringView/loopsPager.spec.ts
+++ b/e2e/designer/monitoringView/loopsPager.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { GoToMockWorkflow, LoadRunFile } from '../utils/GoToWorkflow';
+
+test.describe(
+  'Loops pager in monitoring view tests',
+  {
+    tag: '@mock',
+  },
+  () => {
+    test('Success run check', async ({ page }) => {
+      await page.goto('/');
+
+      await GoToMockWorkflow(page, 'Loops pager');
+      await LoadRunFile(page, 'SuccessRun');
+
+      // Verify status for success in previous action
+      await expect(page.getByTestId('msla-pill-initialize_variable_status')).toBeVisible();
+      await expect(page.getByTestId('msla-pill-initialize_variable_status')).toHaveAttribute('aria-label', '0.9 seconds. Succeeded');
+
+      // Verify status for success in until action
+      await expect(page.getByTestId('msla-pill-until_status')).toBeVisible();
+      await expect(page.getByTestId('msla-pill-until_status')).toHaveAttribute('aria-label', '9.6 seconds. Succeeded');
+
+      // Verify pager loads
+      await expect(page.getByTestId('msla-pager-v2-until')).toBeVisible();
+    });
+  }
+);

--- a/e2e/designer/monitoringView/monitoringView.spec.ts
+++ b/e2e/designer/monitoringView/monitoringView.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow, LoadRunFile } from './utils/GoToWorkflow';
+import { GoToMockWorkflow, LoadRunFile } from '../utils/GoToWorkflow';
 
 test.describe(
   'Monitoring view tests sanity check',

--- a/libs/designer/src/lib/ui/CustomNodes/GraphContainerNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/GraphContainerNode.tsx
@@ -21,10 +21,8 @@ const GraphContainerNode = ({ targetPosition = Position.Top, sourcePosition = Po
   const hasFooter = nodeMetadata?.subgraphType === SUBGRAPH_TYPES.UNTIL_DO;
   const graphContainerId = isSubgraphContainer ? removeIdTag(id) : id;
   const parentRunId = useParentRunId(graphContainerId);
-  const runData = useRunData(isSubgraphContainer ? (parentRunId ?? '') : graphContainerId);
-
+  const runData = useRunData(isSubgraphContainer ? (parentRunId ?? graphContainerId) : graphContainerId);
   const nodeSize = useNodeSize(id);
-
   const nodeLeafIndex = useNodeLeafIndex(id);
 
   return (

--- a/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
@@ -135,8 +135,6 @@ const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Posi
 
   const nodeIndex = useNodeIndex(subgraphId);
 
-  console.log('charlie', metadata);
-
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center' }}>

--- a/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
@@ -48,7 +48,8 @@ const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Posi
   const isMonitoringView = useMonitoringView();
   const normalizedType = node?.type.toLowerCase();
   const parentRunId = useParentRunId(subgraphId);
-  const parentRunData = useRunData(parentRunId ?? '');
+  const runData = useRunData(parentRunId ?? subgraphId);
+
   const title = useNodeDisplayName(subgraphId);
 
   const isAddCase = metadata?.subgraphType === SUBGRAPH_TYPES.SWITCH_ADD_CASE;
@@ -134,6 +135,8 @@ const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Posi
 
   const nodeIndex = useNodeIndex(subgraphId);
 
+  console.log('charlie', metadata);
+
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -143,7 +146,7 @@ const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Posi
             <>
               <SubgraphCard
                 id={subgraphId}
-                active={isMonitoringView ? !isNullOrUndefined(parentRunData?.status) : true}
+                active={isMonitoringView ? !isNullOrUndefined(runData?.status) : true}
                 parentId={metadata?.graphId}
                 subgraphType={metadata.subgraphType}
                 title={title}

--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -3,7 +3,13 @@ import type { AppDispatch } from '../../../core';
 import { useActionMetadata, useNodeMetadata, useRunInstance } from '../../../core/state/workflow/workflowSelectors';
 import { setRunIndex } from '../../../core/state/workflow/workflowSlice';
 import { getForeachItemsCount } from './helper';
-import { RunService, FindPreviousAndNextPage, isNullOrUndefined, type LogicAppsV2 } from '@microsoft/logic-apps-shared';
+import {
+  RunService,
+  FindPreviousAndNextPage,
+  isNullOrUndefined,
+  type LogicAppsV2,
+  replaceWhiteSpaceWithUnderscore,
+} from '@microsoft/logic-apps-shared';
 import type { PageChangeEventArgs, PageChangeEventHandler } from '@microsoft/designer-ui';
 import { Pager } from '@microsoft/designer-ui';
 import { useCallback, useMemo } from 'react';
@@ -102,14 +108,16 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
   }
 
   return isLoading ? null : (
-    <Pager
-      current={currentPage + 1}
-      onChange={onPagerChange}
-      max={forEachItemsCount}
-      maxLength={forEachItemsCount.toString().length + 1}
-      min={1}
-      readonlyPagerInput={false}
-      failedIterationProps={failedIterationProps}
-    />
+    <div data-automation-id={`msla-pager-v2-${replaceWhiteSpaceWithUnderscore(scopeId)}`}>
+      <Pager
+        current={currentPage + 1}
+        onChange={onPagerChange}
+        max={forEachItemsCount}
+        maxLength={forEachItemsCount.toString().length + 1}
+        min={1}
+        readonlyPagerInput={false}
+        failedIterationProps={failedIterationProps}
+      />
+    </div>
   );
 };

--- a/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -33,8 +33,14 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
   } = useQuery<any>(
     ['runRepetitions', { nodeId: scopeId, runId: runInstance?.id }],
     async () => {
-      const { value } = await RunService().getScopeRepetitions({ nodeId: scopeId, runId: runInstance?.id }, constants.FLOW_STATUS.FAILED);
-      const _failedRepetitions: number[] = value.reduce((acc: number[], current: LogicAppsV2.RunRepetition) => {
+      let failedRunRepetitions: LogicAppsV2.RunRepetition[] = [];
+      try {
+        const { value } = await RunService().getScopeRepetitions({ nodeId: scopeId, runId: runInstance?.id }, constants.FLOW_STATUS.FAILED);
+        failedRunRepetitions = value;
+      } catch {
+        failedRunRepetitions = [];
+      }
+      const _failedRepetitions: number[] = failedRunRepetitions.reduce((acc: number[], current: LogicAppsV2.RunRepetition) => {
         const scopeObject = current.properties?.repetitionIndexes?.find((item) => item.scopeName === scopeId);
         const indexOfFail = isNullOrUndefined(scopeObject) ? undefined : scopeObject.itemIndex;
         acc.push(indexOfFail ?? []);
@@ -46,7 +52,7 @@ export const LoopsPager = ({ metadata, scopeId, collapsed }: LoopsPagerProps) =>
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,
-      enabled: normalizedType === constants.NODE.TYPE.FOREACH,
+      enabled: normalizedType === constants.NODE.TYPE.FOREACH || normalizedType === constants.NODE.TYPE.UNTIL,
     }
   );
 


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->


With the old behavior the loop pager wasn't getting rendered and also the content inside the subgraph node was getting the inactive class

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

Loop pager now renders correctly and the content inside the subgraph node doesn't render as inactive

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

It is not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

Already added e2e tests for this behavior

## Screenshots or Videos (if applicable)

#### Old behavior

![Image (1)](https://github.com/user-attachments/assets/4f31b884-53a9-44e4-b448-286b0f3d2d40)


#### New behavior

<img width="373" alt="Screenshot 2025-02-04 at 3 21 27 PM" src="https://github.com/user-attachments/assets/c28e73a3-71ac-48d0-b44d-9d79d97103b2" />

