### PR TITLE
fix(vscode): automated testing bug in config workspace path and C# class generation

### DIFF
--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -499,7 +499,7 @@ export async function createTestSettingsConfigFile(unitTestFolderPath: string, w
 
   let templateContent = await fse.readFile(templatePath, 'utf-8');
   templateContent = templateContent
-    .replace(/%WorkspacePath%/g, '../../../../')
+    .replace(/%WorkspacePath%/g, '../../../../../')
     .replace(/%LogicAppName%/g, logicAppName)
     .replace(/%WorkflowName%/g, workflowName);
 
@@ -990,7 +990,9 @@ export function generateClassCode(classDef: ClassDefinition): string {
   sb.push('        /// </summary>');
   sb.push(`        public ${classDef.className}()`);
   sb.push('        {');
-  sb.push('            this.StatusCode = HttpStatusCode.OK;');
+  if (classDef.inheritsFrom === 'MockOutput') {
+    sb.push('            this.StatusCode = HttpStatusCode.OK;');
+  }
 
   for (const prop of classDef.properties) {
     if (prop.propertyType === 'string') {


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

1. Currently use path "../../../../" as relative workspace path in test settings config (invalid)
2. Set StatusCode property in ctor of all generated classes

## New Behavior

1. Change path to "../../../../../" for workspace path in test settings config
2. Only set StatusCode property in generated classes which extend MockOutput

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Added updated tests for generateClassCode/createTestSettingsConfigFile to catch these bugs

## Screenshots or Videos (if applicable)

N/A
