### PR TITLE
fix(Designer): Fixed loop causing rerender in monitoring view (v5.44)

### DIFF
--- a/libs/designer/src/lib/core/store.ts
+++ b/libs/designer/src/lib/core/store.ts
@@ -16,6 +16,12 @@ import { configureStore } from '@reduxjs/toolkit';
 import type {} from 'redux-thunk';
 import { storeStateHistoryMiddleware } from './utils/middleware';
 
+declare global {
+  interface Window {
+    __REDUX_ACTION_LOG__?: string[];
+  }
+}
+
 export const store = configureStore({
   reducer: {
     workflow: workflowReducer,
@@ -42,6 +48,18 @@ export const store = configureStore({
 if (process.env.NODE_ENV === 'development') {
   (window as any).DesignerStore = store;
 }
+
+// Log actions for testing purposes
+if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
+  window.__REDUX_ACTION_LOG__ = [];
+  const originalDispatch = store.dispatch;
+  store.dispatch = (action: any) => {
+    window.__REDUX_ACTION_LOG__?.push(action.type);
+    return originalDispatch(action);
+  };
+}
+
+export default store;
 
 // Infer the `AppStore` from the store itself
 export type AppStore = typeof store;

--- a/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -76,6 +76,7 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
   const runData = useRunData(id);
   const parentRunId = useParentRunId(id);
   const parentRunData = useRunData(parentRunId ?? '');
+  const selfRunData = useRunData(id);
   const nodesMetaData = useNodesMetadata();
   const repetitionName = useMemo(
     () => getRepetitionName(parentRunIndex, id, nodesMetaData, operationsInfo),
@@ -120,9 +121,14 @@ const DefaultNode = ({ targetPosition = Position.Top, sourcePosition = Position.
 
   useEffect(() => {
     if (!isNullOrUndefined(repetitionRunData)) {
+      if (selfRunData?.correlation?.actionTrackingId === repetitionRunData?.properties?.correlation?.actionTrackingId) {
+        // if the correlation id is the same, we don't need to update the repetition run data
+        return;
+      }
+
       dispatch(setRepetitionRunData({ nodeId: id, runData: repetitionRunData.properties as LogicAppsV2.WorkflowRunAction }));
     }
-  }, [dispatch, repetitionRunData, id]);
+  }, [dispatch, repetitionRunData, id, selfRunData?.correlation?.actionTrackingId]);
 
   const { dependencies, loopSources } = useTokenDependencies(id);
 

--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -65,6 +65,7 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
   const runData = useRunData(scopeId);
   const parentRunId = useParentRunId(scopeId);
   const parentRunData = useRunData(parentRunId ?? '');
+  const selfRunData = useRunData(scopeId);
   const nodesMetaData = useNodesMetadata();
   const repetitionName = useMemo(
     () => getRepetitionName(parentRunIndex, scopeId, nodesMetaData, operationsInfo),
@@ -102,9 +103,14 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
 
   useEffect(() => {
     if (!isNullOrUndefined(repetitionRunData)) {
+      if (selfRunData?.correlation?.actionTrackingId === repetitionRunData?.properties?.correlation?.actionTrackingId) {
+        // if the correlation id is the same, we don't need to update the repetition run data
+        return;
+      }
+
       dispatch(setRepetitionRunData({ nodeId: scopeId, runData: repetitionRunData.properties as LogicAppsV2.WorkflowRunAction }));
     }
-  }, [dispatch, repetitionRunData, scopeId]);
+  }, [dispatch, repetitionRunData, scopeId, selfRunData?.correlation?.actionTrackingId]);
 
   const { dependencies, loopSources } = useTokenDependencies(scopeId);
   const [{ isDragging }, drag, dragPreview] = useDrag(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = 'development'; // Set before importing Playwright
+
 import { defineConfig, devices } from '@playwright/test';
 import 'dotenv/config';
 


### PR DESCRIPTION
## Main Changes

Fixed loop causing rerender in monitoring view
Components were being _fully_ rerendered for some reason when `setRepetitionRunData` was called, and it was recursively being called in the useEffect.
We now catch it if the data is already present and the rerenders are prevented.

> [!IMPORTANT]
> **TESTS**: Improved our real-api loop monitoring e2e test to cover this issue
> **RISK**: Low risk, Carlos and I have both tested all loop scenarios 

> [!NOTE]
> Cherry-picked from https://github.com/Azure/LogicAppsUX/pull/6686