### PR TITLE
fix(vscode): Bug with path separator in local tests

### DIFF
--- a/apps/vs-code-designer/src/app/utils/tree/__test__/assets.test.ts
+++ b/apps/vs-code-designer/src/app/utils/tree/__test__/assets.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getIconPath, getThemedIconPath } from '../assets';
+import path from 'path';
 
 vi.mock('../../../../extensionVariables', () => ({
   ext: {
@@ -13,7 +14,7 @@ describe('assets utility functions', () => {
   describe('getIconPath', () => {
     it('should return the correct icon path', () => {
       const iconName = 'testIcon';
-      const expectedPath = 'mocked/path/assets/testIcon.svg';
+      const expectedPath = path.join('mocked', 'path', 'assets', 'testIcon.svg');
       const result = getIconPath(iconName);
       expect(result).toBe(expectedPath);
     });
@@ -23,8 +24,8 @@ describe('assets utility functions', () => {
     it('should return the correct themed icon path', () => {
       const iconName = 'testIcon';
       const expectedPath = {
-        light: 'mocked/path/assets/light/testIcon.svg',
-        dark: 'mocked/path/assets/dark/testIcon.svg',
+        light: path.join('mocked', 'path', 'assets', 'light', 'testIcon.svg'),
+        dark: path.join('mocked', 'path', 'assets', 'dark', 'testIcon.svg'),
       };
       const result = getThemedIconPath(iconName);
       expect(result).toEqual(expectedPath);


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Tests in apps/vs-code-designer/src/app/utils/tree/__test__/assets.test.ts fail locally due to mismatched OS path separators

## New Behavior

Use path.join on expected value in assert

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Fix existing test, no new tests required

## Screenshots or Videos (if applicable)

N/A
