### PR TITLE
Fix(Data Mapper): extra '/' added to custom values on for/if

### DIFF
--- a/libs/data-mapper-v2/src/mapHandling/MapDefinitionDeserializer.ts
+++ b/libs/data-mapper-v2/src/mapHandling/MapDefinitionDeserializer.ts
@@ -423,7 +423,8 @@ export class MapDefinitionDeserializer {
     rightSideStringOrObject: string | object,
     connections: ConnectionDictionary
   ) => {
-    const leftSideKeyNoGuid = removeGuidFromKey(leftSideKey);
+    const leftSideKeyFormatted = leftSideKey.replaceAll('\\"', '"');
+    const leftSideKeyNoGuid = removeGuidFromKey(leftSideKeyFormatted);
     const tokens = separateFunctions(leftSideKeyNoGuid);
     const forOrIfObj = createSchemaNodeOrFunction(tokens);
     if ((forOrIfObj.term as ParseFunc).name.includes(DReservedToken.if)) {

--- a/libs/data-mapper-v2/src/mapHandling/__test__/MapDefinitionDeserializer.spec.ts
+++ b/libs/data-mapper-v2/src/mapHandling/__test__/MapDefinitionDeserializer.spec.ts
@@ -407,6 +407,24 @@ describe('mapDefinitions/MapDefinitionDeserializer', () => {
         expect(count2Input).toEqual('source-/ns0:Root/CumulativeExpression/Population/State/County/Person/Sex/Female');
       });
 
+      it('creates conditional property connection with a function and custom value', () => {
+        // tests issue where custom values were being loaded with extra '/'; only stripped this in vs-code-designer for target side!
+        simpleMap['ns0:Root'] = {
+          ConditionalMapping: {
+            '6746506B-6072-41DE-8B64-81CE6E7AF9DD-$if(is-string(\\"USA\\"))': {
+              ItemDiscount: '/ns0:Root/ConditionalMapping/ItemPrice',
+            },
+          },
+        };
+
+        const mapDefinitionDeserializer = new MapDefinitionDeserializer(simpleMap, extendedSource, extendedTarget, functionMock);
+        const result = mapDefinitionDeserializer.convertFromMapDefinition();
+        const resultEntries = Object.entries(result);
+        resultEntries.sort();
+
+        expect((resultEntries[0][1].inputs[0] as CustomValueConnection).value).toEqual('USA'); // ensures extra connections aren't made
+      });
+
       it('creates a simple conditional property connection with a function', () => {
         // tests issue with input connections to function being re-created
         simpleMap['ns0:Root'] = {

--- a/libs/data-mapper-v2/src/mapHandling/__test__/MapDefinitionDeserializer.spec.ts
+++ b/libs/data-mapper-v2/src/mapHandling/__test__/MapDefinitionDeserializer.spec.ts
@@ -422,7 +422,7 @@ describe('mapDefinitions/MapDefinitionDeserializer', () => {
         const resultEntries = Object.entries(result);
         resultEntries.sort();
 
-        expect((resultEntries[0][1].inputs[0] as CustomValueConnection).value).toEqual('USA'); // ensures extra connections aren't made
+        expect((resultEntries[0][1].inputs[0] as CustomValueConnection).value).toEqual('"USA"'); // ensures extra connections aren't made
       });
 
       it('creates a simple conditional property connection with a function', () => {


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior
 extra '/' added in deserialization

https://msazure.visualstudio.com/One/_workitems/edit/31371895/

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
