### PR TITLE
fix(vscode): Workspace fixes for empty vscode and designtime directory creation

### DIFF
--- a/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
+++ b/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
@@ -86,7 +86,7 @@ export async function isLogicAppProjectInRoot(workspaceFolder: WorkspaceFolder |
     return false;
   }
 
-  return false;
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

VSCode with no folder opens causes an issue when creating a workspace. Designtime directory does not always create.

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

Check that there are no folders open before creating a workspace.
Ensure that design time directory is created with new logic app projects in a workspace.

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
