### PR TITLE
fix(vscode): updateCsprojFile not called in create from run

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -10,6 +10,7 @@ import {
   createTestExecutorFile,
   createTestSettingsConfigFile,
   ensureCsproj,
+  updateCsprojFile,
   extractAndValidateRunId,
   getUnitTestPaths,
   handleError,
@@ -262,6 +263,10 @@ async function generateUnitTestFromRun(
       logTelemetry(context, { nugetConfigFileCreated: 'false', nugetConfigFailReason });
       throw nugetError;
     }
+
+    const csprojFilePath = path.join(paths.logicAppTestFolderPath, `${paths.logicAppName}.csproj`);
+    const isCsprojUpdated = await updateCsprojFile(csprojFilePath, workflowName);
+    logTelemetry(context, { csprojUpdated: isCsprojUpdated ? 'true' : 'false' });
 
     try {
       ext.outputChannel.appendLog(localize('checkingWorkspace', 'Checking if tests directory is already part of the workspace...'));

--- a/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
@@ -647,7 +647,12 @@ describe('updateCsprojFile', () => {
     await updateCsprojFile(csprojFilePath, workflowName);
 
     expect(readFileSpy).toHaveBeenCalled();
-    expect(writeFileSpy).toHaveBeenCalledWith(csprojFilePath, expect.any(String), 'utf8', expect.any(Function));
+    expect(writeFileSpy).toHaveBeenCalledWith(
+      csprojFilePath,
+      expect.stringContaining('%(RecursiveDir)%(Filename)%(Extension)'),
+      'utf8',
+      expect.any(Function)
+    );
     expect(ext.outputChannel.appendLog).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

updateCsprojFile is never called in create unit test from run, which can result in misconfigured csproj file

## New Behavior

Add updateCsprojFile call after ensureCsprojFile

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

saveBlankUnitTest/createUnitTestFromRun to be covered in vendor testing (no E2E tests currently)

## Screenshots or Videos (if applicable)

N/A
