### PR TITLE
fix(Designer): Fixes an issue where '\"'  causing json errors in expressions

### DIFF
--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -165,9 +165,7 @@ export function TokenPicker({
   }, [anchorKey, editor, windowDimensions.height]);
 
   const handleInitializeExpression = (s: string, n: NodeKey) => {
-    console.log(s);
     const escapedString = escapeString(s, /*requireSingleQuotesWrap*/ true);
-    console.log(escapedString);
     setExpression({ value: escapedString, selectionStart: 0, selectionEnd: 0 });
     setSelectedMode(TokenPickerMode.EXPRESSION);
     setExpressionToBeUpdated(n);

--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -165,7 +165,9 @@ export function TokenPicker({
   }, [anchorKey, editor, windowDimensions.height]);
 
   const handleInitializeExpression = (s: string, n: NodeKey) => {
+    console.log(s);
     const escapedString = escapeString(s, /*requireSingleQuotesWrap*/ true);
+    console.log(escapedString);
     setExpression({ value: escapedString, selectionStart: 0, selectionEnd: 0 });
     setSelectedMode(TokenPickerMode.EXPRESSION);
     setExpressionToBeUpdated(n);

--- a/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/tokenpickerfooter.tsx
@@ -115,7 +115,6 @@ export function TokenPickerFooter({
     let currExpression: Expression | null = null;
     const unescapedExpressionValue = unescapeString(expression.value);
     try {
-      console.log(unescapedExpressionValue);
       currExpression = ExpressionParser.parseExpression(unescapedExpressionValue);
     } catch (ex) {
       console.log(ex);

--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
@@ -411,7 +411,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{"newUnb3_1": @xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')}'
+        '{"newUnb3_1": @xpath(xml(triggerBody()), \'string(/*[local-name()=\"DynamicsSOCSV\"])\')}'
       );
     });
 
@@ -485,7 +485,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{"newUnb3_1": "@xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')"}'
+        '{"newUnb3_1": "@xpath(xml(triggerBody()), \'string(/*[local-name()=\"DynamicsSOCSV\"])\')"}'
       );
     });
 

--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
@@ -411,7 +411,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{"newUnb3_1": @xpath(xml(triggerBody()), \'string(/*[local-name()=\"DynamicsSOCSV\"])\')}'
+        '{"newUnb3_1":"@xpath(xml(triggerBody()), \'string(/*[local-name()=\\"DynamicsSOCSV\\"])\')"}'
       );
     });
 
@@ -485,7 +485,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{"newUnb3_1": "@xpath(xml(triggerBody()), \'string(/*[local-name()=\"DynamicsSOCSV\"])\')"}'
+        '{"newUnb3_1":"@{xpath(xml(triggerBody()), \'string(/*[local-name()=\\"DynamicsSOCSV\\"])\')}"}'
       );
     });
 

--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper.spec.ts
@@ -411,7 +411,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{\n  "newUnb3_1": @{xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')}\n}'
+        '{"newUnb3_1": @xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')}'
       );
     });
 
@@ -485,7 +485,7 @@ describe('core/utils/parameters/helper', () => {
       ];
 
       expect(parameterValueToJSONString(parameterValue, /* applyCasting */ false, /* forValidation */ true)).toBe(
-        '{\n  "newUnb3_1": "@{xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')}"\n}'
+        '{"newUnb3_1": "@xpath(xml(triggerBody()), \'string(/*[local-name()="DynamicsSOCSV"])\')"}'
       );
     });
 

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -3671,8 +3671,10 @@ export function parameterValueToJSONString(parameterValue: ValueSegment[], apply
         const nextExpressionIsLiteral =
           i < updatedParameterValue.length - 1 && updatedParameterValue[i + 1].type !== ValueSegmentType.TOKEN;
         tokenExpression = `@${stringifiedTokenExpression}`;
-        tokenExpression = lastExpressionWasLiteral ? `"${tokenExpression}` : tokenExpression;
-        tokenExpression = nextExpressionIsLiteral ? `${tokenExpression}"` : `${tokenExpression}`;
+        // eslint-disable-next-line no-useless-escape
+        tokenExpression = lastExpressionWasLiteral ? `\"${tokenExpression}` : tokenExpression;
+        // eslint-disable-next-line no-useless-escape
+        tokenExpression = nextExpressionIsLiteral ? `${tokenExpression}\"` : `${tokenExpression}`;
       }
 
       parameterValueString += tokenExpression;

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -3651,7 +3651,7 @@ export function parameterValueToJSONString(parameterValue: ValueSegment[], apply
     let tokenExpression: string = expression.value;
 
     if (isTokenValueSegment(expression)) {
-      const stringifiedTokenExpression = tokenExpression;
+      const stringifiedTokenExpression = JSON.stringify(tokenExpression).slice(1, -1);
       // Note: Stringify the token expression to escape double quotes and other characters which must be escaped in JSON.
       if (shouldInterpolate) {
         if (applyCasting) {

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
@@ -72,130 +72,125 @@ describe('canStringBeConverted', () => {
 
 describe('unescapeString', () => {
   it('unescapes newline characters', () => {
-    const input = 'Hello\\nWorld';
-    const expectedOutput = 'Hello\nWorld';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(unescapeString('Hello\\nWorld')).toBe('Hello\nWorld');
   });
 
   it('unescapes carriage return characters', () => {
-    const input = 'Hello\\rWorld';
-    const expectedOutput = 'Hello\rWorld';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(unescapeString('Hello\\rWorld')).toBe('Hello\rWorld');
   });
 
   it('unescapes tab characters', () => {
-    const input = 'Hello\\tWorld';
-    const expectedOutput = 'Hello\tWorld';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(unescapeString('Hello\\tWorld')).toBe('Hello\tWorld');
   });
 
   it('unescapes vertical tab characters', () => {
-    const input = 'Hello\\vWorld';
-    const expectedOutput = 'Hello\vWorld';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(unescapeString('Hello\\vWorld')).toBe('Hello\vWorld');
+  });
+
+  it('unescapes backslashes', () => {
+    expect(unescapeString('Hello\\\\World')).toBe('Hello\\World');
+  });
+
+  it('unescapes double quotes', () => {
+    expect(unescapeString('Hello\\"World"')).toBe('Hello"World"');
   });
 
   it('returns the same string if there are no escape sequences', () => {
-    const input = 'Hello World';
-    const expectedOutput = 'Hello World';
-    const result = unescapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(unescapeString('Hello World')).toBe('Hello World');
+  });
+
+  it('handles multiple escape sequences in a row', () => {
+    expect(unescapeString('Line1\\nLine2\\tTabbed')).toBe('Line1\nLine2\tTabbed');
+  });
+
+  it('handles an empty string', () => {
+    expect(unescapeString('')).toBe('');
+  });
+
+  it('ignores invalid escape sequences', () => {
+    expect(unescapeString('Hello\\xWorld')).toBe('Hello\\xWorld');
   });
 });
 
 describe('escapeString', () => {
   it('escapes newline characters', () => {
-    const input = 'Hello\nWorld';
-    const expectedOutput = 'Hello\\nWorld';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(escapeString('Hello\nWorld')).toBe('Hello\\nWorld');
   });
 
   it('escapes carriage return characters', () => {
-    const input = 'Hello\rWorld';
-    const expectedOutput = 'Hello\\rWorld';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(escapeString('Hello\rWorld')).toBe('Hello\\rWorld');
   });
 
   it('escapes tab characters', () => {
-    const input = 'Hello\tWorld';
-    const expectedOutput = 'Hello\\tWorld';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(escapeString('Hello\tWorld')).toBe('Hello\\tWorld');
   });
 
   it('escapes vertical tab characters', () => {
-    const input = 'Hello\vWorld';
-    const expectedOutput = 'Hello\\vWorld';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(escapeString('Hello\vWorld')).toBe('Hello\\vWorld');
   });
 
   it('returns the same string if there are no special characters', () => {
-    const input = 'Hello World';
-    const expectedOutput = 'Hello World';
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
+    expect(escapeString('Hello World')).toBe('Hello World');
   });
 
-  it('should correctly escape newline characters', () => {
-    expect(escapeString('\n')).toEqual('\\n');
-    expect(escapeString('Test\nTest')).toEqual('Test\\nTest');
+  it('escapes newline characters', () => {
+    expect(escapeString('\n')).toBe('\\n');
+    expect(escapeString('Test\nTest')).toBe('Test\\nTest');
   });
 
-  it('should correctly escape backslashes and newline characters together', () => {
-    expect(escapeString('\\\n')).toEqual('\\\\n');
-    expect(escapeString('Test\\\nTest')).toEqual('Test\\\\nTest');
+  it('escapes backslashes and newline characters together', () => {
+    expect(escapeString('\\\n')).toBe('\\\\n');
+    expect(escapeString('Test\\\nTest')).toBe('Test\\\\nTest');
   });
 
-  it('should handle an empty string', () => {
-    expect(escapeString('')).toEqual('');
+  it('handles an empty string', () => {
+    expect(escapeString('')).toBe('');
   });
 
-  it('does not escape characters if requireSingleQuotesWrap is true and there are no surrounding single quotes', () => {
-    const input = 'Test\nTest';
-    const result = escapeString(input, true);
-    expect(result).toBe(input); // No change, since it's not surrounded by single quotes
+  it('does not escape characters if requireSingleQuotesWrap is true and the string is not wrapped in single quotes', () => {
+    expect(escapeString('Test\nTest', true)).toBe('Test\nTest');
   });
 
-  it('escapes characters if requireSingleQuotesWrap is true and the string is surrounded by single quotes', () => {
-    const input = "'Test\nTest'";
-    const expectedOutput = "'Test\\nTest'";
-    const result = escapeString(input, true);
-    expect(result).toBe(expectedOutput); // Should escape \n
+  it('escapes characters if requireSingleQuotesWrap is true and the string is wrapped in single quotes', () => {
+    expect(escapeString("'Test\nTest'", true)).toBe("'Test\\nTest'");
   });
 
-  it('escapes characters even if the string contains multiple lines when requireSingleQuotesWrap is true and surrounded by single quotes', () => {
-    const input = "'Test\nAnotherLine\nTest'";
-    const expectedOutput = `'Test
+  it('escapes multiple newlines when requireSingleQuotesWrap is true and wrapped in single quotes', () => {
+    expect(escapeString("'Test\nAnotherLine\nTest'", true)).toBe(`'Test
 AnotherLine
-Test'`;
-    const result = escapeString(input, true);
-    expect(result).toBe(expectedOutput);
+Test'`);
   });
 
-  it('does not escape characters if requireSingleQuotesWrap is true and string is not surrounded by single quotes', () => {
-    const input = 'Test\nTest';
-    const result = escapeString(input, true);
-    expect(result).toBe(input); // No change, since it's not surrounded by single quotes
+  it('escapes characters even if requireSingleQuotesWrap is false, regardless of surrounding quotes', () => {
+    expect(escapeString("'Test\nTest'", false)).toBe("'Test\\nTest'");
   });
 
-  it('escapes characters when requireSingleQuotesWrap is false regardless of surrounding quotes', () => {
-    const input = "'Test\nTest'";
-    const expectedOutput = "'Test\\nTest'";
-    const result = escapeString(input, false);
-    expect(result).toBe(expectedOutput);
+  it('escapes characters when requireSingleQuotesWrap is undefined, regardless of surrounding quotes', () => {
+    expect(escapeString("'Test\nTest'")).toBe("'Test\\nTest'");
   });
 
-  it('escapes characters when requireSingleQuotesWrap is undefined regardless of surrounding quotes', () => {
-    const input = "'Test\nTest'";
-    const expectedOutput = "'Test\\nTest'";
-    const result = escapeString(input);
-    expect(result).toBe(expectedOutput);
+  it('escapes double quotes only when requireSingleQuotesWrap is true', () => {
+    expect(escapeString(`concat('{', '"ErrorDetail"', ':', '"Exchange get failed with exchange id', '-', '"}')`, true)).toBe(
+      `concat('{', '\\"ErrorDetail\\"', ':', '\\"Exchange get failed with exchange id', '-', '\\"}')`
+    );
+    expect(escapeString(`concat('{', '"ErrorDetail"', ':', '"Exchange get failed with exchange id', '-', '"}')`, false)).toBe(
+      `concat('{', '"ErrorDetail"', ':', '"Exchange get failed with exchange id', '-', '"}')`
+    );
+  });
+
+  it('escapes double quotes and newlines when requireSingleQuotesWrap is true', () => {
+    expect(escapeString('\'Hello\n"World"\'', true)).toBe('\'Hello\\n\\"World\\"\'');
+  });
+
+  it('does not escape double quotes when requireSingleQuotesWrap is false', () => {
+    expect(escapeString('Hello "World"', false)).toBe('Hello "World"');
+  });
+
+  it('escapes double quotes and other characters when requireSingleQuotesWrap is true and surrounded by single quotes', () => {
+    expect(escapeString('\'Test\n"AnotherTest"\'', true)).toBe('\'Test\\n\\"AnotherTest\\"\'');
+  });
+
+  it('does not escape double quotes when requireSingleQuotesWrap is false', () => {
+    expect(escapeString('Test "Hello"', false)).toBe('Test "Hello"');
   });
 });

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -55,7 +55,7 @@ export const cleanResourceId = (resourceId?: string): string => {
 };
 
 export const unescapeString = (input: string): string => {
-  return input.replace(/\\([nrtv])/g, (_match, char) => {
+  return input.replace(/\\([nrtv"\\])/g, (_match, char) => {
     switch (char) {
       case 'n':
         return '\n';
@@ -65,6 +65,10 @@ export const unescapeString = (input: string): string => {
         return '\t';
       case 'v':
         return '\v';
+      case '"':
+        return '"';
+      case '\\':
+        return '\\';
       default:
         return char;
     }
@@ -72,11 +76,12 @@ export const unescapeString = (input: string): string => {
 };
 
 export const escapeString = (input: string, requireSingleQuotesWrap?: boolean): string => {
-  if (requireSingleQuotesWrap && !/'.*[\n\r\t\v].*'/.test(input)) {
+  // Only apply escaping if requireSingleQuotesWrap is true and the input is wrapped in single quotes
+  if (requireSingleQuotesWrap && !/'.*[\n\r\t\v"].*'/.test(input)) {
     return input;
   }
 
-  return input?.replace(/[\n\r\t\v]/g, (char) => {
+  return input?.replace(/[\n\r\t\v"]/g, (char) => {
     switch (char) {
       case '\n':
         return '\\n';
@@ -86,6 +91,8 @@ export const escapeString = (input: string, requireSingleQuotesWrap?: boolean): 
         return '\\t';
       case '\v':
         return '\\v';
+      case '"':
+        return requireSingleQuotesWrap ? '\\"' : '"'; // Escape only if requireSingleQuotesWrap is true
       default:
         return char;
     }


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->
Fixes: https://github.com/Azure/LogicAppsUX/issues/6618
## New Behavior
User should always have the same expression, whether its opening an existing expression, saving a new expression, viewing it on the code view, etc. regardless of escape character - all of which should be handled behind the scenes
 

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 
E2E test and Unit tests have been added

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
