### PR TITLE
fix(vscode): Fix parameterize connection checks to check all connections

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/cloudToLocalHelper.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/cloudToLocalHelper.ts
@@ -10,7 +10,7 @@ import { isEmptyString } from '@microsoft/logic-apps-shared';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { getParametersJson } from '../../utils/codeless/parameter';
-import { isConnectionsParameterized, parameterizeConnection } from '../../utils/codeless/parameterizer';
+import { areAllConnectionsParameterized, parameterizeConnection } from '../../utils/codeless/parameterizer';
 import * as path from 'path';
 import * as fs from 'fs';
 import { isCSharpProject } from '../initProjectForVSCode/detectProjectLanguage';
@@ -211,7 +211,7 @@ export async function parameterizeConnectionsDuringImport(
       const connectionsData = JSON.parse(connectionsJson);
       const parametersJson = await getParametersJson(projectPath);
 
-      if (isConnectionsParameterized(connectionsData)) {
+      if (areAllConnectionsParameterized(connectionsData)) {
         window.showInformationMessage(localize('connectionsAlreadyParameterized', 'Connections are already parameterized.'));
         return;
       }

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -16,7 +16,7 @@ import { localize } from '../../../localize';
 import { getLocalSettingsJson } from '../../utils/appSettings/localSettings';
 import { getConnectionsJson } from '../../utils/codeless/connection';
 import { getAuthorizationToken, getCloudHost } from '../../utils/codeless/getAuthorizationToken';
-import { isConnectionsParameterized } from '../../utils/codeless/parameterizer';
+import { areAllConnectionsParameterized } from '../../utils/codeless/parameterizer';
 import { addLocalFuncTelemetry } from '../../utils/funcCoreTools/funcVersion';
 import { unzipLogicAppArtifacts } from '../../utils/taskUtils';
 import { tryGetLogicAppProjectRoot } from '../../utils/verifyIsProject';
@@ -47,7 +47,7 @@ export async function generateDeploymentScripts(context: IActionContext): Promis
     const projectRoot = vscode.Uri.file(projectPath);
     const connectionsJson = await getConnectionsJson(projectPath);
     const connectionsData: ConnectionsData = isEmptyString(connectionsJson) ? {} : JSON.parse(connectionsJson);
-    const isParameterized = await isConnectionsParameterized(connectionsData);
+    const isParameterized = await areAllConnectionsParameterized(connectionsData);
     const workflowFiles = getWorkflowFilePaths(projectPath);
     if (!(await ConvertToWorkspace(context))) {
       ext.outputChannel.appendLog(localize('exitScriptGen', 'Exiting script generation...'));

--- a/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
+++ b/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
@@ -9,7 +9,7 @@ import { localize } from '../../localize';
 import { getLocalSettingsJson } from '../utils/appSettings/localSettings';
 import { getConnectionsJson, saveConnectionReferences } from '../utils/codeless/connection';
 import { getParametersJson, saveWorkflowParameter } from '../utils/codeless/parameter';
-import { isConnectionsParameterized, parameterizeConnection } from '../utils/codeless/parameterizer';
+import { areAllConnectionsParameterized, parameterizeConnection } from '../utils/codeless/parameterizer';
 import { tryGetLogicAppProjectRoot } from '../utils/verifyIsProject';
 import { getGlobalSetting, updateGlobalSetting } from '../utils/vsCodeConfig/settings';
 import { getWorkspaceFolder } from '../utils/workspace';
@@ -73,7 +73,7 @@ export async function parameterizeConnections(context: IActionContext, skipPromp
           any
         >;
 
-        if (isConnectionsParameterized(connectionsData)) {
+        if (areAllConnectionsParameterized(connectionsData)) {
           window.showInformationMessage(localize('connectionsAlreadyParameterized', 'Connections are already parameterized.'));
           return;
         }

--- a/apps/vs-code-designer/src/app/utils/codeless/__test__/parameterizer.test.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/__test__/parameterizer.test.ts
@@ -1,10 +1,190 @@
-import { parameterizeConnection } from '../parameterizer';
+import { parameterizeConnection, areAllConnectionsParameterized, hasParameterizedConnection } from '../parameterizer';
 import type {
   ConnectionReferenceModel,
   FunctionConnectionModel,
   APIManagementConnectionModel,
+  ConnectionsData,
 } from '@microsoft/vscode-extension-logic-apps';
 import { describe, it, expect } from 'vitest';
+
+describe('hasParameterizedConnection', () => {
+  it('should return true when there is one parameterized connection among others that are not parameterized', () => {
+    const connectionsData: ConnectionsData = {
+      managedApiConnections: {
+        connection1: {
+          api: {
+            id: '/subscriptions/subscription-test-id/providers/Microsoft.Web/locations/eastus2/managedApis/connection1',
+          },
+          connection: {
+            id: '/subscriptions/subscription-test-id/resourceGroups/vs-code-debug/providers/Microsoft.Web/connections/connection1',
+          },
+          connectionRuntimeUrl: 'https://example.com/runtimeUrl',
+          authentication: {
+            type: 'Raw',
+            scheme: 'Key',
+            parameter: 'connectionKey',
+          },
+        },
+        connection2: {
+          api: {
+            id: "/subscriptions/@{appsetting('WORKFLOWS_SUBSCRIPTION_ID')}/providers/Microsoft.Web/locations/@{appsetting('WORKFLOWS_LOCATION_NAME')}/managedApis/connection2",
+          },
+          connection: {
+            id: "/subscriptions/@{appsetting('WORKFLOWS_SUBSCRIPTION_ID')}/resourceGroups/@{appsetting('WORKFLOWS_RESOURCE_GROUP_NAME')}/providers/Microsoft.Web/connections/connection2",
+          },
+          connectionRuntimeUrl: "@parameters('connection2-ConnectionRuntimeUrl')",
+          authentication: {
+            type: 'Raw',
+            scheme: 'Key',
+            parameter: "@appsetting('connection2-connectionKey')",
+          },
+        },
+      },
+    };
+
+    const result = hasParameterizedConnection(connectionsData);
+    expect(result).toBe(true);
+  });
+
+  it('should return false when there are no parameterized connections', () => {
+    const connectionsData: ConnectionsData = {
+      managedApiConnections: {
+        connection1: {
+          api: {
+            id: '/subscriptions/subscription-test-id/providers/Microsoft.Web/locations/eastus2/managedApis/connection1',
+          },
+          connection: {
+            id: '/subscriptions/subscription-test-id/resourceGroups/vs-code-debug/providers/Microsoft.Web/connections/connection1',
+          },
+          connectionRuntimeUrl: 'https://example.com/runtimeUrl',
+          authentication: {
+            type: 'Raw',
+            scheme: 'Key',
+            parameter: 'connectionKey',
+          },
+        },
+      },
+      functionConnections: {
+        function1: {
+          function: {
+            id: '/subscriptions/subscription-test-id/resourceGroups/vs-code-debug/providers/Microsoft.Web/sites/vscodesite/functions/HttpTrigger',
+          },
+          triggerUrl: 'https://vscodesite.azurewebsites.net/api/httptrigger',
+          authentication: {
+            type: 'QueryString',
+            name: 'Code',
+            value: 'functionAppKey',
+          },
+          displayName: 'func01',
+        },
+      },
+    };
+
+    const result = hasParameterizedConnection(connectionsData);
+    expect(result).toBe(false);
+  });
+
+  it('should return true when there are no connections', () => {
+    const connectionsData: ConnectionsData = {};
+
+    const result = hasParameterizedConnection(connectionsData);
+    expect(result).toBe(true);
+  });
+});
+
+describe('areAllConnectionsParameterized', () => {
+  it('should return true when all connections are parameterized', () => {
+    const connectionsData: ConnectionsData = {
+      managedApiConnections: {
+        connection1: {
+          api: {
+            id: "/subscriptions/@{appsetting('WORKFLOWS_SUBSCRIPTION_ID')}/providers/Microsoft.Web/locations/@{appsetting('WORKFLOWS_LOCATION_NAME')}/managedApis/connection1",
+          },
+          connection: {
+            id: "/subscriptions/@{appsetting('WORKFLOWS_SUBSCRIPTION_ID')}/resourceGroups/@{appsetting('WORKFLOWS_RESOURCE_GROUP_NAME')}/providers/Microsoft.Web/connections/connection1",
+          },
+          connectionRuntimeUrl: "@parameters('connection1-ConnectionRuntimeUrl')",
+          authentication: {
+            type: 'Raw',
+            scheme: 'Key',
+            parameter: "@appsetting('connection1-connectionKey')",
+          },
+        },
+      },
+      functionConnections: {
+        function1: {
+          function: {
+            id: "/subscriptions/@{appsetting('WORKFLOWS_SUBSCRIPTION_ID')}/resourceGroups/@{parameters('azureFunctionOperation-ResourceGroup')}/providers/Microsoft.Web/sites/@{parameters('azureFunctionOperation-SiteName')}/functions/HttpTrigger",
+          },
+          triggerUrl: "@parameters('azureFunctionOperation-TriggerUrl')",
+          authentication: {
+            type: 'QueryString',
+            name: 'Code',
+            value: "@appsetting('azureFunctionOperation_functionAppKey')",
+          },
+          displayName: 'func01',
+        },
+      },
+    };
+
+    const result = areAllConnectionsParameterized(connectionsData);
+    expect(result).toBe(true);
+  });
+
+  it('should return false when not all connections are parameterized', () => {
+    const connectionsData: ConnectionsData = {
+      managedApiConnections: {
+        connection1: {
+          api: {
+            id: "/subscriptions/@{appsetting('WORKFLOWS_SUBSCRIPTION_ID')}/providers/Microsoft.Web/locations/@{appsetting('WORKFLOWS_LOCATION_NAME')}/managedApis/connection1",
+          },
+          connection: {
+            id: "/subscriptions/@{appsetting('WORKFLOWS_SUBSCRIPTION_ID')}/resourceGroups/@{appsetting('WORKFLOWS_RESOURCE_GROUP_NAME')}/providers/Microsoft.Web/connections/connection1",
+          },
+          connectionRuntimeUrl: "@parameters('connection1-ConnectionRuntimeUrl')",
+          authentication: {
+            type: 'Raw',
+            scheme: 'Key',
+            parameter: "@appsetting('connection1-connectionKey')",
+          },
+        },
+      },
+      functionConnections: {
+        function1: {
+          function: {
+            id: '/subscriptions/subscription-test-id/resourceGroups/vs-code-debug/providers/Microsoft.Web/sites/vscodesite/functions/HttpTrigger',
+          },
+          triggerUrl: 'https://vscodesite.azurewebsites.net/api/httptrigger',
+          authentication: {
+            type: 'QueryString',
+            name: 'Code',
+            value: "@appsetting('azureFunctionOperation_functionAppKey')",
+          },
+          displayName: 'func01',
+        },
+      },
+      apiManagementConnections: {
+        apiManagement1: {
+          apiId:
+            '/subscriptions/subscription-test-id/resourceGroups/vs-code-debug/providers/Microsoft.ApiManagement/service/vscodeservicename/apis/echo-api',
+          baseUrl: "@parameters('apiManagementOperation-BaseUrl')",
+          subscriptionKey: "@appsetting('apiManagementOperation_SubscriptionKey')",
+          displayName: 'api01',
+        },
+      },
+    };
+
+    const result = areAllConnectionsParameterized(connectionsData);
+    expect(result).toBe(false);
+  });
+
+  it('should return true when connectionsData is empty', () => {
+    const connectionsData: ConnectionsData = {};
+
+    const result = areAllConnectionsParameterized(connectionsData);
+    expect(result).toBe(true);
+  });
+});
 
 describe('parameterizeConnection for ConnectionReferenceModel', () => {
   it('should parameterize Connection Reference', () => {

--- a/apps/vs-code-designer/src/app/utils/codeless/__test__/parameterizer.test.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/__test__/parameterizer.test.ts
@@ -1,4 +1,4 @@
-import { parameterizeConnection, areAllConnectionsParameterized, hasParameterizedConnection } from '../parameterizer';
+import { parameterizeConnection, areAllConnectionsParameterized } from '../parameterizer';
 import type {
   ConnectionReferenceModel,
   FunctionConnectionModel,
@@ -6,91 +6,6 @@ import type {
   ConnectionsData,
 } from '@microsoft/vscode-extension-logic-apps';
 import { describe, it, expect } from 'vitest';
-
-describe('hasParameterizedConnection', () => {
-  it('should return true when there is one parameterized connection among others that are not parameterized', () => {
-    const connectionsData: ConnectionsData = {
-      managedApiConnections: {
-        connection1: {
-          api: {
-            id: '/subscriptions/subscription-test-id/providers/Microsoft.Web/locations/eastus2/managedApis/connection1',
-          },
-          connection: {
-            id: '/subscriptions/subscription-test-id/resourceGroups/vs-code-debug/providers/Microsoft.Web/connections/connection1',
-          },
-          connectionRuntimeUrl: 'https://example.com/runtimeUrl',
-          authentication: {
-            type: 'Raw',
-            scheme: 'Key',
-            parameter: 'connectionKey',
-          },
-        },
-        connection2: {
-          api: {
-            id: "/subscriptions/@{appsetting('WORKFLOWS_SUBSCRIPTION_ID')}/providers/Microsoft.Web/locations/@{appsetting('WORKFLOWS_LOCATION_NAME')}/managedApis/connection2",
-          },
-          connection: {
-            id: "/subscriptions/@{appsetting('WORKFLOWS_SUBSCRIPTION_ID')}/resourceGroups/@{appsetting('WORKFLOWS_RESOURCE_GROUP_NAME')}/providers/Microsoft.Web/connections/connection2",
-          },
-          connectionRuntimeUrl: "@parameters('connection2-ConnectionRuntimeUrl')",
-          authentication: {
-            type: 'Raw',
-            scheme: 'Key',
-            parameter: "@appsetting('connection2-connectionKey')",
-          },
-        },
-      },
-    };
-
-    const result = hasParameterizedConnection(connectionsData);
-    expect(result).toBe(true);
-  });
-
-  it('should return false when there are no parameterized connections', () => {
-    const connectionsData: ConnectionsData = {
-      managedApiConnections: {
-        connection1: {
-          api: {
-            id: '/subscriptions/subscription-test-id/providers/Microsoft.Web/locations/eastus2/managedApis/connection1',
-          },
-          connection: {
-            id: '/subscriptions/subscription-test-id/resourceGroups/vs-code-debug/providers/Microsoft.Web/connections/connection1',
-          },
-          connectionRuntimeUrl: 'https://example.com/runtimeUrl',
-          authentication: {
-            type: 'Raw',
-            scheme: 'Key',
-            parameter: 'connectionKey',
-          },
-        },
-      },
-      functionConnections: {
-        function1: {
-          function: {
-            id: '/subscriptions/subscription-test-id/resourceGroups/vs-code-debug/providers/Microsoft.Web/sites/vscodesite/functions/HttpTrigger',
-          },
-          triggerUrl: 'https://vscodesite.azurewebsites.net/api/httptrigger',
-          authentication: {
-            type: 'QueryString',
-            name: 'Code',
-            value: 'functionAppKey',
-          },
-          displayName: 'func01',
-        },
-      },
-    };
-
-    const result = hasParameterizedConnection(connectionsData);
-    expect(result).toBe(false);
-  });
-
-  it('should return true when there are no connections', () => {
-    const connectionsData: ConnectionsData = {};
-
-    const result = hasParameterizedConnection(connectionsData);
-    expect(result).toBe(true);
-  });
-});
 
 describe('areAllConnectionsParameterized', () => {
   it('should return true when all connections are parameterized', () => {

--- a/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
@@ -72,7 +72,7 @@ export function parameterizeConnection(
  */
 export function hasParameterizedConnection(connectionsData: ConnectionsData): boolean {
   if (!connectionsData || Object.keys(connectionsData).length === 0) {
-    return false;
+    return true;
   }
   for (const connectionType in connectionsData) {
     if (connectionType !== 'serviceProviderConnections') {
@@ -105,7 +105,7 @@ export function hasParameterizedConnection(connectionsData: ConnectionsData): bo
  */
 export function areAllConnectionsParameterized(connectionsData: ConnectionsData): boolean {
   if (!connectionsData || Object.keys(connectionsData).length === 0) {
-    return false;
+    return true;
   }
   for (const connectionType in connectionsData) {
     if (connectionType !== 'serviceProviderConnections') {

--- a/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
@@ -66,54 +66,6 @@ export function parameterizeConnection(
 }
 
 /**
- * Checks if there exists a parameterized connection data entry.
- * @param {ConnectionsData} connectionsData - The connections data object.
- * @returns A boolean indicating whether the connections data is parameterized or not.
- */
-export function hasParameterizedConnection(connectionsData: ConnectionsData): boolean {
-  if (!connectionsData || Object.keys(connectionsData).length === 0) {
-    return true;
-  }
-  for (const connectionType in connectionsData) {
-    if (connectionType !== 'serviceProviderConnections') {
-      const connectionTypeJson = connectionsData[connectionType];
-      for (const connectionKey in connectionTypeJson) {
-        const connection = connectionTypeJson[connectionKey];
-        if (isConnectionReferenceModel(connection)) {
-          if (
-            connection.api.id.includes('@appsetting') ||
-            connection.api.id.includes('@{appsetting') ||
-            connection.connectionRuntimeUrl.includes('@parameters') ||
-            connection.connectionRuntimeUrl.includes('@{parameters')
-          ) {
-            return true;
-          }
-        } else if (isFunctionConnectionModel(connection)) {
-          if (
-            connection.function.id.includes('@parameters') ||
-            connection.function.id.includes('@{parameters') ||
-            connection.triggerUrl.includes('@parameters') ||
-            connection.triggerUrl.includes('@{parameters')
-          ) {
-            return true;
-          }
-        } else if (isAPIManagementConnectionModel(connection)) {
-          if (
-            connection.apiId.includes('@parameters') ||
-            connection.apiId.includes('@{parameters') ||
-            connection.baseUrl.includes('@parameters') ||
-            connection.baseUrl.includes('@{parameters')
-          ) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-  return false;
-}
-
-/**
  * Checks if all connections are parameterized.
  * @param {ConnectionsData} connectionsData - The connections data object.
  * @returns A boolean indicating whether all connections are parameterized or not.

--- a/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
@@ -66,13 +66,13 @@ export function parameterizeConnection(
 }
 
 /**
- * Checks if the connections data is parameterized.
+ * Checks if there exists a parameterized connection data entry.
  * @param {ConnectionsData} connectionsData - The connections data object.
  * @returns A boolean indicating whether the connections data is parameterized or not.
  */
-export function isConnectionsParameterized(connectionsData: ConnectionsData): boolean {
+export function hasParameterizedConnection(connectionsData: ConnectionsData): boolean {
   if (!connectionsData || Object.keys(connectionsData).length === 0) {
-    return true;
+    return false;
   }
   for (const connectionType in connectionsData) {
     if (connectionType !== 'serviceProviderConnections') {
@@ -96,6 +96,39 @@ export function isConnectionsParameterized(connectionsData: ConnectionsData): bo
     }
   }
   return false;
+}
+
+/**
+ * Checks if all connections are parameterized.
+ * @param {ConnectionsData} connectionsData - The connections data object.
+ * @returns A boolean indicating whether all connections are parameterized or not.
+ */
+export function areAllConnectionsParameterized(connectionsData: ConnectionsData): boolean {
+  if (!connectionsData || Object.keys(connectionsData).length === 0) {
+    return false;
+  }
+  for (const connectionType in connectionsData) {
+    if (connectionType !== 'serviceProviderConnections') {
+      const connectionTypeJson = connectionsData[connectionType];
+      for (const connectionKey in connectionTypeJson) {
+        const connection = connectionTypeJson[connectionKey];
+        if (isConnectionReferenceModel(connection)) {
+          if (!connection.api.id.includes('@appsetting') || !connection.connectionRuntimeUrl.includes('@parameters')) {
+            return false;
+          }
+        } else if (isFunctionConnectionModel(connection)) {
+          if (!connection.function.id.includes('@parameters') || !connection.triggerUrl.includes('@parameters')) {
+            return false;
+          }
+        } else if (isAPIManagementConnectionModel(connection)) {
+          if (!connection.apiId.includes('@parameters') || !connection.baseUrl.includes('@parameters')) {
+            return false;
+          }
+        }
+      }
+    }
+  }
+  return true;
 }
 
 /**

--- a/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/parameterizer.ts
@@ -80,15 +80,30 @@ export function hasParameterizedConnection(connectionsData: ConnectionsData): bo
       for (const connectionKey in connectionTypeJson) {
         const connection = connectionTypeJson[connectionKey];
         if (isConnectionReferenceModel(connection)) {
-          if (connection.api.id.includes('@appsetting') || connection.connectionRuntimeUrl.includes('@parameters')) {
+          if (
+            connection.api.id.includes('@appsetting') ||
+            connection.api.id.includes('@{appsetting') ||
+            connection.connectionRuntimeUrl.includes('@parameters') ||
+            connection.connectionRuntimeUrl.includes('@{parameters')
+          ) {
             return true;
           }
         } else if (isFunctionConnectionModel(connection)) {
-          if (connection.function.id.includes('@parameters') || connection.triggerUrl.includes('@parameters')) {
+          if (
+            connection.function.id.includes('@parameters') ||
+            connection.function.id.includes('@{parameters') ||
+            connection.triggerUrl.includes('@parameters') ||
+            connection.triggerUrl.includes('@{parameters')
+          ) {
             return true;
           }
         } else if (isAPIManagementConnectionModel(connection)) {
-          if (connection.apiId.includes('@parameters') || connection.baseUrl.includes('@parameters')) {
+          if (
+            connection.apiId.includes('@parameters') ||
+            connection.apiId.includes('@{parameters') ||
+            connection.baseUrl.includes('@parameters') ||
+            connection.baseUrl.includes('@{parameters')
+          ) {
             return true;
           }
         }
@@ -113,15 +128,24 @@ export function areAllConnectionsParameterized(connectionsData: ConnectionsData)
       for (const connectionKey in connectionTypeJson) {
         const connection = connectionTypeJson[connectionKey];
         if (isConnectionReferenceModel(connection)) {
-          if (!connection.api.id.includes('@appsetting') || !connection.connectionRuntimeUrl.includes('@parameters')) {
+          if (
+            !(connection.api.id.includes('@appsetting') || connection.api.id.includes('@{appsetting')) ||
+            !(connection.connectionRuntimeUrl.includes('@parameters') || connection.connectionRuntimeUrl.includes('@{parameters'))
+          ) {
             return false;
           }
         } else if (isFunctionConnectionModel(connection)) {
-          if (!connection.function.id.includes('@parameters') || !connection.triggerUrl.includes('@parameters')) {
+          if (
+            !(connection.function.id.includes('@parameters') || connection.function.id.includes('@{parameters')) ||
+            !(connection.triggerUrl.includes('@parameters') || connection.triggerUrl.includes('@{parameters'))
+          ) {
             return false;
           }
         } else if (isAPIManagementConnectionModel(connection)) {
-          if (!connection.apiId.includes('@parameters') || !connection.baseUrl.includes('@parameters')) {
+          if (
+            !(connection.apiId.includes('@parameters') || !connection.baseUrl.includes('@parameters')) ||
+            !(connection.apiId.includes('@{parameters') || connection.baseUrl.includes('@{parameters'))
+          ) {
             return false;
           }
         }


### PR DESCRIPTION
## Type of Change

* [ x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior
Parameterize connections command relies on a check which checks connections if they are parameterized. Currently, that check only checks connections until they see one connection that is parameterized but then skips the rest. This change will make sure that check will return true if all connections are parameterized.
