### PR TITLE
fix(vscode): Add workflow and logic app creation back to azure blade

### DIFF
--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -376,8 +376,16 @@
     "menus": {
       "azureLogicAppsStandard.submenus.workspaceActions": [
         {
+          "command": "azureLogicAppsStandard.createNewProject",
+          "group": "1_create@1"
+        },
+        {
           "command": "azureLogicAppsStandard.createNewCodeProject",
           "group": "1_create@2"
+        },
+        {
+          "command": "azureLogicAppsStandard.createCodeless",
+          "group": "1_create@3"
         },
         {
           "command": "azureLogicAppsStandard.deploy",


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->
Logic App project creation and workflow creation was removed from the azure blade previously. 

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->
Logic App project creation and workflow creation is accessible from the azure blade again.

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
