### PR TITLE
feat(designer): Remove animation for delete node modal

### DIFF
--- a/libs/designer-ui/src/lib/modals/DeleteNodeModal.tsx
+++ b/libs/designer-ui/src/lib/modals/DeleteNodeModal.tsx
@@ -117,7 +117,7 @@ export const DeleteNodeModal = (props: DeleteNodeModalProps) => {
   }, [closingLoadingMessage, onDismiss]);
 
   return (
-    <Dialog inertTrapFocus={true} open={isOpen} aria-labelledby={title} onOpenChange={onClosing}>
+    <Dialog inertTrapFocus={true} open={isOpen} aria-labelledby={title} onOpenChange={onClosing} surfaceMotion={null}>
       <DialogSurface>
         <DialogBody>
           <DialogTitle>{nodeId ? title : ''}</DialogTitle>


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [X] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

- Delete modal has a slow animation that makes it look like its taking a slightly long time to load

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

- Remove the animation of loading the background of the modal, thus its makes it look like its loading faster or there is no delay

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->

#### With animation
https://github.com/user-attachments/assets/fb5afc8f-658c-4cd1-a801-f0c3f01ca09c


#### Without animation
https://github.com/user-attachments/assets/47fa07c7-a11a-4d7d-97b8-1f7488f773be




