### PR TITLE
fix(designer): Fix item count when adding operations in scope and subgraph

### DIFF
--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -89,7 +89,7 @@ export const addNodeToWorkflow = (
 
   // Increase action count of graph
   if (nodesMetadata[workflowGraph.id]) {
-    nodesMetadata[workflowGraph.id].actionCount = nodesMetadata[graphId].actionCount ?? 0 + 1;
+    nodesMetadata[workflowGraph.id].actionCount = (nodesMetadata[graphId].actionCount ?? 0) + 1;
   }
 
   // If the added node is a do-until, we need to set the subgraphtype for the header

--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -241,7 +241,7 @@ export const addSwitchCaseToWorkflow = (caseId: string, switchNode: WorkflowNode
 
   // Increase action count of graph
   if (nodesMetadata[switchNode.id]) {
-    nodesMetadata[switchNode.id].actionCount = nodesMetadata[switchNode.id].actionCount ?? 0 + 1;
+    nodesMetadata[switchNode.id].actionCount = (nodesMetadata[switchNode.id].actionCount ?? 0) + 1;
   }
 };
 
@@ -273,6 +273,6 @@ export const addAgentConditionToWorkflow = (
 
   // Increase action count of graph
   if (nodesMetadata[agentNode.id]) {
-    nodesMetadata[agentNode.id].actionCount = nodesMetadata[agentNode.id].actionCount ?? 0 + 1;
+    nodesMetadata[agentNode.id].actionCount = (nodesMetadata[agentNode.id].actionCount ?? 0) + 1;
   }
 };


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

- When adding action to scope and subgraph nodes, the logic to sum the number of items in the scope card was returning always 1.

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

- Now the logic to sum the number of items in the scope card is working correctly

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->

#### Issue
https://github.com/user-attachments/assets/130dc1d2-b3d7-455a-aeb6-bcf869bd5a70


#### Working

https://github.com/user-attachments/assets/cc4ece15-5de8-4af1-877f-eb7d524f00c2




