### PR TITLE
fix(Templates): Made `useWorkflowTemplate` hook + usage null safe

### DIFF
--- a/libs/designer/src/lib/core/state/templates/templateselectors.ts
+++ b/libs/designer/src/lib/core/state/templates/templateselectors.ts
@@ -8,9 +8,9 @@ export const useTemplateWorkflows = () => {
   return useSelector((state: RootState) => state.template.workflows ?? {});
 };
 
-export const useWorkflowTemplate = (workflowId: string): WorkflowTemplateData => {
+export const useWorkflowTemplate = (workflowId: string): WorkflowTemplateData | undefined => {
   return useSelector((state: RootState) => {
-    return state.template.workflows[workflowId];
+    return state.template.workflows?.[workflowId];
   });
 };
 

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/quickViewPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/quickViewPanel.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link, Text } from '@fluentui/react-components';
 import { Icon, Panel, PanelType } from '@fluentui/react';
 import { useIntl } from 'react-intl';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { TemplatesPanelContent, TemplatesPanelFooter, TemplatesPanelHeader } from '@microsoft/designer-ui';
 import { getQuickViewTabs } from '../../../../core/templates/utils/helper';
 import Markdown from 'react-markdown';
@@ -46,7 +46,8 @@ export const QuickViewPanel = ({
       shouldCloseByDefault: !state.templateOptions.viewTemplateDetails,
     })
   );
-  const { manifest } = useWorkflowTemplate(workflowId);
+  const workflowTemplate = useWorkflowTemplate(workflowId);
+  const manifest = useMemo(() => workflowTemplate?.manifest, [workflowTemplate]);
   const panelTabs = getQuickViewTabs(
     intl,
     dispatch,
@@ -74,9 +75,9 @@ export const QuickViewPanel = ({
   const onRenderHeaderContent = useCallback(
     () => (
       <QuickViewPanelHeader
-        title={manifest.title}
-        summary={manifest.summary}
-        sourceCodeUrl={manifest.sourceCodeUrl}
+        title={manifest?.title ?? ''}
+        summary={manifest?.summary ?? ''}
+        sourceCodeUrl={manifest?.sourceCodeUrl}
         details={templateManifest?.details ?? {}}
       />
     ),

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/summaryTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/summaryTab.tsx
@@ -11,10 +11,12 @@ import { useTemplateManifest, useWorkflowTemplate } from '../../../../../core/st
 import { ConnectionsList } from '../../../../templates/connections/connections';
 import { Open16Regular } from '@fluentui/react-icons';
 import { isMultiWorkflowTemplate } from '../../../../../core/actions/bjsworkflow/templates';
+import { useMemo } from 'react';
 
 export const SummaryPanel = ({ workflowId }: { workflowId: string }) => {
   const intl = useIntl();
-  const { manifest: workflowManifest } = useWorkflowTemplate(workflowId);
+  const workflowTemplate = useWorkflowTemplate(workflowId);
+  const workflowManifest = useMemo(() => workflowTemplate?.manifest, [workflowTemplate]);
   const templateManifest = useTemplateManifest();
   const isMultiWorkflow = isMultiWorkflowTemplate(templateManifest);
   const templateHasConnections = Object.keys(workflowManifest?.connections || {}).length > 0;
@@ -52,9 +54,9 @@ export const SummaryPanel = ({ workflowId }: { workflowId: string }) => {
                 description: 'Text to show no connections present in the template.',
               })}
         </Text>
-        {templateHasConnections ? <ConnectionsList connections={workflowManifest.connections} /> : null}
+        {templateHasConnections ? <ConnectionsList connections={workflowManifest?.connections ?? {}} /> : null}
       </div>
-      {workflowManifest.prerequisites ? (
+      {workflowManifest?.prerequisites ? (
         <div className="msla-template-overview-section">
           <Text className="msla-template-overview-section-title">
             {intl.formatMessage({
@@ -64,7 +66,7 @@ export const SummaryPanel = ({ workflowId }: { workflowId: string }) => {
             })}
           </Text>
           <Markdown className="msla-template-markdown" linkTarget="_blank">
-            {workflowManifest.prerequisites}
+            {workflowManifest?.prerequisites}
           </Markdown>
         </div>
       ) : null}

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/workflowTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/workflowTab.tsx
@@ -10,7 +10,9 @@ import { LogEntryLevel, LoggerService, type Template } from '@microsoft/logic-ap
 import { useWorkflowTemplate } from '../../../../../core/state/templates/templateselectors';
 
 export const WorkflowPanel = ({ workflowId }: { workflowId: string }) => {
-  const { manifest, images } = useWorkflowTemplate(workflowId);
+  const workflowTemplate = useWorkflowTemplate(workflowId);
+  const manifest = useMemo(() => workflowTemplate?.manifest, [workflowTemplate]);
+  const images = useMemo(() => workflowTemplate?.images, [workflowTemplate]);
   const { isInverted } = useTheme();
   const imageName = useMemo(() => (isInverted ? images?.dark : images?.light), [isInverted, images]);
 

--- a/libs/designer/src/lib/ui/templates/basics/resource.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/resource.tsx
@@ -8,6 +8,7 @@ import { validateWorkflowName } from '../../../core/actions/bjsworkflow/template
 import { useIntl } from 'react-intl';
 import { useTemplatesStrings } from '../templatesStrings';
 import { TemplateDisplay } from '../review/ReviewAddPanel';
+import { useMemo } from 'react';
 
 interface ResourceSectionProps {
   workflowId: string;
@@ -59,10 +60,9 @@ export const ResourceSection = (props: ResourceSectionProps) => {
 const WorkflowName = ({ workflowId, label, placeholder }: { workflowId: string; label: string; placeholder?: string }) => {
   const dispatch = useDispatch<AppDispatch>();
   const styles = useStyles();
-  const {
-    workflowName,
-    errors: { workflow: workflowError },
-  } = useWorkflowTemplate(workflowId);
+  const workflowTemplate = useWorkflowTemplate(workflowId);
+  const workflowName = useMemo(() => workflowTemplate?.workflowName, [workflowTemplate]);
+  const workflowError = useMemo(() => workflowTemplate?.errors?.workflow, [workflowTemplate]);
   const { subscriptionId, resourceGroupName } = useSelector((state: RootState) => ({
     subscriptionId: state.workflow.subscriptionId,
     resourceGroupName: state.workflow.resourceGroup,

--- a/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
+++ b/libs/designer/src/lib/ui/templates/basics/singleworkflow.tsx
@@ -14,12 +14,16 @@ import { useTemplatesStrings } from '../templatesStrings';
 
 export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => {
   const dispatch = useDispatch<AppDispatch>();
-  const {
-    workflowName,
-    errors: { workflow: workflowError, kind: kindError },
-    kind,
-    manifest,
-  } = useWorkflowTemplate(workflowId);
+  const workflowTemplate = useWorkflowTemplate(workflowId);
+  const { workflowName, errors, kind, manifest } = useMemo(
+    () => ({
+      workflowName: workflowTemplate?.workflowName,
+      errors: workflowTemplate?.errors,
+      kind: workflowTemplate?.kind,
+      manifest: workflowTemplate?.manifest,
+    }),
+    [workflowTemplate]
+  );
   const { isNameEditable, isKindEditable } = useWorkflowBasicsEditable(workflowId);
   const { enableResourceSelection, isConsumption, subscriptionId, resourceGroupName } = useSelector((state: RootState) => ({
     isConsumption: state.workflow.isConsumption,
@@ -140,10 +144,10 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
           });
           dispatch(updateWorkflowNameValidationError({ id: workflowId, error: validationError }));
         }}
-        errorMessage={workflowError}
+        errorMessage={errors?.workflow}
       />
       {isConsumption ? null : (
-        <div className={kindError ? 'msla-templates-tab-stateType-error' : ''}>
+        <div className={errors?.kind ? 'msla-templates-tab-stateType-error' : ''}>
           <Label className="msla-templates-tab-label" required={true} htmlFor={'stateTypeLabel'}>
             {intlText.STATE_TYPE}
           </Label>
@@ -179,7 +183,7 @@ export const SingleWorkflowBasics = ({ workflowId }: { workflowId: string }) => 
           />
         </div>
       )}
-      {kindError && <Text className="msla-templates-tab-stateType-error-message">{kindError}</Text>}
+      {errors?.kind && <Text className="msla-templates-tab-stateType-error-message">{errors?.kind}</Text>}
     </div>
   );
 };


### PR DESCRIPTION
## Main Changes

Made the `useWorkflowTemplate` hook + usage null-safe.
Was throwing errors over in AI-Foundry due to a race condition with an async-thunk call.