### PR TITLE
fix(vscode): Fix for adding sql for multiple logic apps in a workspace

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/useSQLStorage.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/useSQLStorage.ts
@@ -6,21 +6,25 @@ import { sqlStorageConnectionStringKey } from '../../../constants';
 import { localize } from '../../../localize';
 import { addOrUpdateLocalAppSettings } from '../../utils/appSettings/localSettings';
 import { getLogicAppProjectRoot } from '../../utils/codeless/connection';
-import { getLocalSettingsFile } from '../appSettings/getLocalSettingsFile';
+import { tryGetLogicAppProjectRoot } from '../../utils/verifyIsProject';
+import { getWorkspaceFolder } from '../../utils/workspace';
 import { validateSQLConnectionString } from '../deploy/storageAccountSteps/SQLStringNameStep';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 
-export async function useSQLStorage(context: IActionContext) {
+export async function useSQLStorage(context: IActionContext, target: vscode.Uri) {
+  if (target === undefined || Object.keys(target).length === 0) {
+    const workspaceFolder = await getWorkspaceFolder(context);
+    const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
+    target = vscode.Uri.file(projectPath);
+  }
   const sqlConnectionString = await context.ui.showInputBox({
     placeHolder: localize('sqlConnectionStringPlaceholder', 'SQL connection string'),
     prompt: localize('sqlConnectionStringPrompt', 'Provide your SQL connection string'),
     validateInput: async (connectionString: string): Promise<string | undefined> => await validateSQLConnectionString(connectionString),
   });
 
-  const message: string = localize('selectLocalSettings', 'Select your local settings file.');
-  const localSettingsFile: string = await getLocalSettingsFile(context, message);
-  const projectPath = await getLogicAppProjectRoot(context, localSettingsFile);
+  const projectPath = await getLogicAppProjectRoot(context, target.fsPath);
 
   if (!projectPath) {
     throw new Error(localize('FunctionRootFolderError', 'Unable to determine logic app project root folder.'));


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

WIth multiple logic apps in a workspace, the sql connection is only added to the first logic app in the list regardless of which logic app is selected.

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

This change corrects the above behavior to have the sql string inserted into the local.settings.json of the selected logic app.

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
