### PR TITLE
fix(vscode): Add validation for workspace and logic app name

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createCodeless/createCodelessSteps/ScriptSteps/ScriptWorkflowNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createCodeless/createCodelessSteps/ScriptSteps/ScriptWorkflowNameStep.ts
@@ -15,7 +15,7 @@ export class ScriptWorkflowNameStep extends WorkflowNameStepBase<IScriptWorkflow
     return await this.getUniqueFsPath(context.projectPath, template.defaultFunctionName);
   }
 
-  protected async validateFunctionNameCore(context: IScriptWorkflowWizardContext, name: string): Promise<string | undefined> {
+  protected async validateNameCore(context: IScriptWorkflowWizardContext, name: string): Promise<string | undefined> {
     if (await fse.pathExists(path.join(context.projectPath, name))) {
       return localize('existingFolderError', 'A folder with the name "{0}" already exists.', name);
     }

--- a/apps/vs-code-designer/src/app/commands/createCodeless/createCodelessSteps/WorkflowNameStepBase.ts
+++ b/apps/vs-code-designer/src/app/commands/createCodeless/createCodelessSteps/WorkflowNameStepBase.ts
@@ -7,10 +7,11 @@ import { AzureWizardPromptStep, nonNullProp } from '@microsoft/vscode-azext-util
 import type { IFunctionWizardContext, IWorkflowTemplate } from '@microsoft/vscode-extension-logic-apps';
 import * as fse from 'fs-extra';
 import * as path from 'path';
+import { workflowNameValidation } from '../../../../constants';
 
 export abstract class WorkflowNameStepBase<T extends IFunctionWizardContext> extends AzureWizardPromptStep<T> {
   protected abstract getUniqueFunctionName(context: T): Promise<string | undefined>;
-  protected abstract validateFunctionNameCore(context: T, name: string): Promise<string | undefined>;
+  protected abstract validateNameCore(context: T, name: string): Promise<string | undefined>;
 
   public async prompt(context: T): Promise<void> {
     const template: IWorkflowTemplate = nonNullProp(context, 'functionTemplate');
@@ -19,7 +20,7 @@ export abstract class WorkflowNameStepBase<T extends IFunctionWizardContext> ext
     context.functionName = await context.ui.showInputBox({
       placeHolder: localize('workflowNamePlaceholder', 'Workflow name'),
       prompt: localize('workflowNamePrompt', 'Provide a workflow name'),
-      validateInput: async (s: string): Promise<string | undefined> => await this.validateFunctionName(context, s),
+      validateInput: async (s: string): Promise<string | undefined> => await this.validateWorkflowName(context, s),
       value: uniqueWorkflowName || template.defaultFunctionName,
     });
   }
@@ -43,18 +44,16 @@ export abstract class WorkflowNameStepBase<T extends IFunctionWizardContext> ext
     return undefined;
   }
 
-  private async validateFunctionName(context: T, name: string | undefined): Promise<string | undefined> {
+  private async validateWorkflowName(context: T, name: string | undefined): Promise<string | undefined> {
     if (!name) {
-      return localize('emptyTemplateNameError', 'The function name cannot be empty.');
+      return localize('emptyWorkflowNameError', 'The workflow name cannot be empty.');
     }
-    if (!functionNameRegex.test(name)) {
+    if (!workflowNameValidation.test(name)) {
       return localize(
-        'functionNameInvalidMessage',
-        'Function name must start with a letter and can only contain letters, digits, "_" and "-".'
+        'workflowNameInvalidMessage',
+        'Workflow name must start with a letter and can only contain letters, digits, "_" and "-".'
       );
     }
-    return await this.validateFunctionNameCore(context, name);
+    return await this.validateNameCore(context, name);
   }
 }
-
-const functionNameRegex = /^[a-z][a-z\d_-]*$/i;

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetWorkspaceName.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetWorkspaceName.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs-extra';
 import { OpenBehavior } from '@microsoft/vscode-extension-logic-apps';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
 import * as path from 'path';
+import { workspaceNameValidation } from '../../../../constants';
 
 export class SetWorkspaceName extends AzureWizardPromptStep<IProjectWizardContext> {
   public hideStepCount = true;
@@ -17,7 +18,9 @@ export class SetWorkspaceName extends AzureWizardPromptStep<IProjectWizardContex
     context.workspaceName = await context.ui.showInputBox({
       placeHolder: localize('setWorkspaceName', 'Workspace name'),
       prompt: localize('workspaceNamePrompt', 'Provide a workspace name'),
+      validateInput: async (input: string): Promise<string | undefined> => await this.validateWorkspaceName(input),
     });
+
     //save uri variable for open project folder command
     context.workspaceCustomFilePath = path.join(context.projectPath, context.workspaceName);
     await fs.ensureDir(context.workspacePath);
@@ -33,5 +36,18 @@ export class SetWorkspaceName extends AzureWizardPromptStep<IProjectWizardContex
 
   public shouldPrompt(): boolean {
     return true;
+  }
+
+  private async validateWorkspaceName(name: string | undefined): Promise<string | undefined> {
+    if (!name) {
+      return localize('emptyWorkspaceName', 'The workspace name cannot be empty.');
+    }
+    if (!workspaceNameValidation.test(name)) {
+      return localize(
+        'workspaceNameInvalidMessage',
+        'Workspace name must start with a letter and can only contain letters, digits, "_" and "-".'
+      );
+    }
+    return undefined;
   }
 }

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/setMethodName.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/setMethodName.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import * as fse from 'fs-extra';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
+import * as path from 'path';
 
 export class setMethodName extends AzureWizardPromptStep<IProjectWizardContext> {
   public hideStepCount = true;
@@ -19,7 +20,7 @@ export class setMethodName extends AzureWizardPromptStep<IProjectWizardContext> 
     });
   }
 
-  public shouldPrompt(_context: IProjectWizardContext): boolean {
+  public shouldPrompt(): boolean {
     return true;
   }
 
@@ -42,7 +43,7 @@ export class setMethodName extends AzureWizardPromptStep<IProjectWizardContext> 
       const workspaceFileContent = await vscode.workspace.fs.readFile(vscode.Uri.file(context.workspaceCustomFilePath));
       const workspaceFileJson = JSON.parse(workspaceFileContent.toString());
 
-      if (workspaceFileJson.folders && workspaceFileJson.folders.some((folder: { path: string }) => folder.path === `./${name}`)) {
+      if (workspaceFileJson.folders && workspaceFileJson.folders.some((folder: { path: string }) => folder.path === path.join('.', name))) {
         return localize('functionNameExistsInWorkspaceError', 'A function with this name already exists in the workspace.');
       }
     }

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -348,3 +348,8 @@ export type COMMON_ERRORS = (typeof COMMON_ERRORS)[keyof typeof COMMON_ERRORS];
 // Environment Variables
 export const azurePublicBaseUrl = 'https://management.azure.com';
 export const sqlConnectionStringSecretName = 'sqlconnectionstring';
+
+//Regex validations
+export const workflowNameValidation = /^[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*$/i;
+export const logicAppNameValidation = /^[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*$/i;
+export const workspaceNameValidation = /^[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*$/i;


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

Fixes #6643 

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

Workspace names/ Logic app names allow spaces and special characters apart from the allowed ones in their name

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

Workspace names/ Logic app names now do not allow spaces and special characters apart from the allowed ones.

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

Currently tested by vendors

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
![CleanShot 2025-02-26 at 16 00 53@2x](https://github.com/user-attachments/assets/4c704382-296b-431d-b652-46924d0b7ad5)

