### PR TITLE
feat(template): Support overriding managed api connections

### DIFF
--- a/libs/designer/src/lib/ui/templates/connections/workflowconnections.tsx
+++ b/libs/designer/src/lib/ui/templates/connections/workflowconnections.tsx
@@ -65,11 +65,13 @@ export const WorkflowConnections = ({ connections }: WorkflowConnectionsProps) =
     location,
     connections: { references, mapping },
     workflows,
+    viewTemplateDetails,
   } = useSelector((state: RootState) => ({
     subscriptionId: state.workflow.subscriptionId,
     location: state.workflow.location,
     connections: state.workflow.connections,
     workflows: state.template.workflows,
+    viewTemplateDetails: state.templateOptions.viewTemplateDetails,
   }));
   const columnsNames = {
     name: intl.formatMessage({ defaultMessage: 'Name', id: 'tRe2Ct', description: 'Column name for connector name' }),
@@ -84,6 +86,7 @@ export const WorkflowConnections = ({ connections }: WorkflowConnectionsProps) =
       Object.values(workflows).map((workflow) =>
         workflow.connectionKeys.map((key) => {
           const connectionItem = connections[key];
+
           return {
             id: guid(),
             workflowId: workflow.id,
@@ -183,10 +186,13 @@ export const WorkflowConnections = ({ connections }: WorkflowConnectionsProps) =
   );
 
   const onConnectionsLoaded = async (loadedConnections: Connection[], item: ConnectionItem): Promise<void> => {
+    const connectionIdToOverride = viewTemplateDetails?.connectionsOverride?.[item.connectionKey]?.connectionId;
     const itemHasConnection = item.connection?.id && item.connection?.displayName === undefined;
     const connectionToUse = itemHasConnection
       ? loadedConnections.find((connection) => connection.id === item.connection?.id)
-      : loadedConnections[0];
+      : connectionIdToOverride
+        ? loadedConnections.find((connection) => connection.id === connectionIdToOverride)
+        : loadedConnections[0];
     const hasConnection = loadedConnections.length > 0;
     updateItemInConnectionsList({
       ...item,

--- a/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/template.ts
@@ -73,6 +73,10 @@ interface ContentInfo<T> {
   isEditable?: boolean;
 }
 
+interface ConnectionInfo {
+  connectionId: string;
+}
+
 export interface ViewTemplateDetails {
   id: string;
   basicsOverride?: Record<
@@ -83,4 +87,5 @@ export interface ViewTemplateDetails {
     }
   >;
   parametersOverride?: Record<string, ContentInfo<any>>;
+  connectionsOverride?: Record<string, ConnectionInfo>;
 }


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior
When going to connections tab, an existing connection, if exists, will automatically be used.

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

## New Behavior

Add option to allow overriding managed api connections, so the specified connection provided by the caller will automatically be selected.

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan

Manually tested locally
<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
