### PR TITLE
fix(designer): Fix correct property for subgraph iteration

### DIFF
--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -288,8 +288,9 @@ export const workflowSlice = createSlice({
           ...nodeMetadata,
           runData: {
             status: tools[toolId].status,
-            repetitionCount: tools[toolId].repetitions,
+            repetitionCount: tools[toolId].iterations,
           },
+          runIndex: 0,
         };
         state.nodesMetadata[toolId] = nodeData as NodeMetadata;
       });


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other



- Renamed `repetitions` to `iterations` in the `runData` object to improve clarity.
- Added a new property `runIndex` with an initial value of `0` to the `nodeMetadata` object.


## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->


![CleanShot 2025-03-28 at 10 36 46@2x](https://github.com/user-attachments/assets/b1a70944-9a76-4dee-8dc1-b23de82455f7)
