### PR TITLE
fix(designer): Skip auto create connection for oauth in designer and for multi auth

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -456,7 +456,7 @@ export function hasOnlyOAuthParameters(connector: Connector): boolean {
 }
 
 function connectorHasMultiAuth(connector: Connector): boolean {
-  return connector !== undefined && connector.properties.connectionParameterSets !== undefined;
+  return connector !== undefined && connector.properties?.connectionParameterSets !== undefined;
 }
 
 // This only checks if this connector has any OAuth connection, it can be just part of Multi Auth
@@ -472,7 +472,7 @@ function hasPrerequisiteConnection(connector: Connector): boolean {
 }
 
 function needsSimpleConnection(connector: Connector): boolean {
-  if (!connector || connector.properties?.connectionParameterSets !== undefined) {
+  if (!connector || connectorHasMultiAuth(connector)) {
     return false;
   }
 

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/connectionsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/connectionsPanel.tsx
@@ -36,6 +36,7 @@ export const ConnectionPanel = (props: CommonPanelProps) => {
         connector: connector as Connector,
         referenceKeys: Object.keys(references),
         operationInfo,
+        skipOAuth: true,
         applyNewConnection: (connection: Connection) =>
           dispatch(updateNodeConnection({ nodeId: selectedNodeId, connection, connector: connector as Connector })),
         onSuccess: () => dispatch(closeConnectionsFlow({ nodeId: selectedNodeId })),

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.tsx
@@ -68,6 +68,7 @@ export const SelectConnection = () => {
       connector: connector as Connector,
       operationInfo,
       referenceKeys: Object.keys(references),
+      skipOAuth: true,
       applyNewConnection: saveSelectionCallback,
       onSuccess: closeConnectionsFlow,
       onManualConnectionCreation: () => {


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Change
Skipping auto creation of oauth connection in designer and only enabled it for templates.
Also skipping auto creation when it is multi auth connector [this is the actual bug]
