### PR TITLE
feat(Templates): Support ViewTemplate data Override

### DIFF
--- a/apps/Standalone/src/templates/app/LocalTemplates.tsx
+++ b/apps/Standalone/src/templates/app/LocalTemplates.tsx
@@ -72,9 +72,30 @@ export const LocalTemplates = () => {
         services={services}
         isConsumption={isConsumption}
         isCreateView={!isConsumption}
-        viewTemplate={isSingleTemplateView ? { id: templatesView } : undefined}
         customTemplates={localManifests}
         existingWorkflowName={undefined}
+        viewTemplate={
+          isSingleTemplateView
+            ? {
+                id: templatesView,
+                parametersOverride: {
+                  'OpenAIEmbeddingModel_#workflowname#': { value: 'overriden-default-editable' },
+                  'OpenAIChatModel_#workflowname#': { value: 'overriden-default-non-editable', isEditable: false },
+                  'LogicMessage_#workflowname#': { value: 'overriden-default-non-editable', isEditable: false },
+                },
+                basicsOverride: {
+                  ['SimpleParametersOnly']: {
+                    name: { value: 'overriden-name', isEditable: false },
+                    kind: { value: 'stateful', isEditable: false },
+                  },
+                  ['Workflow1']: {
+                    name: { value: 'overriden-name', isEditable: false },
+                    kind: { value: 'stateful', isEditable: false },
+                  },
+                },
+              }
+            : undefined
+        }
       >
         <div
           style={{

--- a/apps/Standalone/src/templates/app/LocalTemplates.tsx
+++ b/apps/Standalone/src/templates/app/LocalTemplates.tsx
@@ -84,7 +84,7 @@ export const LocalTemplates = () => {
                   'LogicMessage_#workflowname#': { value: 'overriden-default-non-editable', isEditable: false },
                 },
                 basicsOverride: {
-                  ['SimpleParametersOnly']: {
+                  ['default']: {
                     name: { value: 'overriden-name', isEditable: false },
                     kind: { value: 'stateful', isEditable: false },
                   },

--- a/apps/Standalone/src/templates/app/TemplatesStandard.tsx
+++ b/apps/Standalone/src/templates/app/TemplatesStandard.tsx
@@ -227,6 +227,8 @@ export const TemplatesStandard = () => {
                   'sharepoint-site-name_#workflowname#': { value: 'overriden-empty' },
                   'TeamsChannelID_#workflowname#': { value: 'overriden-default', isEditable: false },
                   'TeamsTeamID_#workflowname#': { value: 'overriden-default-editable' },
+                  'OpenAIEmbeddingModel_#workflowname#': { value: 'overriden-default-editable' },
+                  'SharepointSiteAddress_#workflowname#': { value: 'overriden-default-non-editable', isEditable: false },
                 },
                 basicsOverride: {
                   [templatesView]: {

--- a/apps/Standalone/src/templates/app/TemplatesStandard.tsx
+++ b/apps/Standalone/src/templates/app/TemplatesStandard.tsx
@@ -223,7 +223,7 @@ export const TemplatesStandard = () => {
             ? {
                 id: templatesView,
                 parametersOverride: {
-                  'odataTopDefault_#workflowname#': { value: '0', isEditable: false },
+                  'odataTopDefault_#workflowname#': { value: 0, isEditable: false },
                   'sharepoint-site-name_#workflowname#': { value: 'overriden-empty' },
                   'TeamsChannelID_#workflowname#': { value: 'overriden-default', isEditable: false },
                   'TeamsTeamID_#workflowname#': { value: 'overriden-default-editable' },

--- a/apps/Standalone/src/templates/app/TemplatesStandard.tsx
+++ b/apps/Standalone/src/templates/app/TemplatesStandard.tsx
@@ -225,9 +225,15 @@ export const TemplatesStandard = () => {
                 parametersOverride: {
                   'odataTopDefault_#workflowname#': { value: '0', isEditable: false },
                   'sharepoint-site-name_#workflowname#': { value: 'overriden-empty' },
+                  'TeamsChannelID_#workflowname#': { value: 'overriden-default', isEditable: false },
+                  'TeamsTeamID_#workflowname#': { value: 'overriden-default-editable' },
                 },
                 basicsOverride: {
-                  [`${templatesView}`]: {
+                  [templatesView]: {
+                    name: { value: 'overriden-name', isEditable: false },
+                    kind: { value: 'stateful', isEditable: false },
+                  },
+                  ['ingest-index-ai-sharepoint-rag']: {
                     name: { value: 'overriden-name', isEditable: false },
                     kind: { value: 'stateful', isEditable: false },
                   },

--- a/apps/Standalone/src/templates/app/TemplatesStandard.tsx
+++ b/apps/Standalone/src/templates/app/TemplatesStandard.tsx
@@ -218,7 +218,23 @@ export const TemplatesStandard = () => {
         isConsumption={false}
         isCreateView={true}
         existingWorkflowName={existingWorkflowName}
-        viewTemplate={isSingleTemplateView ? { id: templatesView } : undefined}
+        viewTemplate={
+          isSingleTemplateView
+            ? {
+                id: templatesView,
+                parametersOverride: {
+                  'odataTopDefault_#workflowname#': { value: '0', isEditable: false },
+                  'sharepoint-site-name_#workflowname#': { value: 'overriden-empty' },
+                },
+                basicsOverride: {
+                  [`${templatesView}`]: {
+                    name: { value: 'overriden-name', isEditable: false },
+                    kind: { value: 'stateful', isEditable: false },
+                  },
+                },
+              }
+            : undefined
+        }
       >
         <div
           style={{

--- a/e2e/templates/createWorkflowPanel.spec.ts
+++ b/e2e/templates/createWorkflowPanel.spec.ts
@@ -57,7 +57,7 @@ test.describe(
       expect(await page.getByRole('button', { name: 'update' }).isDisabled()).toBeTruthy();
 
       await page.getByRole('tab', { name: 'Parameters' }).click();
-      await page.locator('[data-testid="msla-templates-parameter-value"]').fill(parameterValue);
+      await page.locator('[data-testid="msla-templates-parameter-value-LogicMessage_#workflowname#"]').fill(parameterValue);
       await page.getByRole('button', { name: 'Next' }).click();
 
       await expect(page.getByText('----', { exact: true })).not.toBeVisible();

--- a/e2e/templates/viewtemplate.spec.ts
+++ b/e2e/templates/viewtemplate.spec.ts
@@ -25,5 +25,38 @@ test.describe(
       await expect(page.getByText('Stateful', { exact: true })).toBeVisible();
       expect(await page.getByRole('button', { name: 'Create' }).isDisabled()).toBeTruthy();
     });
+
+    test('Create panels should have overriden data from viewTemplate params provided', async ({ page }) => {
+      await page.goto('/templates');
+      await page.getByText('Local', { exact: true }).click();
+      await page.getByRole('combobox', { name: 'Gallery' }).click();
+      await page.getByText('Simple Parameters', { exact: true }).click();
+      await page.waitForTimeout(10);
+
+      expect(await page.getByRole('button', { name: 'Close' }).isDisabled()).toBeTruthy();
+      expect(await page.getByRole('tab', { name: 'Workflow' })).toBeVisible();
+      expect(await page.getByRole('tab', { name: 'Summary' })).toBeVisible();
+      await page.getByRole('button', { name: 'Use this template' }).click();
+
+      await expect(page.getByText('Create a new workflow from template', {})).toBeVisible();
+      expect(await page.getByRole('button', { name: 'Close' }).isDisabled()).toBeTruthy();
+
+      expect(await page.locator('[data-testid="msla-templates-workflowName"]').isDisabled()).toBeTruthy();
+      await expect(await page.locator('[data-testid="msla-templates-workflowName"]')).toHaveValue('overriden-name');
+      await expect(page.getByRole('radio', { name: 'Stateful' })).toBeDisabled();
+
+      await page.getByRole('tab', { name: 'Parameters' }).click();
+      expect(await page.locator('[data-testid="msla-templates-parameter-value-LogicMessage_#workflowname#"]').isDisabled()).toBeTruthy();
+      await expect(await page.locator('[data-testid="msla-templates-parameter-value-LogicMessage_#workflowname#"]')).toHaveValue(
+        'overriden-default-non-editable'
+      );
+
+      await page.getByRole('tab', { name: 'Review + create' }).click();
+      await expect(page.getByText('----', { exact: true })).not.toBeVisible();
+      await expect(page.getByText('overriden-name', { exact: true })).toBeVisible();
+      await expect(page.getByText('Stateful', { exact: true })).toBeVisible();
+      await expect(page.getByText('overriden-default-non-editable', { exact: true })).toBeVisible();
+      expect(await page.getByRole('button', { name: 'Create' }).isDisabled()).toBeFalsy();
+    });
   }
 );

--- a/e2e/templates/viewtemplate.spec.ts
+++ b/e2e/templates/viewtemplate.spec.ts
@@ -18,12 +18,17 @@ test.describe(
       expect(await page.getByRole('tab', { name: 'Summary' })).toBeVisible();
       await page.getByRole('button', { name: 'Use this template' }).click();
 
+      expect(await page.locator('[data-testid="msla-templates-workflowName"]').isDisabled()).toBeTruthy();
+      await expect(await page.locator('[data-testid="msla-templates-workflowName"]')).toHaveValue('overriden-name');
+      await expect(page.getByRole('radio', { name: 'Stateful' })).toBeDisabled();
+
       await expect(page.getByText('Create a new workflow from template', {})).toBeVisible();
       expect(await page.getByRole('button', { name: 'Close' }).isDisabled()).toBeTruthy();
       await page.getByRole('tab', { name: 'Review + create' }).click();
-      await expect(page.getByText('----', { exact: true })).toBeVisible();
+      await expect(page.getByText('----', { exact: true })).not.toBeVisible();
+      await expect(page.getByText('overriden-name', { exact: true })).toBeVisible();
       await expect(page.getByText('Stateful', { exact: true })).toBeVisible();
-      expect(await page.getByRole('button', { name: 'Create' }).isDisabled()).toBeTruthy();
+      expect(await page.getByRole('button', { name: 'Create' }).isDisabled()).toBeFalsy();
     });
 
     test('Create panels should have overriden data from viewTemplate params provided', async ({ page }) => {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -235,12 +235,17 @@ const loadTemplateFromResourcePath = async (
       }
     }
   } else {
-    const workflowId = templateName;
-    const workflowData = await loadWorkflowTemplateFromManifest(workflowId, templateName, manifest, isCustomTemplate, viewTemplateData);
+    const workflowData = await loadWorkflowTemplateFromManifest(
+      /* workflowId */ templateName,
+      templateName,
+      manifest,
+      isCustomTemplate,
+      viewTemplateData
+    );
 
     if (workflowData) {
       data.workflows = {
-        [workflowId]: workflowData.workflow,
+        [templateName]: workflowData.workflow,
       };
       data.parameterDefinitions = workflowData.parameterDefinitions;
       data.connections = workflowData.connections;

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -271,7 +271,7 @@ const loadWorkflowTemplateFromManifest = async (
     const parameterDefinitions = templateManifest.parameters?.reduce((result: Record<string, Template.ParameterDefinition>, parameter) => {
       result[parameter.name] = {
         ...parameter,
-        value: viewTemplateData?.parametersOverride?.[parameter.name]?.value ?? parameter.default,
+        value: viewTemplateData?.parametersOverride?.[parameter.name]?.value?.toString() ?? parameter.default,
         associatedWorkflows: [templateManifest.title],
       };
       return result;

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -267,17 +267,15 @@ const loadWorkflowTemplateFromManifest = async (
   try {
     const { templateManifest, templateWorkflowDefinition } = await getWorkflowAndManifest(templatePath, manifest, isCustomTemplate);
     const parameterDefinitions = templateManifest.parameters?.reduce((result: Record<string, Template.ParameterDefinition>, parameter) => {
-      const viewTemplateParameterData = viewTemplateData?.parametersOverride?.[parameter.name];
-
       result[parameter.name] = {
         ...parameter,
-        value: viewTemplateParameterData ? viewTemplateParameterData.value : parameter.default,
+        value: viewTemplateData?.parametersOverride?.[parameter.name]?.value ?? parameter.default,
         associatedWorkflows: [templateManifest.title],
       };
       return result;
     }, {});
 
-    const overridenKind = viewTemplateData?.basicsOverride?.[workflowId]?.kind?.value;
+    const overrideKind = viewTemplateData?.basicsOverride?.[workflowId]?.kind?.value;
 
     return {
       workflow: {
@@ -286,8 +284,8 @@ const loadWorkflowTemplateFromManifest = async (
         manifest: templateManifest,
         workflowName: viewTemplateData?.basicsOverride?.[workflowId]?.name?.value ?? '',
         kind:
-          overridenKind && templateManifest.kinds?.includes(overridenKind)
-            ? overridenKind
+          overrideKind && templateManifest.kinds?.includes(overrideKind)
+            ? overrideKind
             : templateManifest.kinds?.length
               ? templateManifest.kinds[0]
               : 'stateful',

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -32,7 +32,9 @@ export interface WorkflowTemplateData {
   workflowDefinition: LogicAppsV2.WorkflowDefinition;
   manifest: Template.Manifest;
   workflowName: string | undefined;
+  isWorkflowNameEditable?: boolean;
   kind: string | undefined;
+  isKindEditable?: boolean;
   images?: Record<string, string>;
   connectionKeys: string[];
   errors: {
@@ -273,6 +275,7 @@ const loadWorkflowTemplateFromManifest = async (
         ...parameter,
         value: viewTemplateParameterData ? viewTemplateParameterData.value : parameter.default,
         associatedWorkflows: [templateManifest.title],
+        isEditable: viewTemplateParameterData?.isEditable,
       };
       return result;
     }, {});
@@ -283,9 +286,11 @@ const loadWorkflowTemplateFromManifest = async (
         workflowDefinition: (templateWorkflowDefinition as any)?.default ?? templateWorkflowDefinition,
         manifest: templateManifest,
         workflowName: viewTemplateData?.basicsOverride?.[workflowId]?.name?.value ?? '',
+        isWorkflowNameEditable: viewTemplateData?.basicsOverride?.[workflowId]?.name?.isEditable,
         kind:
           viewTemplateData?.basicsOverride?.[workflowId]?.kind?.value ??
           (templateManifest.kinds?.length ? templateManifest.kinds[0] : 'stateful'),
+        isKindEditable: viewTemplateData?.basicsOverride?.[workflowId]?.kind?.isEditable,
         images: templateManifest.images,
         connectionKeys: Object.keys(templateManifest.connections),
         errors: {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -255,7 +255,7 @@ const loadWorkflowTemplateFromManifest = async (
   templatePath: string,
   manifest: Template.Manifest | undefined,
   isCustomTemplate: boolean,
-  viewTemplateData?: Template.ViewTemplateDetails
+  viewTemplateData: Template.ViewTemplateDetails | undefined
 ): Promise<
   | {
       workflow: WorkflowTemplateData;
@@ -273,14 +273,9 @@ const loadWorkflowTemplateFromManifest = async (
         ...parameter,
         value: viewTemplateParameterData ? viewTemplateParameterData.value : parameter.default,
         associatedWorkflows: [templateManifest.title],
-        isEditable: viewTemplateParameterData?.isEditable,
       };
       return result;
     }, {});
-
-    if (viewTemplateData?.basicsOverride?.[workflowId]?.name?.isEditable === false) {
-      templateManifest.kinds = [viewTemplateData?.basicsOverride?.[workflowId]?.name?.value as Template.WorkflowKindType];
-    }
 
     return {
       workflow: {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -275,10 +275,12 @@ const loadWorkflowTemplateFromManifest = async (
         ...parameter,
         value: viewTemplateParameterData ? viewTemplateParameterData.value : parameter.default,
         associatedWorkflows: [templateManifest.title],
-        isEditable: viewTemplateParameterData?.isEditable,
+        isEditable: viewTemplateParameterData?.isEditable ?? true,
       };
       return result;
     }, {});
+
+    const viewTemplateKind = viewTemplateData?.basicsOverride?.[workflowId]?.kind?.value;
 
     return {
       workflow: {
@@ -286,11 +288,14 @@ const loadWorkflowTemplateFromManifest = async (
         workflowDefinition: (templateWorkflowDefinition as any)?.default ?? templateWorkflowDefinition,
         manifest: templateManifest,
         workflowName: viewTemplateData?.basicsOverride?.[workflowId]?.name?.value ?? '',
-        isWorkflowNameEditable: viewTemplateData?.basicsOverride?.[workflowId]?.name?.isEditable,
+        isWorkflowNameEditable: viewTemplateData?.basicsOverride?.[workflowId]?.name?.isEditable ?? true,
         kind:
-          viewTemplateData?.basicsOverride?.[workflowId]?.kind?.value ??
-          (templateManifest.kinds?.length ? templateManifest.kinds[0] : 'stateful'),
-        isKindEditable: viewTemplateData?.basicsOverride?.[workflowId]?.kind?.isEditable,
+          viewTemplateKind && templateManifest.kinds?.includes(viewTemplateKind)
+            ? viewTemplateKind
+            : templateManifest.kinds?.length
+              ? templateManifest.kinds[0]
+              : 'stateful',
+        isKindEditable: templateManifest?.kinds?.length !== 1 || (viewTemplateData?.basicsOverride?.[workflowId]?.kind?.isEditable ?? true),
         images: templateManifest.images,
         connectionKeys: Object.keys(templateManifest.connections),
         errors: {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -32,9 +32,7 @@ export interface WorkflowTemplateData {
   workflowDefinition: LogicAppsV2.WorkflowDefinition;
   manifest: Template.Manifest;
   workflowName: string | undefined;
-  isWorkflowNameEditable?: boolean;
   kind: string | undefined;
-  isKindEditable?: boolean;
   images?: Record<string, string>;
   connectionKeys: string[];
   errors: {
@@ -275,12 +273,11 @@ const loadWorkflowTemplateFromManifest = async (
         ...parameter,
         value: viewTemplateParameterData ? viewTemplateParameterData.value : parameter.default,
         associatedWorkflows: [templateManifest.title],
-        isEditable: viewTemplateParameterData?.isEditable ?? true,
       };
       return result;
     }, {});
 
-    const viewTemplateKind = viewTemplateData?.basicsOverride?.[workflowId]?.kind?.value;
+    const overridenKind = viewTemplateData?.basicsOverride?.[workflowId]?.kind?.value;
 
     return {
       workflow: {
@@ -288,14 +285,12 @@ const loadWorkflowTemplateFromManifest = async (
         workflowDefinition: (templateWorkflowDefinition as any)?.default ?? templateWorkflowDefinition,
         manifest: templateManifest,
         workflowName: viewTemplateData?.basicsOverride?.[workflowId]?.name?.value ?? '',
-        isWorkflowNameEditable: viewTemplateData?.basicsOverride?.[workflowId]?.name?.isEditable ?? true,
         kind:
-          viewTemplateKind && templateManifest.kinds?.includes(viewTemplateKind)
-            ? viewTemplateKind
+          overridenKind && templateManifest.kinds?.includes(overridenKind)
+            ? overridenKind
             : templateManifest.kinds?.length
               ? templateManifest.kinds[0]
               : 'stateful',
-        isKindEditable: templateManifest?.kinds?.length !== 1 && (viewTemplateData?.basicsOverride?.[workflowId]?.kind?.isEditable ?? true),
         images: templateManifest.images,
         connectionKeys: Object.keys(templateManifest.connections),
         errors: {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -295,7 +295,7 @@ const loadWorkflowTemplateFromManifest = async (
             : templateManifest.kinds?.length
               ? templateManifest.kinds[0]
               : 'stateful',
-        isKindEditable: templateManifest?.kinds?.length !== 1 || (viewTemplateData?.basicsOverride?.[workflowId]?.kind?.isEditable ?? true),
+        isKindEditable: templateManifest?.kinds?.length !== 1 && (viewTemplateData?.basicsOverride?.[workflowId]?.kind?.isEditable ?? true),
         images: templateManifest.images,
         connectionKeys: Object.keys(templateManifest.connections),
         errors: {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -232,17 +232,12 @@ const loadTemplateFromResourcePath = async (
       }
     }
   } else {
-    const workflowData = await loadWorkflowTemplateFromManifest(
-      /* workflowId */ templateName,
-      templateName,
-      manifest,
-      isCustomTemplate,
-      viewTemplateData
-    );
+    const workflowId = 'default';
+    const workflowData = await loadWorkflowTemplateFromManifest(workflowId, templateName, manifest, isCustomTemplate, viewTemplateData);
 
     if (workflowData) {
       data.workflows = {
-        [templateName]: workflowData.workflow,
+        [workflowId]: workflowData.workflow,
       };
       data.parameterDefinitions = workflowData.parameterDefinitions;
       data.connections = workflowData.connections;

--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -125,15 +125,12 @@ export const initializeTemplateServices = createAsyncThunk(
 export const loadTemplate = createAsyncThunk(
   'loadTemplate',
   async (
-    {
-      preLoadedManifest,
-      viewTemplateDetails,
-      isCustomTemplate = false,
-    }: { preLoadedManifest: Template.Manifest | undefined; viewTemplateDetails?: Template.ViewTemplateDetails; isCustomTemplate?: boolean },
+    { preLoadedManifest, isCustomTemplate = false }: { preLoadedManifest: Template.Manifest | undefined; isCustomTemplate?: boolean },
     thunkAPI
   ) => {
     const currentState: RootState = thunkAPI.getState() as RootState;
     const currentTemplateName = currentState.template.templateName;
+    const viewTemplateDetails = currentState.templateOptions.viewTemplateDetails;
     const viewTemplateData = currentTemplateName === viewTemplateDetails?.id ? viewTemplateDetails : undefined;
 
     if (currentTemplateName) {
@@ -280,7 +277,7 @@ const loadWorkflowTemplateFromManifest = async (
       return result;
     }, {});
 
-    const overrideKind = viewTemplateData?.basicsOverride?.[workflowId]?.kind?.value;
+    const overridenKind = viewTemplateData?.basicsOverride?.[workflowId]?.kind?.value;
 
     return {
       workflow: {
@@ -289,8 +286,8 @@ const loadWorkflowTemplateFromManifest = async (
         manifest: templateManifest,
         workflowName: viewTemplateData?.basicsOverride?.[workflowId]?.name?.value ?? '',
         kind:
-          overrideKind && templateManifest.kinds?.includes(overrideKind)
-            ? overrideKind
+          overridenKind && templateManifest.kinds?.includes(overridenKind)
+            ? overridenKind
             : templateManifest.kinds?.length
               ? templateManifest.kinds[0]
               : 'stateful',

--- a/libs/designer/src/lib/core/state/templates/manifestSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/manifestSlice.ts
@@ -7,23 +7,6 @@ import type { FilterObject } from '@microsoft/designer-ui';
 export const templatesCountPerPage = 25;
 const initialPageNum = 0;
 
-interface ContentInfo<T> {
-  value: T;
-  isEditable?: boolean;
-}
-
-export interface ViewTemplateDetails {
-  id: string;
-  basicsOverride?: Record<
-    string,
-    {
-      name?: ContentInfo<string>;
-      kind?: ContentInfo<string>;
-    }
-  >;
-  parametersOverride?: Record<string, ContentInfo<any>>;
-}
-
 export interface ManifestState {
   availableTemplateNames?: ManifestName[];
   filteredTemplateNames?: ManifestName[];
@@ -37,7 +20,7 @@ export interface ManifestState {
     connectors: FilterObject[] | undefined;
     detailFilters: Record<string, FilterObject[]>;
   };
-  viewTemplateDetails?: ViewTemplateDetails;
+  viewTemplateDetails?: Template.ViewTemplateDetails;
 }
 
 type ManifestName = string;
@@ -135,7 +118,7 @@ export const manifestSlice = createSlice({
       state.filters.detailFilters = currentDetailFilters;
       state.filters.pageNum = initialPageNum;
     },
-    setViewTemplateDetails: (state, action: PayloadAction<ViewTemplateDetails>) => {
+    setViewTemplateDetails: (state, action: PayloadAction<Template.ViewTemplateDetails>) => {
       state.viewTemplateDetails = action.payload;
     },
   },

--- a/libs/designer/src/lib/core/state/templates/manifestSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/manifestSlice.ts
@@ -20,7 +20,6 @@ export interface ManifestState {
     connectors: FilterObject[] | undefined;
     detailFilters: Record<string, FilterObject[]>;
   };
-  viewTemplateDetails?: Template.ViewTemplateDetails;
 }
 
 type ManifestName = string;
@@ -118,9 +117,6 @@ export const manifestSlice = createSlice({
       state.filters.detailFilters = currentDetailFilters;
       state.filters.pageNum = initialPageNum;
     },
-    setViewTemplateDetails: (state, action: PayloadAction<Template.ViewTemplateDetails>) => {
-      state.viewTemplateDetails = action.payload;
-    },
   },
   extraReducers: (builder) => {
     builder.addCase(loadGithubManifestNames.fulfilled, (state, action) => {
@@ -155,7 +151,6 @@ export const {
   setSortKey,
   setConnectorsFilters,
   setDetailsFilters,
-  setViewTemplateDetails,
 } = manifestSlice.actions;
 export default manifestSlice.reducer;
 

--- a/libs/designer/src/lib/core/state/templates/store.ts
+++ b/libs/designer/src/lib/core/state/templates/store.ts
@@ -4,12 +4,14 @@ import workflowReducer from './workflowSlice';
 import templateReducer from './templateSlice';
 import manifestReducer from './manifestSlice';
 import panelReducer from './panelSlice';
+import templateOptionsReducer from './templateOptionsSlice';
 
 const rootReducer = combineReducers({
   workflow: workflowReducer,
   template: templateReducer,
   manifest: manifestReducer,
   panel: panelReducer,
+  templateOptions: templateOptionsReducer,
 });
 
 export const setupStore = (preloadedState?: Partial<RootState>) => {

--- a/libs/designer/src/lib/core/state/templates/templateOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/templateOptionsSlice.ts
@@ -12,8 +12,8 @@ const initialState: TemplateOptionsState = {
   servicesInitialized: false,
 };
 
-export const templateSlice = createSlice({
-  name: 'template',
+export const templateOptionsSlice = createSlice({
+  name: 'templateOptions',
   initialState,
   reducers: {
     setViewTemplateDetails: (state, action: PayloadAction<Template.ViewTemplateDetails>) => {
@@ -27,5 +27,5 @@ export const templateSlice = createSlice({
   },
 });
 
-export const { setViewTemplateDetails } = templateSlice.actions;
-export default templateSlice.reducer;
+export const { setViewTemplateDetails } = templateOptionsSlice.actions;
+export default templateOptionsSlice.reducer;

--- a/libs/designer/src/lib/core/state/templates/templateOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/templateOptionsSlice.ts
@@ -1,0 +1,31 @@
+import type { Template } from '@microsoft/logic-apps-shared';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+import { initializeTemplateServices } from '../../actions/bjsworkflow/templates';
+
+export interface TemplateOptionsState {
+  servicesInitialized: boolean;
+  viewTemplateDetails?: Template.ViewTemplateDetails;
+}
+
+const initialState: TemplateOptionsState = {
+  servicesInitialized: false,
+};
+
+export const templateSlice = createSlice({
+  name: 'template',
+  initialState,
+  reducers: {
+    setViewTemplateDetails: (state, action: PayloadAction<Template.ViewTemplateDetails>) => {
+      state.viewTemplateDetails = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(initializeTemplateServices.fulfilled, (state, action) => {
+      state.servicesInitialized = action.payload;
+    });
+  },
+});
+
+export const { setViewTemplateDetails } = templateSlice.actions;
+export default templateSlice.reducer;

--- a/libs/designer/src/lib/core/state/templates/templateSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/templateSlice.ts
@@ -2,12 +2,10 @@ import { getIntl, getRecordEntry, type Template } from '@microsoft/logic-apps-sh
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { getCurrentWorkflowNames, validateConnectionsValue, validateParameterValue } from '../../templates/utils/helper';
-import { initializeTemplateServices, loadTemplate, validateWorkflowName, type TemplatePayload } from '../../actions/bjsworkflow/templates';
+import { loadTemplate, validateWorkflowName, type TemplatePayload } from '../../actions/bjsworkflow/templates';
 
 export interface TemplateState extends TemplatePayload {
   templateName?: string;
-  servicesInitialized: boolean;
-  viewTemplateDetails?: Template.ViewTemplateDetails;
 }
 
 const initialState: TemplateState = {
@@ -15,7 +13,6 @@ const initialState: TemplateState = {
   workflows: {},
   parameterDefinitions: {},
   connections: {},
-  servicesInitialized: false,
   errors: {
     parameters: {},
     connections: undefined,
@@ -28,11 +25,6 @@ export const templateSlice = createSlice({
   reducers: {
     changeCurrentTemplateName: (state, action: PayloadAction<string>) => {
       state.templateName = action.payload;
-      state.viewTemplateDetails = undefined;
-    },
-    setViewTemplateDetails: (state, action: PayloadAction<Template.ViewTemplateDetails>) => {
-      state.templateName = action.payload.id;
-      state.viewTemplateDetails = action.payload;
     },
     updateWorkflowName: (state, action: PayloadAction<{ id: string; name: string | undefined }>) => {
       const { id, name } = action.payload;
@@ -145,16 +137,11 @@ export const templateSlice = createSlice({
         connections: undefined,
       };
     });
-
-    builder.addCase(initializeTemplateServices.fulfilled, (state, action) => {
-      state.servicesInitialized = action.payload;
-    });
   },
 });
 
 export const {
   changeCurrentTemplateName,
-  setViewTemplateDetails,
   updateWorkflowName,
   updateKind,
   validateWorkflowsBasicInfo,

--- a/libs/designer/src/lib/core/state/templates/templateSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/templateSlice.ts
@@ -7,6 +7,7 @@ import { initializeTemplateServices, loadTemplate, validateWorkflowName, type Te
 export interface TemplateState extends TemplatePayload {
   templateName?: string;
   servicesInitialized: boolean;
+  viewTemplateDetails?: Template.ViewTemplateDetails;
 }
 
 const initialState: TemplateState = {
@@ -27,6 +28,11 @@ export const templateSlice = createSlice({
   reducers: {
     changeCurrentTemplateName: (state, action: PayloadAction<string>) => {
       state.templateName = action.payload;
+      state.viewTemplateDetails = undefined;
+    },
+    setViewTemplateDetails: (state, action: PayloadAction<Template.ViewTemplateDetails>) => {
+      state.templateName = action.payload.id;
+      state.viewTemplateDetails = action.payload;
     },
     updateWorkflowName: (state, action: PayloadAction<{ id: string; name: string | undefined }>) => {
       const { id, name } = action.payload;
@@ -148,6 +154,7 @@ export const templateSlice = createSlice({
 
 export const {
   changeCurrentTemplateName,
+  setViewTemplateDetails,
   updateWorkflowName,
   updateKind,
   validateWorkflowsBasicInfo,

--- a/libs/designer/src/lib/core/state/templates/templateselectors.ts
+++ b/libs/designer/src/lib/core/state/templates/templateselectors.ts
@@ -3,7 +3,7 @@ import type { RootState } from './store';
 import type { WorkflowTemplateData } from '../../actions/bjsworkflow/templates';
 
 export const useAreServicesInitialized = () => {
-  return useSelector((state: RootState) => state.template.servicesInitialized ?? false);
+  return useSelector((state: RootState) => state.templateOptions.servicesInitialized ?? false);
 };
 
 export const useTemplateWorkflows = () => {
@@ -13,6 +13,15 @@ export const useTemplateWorkflows = () => {
 export const useWorkflowTemplate = (workflowId: string): WorkflowTemplateData => {
   return useSelector((state: RootState) => {
     return state.template.workflows[workflowId];
+  });
+};
+
+export const useWorkflowBasicsEditable = (workflowId: string) => {
+  return useSelector((state: RootState) => {
+    return {
+      isNameEditable: state.templateOptions.viewTemplateDetails?.basicsOverride?.[workflowId]?.name?.isEditable ?? true,
+      isKindEditable: state.templateOptions.viewTemplateDetails?.basicsOverride?.[workflowId]?.kind?.isEditable ?? true,
+    };
   });
 };
 

--- a/libs/designer/src/lib/core/state/templates/templateselectors.ts
+++ b/libs/designer/src/lib/core/state/templates/templateselectors.ts
@@ -16,16 +16,6 @@ export const useWorkflowTemplate = (workflowId: string): WorkflowTemplateData =>
   });
 };
 
-export const useViewTemplateBasicsEditable = (workflowId: string) => {
-  return useSelector((state: RootState) => {
-    const basicsOverrideDetails = state.template.viewTemplateDetails?.basicsOverride?.[workflowId];
-    return {
-      isNameEditable: basicsOverrideDetails?.name?.isEditable ?? true,
-      isKindEditable: basicsOverrideDetails?.kind?.isEditable ?? true,
-    };
-  });
-};
-
 export const useDefaultWorkflowTemplate = (): WorkflowTemplateData => {
   return useSelector((state: RootState) => {
     const workflows = state.template.workflows ?? {};

--- a/libs/designer/src/lib/core/state/templates/templateselectors.ts
+++ b/libs/designer/src/lib/core/state/templates/templateselectors.ts
@@ -16,6 +16,16 @@ export const useWorkflowTemplate = (workflowId: string): WorkflowTemplateData =>
   });
 };
 
+export const useViewTemplateBasicsEditable = (workflowId: string) => {
+  return useSelector((state: RootState) => {
+    const basicsOverrideDetails = state.template.viewTemplateDetails?.basicsOverride?.[workflowId];
+    return {
+      isNameEditable: basicsOverrideDetails?.name?.isEditable ?? true,
+      isKindEditable: basicsOverrideDetails?.kind?.isEditable ?? true,
+    };
+  });
+};
+
 export const useDefaultWorkflowTemplate = (): WorkflowTemplateData => {
   return useSelector((state: RootState) => {
     const workflows = state.template.workflows ?? {};

--- a/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
+++ b/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
@@ -3,7 +3,6 @@ import type React from 'react';
 import { useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from '../state/templates/store';
-import type { ViewTemplateDetails } from '../state/templates/manifestSlice';
 import {
   loadGithubManifestNames,
   loadGithubManifests,
@@ -27,7 +26,7 @@ export interface TemplatesDataProviderProps {
   services: TemplateServiceOptions;
   connectionReferences: ConnectionReferences;
   customTemplates?: Record<string, Template.Manifest>;
-  viewTemplate?: ViewTemplateDetails;
+  viewTemplate?: Template.ViewTemplateDetails;
   children?: React.ReactNode;
 }
 

--- a/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
+++ b/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
@@ -87,13 +87,11 @@ export const TemplatesDataProvider = (props: TemplatesDataProviderProps) => {
     dispatch,
     servicesInitialized,
     props.services,
-    props.resourceDetails,
-    props.connectionReferences,
     props.existingWorkflowName,
     props.isConsumption,
+    props.resourceDetails,
+    props.connectionReferences,
     props.isCreateView,
-    props.viewTemplate,
-    props.customTemplates,
   ]);
 
   useEffect(() => {

--- a/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
+++ b/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
@@ -16,6 +16,7 @@ import { getFilteredTemplates } from './utils/helper';
 import { initializeTemplateServices } from '../actions/bjsworkflow/templates';
 import type { Template } from '@microsoft/logic-apps-shared';
 import { setViewTemplateDetails } from '../state/templates/templateOptionsSlice';
+import { changeCurrentTemplateName } from '../state/templates/templateSlice';
 
 export interface TemplatesDataProviderProps {
   isConsumption: boolean | undefined;
@@ -94,6 +95,7 @@ export const TemplatesDataProvider = (props: TemplatesDataProviderProps) => {
 
   useEffect(() => {
     if (props.viewTemplate) {
+      dispatch(changeCurrentTemplateName(props.viewTemplate.id));
       dispatch(setViewTemplateDetails(props.viewTemplate));
     }
   }, [dispatch, props.viewTemplate]);

--- a/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
+++ b/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
@@ -8,7 +8,6 @@ import {
   loadGithubManifests,
   setCustomTemplates,
   setFilteredTemplateNames,
-  setViewTemplateDetails,
 } from '../state/templates/manifestSlice';
 import { type ResourceDetails, setInitialData } from '../state/templates/workflowSlice';
 import { useAreServicesInitialized } from '../state/templates/templateselectors';
@@ -16,7 +15,7 @@ import type { ConnectionReferences } from '../../common/models/workflow';
 import { getFilteredTemplates } from './utils/helper';
 import { initializeTemplateServices } from '../actions/bjsworkflow/templates';
 import type { Template } from '@microsoft/logic-apps-shared';
-import { changeCurrentTemplateName } from '../state/templates/templateSlice';
+import { setViewTemplateDetails } from '../state/templates/templateSlice';
 
 export interface TemplatesDataProviderProps {
   isConsumption: boolean | undefined;
@@ -95,7 +94,6 @@ export const TemplatesDataProvider = (props: TemplatesDataProviderProps) => {
 
   useEffect(() => {
     if (props.viewTemplate) {
-      dispatch(changeCurrentTemplateName(props.viewTemplate.id));
       dispatch(setViewTemplateDetails(props.viewTemplate));
     }
   }, [dispatch, props.viewTemplate]);

--- a/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
+++ b/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
@@ -15,7 +15,7 @@ import type { ConnectionReferences } from '../../common/models/workflow';
 import { getFilteredTemplates } from './utils/helper';
 import { initializeTemplateServices } from '../actions/bjsworkflow/templates';
 import type { Template } from '@microsoft/logic-apps-shared';
-import { setViewTemplateDetails } from '../state/templates/templateSlice';
+import { setViewTemplateDetails } from '../state/templates/templateOptionsSlice';
 
 export interface TemplatesDataProviderProps {
   isConsumption: boolean | undefined;

--- a/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/createWorkflowPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/createWorkflowPanel.tsx
@@ -53,7 +53,7 @@ export const CreateWorkflowPanel = ({
     isOpen: state.panel.isOpen,
     isCreateView: state.workflow.isCreateView,
     currentPanelView: state.panel.currentPanelView,
-    shouldCloseByDefault: !state.template.viewTemplateDetails,
+    shouldCloseByDefault: !state.templateOptions.viewTemplateDetails,
   }));
   const isMultiWorkflow = useMemo(() => !!manifest && isMultiWorkflowTemplate(manifest), [manifest]);
 

--- a/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/createWorkflowPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/createWorkflowPanel.tsx
@@ -53,7 +53,7 @@ export const CreateWorkflowPanel = ({
     isOpen: state.panel.isOpen,
     isCreateView: state.workflow.isCreateView,
     currentPanelView: state.panel.currentPanelView,
-    shouldCloseByDefault: !state.manifest.viewTemplateDetails,
+    shouldCloseByDefault: !state.template.viewTemplateDetails,
   }));
   const isMultiWorkflow = useMemo(() => !!manifest && isMultiWorkflowTemplate(manifest), [manifest]);
 

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/quickViewPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/quickViewPanel.tsx
@@ -41,7 +41,7 @@ export const QuickViewPanel = ({
     workflowAppName: state.workflow.workflowAppName,
     isOpen: state.panel.isOpen,
     currentPanelView: state.panel.currentPanelView,
-    shouldCloseByDefault: !state.template.viewTemplateDetails,
+    shouldCloseByDefault: !state.templateOptions.viewTemplateDetails,
   }));
   const { manifest } = useWorkflowTemplate(workflowId);
   const panelTabs = getQuickViewTabs(

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/quickViewPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/quickViewPanel.tsx
@@ -41,7 +41,7 @@ export const QuickViewPanel = ({
     workflowAppName: state.workflow.workflowAppName,
     isOpen: state.panel.isOpen,
     currentPanelView: state.panel.currentPanelView,
-    shouldCloseByDefault: !state.manifest.viewTemplateDetails,
+    shouldCloseByDefault: !state.template.viewTemplateDetails,
   }));
   const { manifest } = useWorkflowTemplate(workflowId);
   const panelTabs = getQuickViewTabs(

--- a/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
@@ -31,7 +31,7 @@ interface WorkflowItem {
 
 export const MultiWorkflowBasics = () => {
   const dispatch = useDispatch<AppDispatch>();
-  const { workflows, viewTemplateDetails } = useSelector((state: RootState) => state.template);
+  const { workflows } = useSelector((state: RootState) => state.template);
   const { data: existingWorkflowNames } = useExistingWorkflowNames();
 
   const intl = useIntl();
@@ -81,9 +81,9 @@ export const MultiWorkflowBasics = () => {
     Object.values(workflows).map((workflow) => ({
       id: workflow.id,
       name: workflow.workflowName,
-      isNameEditable: viewTemplateDetails?.basicsOverride?.[workflow.id]?.name?.isEditable ?? true,
+      isNameEditable: workflow?.isWorkflowNameEditable ?? true,
       kind: workflow.kind ?? (workflow.manifest.kinds?.length ? workflow.manifest.kinds[0] : WorkflowKind.STATEFUL),
-      isKindEditable: viewTemplateDetails?.basicsOverride?.[workflow.id]?.kind?.isEditable ?? true,
+      isKindEditable: workflow?.isKindEditable ?? true,
       allowedKinds: workflow.manifest.kinds?.length
         ? workflow.manifest.kinds.map((kind) => ({
             key: kind,

--- a/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
@@ -15,7 +15,9 @@ import { getCurrentWorkflowNames } from '../../../core/templates/utils/helper';
 interface WorkflowItem {
   id: string;
   name?: string;
+  isNameEditable?: boolean;
   kind?: string;
+  isKindEditable?: boolean;
   allowedKinds: {
     key: string;
     text: string;
@@ -29,7 +31,7 @@ interface WorkflowItem {
 
 export const MultiWorkflowBasics = () => {
   const dispatch = useDispatch<AppDispatch>();
-  const workflows = useSelector((state: RootState) => state.template.workflows);
+  const { workflows, viewTemplateDetails } = useSelector((state: RootState) => state.template);
   const { data: existingWorkflowNames } = useExistingWorkflowNames();
 
   const intl = useIntl();
@@ -79,7 +81,9 @@ export const MultiWorkflowBasics = () => {
     Object.values(workflows).map((workflow) => ({
       id: workflow.id,
       name: workflow.workflowName,
+      isNameEditable: viewTemplateDetails?.basicsOverride?.[workflow.id]?.name?.isEditable ?? true,
       kind: workflow.kind ?? (workflow.manifest.kinds?.length ? workflow.manifest.kinds[0] : WorkflowKind.STATEFUL),
+      isKindEditable: viewTemplateDetails?.basicsOverride?.[workflow.id]?.kind?.isEditable ?? true,
       allowedKinds: workflow.manifest.kinds?.length
         ? workflow.manifest.kinds.map((kind) => ({
             key: kind,
@@ -197,6 +201,7 @@ export const MultiWorkflowBasics = () => {
           <TextField
             aria-label={item.name}
             className="msla-templates-basics-name"
+            disabled={!item?.isNameEditable}
             value={item.name}
             onChange={(_event, newValue) => handleWorkflowNameChange(item, newValue)}
             onBlur={() => handleWorkflowNameBlur(item)}
@@ -209,7 +214,7 @@ export const MultiWorkflowBasics = () => {
           <Dropdown
             aria-label={item.kind}
             className="msla-templates-basics-state"
-            disabled={item.allowedKinds.length === 1}
+            disabled={item.allowedKinds.length === 1 || !item?.isKindEditable}
             options={item.allowedKinds}
             selectedKey={item.kind}
             onChange={(_event, option) => handleWorkflowKindChange(item, option?.key as string)}

--- a/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
@@ -32,6 +32,7 @@ interface WorkflowItem {
 export const MultiWorkflowBasics = () => {
   const dispatch = useDispatch<AppDispatch>();
   const { workflows } = useSelector((state: RootState) => state.template);
+  const workflowBasics = useSelector((state: RootState) => state.templateOptions.viewTemplateDetails?.basicsOverride);
   const { data: existingWorkflowNames } = useExistingWorkflowNames();
 
   const intl = useIntl();
@@ -81,9 +82,9 @@ export const MultiWorkflowBasics = () => {
     Object.values(workflows).map((workflow) => ({
       id: workflow.id,
       name: workflow.workflowName,
-      isNameEditable: workflow?.isWorkflowNameEditable ?? true,
+      isNameEditable: workflowBasics?.[workflow.id]?.name?.isEditable ?? true,
       kind: workflow.kind ?? (workflow.manifest.kinds?.length ? workflow.manifest.kinds[0] : WorkflowKind.STATEFUL),
-      isKindEditable: workflow?.isKindEditable ?? true,
+      isKindEditable: workflowBasics?.[workflow.id]?.kind?.isEditable ?? true,
       allowedKinds: workflow.manifest.kinds?.length
         ? workflow.manifest.kinds.map((kind) => ({
             key: kind,

--- a/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
@@ -214,7 +214,7 @@ export const MultiWorkflowBasics = () => {
           <Dropdown
             aria-label={item.kind}
             className="msla-templates-basics-state"
-            disabled={item.allowedKinds.length === 1 || !item?.isKindEditable}
+            disabled={!item?.isKindEditable}
             options={item.allowedKinds}
             selectedKey={item.kind}
             onChange={(_event, option) => handleWorkflowKindChange(item, option?.key as string)}

--- a/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/multiworkflow.tsx
@@ -32,7 +32,7 @@ interface WorkflowItem {
 export const MultiWorkflowBasics = () => {
   const dispatch = useDispatch<AppDispatch>();
   const { workflows } = useSelector((state: RootState) => state.template);
-  const workflowBasics = useSelector((state: RootState) => state.templateOptions.viewTemplateDetails?.basicsOverride);
+  const basicsOverrideByWorkflow = useSelector((state: RootState) => state.templateOptions.viewTemplateDetails?.basicsOverride);
   const { data: existingWorkflowNames } = useExistingWorkflowNames();
 
   const intl = useIntl();
@@ -82,9 +82,9 @@ export const MultiWorkflowBasics = () => {
     Object.values(workflows).map((workflow) => ({
       id: workflow.id,
       name: workflow.workflowName,
-      isNameEditable: workflowBasics?.[workflow.id]?.name?.isEditable ?? true,
+      isNameEditable: basicsOverrideByWorkflow?.[workflow.id]?.name?.isEditable ?? true,
       kind: workflow.kind ?? (workflow.manifest.kinds?.length ? workflow.manifest.kinds[0] : WorkflowKind.STATEFUL),
-      isKindEditable: workflowBasics?.[workflow.id]?.kind?.isEditable ?? true,
+      isKindEditable: basicsOverrideByWorkflow?.[workflow.id]?.kind?.isEditable ?? true,
       allowedKinds: workflow.manifest.kinds?.length
         ? workflow.manifest.kinds.map((kind) => ({
             key: kind,

--- a/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
@@ -19,7 +19,6 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
     errors: { workflow: workflowError, kind: kindError },
     kind,
     isKindEditable,
-    manifest,
   } = useWorkflowTemplate(workflowId);
   const { existingWorkflowName } = useSelector((state: RootState) => state.workflow);
   const { data: existingWorkflowNames } = useExistingWorkflowNames();
@@ -169,7 +168,7 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
             }
           }}
           selectedKey={kind}
-          disabled={manifest?.kinds?.length === 1 || isKindEditable === false}
+          disabled={isKindEditable === false}
         />
       </div>
       {kindError && <Text className="msla-templates-tab-stateType-error-message">{kindError}</Text>}

--- a/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
@@ -7,7 +7,7 @@ import { Link, Text } from '@fluentui/react-components';
 import { useCallback, useMemo } from 'react';
 import { useExistingWorkflowNames } from '../../../core/queries/template';
 import { Open16Regular } from '@fluentui/react-icons';
-import { useViewTemplateBasicsEditable, useWorkflowTemplate } from '../../../core/state/templates/templateselectors';
+import { useWorkflowTemplate } from '../../../core/state/templates/templateselectors';
 import { validateWorkflowName } from '../../../core/actions/bjsworkflow/templates';
 import { useFunctionalState } from '@react-hookz/web';
 
@@ -15,11 +15,12 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
   const dispatch = useDispatch<AppDispatch>();
   const {
     workflowName,
+    isWorkflowNameEditable,
     errors: { workflow: workflowError, kind: kindError },
     kind,
+    isKindEditable,
     manifest,
   } = useWorkflowTemplate(workflowId);
-  const { isNameEditable, isKindEditable } = useViewTemplateBasicsEditable(workflowId);
   const { existingWorkflowName } = useSelector((state: RootState) => state.workflow);
   const { data: existingWorkflowNames } = useExistingWorkflowNames();
   const [name, setName] = useFunctionalState(existingWorkflowName ?? workflowName);
@@ -129,7 +130,7 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
           setName(newValue);
           dispatch(updateWorkflowName({ id: workflowId, name: newValue }));
         }}
-        disabled={!!existingWorkflowName || !isNameEditable}
+        disabled={!!existingWorkflowName || isWorkflowNameEditable === false}
         onBlur={() => {
           const validationError = validateWorkflowName(name(), existingWorkflowNames ?? []);
           dispatch(updateWorkflowNameValidationError({ id: workflowId, error: validationError }));
@@ -168,7 +169,7 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
             }
           }}
           selectedKey={kind}
-          disabled={manifest?.kinds?.length === 1 || !isKindEditable}
+          disabled={manifest?.kinds?.length === 1 || isKindEditable === false}
         />
       </div>
       {kindError && <Text className="msla-templates-tab-stateType-error-message">{kindError}</Text>}

--- a/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
@@ -7,7 +7,7 @@ import { Link, Text } from '@fluentui/react-components';
 import { useCallback, useMemo } from 'react';
 import { useExistingWorkflowNames } from '../../../core/queries/template';
 import { Open16Regular } from '@fluentui/react-icons';
-import { useWorkflowTemplate } from '../../../core/state/templates/templateselectors';
+import { useWorkflowBasicsEditable, useWorkflowTemplate } from '../../../core/state/templates/templateselectors';
 import { validateWorkflowName } from '../../../core/actions/bjsworkflow/templates';
 import { useFunctionalState } from '@react-hookz/web';
 
@@ -15,11 +15,11 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
   const dispatch = useDispatch<AppDispatch>();
   const {
     workflowName,
-    isWorkflowNameEditable,
     errors: { workflow: workflowError, kind: kindError },
     kind,
-    isKindEditable,
+    manifest,
   } = useWorkflowTemplate(workflowId);
+  const { isNameEditable, isKindEditable } = useWorkflowBasicsEditable(workflowId);
   const { existingWorkflowName } = useSelector((state: RootState) => state.workflow);
   const { data: existingWorkflowNames } = useExistingWorkflowNames();
   const [name, setName] = useFunctionalState(existingWorkflowName ?? workflowName);
@@ -129,7 +129,7 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
           setName(newValue);
           dispatch(updateWorkflowName({ id: workflowId, name: newValue }));
         }}
-        disabled={!!existingWorkflowName || isWorkflowNameEditable === false}
+        disabled={!!existingWorkflowName || !isNameEditable}
         onBlur={() => {
           const validationError = validateWorkflowName(name(), existingWorkflowNames ?? []);
           dispatch(updateWorkflowNameValidationError({ id: workflowId, error: validationError }));
@@ -168,7 +168,7 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
             }
           }}
           selectedKey={kind}
-          disabled={isKindEditable === false}
+          disabled={manifest?.kinds?.length === 1 || !isKindEditable}
         />
       </div>
       {kindError && <Text className="msla-templates-tab-stateType-error-message">{kindError}</Text>}

--- a/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
@@ -7,7 +7,7 @@ import { Link, Text } from '@fluentui/react-components';
 import { useCallback, useMemo } from 'react';
 import { useExistingWorkflowNames } from '../../../core/queries/template';
 import { Open16Regular } from '@fluentui/react-icons';
-import { useWorkflowTemplate } from '../../../core/state/templates/templateselectors';
+import { useViewTemplateBasicsEditable, useWorkflowTemplate } from '../../../core/state/templates/templateselectors';
 import { validateWorkflowName } from '../../../core/actions/bjsworkflow/templates';
 import { useFunctionalState } from '@react-hookz/web';
 
@@ -19,6 +19,7 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
     kind,
     manifest,
   } = useWorkflowTemplate(workflowId);
+  const { isNameEditable, isKindEditable } = useViewTemplateBasicsEditable(workflowId);
   const { existingWorkflowName } = useSelector((state: RootState) => state.workflow);
   const { data: existingWorkflowNames } = useExistingWorkflowNames();
   const [name, setName] = useFunctionalState(existingWorkflowName ?? workflowName);
@@ -128,7 +129,7 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
           setName(newValue);
           dispatch(updateWorkflowName({ id: workflowId, name: newValue }));
         }}
-        disabled={!!existingWorkflowName}
+        disabled={!!existingWorkflowName || !isNameEditable}
         onBlur={() => {
           const validationError = validateWorkflowName(name(), existingWorkflowNames ?? []);
           dispatch(updateWorkflowNameValidationError({ id: workflowId, error: validationError }));
@@ -167,7 +168,7 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
             }
           }}
           selectedKey={kind}
-          disabled={manifest?.kinds?.length === 1}
+          disabled={manifest?.kinds?.length === 1 || !isKindEditable}
         />
       </div>
       {kindError && <Text className="msla-templates-tab-stateType-error-message">{kindError}</Text>}

--- a/libs/designer/src/lib/ui/templates/parameters/displayParameters.tsx
+++ b/libs/designer/src/lib/ui/templates/parameters/displayParameters.tsx
@@ -140,6 +140,7 @@ export const DisplayParameters = () => {
             id="msla-templates-parameter-value"
             aria-label={item.value}
             value={item.value}
+            disabled={item.isEditable === false}
             onChange={(_event, newValue) => {
               handleParameterValueChange(item, newValue ?? '');
             }}

--- a/libs/designer/src/lib/ui/templates/parameters/displayParameters.tsx
+++ b/libs/designer/src/lib/ui/templates/parameters/displayParameters.tsx
@@ -17,6 +17,7 @@ export const DisplayParameters = () => {
     parameterDefinitions,
     errors: { parameters: parameterErrors },
   } = useSelector((state: RootState) => state.template);
+  const parametersOverride = useSelector((state: RootState) => state.templateOptions.viewTemplateDetails?.parametersOverride);
   const isSingleWorkflow = useMemo(() => Object.keys(workflows).length === 1, [workflows]);
 
   const resources = {
@@ -140,7 +141,7 @@ export const DisplayParameters = () => {
             id="msla-templates-parameter-value"
             aria-label={item.value}
             value={item.value}
-            disabled={item.isEditable === false}
+            disabled={parametersOverride?.[item.name]?.isEditable === false}
             onChange={(_event, newValue) => {
               handleParameterValueChange(item, newValue ?? '');
             }}

--- a/libs/designer/src/lib/ui/templates/parameters/displayParameters.tsx
+++ b/libs/designer/src/lib/ui/templates/parameters/displayParameters.tsx
@@ -137,8 +137,8 @@ export const DisplayParameters = () => {
         return (
           <TextField
             className="msla-templates-parameters-values"
-            data-testid="msla-templates-parameter-value"
-            id="msla-templates-parameter-value"
+            data-testid={`msla-templates-parameter-value-${item.name}`}
+            id={`msla-templates-parameter-value-${item.name}`}
             aria-label={item.value}
             value={item.value}
             disabled={parametersOverride?.[item.name]?.isEditable === false}

--- a/libs/designer/src/lib/ui/templates/templateview.tsx
+++ b/libs/designer/src/lib/ui/templates/templateview.tsx
@@ -26,7 +26,7 @@ export const TemplatesView = (props: TemplateViewProps) => {
     templateName: state.template.templateName,
     allTemplates: state.manifest.availableTemplates,
     customTemplateNames: state.manifest.customTemplateNames,
-    viewTemplateDetails: state.template.viewTemplateDetails,
+    viewTemplateDetails: state.templateOptions.viewTemplateDetails,
     manifest: state.template.manifest,
   }));
 

--- a/libs/designer/src/lib/ui/templates/templateview.tsx
+++ b/libs/designer/src/lib/ui/templates/templateview.tsx
@@ -26,7 +26,7 @@ export const TemplatesView = (props: TemplateViewProps) => {
     templateName: state.template.templateName,
     allTemplates: state.manifest.availableTemplates,
     customTemplateNames: state.manifest.customTemplateNames,
-    viewTemplateDetails: state.manifest.viewTemplateDetails,
+    viewTemplateDetails: state.template.viewTemplateDetails,
     manifest: state.template.manifest,
   }));
 

--- a/libs/designer/src/lib/ui/templates/templateview.tsx
+++ b/libs/designer/src/lib/ui/templates/templateview.tsx
@@ -22,11 +22,10 @@ export const TemplatesView = (props: TemplateViewProps) => {
   const { showCloseButton, panelWidth, createWorkflow, onClose } = props;
   const dispatch = useDispatch<AppDispatch>();
   const intl = useIntl();
-  const { templateName, manifest, allTemplates, customTemplateNames, viewTemplateDetails } = useSelector((state: RootState) => ({
+  const { templateName, manifest, allTemplates, customTemplateNames } = useSelector((state: RootState) => ({
     templateName: state.template.templateName,
     allTemplates: state.manifest.availableTemplates,
     customTemplateNames: state.manifest.customTemplateNames,
-    viewTemplateDetails: state.templateOptions.viewTemplateDetails,
     manifest: state.template.manifest,
   }));
 
@@ -38,9 +37,9 @@ export const TemplatesView = (props: TemplateViewProps) => {
 
   useEffect(() => {
     if (templateName) {
-      dispatch(loadTemplate({ preLoadedManifest: customTemplateManifest, isCustomTemplate, viewTemplateDetails }));
+      dispatch(loadTemplate({ preLoadedManifest: customTemplateManifest, isCustomTemplate }));
     }
-  }, [customTemplateManifest, dispatch, isCustomTemplate, viewTemplateDetails, templateName, allTemplates]);
+  }, [customTemplateManifest, dispatch, isCustomTemplate, templateName]);
 
   if (!manifest) {
     return templateName ? (

--- a/libs/designer/src/lib/ui/templates/templateview.tsx
+++ b/libs/designer/src/lib/ui/templates/templateview.tsx
@@ -37,7 +37,6 @@ export const TemplatesView = (props: TemplateViewProps) => {
   );
 
   useEffect(() => {
-    console.log('---', templateName, viewTemplateDetails, allTemplates, customTemplateManifest);
     if (templateName) {
       dispatch(loadTemplate({ preLoadedManifest: customTemplateManifest, isCustomTemplate, viewTemplateDetails }));
     }

--- a/libs/designer/src/lib/ui/templates/templateview.tsx
+++ b/libs/designer/src/lib/ui/templates/templateview.tsx
@@ -22,10 +22,11 @@ export const TemplatesView = (props: TemplateViewProps) => {
   const { showCloseButton, panelWidth, createWorkflow, onClose } = props;
   const dispatch = useDispatch<AppDispatch>();
   const intl = useIntl();
-  const { templateName, manifest, allTemplates, customTemplateNames } = useSelector((state: RootState) => ({
+  const { templateName, manifest, allTemplates, customTemplateNames, viewTemplateDetails } = useSelector((state: RootState) => ({
     templateName: state.template.templateName,
     allTemplates: state.manifest.availableTemplates,
     customTemplateNames: state.manifest.customTemplateNames,
+    viewTemplateDetails: state.manifest.viewTemplateDetails,
     manifest: state.template.manifest,
   }));
 
@@ -37,9 +38,9 @@ export const TemplatesView = (props: TemplateViewProps) => {
 
   useEffect(() => {
     if (templateName) {
-      dispatch(loadTemplate({ preLoadedManifest: customTemplateManifest, isCustomTemplate }));
+      dispatch(loadTemplate({ preLoadedManifest: customTemplateManifest, isCustomTemplate, viewTemplateDetails }));
     }
-  }, [customTemplateManifest, dispatch, isCustomTemplate, templateName]);
+  }, [customTemplateManifest, dispatch, isCustomTemplate, viewTemplateDetails, templateName]);
 
   if (!manifest) {
     return templateName ? (

--- a/libs/designer/src/lib/ui/templates/templateview.tsx
+++ b/libs/designer/src/lib/ui/templates/templateview.tsx
@@ -37,10 +37,11 @@ export const TemplatesView = (props: TemplateViewProps) => {
   );
 
   useEffect(() => {
+    console.log('---', templateName, viewTemplateDetails, allTemplates, customTemplateManifest);
     if (templateName) {
       dispatch(loadTemplate({ preLoadedManifest: customTemplateManifest, isCustomTemplate, viewTemplateDetails }));
     }
-  }, [customTemplateManifest, dispatch, isCustomTemplate, viewTemplateDetails, templateName]);
+  }, [customTemplateManifest, dispatch, isCustomTemplate, viewTemplateDetails, templateName, allTemplates]);
 
   if (!manifest) {
     return templateName ? (

--- a/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
@@ -45,7 +45,6 @@ export interface Parameter {
 
 export interface ParameterDefinition extends Parameter {
   associatedWorkflows?: string[];
-  isEditable?: boolean;
 }
 
 export interface Connection {

--- a/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
@@ -45,6 +45,7 @@ export interface Parameter {
 
 export interface ParameterDefinition extends Parameter {
   associatedWorkflows?: string[];
+  isEditable?: boolean;
 }
 
 export interface Connection {
@@ -56,4 +57,21 @@ export interface TemplateContext {
   templateId: string;
   workflowAppName?: string;
   isMultiWorkflow: boolean;
+}
+
+interface ContentInfo<T> {
+  value: T;
+  isEditable?: boolean;
+}
+
+export interface ViewTemplateDetails {
+  id: string;
+  basicsOverride?: Record<
+    string,
+    {
+      name?: ContentInfo<string>;
+      kind?: ContentInfo<string>;
+    }
+  >;
+  parametersOverride?: Record<string, ContentInfo<any>>;
 }

--- a/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
@@ -45,6 +45,7 @@ export interface Parameter {
 
 export interface ParameterDefinition extends Parameter {
   associatedWorkflows?: string[];
+  isEditable?: boolean;
 }
 
 export interface Connection {
@@ -69,7 +70,7 @@ export interface ViewTemplateDetails {
     string,
     {
       name?: ContentInfo<string>;
-      kind?: ContentInfo<string>;
+      kind?: ContentInfo<WorkflowKindType>;
     }
   >;
   parametersOverride?: Record<string, ContentInfo<any>>;


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [X] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

## New Behavior

- overrides basics & parameters info when present from viewTemplateData
- Moved ViewTemplateDetails interface to template model file for reusability
- Using viewTemplateDeatails only when currentTemplateName === viewTemplateDetails.id (extra protection)
- kind is set to viewTemplateDetails kind only when following is present from the template manifest

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan

e2e tests on prefilled data on viewTemplate selection

## Screenshots or Videos (if applicable)
https://github.com/user-attachments/assets/3a19e529-bc88-49c7-a0ca-b3f25e9039df

