### PR TITLE
fix(designer): Dictionary Editor to not use string interpolation for tokens if ANY value type

### DIFF
--- a/e2e/designer/editors/dictionary.spec.ts
+++ b/e2e/designer/editors/dictionary.spec.ts
@@ -1,46 +1,69 @@
 import { test, expect } from '@playwright/test';
 import { GoToMockWorkflow } from '../utils/GoToWorkflow';
 
-test(
+test.describe(
   'dictionary editor',
   {
     tag: '@mock',
   },
-  async ({ page }) => {
-    await page.goto('/');
+  async () => {
+    test('Should handle dictionary serialization', async ({ page }) => {
+      await page.goto('/');
 
-    await GoToMockWorkflow(page, 'Panel');
-    await page.getByLabel('Insert a new step between Initialize ArrayVariable and Parse JSON').click();
-    await page.getByText('Add an action').click();
-    await page.getByLabel('HTTP', { exact: true }).click();
-    await page.getByLabel('HTTP', { exact: true }).click();
-    await page.getByLabel('Headers key item').getByRole('paragraph').click();
-    await page.getByLabel('Headers key item').fill('testkey');
-    await page.getByLabel('Headers value item').getByRole('paragraph').click();
-    await page.getByLabel('Headers value item 0').fill('testValue');
-    await page.getByLabel('Headers key item 1').getByRole('paragraph').click();
-    await page.getByLabel('Headers key item 1').fill('testkey2');
-    await page.getByLabel('Headers value item 1').getByRole('paragraph').click();
-    await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-dynamic-content"]').click();
-    await page.getByRole('button', { name: 'string' }).click();
-    await page.getByLabel('Switch to text mode').first().click();
+      await GoToMockWorkflow(page, 'Panel');
+      await page.getByLabel('Insert a new step between Initialize ArrayVariable and Parse JSON').click();
+      await page.getByText('Add an action').click();
+      await page.getByLabel('HTTP', { exact: true }).click();
+      await page.getByLabel('HTTP', { exact: true }).click();
+      await page.getByLabel('Headers key item').getByRole('paragraph').click();
+      await page.getByLabel('Headers key item').fill('testkey');
+      await page.getByLabel('Headers value item').getByRole('paragraph').click();
+      await page.getByLabel('Headers value item 0').fill('testValue');
+      await page.getByLabel('Headers key item 1').getByRole('paragraph').click();
+      await page.getByLabel('Headers key item 1').fill('testkey2');
+      await page.getByLabel('Headers value item 1').getByRole('paragraph').click();
+      await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-dynamic-content"]').click();
+      await page.getByRole('button', { name: 'string' }).click();
+      await page.getByLabel('Switch to text mode').first().click();
 
-    await page.getByRole('tab', { name: 'Code view' }).click();
-    // because code view does serialization, it sometimes takes a bit of time to update
-    await page.waitForFunction(() => !document.querySelector('#code-view')?.textContent?.includes('loading'), { timeout: 3000 });
-    await expect(page.getByRole('code')).toContainText(
-      '{ "type": "Http", "inputs": { "uri": "", "method": "", "headers": { "testkey": "testValue", "testkey2": "@{triggerBody()?[\'string\']}" } }, "runAfter": { "Initialize_ArrayVariable": [ "SUCCEEDED" ] }, "runtimeConfiguration": { "contentTransfer": { "transferMode": "Chunked" } }}'
-    );
-    await page.getByRole('tab', { name: 'Parameters' }).click();
+      await page.getByRole('tab', { name: 'Code view' }).click();
+      // because code view does serialization, it sometimes takes a bit of time to update
+      await page.waitForFunction(() => !document.querySelector('#code-view')?.textContent?.includes('loading'), { timeout: 3000 });
+      await expect(page.getByRole('code')).toContainText(
+        '{ "type": "Http", "inputs": { "uri": "", "method": "", "headers": { "testkey": "testValue", "testkey2": "@{triggerBody()?[\'string\']}" } }, "runAfter": { "Initialize_ArrayVariable": [ "SUCCEEDED" ] }, "runtimeConfiguration": { "contentTransfer": { "transferMode": "Chunked" } }}'
+      );
+      await page.getByRole('tab', { name: 'Parameters' }).click();
 
-    // verify delete
-    await page.getByLabel('Headers value item 1').getByRole('paragraph').click();
-    await page.getByLabel('Click to delete item').nth(1).click();
-    await page.getByRole('tab', { name: 'Code view' }).click();
-    // because code view does serialization, it sometimes takes a bit of time to update
-    await page.waitForFunction(() => !document.querySelector('#code-view')?.textContent?.includes('loading'), { timeout: 3000 });
-    await expect(page.getByRole('code')).toContainText(
-      '{ "type": "Http", "inputs": { "uri": "", "method": "", "headers": { "testkey": "testValue" } }, "runAfter": { "Initialize_ArrayVariable": [ "SUCCEEDED" ] }, "runtimeConfiguration": { "contentTransfer": { "transferMode": "Chunked" } }}'
-    );
+      // verify delete
+      await page.getByLabel('Headers value item 1').getByRole('paragraph').click();
+      await page.getByLabel('Click to delete item').nth(1).click();
+      await page.getByRole('tab', { name: 'Code view' }).click();
+      // because code view does serialization, it sometimes takes a bit of time to update
+      await page.waitForFunction(() => !document.querySelector('#code-view')?.textContent?.includes('loading'), { timeout: 3000 });
+      await expect(page.getByRole('code')).toContainText(
+        '{ "type": "Http", "inputs": { "uri": "", "method": "", "headers": { "testkey": "testValue" } }, "runAfter": { "Initialize_ArrayVariable": [ "SUCCEEDED" ] }, "runtimeConfiguration": { "contentTransfer": { "transferMode": "Chunked" } }}'
+      );
+    });
+
+    test('Should not do value string interpolation if is of type `any` and has a token', async ({ page }) => {
+      await page.goto('/');
+
+      await GoToMockWorkflow(page, 'Panel');
+      await page.getByLabel('Insert a new step between Initialize ArrayVariable and Parse JSON').click();
+      await page.getByText('Add an action').click();
+      await page.getByPlaceholder('Search').fill('select');
+      await page.getByLabel('Select').click();
+      await page.getByTestId('msla-setting-token-editor-stringeditor-from').click();
+      await page.keyboard.type('[]');
+      await page.getByLabel('Map key item').getByRole('paragraph').click();
+      await page.getByLabel('Map key item').fill('test');
+      await page.getByLabel('Map value item').getByRole('paragraph').click();
+      await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-dynamic-content"]').click();
+      await page.getByRole('button', { name: 'ArrayVariable', exact: true }).click();
+      await page.getByRole('tab', { name: 'Code view' }).click();
+      await expect(page.getByRole('code')).toContainText(
+        '{ "type": "Select", "inputs": { "from": [], "select": { "test": "@variables(\'ArrayVariable\')" } }, "runAfter": { "Initialize_ArrayVariable": [ "SUCCEEDED" ] }}'
+      );
+    });
   }
 );

--- a/libs/designer-ui/src/lib/editor/base/utils/helper.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/helper.ts
@@ -52,6 +52,10 @@ export const isTokenValueSegment = (value: ValueSegment[]): boolean => {
   return value.length === 1 && value[0].type === ValueSegmentType.TOKEN;
 };
 
+export const containsTokenSegments = (segments: ValueSegment[]): boolean => {
+  return segments.some((segment) => segment.type === ValueSegmentType.TOKEN);
+};
+
 export const validateDictionaryStrings = (s: string): boolean => {
   try {
     JSON.parse(s);

--- a/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
@@ -1,7 +1,7 @@
 import constants from '../../../constants';
 import { isEmpty } from '../../../dictionary/expandeddictionary';
 import type { ValueSegment } from '../../models/parameter';
-import { createLiteralValueSegment, insertQutationForStringType } from './helper';
+import { containsTokenSegments, createLiteralValueSegment, insertQutationForStringType } from './helper';
 import { convertSegmentsToString } from './parsesegments';
 import { escapeString } from '@microsoft/logic-apps-shared';
 
@@ -61,7 +61,7 @@ export const convertValueType = (value: ValueSegment[], type?: string): string |
     return type;
   }
   const stringSegments = convertSegmentsToString(value).trim();
-  if (isNonString(stringSegments)) {
+  if (isNonString(stringSegments) || containsTokenSegments(value)) {
     return type;
   }
   return constants.SWAGGER.TYPE.STRING;


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

Currently it goes by the parsed value, but doesn't account for tokens.

## New Behavior

Now does not default with tokens 

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan
Added E2E test

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
