### PR TITLE
fix(Desinger): Modified css export again

### DIFF
--- a/libs/designer/tsup.config.ts
+++ b/libs/designer/tsup.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   splitting: false,
   tsconfig: 'tsconfig.json',
   format: ['cjs', 'esm'],
-  external: ['react', '~@xyflow/react/dist/style.css'],
+  external: ['react', '@xyflow/react/dist/style.css'],
   injectStyle: false,
   loader: {
     '.svg': 'dataurl',


### PR DESCRIPTION
## Main Changes

Modified our XYFlow import to have correct pathing.
Was breaking over in AI Foundry from the `~`, confirmed no effect on our projects.
Last PR didn't fix all instances of the issue: https://github.com/Azure/LogicAppsUX/pull/6791