### PR TITLE
fix(vscode): bug where DateTime properties have invalid type in generated unit…

### DIFF
--- a/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
@@ -15,6 +15,7 @@ import {
   logTelemetry,
   processAndWriteMockableOperations,
   buildClassDefinition,
+  mapJsonTypeToCSharp,
 } from '../../unitTests';
 
 // ============================================================================
@@ -339,5 +340,18 @@ describe('buildClassDefinition', () => {
         },
       ],
     });
+  });
+});
+
+describe('mapJsonTypeToCSharp', () => {
+  it('should map JSON types to C# types correctly', () => {
+    expect(mapJsonTypeToCSharp('string')).toBe('string');
+    expect(mapJsonTypeToCSharp('string', 'date-time')).toBe('DateTime');
+    expect(mapJsonTypeToCSharp('boolean')).toBe('bool');
+    expect(mapJsonTypeToCSharp('integer')).toBe('int');
+    expect(mapJsonTypeToCSharp('number')).toBe('double');
+    expect(mapJsonTypeToCSharp('object')).toBe('JObject');
+    expect(mapJsonTypeToCSharp('any')).toBe('JObject');
+    expect(mapJsonTypeToCSharp('array')).toBe('List<object>');
   });
 });

--- a/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
@@ -185,9 +185,15 @@ describe('generateCSharpClasses', () => {
       type: 'object',
       key1: { type: 'string', description: 'Key 1 description' },
     });
+
     expect(classCode).toContain('public class RootClass');
+    expect(classCode).toContain('/// Key 1 description');
     expect(classCode).toContain('public string Key1 { get; set; }');
     expect(classCode).not.toContain('public HttpStatusCode StatusCode');
+
+    expect(classCode).toContain('public RootClass()');
+    expect(classCode).toContain('this.StatusCode = HttpStatusCode.OK;');
+    expect(classCode).toContain('this.Key1 = string.Empty;');
   });
 });
 
@@ -200,6 +206,12 @@ describe('generateCSharpClasses - Naming and Namespace Validation', () => {
       key: { type: 'string', description: 'test key' },
     };
     const classCode = generateCSharpClasses(namespaceName, rootClassName, data);
+
+    expect(classCode).toContain('using Newtonsoft.Json.Linq;');
+    expect(classCode).toContain('using System.Collections.Generic;');
+    expect(classCode).toContain('using System.Net;');
+    expect(classCode).toContain('using System;');
+
     expect(classCode).toContain(`public class ${rootClassName}`);
     expect(classCode).toContain(`namespace ${namespaceName}.Tests.Mocks`);
     expect(classCode).not.toContain('public HttpStatusCode StatusCode');
@@ -214,6 +226,7 @@ describe('generateClassCode', () => {
       properties: [
         { propertyName: 'Property1', propertyType: 'string', description: 'A string property', isObject: false },
         { propertyName: 'Property2', propertyType: 'int', description: 'An integer property', isObject: false },
+        { propertyName: 'DTProperty', propertyType: 'DateTime', description: 'A DateTime property', isObject: false },
       ],
       children: [],
     };
@@ -221,7 +234,12 @@ describe('generateClassCode', () => {
     expect(classCode).toContain('public class TestClass');
     expect(classCode).toContain('public string Property1 { get; set; }');
     expect(classCode).toContain('public int Property2 { get; set; }');
+    expect(classCode).toContain('public DateTime DTProperty { get; set; }');
+
     expect(classCode).toContain('this.StatusCode = HttpStatusCode.OK;');
+    expect(classCode).toContain('this.Property1 = string.Empty;');
+    expect(classCode).toContain('this.Property2 = 0;');
+    expect(classCode).toContain('this.DTProperty = new DateTime();');
   });
 });
 
@@ -325,6 +343,7 @@ describe('buildClassDefinition', () => {
       nested: {
         type: 'object',
         nestedKey: { type: 'boolean', description: 'Nested key description' },
+        nestedKey2: { type: 'string', format: 'date-time', description: 'Nested key 2 description' },
       },
     });
     expect(classDef).toEqual({
@@ -338,7 +357,10 @@ describe('buildClassDefinition', () => {
         {
           className: 'RootClassNested',
           description: 'Class for RootClassNested representing an object with properties.',
-          properties: [{ propertyName: 'NestedKey', propertyType: 'bool', description: 'Nested key description', isObject: false }],
+          properties: [
+            { propertyName: 'NestedKey', propertyType: 'bool', description: 'Nested key description', isObject: false },
+            { propertyName: 'NestedKey2', propertyType: 'DateTime', description: 'Nested key 2 description', isObject: false },
+          ],
           children: [],
         },
       ],

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -752,7 +752,7 @@ export function buildClassDefinition(className: string, node: any): ClassDefinit
       const propName = toPascalCase(key);
 
       // Determine the child's C# type
-      let csharpType = mapJsonTypeToCSharp(subNode?.type);
+      let csharpType = mapJsonTypeToCSharp(subNode?.type, subNode?.format);
       let isObject = false;
 
       // If it's an object, we must generate a nested class.
@@ -790,10 +790,10 @@ export function buildClassDefinition(className: string, node: any): ClassDefinit
 /**
  * Maps JSON types to corresponding C# types.
  */
-export function mapJsonTypeToCSharp(jsonType: string): string {
+export function mapJsonTypeToCSharp(jsonType: string, jsonFormat?: string): string {
   switch (jsonType) {
     case 'string':
-      return 'string';
+      return jsonFormat === 'date-time' ? 'DateTime' : 'string';
     case 'integer':
       return 'int';
     case 'number':
@@ -848,6 +848,8 @@ export function generateClassCode(classDef: ClassDefinition): string {
   for (const prop of classDef.properties) {
     if (prop.propertyType === 'string') {
       sb.push(`        ${prop.propertyName} = string.Empty;`);
+    } else if (prop.propertyType === 'DateTime') {
+      sb.push(`        ${prop.propertyName} = new DateTime();`);
     } else if (prop.isObject) {
       sb.push(`        ${prop.propertyName} = new ${prop.propertyType}();`);
     } else if (prop.propertyType === 'JObject') {
@@ -976,19 +978,10 @@ export function generateCSharpClasses(namespaceName: string, rootClassName: stri
   const adjustedNamespace = `${namespaceName}.Tests.Mocks`;
 
   // Generate the code for the root class (this also recursively generates nested classes).
+  const requiredNamespaces = ['Newtonsoft.Json.Linq', 'System.Collections.Generic', 'System.Net', 'System'];
   const classCode = generateClassCode(rootDef);
   // rap it all in the needed "using" statements + namespace.
-  const finalCode = [
-    'using Newtonsoft.Json.Linq;',
-    'using System.Collections.Generic;',
-    'using System.Net;',
-    '',
-    `namespace ${adjustedNamespace}`,
-    '{',
-    classCode,
-    '}',
-  ].join('\n');
-  return finalCode;
+  return [...requiredNamespaces.map((ns) => `using ${ns};`), '', `namespace ${adjustedNamespace}`, '{', classCode, '}'].join('\n');
 }
 
 // Static sets for mockable operation types


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Generated C# mock output classes for unit testing have string props instead of DateTime for props with date-time format.

## New Behavior

Pass format to type conversion method, handle date-time case

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Added unit test for "mapJsonTypeToCSharp", "generateCSharpClasses", "generateClassCode", "buildClassDefinition" to ensure proper conversion for different types

## Screenshots or Videos (if applicable)

N/A
