### PR TITLE
fix(vscode): default StatusCode in generated class ctors, remove duplicate StatusCode prop

### DIFF
--- a/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
@@ -186,6 +186,7 @@ describe('generateCSharpClasses', () => {
     });
     expect(classCode).toContain('public class RootClass');
     expect(classCode).toContain('public string Key1 { get; set; }');
+    expect(classCode).not.toContain('public HttpStatusCode StatusCode');
   });
 });
 
@@ -200,6 +201,7 @@ describe('generateCSharpClasses - Naming and Namespace Validation', () => {
     const classCode = generateCSharpClasses(namespaceName, rootClassName, data);
     expect(classCode).toContain(`public class ${rootClassName}`);
     expect(classCode).toContain(`namespace ${namespaceName}.Tests.Mocks`);
+    expect(classCode).not.toContain('public HttpStatusCode StatusCode');
   });
 });
 
@@ -218,6 +220,7 @@ describe('generateClassCode', () => {
     expect(classCode).toContain('public class TestClass');
     expect(classCode).toContain('public string Property1 { get; set; }');
     expect(classCode).toContain('public int Property2 { get; set; }');
+    expect(classCode).toContain('this.StatusCode = HttpStatusCode.OK;');
   });
 });
 

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -844,20 +844,21 @@ export function generateClassCode(classDef: ClassDefinition): string {
   sb.push('    /// </summary>');
   sb.push(`    public ${classDef.className}()`);
   sb.push('    {');
+  sb.push('        this.StatusCode = HttpStatusCode.OK;');
 
   for (const prop of classDef.properties) {
     if (prop.propertyType === 'string') {
-      sb.push(`        ${prop.propertyName} = string.Empty;`);
+      sb.push(`        this.${prop.propertyName} = string.Empty;`);
     } else if (prop.isObject) {
-      sb.push(`        ${prop.propertyName} = new ${prop.propertyType}();`);
+      sb.push(`        this.${prop.propertyName} = new ${prop.propertyType}();`);
     } else if (prop.propertyType === 'JObject') {
-      sb.push(`        ${prop.propertyName} = new JObject();`);
+      sb.push(`        this.${prop.propertyName} = new JObject();`);
     } else if (prop.propertyType.startsWith('List<')) {
-      sb.push(`        ${prop.propertyName} = new ${prop.propertyType}();`);
+      sb.push(`        this.${prop.propertyName} = new ${prop.propertyType}();`);
     } else if (prop.propertyType === 'int') {
-      sb.push(`        ${prop.propertyName} = 0;`);
+      sb.push(`        this.${prop.propertyName} = 0;`);
     } else if (prop.propertyType === 'HttpStatusCode') {
-      sb.push(`        ${prop.propertyName} = HttpStatusCode.OK;`);
+      sb.push(`        this.${prop.propertyName} = HttpStatusCode.OK;`);
     }
   }
 
@@ -966,12 +967,8 @@ export function generateCSharpClasses(namespaceName: string, rootClassName: stri
     ...data, // Merge the data (including "description", subfields, etc.)
   });
 
-  rootDef.properties.push({
-    propertyName: 'StatusCode',
-    propertyType: 'HttpStatusCode', // Use the System.Net enum
-    description: 'The HTTP status code returned by the action. Example: HttpStatusCode.OK for success.',
-    isObject: false,
-  });
+  // StatusCode is defined on the base class and not needed in generated classes
+  delete rootDef.properties['StatusCode'];
 
   const adjustedNamespace = `${namespaceName}.Tests.Mocks`;
 


### PR DESCRIPTION

## Type of Change

* [ ] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Default values are only set for class properties in generated classes, not for StatusCode in the base class. Some actions define duplicate StatusCode prop in generated class

## New Behavior

Default value of HttpStatusCode.OK now set for StatusCode, duplicate props removed

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Updated unit test utils tests to check that StatusCode prop not contained in generated classes and default value is assigned in ctor

## Screenshots or Videos (if applicable)

N/A
