### PR TITLE
feat(templates): Moving templates loading from template service via storage account

### DIFF
--- a/apps/Standalone/src/templates/app/TemplatesConsumption.tsx
+++ b/apps/Standalone/src/templates/app/TemplatesConsumption.tsx
@@ -333,6 +333,8 @@ const getServices = (
   };
 
   const templateService = new BaseTemplateService({
+    httpClient,
+    endpoint: 'https://priti-cxf4h5cpcteue4az.b02.azurefd.net',
     openBladeAfterCreate: (_workflowName: string | undefined) => {
       window.alert('Open blade after create, consumption creation is complete');
     },

--- a/apps/Standalone/src/templates/app/TemplatesStandard.tsx
+++ b/apps/Standalone/src/templates/app/TemplatesStandard.tsx
@@ -490,6 +490,7 @@ const getServices = (
   };
 
   const templateService = new StandardTemplateService({
+    endpoint: 'https://priti-cxf4h5cpcteue4az.b02.azurefd.net',
     baseUrl: armUrl,
     appId: siteResourceId,
     httpClient,

--- a/libs/designer/src/lib/core/state/templates/manifestSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/manifestSlice.ts
@@ -1,4 +1,4 @@
-import type { Template } from '@microsoft/logic-apps-shared';
+import { TemplateService, type Template } from '@microsoft/logic-apps-shared';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import type { RootState } from './store';
@@ -154,7 +154,7 @@ export default manifestSlice.reducer;
 
 const loadManifestNamesFromGithub = async (): Promise<ManifestName[] | undefined> => {
   try {
-    return (await import('./../../templates/templateFiles/manifest.json'))?.default as ManifestName[];
+    return TemplateService().getAllTemplateNames();
   } catch (ex) {
     console.error(ex);
     return undefined;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/template.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/template.ts
@@ -1,6 +1,10 @@
+import type { LogicAppsV2, Template } from '../../../utils/src';
+import type { IHttpClient } from '../httpClient';
 import type { ITemplateService } from '../template';
 
 export interface BaseTemplateServiceOptions {
+  httpClient: IHttpClient;
+  endpoint: string;
   openBladeAfterCreate: (workflowName: string | undefined) => void;
   onAddBlankWorkflow: () => Promise<void>;
   getCustomResource?: (resourcePath: string, artifactType?: string) => Promise<any> | undefined;
@@ -18,4 +22,30 @@ export class BaseTemplateService implements ITemplateService {
   public onAddBlankWorkflow = (): Promise<void> => this.options.onAddBlankWorkflow();
 
   public getCustomResource = (resourcePath: string): Promise<any> | undefined => this.options?.getCustomResource?.(resourcePath);
+
+  public getContentPathUrl: (resourcePath: string) => string = (resourcePath: string) =>
+    `${this.options.endpoint}/templates/${resourcePath}`;
+
+  public getAllTemplateNames = async (): Promise<string[]> => {
+    const response = await this.options.httpClient.get<any>({
+      uri: `${this.options.endpoint}/templates/manifest.json`,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+    });
+
+    return response;
+  };
+
+  public getResourceManifest = async (resourcePath: string): Promise<Template.Manifest> => {
+    return this.options.httpClient.get<any>({
+      uri: `${this.options.endpoint}/templates/${resourcePath}/manifest.json`,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+    });
+  };
+
+  public getWorkflowDefinition = async (resourcePath: string): Promise<LogicAppsV2.WorkflowDefinition> => {
+    return this.options.httpClient.get<any>({
+      uri: `${this.options.endpoint}/templates/${resourcePath}/workflow.json`,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+    });
+  };
 }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/template.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/template.ts
@@ -1,11 +1,9 @@
 import { ArgumentException } from '../../../utils/src';
 import { BaseTemplateService, type BaseTemplateServiceOptions } from '../base/template';
-import type { IHttpClient } from '../httpClient';
 
 interface StandardTemplateServiceOptions extends BaseTemplateServiceOptions {
   baseUrl: string;
   appId?: string;
-  httpClient: IHttpClient;
   apiVersions: {
     subscription: string;
     gateway: string;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/template.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/template.ts
@@ -1,3 +1,4 @@
+import type { LogicAppsV2, Template } from '../../utils/src';
 import { AssertionErrorCode, AssertionException } from '../../utils/src';
 
 export interface ITemplateService {
@@ -5,6 +6,10 @@ export interface ITemplateService {
   openBladeAfterCreate: (workflowName: string | undefined) => void;
   onAddBlankWorkflow: () => Promise<void>;
   getCustomResource?: (resourcePath: string, artifactType?: string) => Promise<any> | undefined;
+  getAllTemplateNames: () => Promise<string[]>;
+  getResourceManifest: (resourcePath: string) => Promise<Template.Manifest>;
+  getWorkflowDefinition: (resourcePath: string) => Promise<LogicAppsV2.WorkflowDefinition>;
+  getContentPathUrl: (resourcePath: string) => string;
 }
 
 let service: ITemplateService;

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   },
   "private": true,
   "scripts": {
-    "postinstall": "pnpm templates",
     "build": "turbo run build",
     "build:extension": "turbo run build:extension",
     "bump": "standard-version --no-verify",
@@ -95,8 +94,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:extension-unit": "turbo run test:extension-unit",
     "testgen": "playwright codegen https://localhost:4200",
-    "vscode:designer:pack": "turbo run vscode:designer:pack",
-    "templates": "ts-node downloadTemplates.js"
+    "vscode:designer:pack": "turbo run vscode:designer:pack"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior
Currently we are packaging all templates as part of build which restricts us to start a designer/portal build for any template updates.

## New Behavior
We will be using template service to fetch all templates/artifacts and manifests and this in turn will use the storage account.
This is a change how we load the templates but for end user there shouldn't be any difference.

* [x] **This is a breaking change.**

## Test Plan
> [!NOTE]
>**TESTS:** E2e will be added in future commit to check for gallery load even for local templates, again no connector details will be loaded.
We will also do manual testing after portal integration to see all templates are loaded correctly.
>**HIGH RISK:** Breaking change, since we are not packaging templates now and loading from a service. To integrate this package we will have to have a portal PR before doing any test deployments else templates will be broken.
