### PR TITLE
fix(vscode): Adjust Folder Insertion to End of Workspace 

### DIFF
--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/__test__/FileManagement.test.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/__test__/FileManagement.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as vscode from 'vscode';
+import { FileManagement } from '../iacGestureHelperFunctions';
+import { localize } from '../../../../localize';
+import { ext } from '../../../../extensionVariables';
+
+/**
+ * Helper to create a mock workspace folder.
+ * @param fsPath The folder path.
+ * @returns A mock WorkspaceFolder.
+ */
+function mockWorkspaceFolder(fsPath: string): vscode.WorkspaceFolder {
+  return {
+    uri: vscode.Uri.file(fsPath),
+    name: 'Test Folder',
+    index: 0,
+  } as vscode.WorkspaceFolder;
+}
+
+describe('FileManagement.addFolderToWorkspace', () => {
+  let updateWorkspaceFoldersSpy: ReturnType<typeof vi.spyOn>;
+  let appendLogSpy: ReturnType<typeof vi.spyOn>;
+  let showErrorMessageSpy: ReturnType<typeof vi.spyOn>;
+
+  const folderPathExisting = '/existing/folder';
+  const folderPathNew = '/new/folder';
+  const folderPathError = '/error/folder';
+
+  beforeEach(() => {
+    // Ensure that ext.outputChannel is defined before spying on it.
+    ext.outputChannel = {
+      name: 'OutputChannel',
+      appendLog: vi.fn(),
+      append: vi.fn(),
+      appendLine: vi.fn(),
+      replace: vi.fn(),
+      clear: vi.fn(),
+      show: vi.fn(),
+      hide: vi.fn(),
+      dispose: vi.fn(),
+    };
+
+    // Spy on the VS Code and extension logging methods.
+    updateWorkspaceFoldersSpy = vi.spyOn(vscode.workspace, 'updateWorkspaceFolders') as any;
+    appendLogSpy = vi.spyOn(ext.outputChannel, 'appendLog');
+    showErrorMessageSpy = vi.spyOn(vscode.window, 'showErrorMessage') as any;
+
+    // Ensure a clean workspaceFolders state.
+    (vscode.workspace as any).workspaceFolders = [];
+  });
+
+  afterEach(() => {
+    // Reset any modifications to the workspace folders.
+    (vscode.workspace as any).workspaceFolders = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('should log and not add the folder if it is already in the workspace', () => {
+    // Arrange: Create a workspace that already contains the folder.
+    const existingFolder = mockWorkspaceFolder(folderPathExisting);
+    (vscode.workspace as any).workspaceFolders = [existingFolder];
+
+    // Act
+    FileManagement.addFolderToWorkspace(folderPathExisting);
+
+    // Assert
+    // First, we log that we are attempting to add the folder.
+    expect(appendLogSpy).toHaveBeenCalledWith(localize('addingFolderToWorkspace', `Adding folder to workspace: ${folderPathExisting}`));
+    // Then, we log that the folder already exists.
+    expect(appendLogSpy).toHaveBeenCalledWith(
+      localize('folderAlreadyInWorkspace', `Folder is already in the workspace: ${folderPathExisting}`)
+    );
+    // And updateWorkspaceFolders should not have been called.
+    expect(updateWorkspaceFoldersSpy).not.toHaveBeenCalled();
+  });
+
+  it('should catch and handle errors thrown during folder addition', () => {
+    // Arrange: Set up an empty workspace.
+    (vscode.workspace as any).workspaceFolders = [];
+    const testError = new Error('Test error');
+    // Stub updateWorkspaceFolders to throw an error.
+    updateWorkspaceFoldersSpy.mockImplementation(() => {
+      throw testError;
+    });
+    const showErrorSpy = vi.spyOn(vscode.window, 'showErrorMessage').mockImplementation(async () => undefined);
+
+    // Act
+    FileManagement.addFolderToWorkspace(folderPathError);
+
+    // Assert
+    // Verify that the error is logged.
+    expect(appendLogSpy).toHaveBeenCalledWith(localize('errorAddingFolder', `Error in addFolderToWorkspace: ${testError}`));
+    // And an error message is shown to the user.
+    expect(showErrorSpy).toHaveBeenCalledWith(
+      localize('errorMessageAddingFolder', 'Failed to add folder to workspace: ') + testError.message
+    );
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/iacGestureHelperFunctions.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/iacGestureHelperFunctions.ts
@@ -22,7 +22,10 @@ export class FileManagement {
       if (isAlreadyInWorkspace) {
         ext.outputChannel.appendLog(localize('folderAlreadyInWorkspace', `Folder is already in the workspace: ${folderPath}`));
       } else {
-        const result = vscode.workspace.updateWorkspaceFolders(0, null, { uri });
+        const insertIndex = existingFolders.length;
+
+        const result = vscode.workspace.updateWorkspaceFolders(insertIndex, 0, { uri });
+
         if (result) {
           ext.outputChannel.appendLog(localize('folderAddedSuccessfully', `Folder added successfully: ${folderPath}`));
         } else {
@@ -31,7 +34,7 @@ export class FileManagement {
           );
         }
       }
-    } catch (error) {
+    } catch (error: any) {
       ext.outputChannel.appendLog(localize('errorAddingFolder', `Error in addFolderToWorkspace: ${error}`));
       vscode.window.showErrorMessage(localize('errorMessageAddingFolder', 'Failed to add folder to workspace: ') + error.message);
     }

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -56,6 +56,7 @@ vi.mock('vscode', () => ({
   },
   workspace: {
     workspaceFolders: [],
+    updateWorkspaceFolders: vi.fn(), // <-- This ensures the method exists.
   },
   Uri: {
     file: (p: string) => ({ fsPath: p, toString: () => p }),


### PR DESCRIPTION
[Work Item: [Bug] Create test from run: Debug adapter process has terminated unexpectedly](https://msazure.visualstudio.com/One/_workitems/edit/31450115)  


## **Type of Change**
- [x] Bug fix  
- [ ] Feature  
- [ ] Other  

## **Current Behavior**
- When adding a folder to the workspace, the code currently inserts the folder at the **front** of the existing workspace.
- This causes VS Code to reload the extension, terminating any active debugging session.
  
## **New Behavior**
- The new folder is now added to the **end** of the workspace.
- Prevents VS Code from reloading the extension and terminating the debugging session.

## **Impact of Change**
- [ ] **This is a breaking change.**
- No breaking changes introduced. Other functionality remains unaffected.

## **Test Plan**
- ✅ Unit tests added to:  
  `apps\vs-code-designer\src\app\commands\generateDeploymentScripts\__test__\FileManagement.test.ts`

## **Screenshots or Videos (if applicable)**
N/A
