### PR TITLE
fix(vscode): Update validation to allow having the csharp file inside the workflow folder

### DIFF
--- a/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
+++ b/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { extensionBundleId, hostFileName, extensionCommand } from '../../constants';
+import { extensionBundleId, hostFileName, extensionCommand, workflowFileName } from '../../constants';
 import { localize } from '../../localize';
 import { getWorkspaceSetting, updateWorkspaceSetting } from './vsCodeConfig/settings';
 import { isNullOrUndefined, isString } from '@microsoft/logic-apps-shared';
@@ -22,16 +22,18 @@ export async function isLogicAppProject(folderPath: string): Promise<boolean> {
 
   if (hasHostJson) {
     const subpaths: string[] = await fse.readdir(folderPath);
-    const workflowJsonPaths = subpaths.map((subpath) => path.join(folderPath, subpath, 'workflow.json'));
+    const workflowJsonPaths = subpaths.map((subpath) => path.join(folderPath, subpath, workflowFileName));
+
     const validWorkflowJsonPaths = await Promise.all(
       workflowJsonPaths.map(async (workflowJsonPath) => {
         if (await fse.pathExists(workflowJsonPath)) {
           const workflowJsonData = await fse.readFile(workflowJsonPath, 'utf-8');
           const workflowJson = JSON.parse(workflowJsonData);
           const schema = workflowJson?.definition?.$schema;
+
           if (schema && schema.includes('Microsoft.Logic') && schema.includes('workflowdefinition.json')) {
             const filesInSubpath = await fse.readdir(path.dirname(workflowJsonPath));
-            if (filesInSubpath.length === 1 && filesInSubpath[0] === 'workflow.json') {
+            if (filesInSubpath.includes(workflowFileName)) {
               return true;
             }
           }

--- a/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
+++ b/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
@@ -18,41 +18,50 @@ const projectSubpathKey = 'projectSubpath';
 // Use 'host.json' and 'local.settings.json' as an indicator that this is a functions project
 export async function isLogicAppProject(folderPath: string): Promise<boolean> {
   const hostFilePath = path.join(folderPath, hostFileName);
-  const hasHostJson: boolean = await fse.pathExists(hostFilePath);
-
-  if (hasHostJson) {
-    const subpaths: string[] = await fse.readdir(folderPath);
-    const workflowJsonPaths = subpaths.map((subpath) => path.join(folderPath, subpath, workflowFileName));
-
-    const validWorkflowJsonPaths = await Promise.all(
-      workflowJsonPaths.map(async (workflowJsonPath) => {
-        if (await fse.pathExists(workflowJsonPath)) {
-          const workflowJsonData = await fse.readFile(workflowJsonPath, 'utf-8');
-          const workflowJson = JSON.parse(workflowJsonData);
-          const schema = workflowJson?.definition?.$schema;
-
-          if (schema && schema.includes('Microsoft.Logic') && schema.includes('workflowdefinition.json')) {
-            const filesInSubpath = await fse.readdir(path.dirname(workflowJsonPath));
-            if (filesInSubpath.includes(workflowFileName)) {
-              return true;
-            }
-          }
-        }
-        return false;
-      })
-    );
-
-    if (!validWorkflowJsonPaths.some(Boolean)) {
-      return false;
-    }
-    const hostJsonData = fse.readFileSync(hostFilePath, 'utf-8');
-    const hostJson = JSON.parse(hostJsonData);
-
-    const hasWorkflowBundle = hostJson?.extensionBundle?.id === extensionBundleId;
-    return hasHostJson && hasWorkflowBundle;
+  if (!(await fse.pathExists(hostFilePath))) {
+    return false;
   }
 
-  return false;
+  const subpaths: string[] = await fse.readdir(folderPath);
+
+  // Helper function to validate a workflow JSON file
+  async function isValidWorkflowFolder(workflowJsonPath: string): Promise<boolean> {
+    if (!(await fse.pathExists(workflowJsonPath))) {
+      return false;
+    }
+    try {
+      const workflowJsonData = await fse.readFile(workflowJsonPath, 'utf-8');
+      const workflowJson = JSON.parse(workflowJsonData);
+      const schema = workflowJson?.definition?.$schema;
+      if (schema && schema.includes('Microsoft.Logic') && schema.includes('workflowdefinition.json')) {
+        const filesInSubpath = await fse.readdir(path.dirname(workflowJsonPath));
+        return filesInSubpath.includes(workflowFileName);
+      }
+    } catch {
+      // Optionally log error if needed
+      return false;
+    }
+    return false;
+  }
+
+  const validWorkflowChecks = await Promise.all(
+    subpaths.map(async (subpath) => {
+      const workflowJsonPath = path.join(folderPath, subpath, workflowFileName);
+      return isValidWorkflowFolder(workflowJsonPath);
+    })
+  );
+
+  if (!validWorkflowChecks.some((valid) => !!valid)) {
+    return false;
+  }
+
+  try {
+    const hostJsonData = await fse.readFile(hostFilePath, 'utf-8');
+    const hostJson = JSON.parse(hostJsonData);
+    return hostJson?.extensionBundle?.id === extensionBundleId;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
+++ b/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
@@ -30,15 +30,14 @@ export async function isLogicAppProject(folderPath: string): Promise<boolean> {
       return false;
     }
     try {
-      const workflowJsonData = await fse.readFile(workflowJsonPath, 'utf-8');
-      const workflowJson = JSON.parse(workflowJsonData);
-      const schema = workflowJson?.definition?.$schema;
-      if (schema && schema.includes('Microsoft.Logic') && schema.includes('workflowdefinition.json')) {
-        const filesInSubpath = await fse.readdir(path.dirname(workflowJsonPath));
-        return filesInSubpath.includes(workflowFileName);
+      const filesInSubpath = await fse.readdir(path.dirname(workflowJsonPath));
+      if (filesInSubpath.includes(workflowFileName)) {
+        const workflowJsonData = await fse.readFile(workflowJsonPath, 'utf-8');
+        const workflowJson = JSON.parse(workflowJsonData);
+        const schema = workflowJson?.definition?.$schema;
+        return schema && schema.includes('Microsoft.Logic') && schema.includes('workflowdefinition.json');
       }
     } catch {
-      // Optionally log error if needed
       return false;
     }
     return false;
@@ -51,7 +50,7 @@ export async function isLogicAppProject(folderPath: string): Promise<boolean> {
     })
   );
 
-  if (!validWorkflowChecks.some((valid) => !!valid)) {
+  if (!validWorkflowChecks.some((valid) => valid)) {
     return false;
   }
 


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

Fixes  #6866

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

- isLogicAppProject is checking for a single workflow.json file, which does not allow having the csharp file inside the workflow folder.

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

- Checking for isLogicAppProject now not only checks for a single workflow.json file, which allows having the csharp file 

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->



https://github.com/user-attachments/assets/769e4c3a-4e89-4923-9ed9-73efe6f3bc90

