### PR TITLE
feat(Templates): Review tab improvements + Template provider useExternalRedux flag

### DIFF
--- a/libs/designer/src/lib/core/state/templates/templateselectors.ts
+++ b/libs/designer/src/lib/core/state/templates/templateselectors.ts
@@ -35,3 +35,11 @@ export const useConnectionReferenceForKey = (key: string): ConnectionReference =
     return connections.references[connections.mapping[key] ?? ''];
   });
 };
+
+export const useTemplateConnections = (): Record<string, Template.Connection> => {
+  return useSelector((state: RootState) => state.template?.connections);
+};
+
+export const useTemplateParameterDefinitions = (): Record<string, Template.ParameterDefinition> => {
+  return useSelector((state: RootState) => state.template?.parameterDefinitions);
+};

--- a/libs/designer/src/lib/core/templates/TemplatesDesignerProvider.tsx
+++ b/libs/designer/src/lib/core/templates/TemplatesDesignerProvider.tsx
@@ -43,39 +43,46 @@ export interface TemplatesDesignerProviderProps {
   id?: string;
   theme?: ThemeType;
   locale?: string;
+  useExternalRedux?: boolean;
   children: React.ReactNode;
 }
 
-export const TemplatesDesignerProvider = ({ id, theme = ThemeType.Light, locale = 'en', children }: TemplatesDesignerProviderProps) => {
-  return (
-    <ReduxProvider store={templateStore}>
-      <TemplatesWrappedContext.Provider value={{}}>
-        <ThemeProvider
-          theme={theme === ThemeType.Light ? AzureThemeLight : AzureThemeDark}
+export const TemplatesDesignerProvider = ({
+  id,
+  theme = ThemeType.Light,
+  locale = 'en',
+  useExternalRedux = false,
+  children,
+}: TemplatesDesignerProviderProps) => {
+  const content = (
+    <TemplatesWrappedContext.Provider value={{}}>
+      <ThemeProvider
+        theme={theme === ThemeType.Light ? AzureThemeLight : AzureThemeDark}
+        style={{ flex: '1 1 1px', display: 'flex', flexDirection: 'column' }}
+      >
+        <FluentProvider
+          theme={theme === ThemeType.Light ? extendedWebLightTheme : extendedWebDarkTheme}
           style={{ flex: '1 1 1px', display: 'flex', flexDirection: 'column' }}
         >
-          <FluentProvider
-            theme={theme === ThemeType.Light ? extendedWebLightTheme : extendedWebDarkTheme}
-            style={{ flex: '1 1 1px', display: 'flex', flexDirection: 'column' }}
+          <IntlProvider
+            locale={locale}
+            defaultLocale={locale}
+            onError={(err) => {
+              if (err.code === 'MISSING_TRANSLATION') {
+                return;
+              }
+              throw err;
+            }}
           >
-            <IntlProvider
-              locale={locale}
-              defaultLocale={locale}
-              onError={(err) => {
-                if (err.code === 'MISSING_TRANSLATION') {
-                  return;
-                }
-                throw err;
-              }}
-            >
-              <ReduxReset id={id} />
-              {children}
-            </IntlProvider>
-          </FluentProvider>
-        </ThemeProvider>
-      </TemplatesWrappedContext.Provider>
-    </ReduxProvider>
+            <ReduxReset id={id} />
+            {children}
+          </IntlProvider>
+        </FluentProvider>
+      </ThemeProvider>
+    </TemplatesWrappedContext.Provider>
   );
+
+  return useExternalRedux ? content : <ReduxProvider store={templateStore}>{content}</ReduxProvider>;
 };
 
 // Redux state persists even through component re-mounts (like with changing the key prop in a parent), so we need to reset the state when the key changes manually

--- a/libs/designer/src/lib/ui/panel/templatePanel/panel.less
+++ b/libs/designer/src/lib/ui/panel/templatePanel/panel.less
@@ -276,6 +276,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 32px;
+		padding: 20px 0px 10px;
 }
 
 .msla-templates-review-block {

--- a/libs/designer/src/lib/ui/templates/review/ReviewAddPanel.tsx
+++ b/libs/designer/src/lib/ui/templates/review/ReviewAddPanel.tsx
@@ -6,6 +6,12 @@ import { normalizeConnectorId } from '@microsoft/logic-apps-shared';
 import { CompactConnectorConnectionStatus } from '../connections/connector';
 import { ResourceDisplay } from './ResourceDisplay';
 import { useTemplatesStrings } from '../templatesStrings';
+import {
+  useTemplateWorkflows,
+  useTemplateConnections,
+  useTemplateParameterDefinitions,
+} from '../../../core/state/templates/templateselectors';
+import { useMemo } from 'react';
 
 const useStyles = makeStyles({
   actionName: {
@@ -22,7 +28,9 @@ type ReviewCreatePanelProps = {
 
 export const ReviewAddPanel = ({ resourceOverrides }: ReviewCreatePanelProps) => {
   const intl = useIntl();
-  const { parameterDefinitions, workflows, connections } = useSelector((state: RootState) => state.template);
+  const workflows = useTemplateWorkflows();
+  const connections = useTemplateConnections();
+  const parameterDefinitions = useTemplateParameterDefinitions();
   const { enableResourceSelection } = useSelector((state: RootState) => state.templateOptions);
   const {
     existingWorkflowName,
@@ -55,6 +63,9 @@ export const ReviewAddPanel = ({ resourceOverrides }: ReviewCreatePanelProps) =>
     }),
   };
 
+  const templateHasConnections = useMemo(() => Object.keys(connections).length > 0, [connections]);
+  const templateHasParameters = useMemo(() => Object.keys(parameterDefinitions).length > 0, [parameterDefinitions]);
+
   return (
     <div className="msla-templates-tab msla-templates-review-container">
       <TemplateDisplay label={resourceOverrides?.templateName} />
@@ -70,27 +81,31 @@ export const ReviewAddPanel = ({ resourceOverrides }: ReviewCreatePanelProps) =>
 
       {enableResourceSelection && <ResourceDisplay />}
 
-      <div className="msla-templates-review-block">
-        <Text>{intlText.AUTHENTICATION}</Text>
-        {Object.keys(connections).map((connectionKey) => (
-          <CompactConnectorConnectionStatus
-            key={connectionKey}
-            connectorId={normalizeConnectorId(connections[connectionKey].connectorId ?? '', subscriptionId, location)}
-            hasConnection={mapping[connectionKey] !== undefined}
-          />
-        ))}
-      </div>
+      {templateHasConnections && (
+        <div className="msla-templates-review-block">
+          <Text>{intlText.AUTHENTICATION}</Text>
+          {Object.keys(connections).map((connectionKey) => (
+            <CompactConnectorConnectionStatus
+              key={connectionKey}
+              connectorId={normalizeConnectorId(connections[connectionKey].connectorId ?? '', subscriptionId, location)}
+              hasConnection={mapping[connectionKey] !== undefined}
+            />
+          ))}
+        </div>
+      )}
 
-      <div className="msla-templates-review-block parameters">
-        <Text>{intlText.PARAMETER}</Text>
-        <Text>{intlText.VALUE}</Text>
-        {Object.values(parameterDefinitions)?.map((parameter) => (
-          <>
-            <Text weight="semibold">{parameter.displayName}</Text>
-            <Text>{parameter.value ?? intlText.PLACEHOLDER}</Text>
-          </>
-        ))}
-      </div>
+      {templateHasParameters && (
+        <div className="msla-templates-review-block parameters">
+          <Text>{intlText.PARAMETER}</Text>
+          <Text>{intlText.VALUE}</Text>
+          {Object.values(parameterDefinitions)?.map((parameter) => (
+            <>
+              <Text weight="semibold">{parameter.displayName}</Text>
+              <Text>{parameter.value ?? intlText.PLACEHOLDER}</Text>
+            </>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/libs/designer/src/lib/ui/templates/styles.less
+++ b/libs/designer/src/lib/ui/templates/styles.less
@@ -32,7 +32,7 @@
 }
 
 .msla-templates-agent-filters-tabs {
-    margin-top: 20px;
+    margin-top: 12px;
 }
 
 .msla-templates-search-and-filters {


### PR DESCRIPTION
## Main Changes

Templates review tabs no longer show auth + parameters if there are no values to display.
Templates provider has new `useExternalRedux` flag to prevent redux provider creation.

Cherry-picked from https://github.com/Azure/LogicAppsUX/pull/6828