### PR TITLE
feat(Templates): Converted `TemplateDisplay` description to markdown

### DIFF
--- a/libs/designer/src/lib/ui/panel/templatePanel/panel.less
+++ b/libs/designer/src/lib/ui/panel/templatePanel/panel.less
@@ -291,4 +291,8 @@
 		grid-template-columns: 1fr 1fr;
 		gap: 6px 32px;
 	}
+
+	&.description {
+		margin: 4px 0;
+	}
 }

--- a/libs/designer/src/lib/ui/templates/templateDisplay.tsx
+++ b/libs/designer/src/lib/ui/templates/templateDisplay.tsx
@@ -28,7 +28,11 @@ export const TemplateDisplay = ({ titleLabel, showDescription, cssOverrides }: T
       <Text weight="semibold" className={styles.actionName}>
         {templateTitle}
       </Text>
-      {showDescription && templateDescription && <Markdown className={'description'}>{templateDescription}</Markdown>}
+      {showDescription && templateDescription && (
+        <Markdown className="msla-template-markdown description" linkTarget="_blank">
+          {templateDescription}
+        </Markdown>
+      )}
     </div>
   );
 };

--- a/libs/designer/src/lib/ui/templates/templateDisplay.tsx
+++ b/libs/designer/src/lib/ui/templates/templateDisplay.tsx
@@ -28,7 +28,7 @@ export const TemplateDisplay = ({ titleLabel, showDescription, cssOverrides }: T
       <Text weight="semibold" className={styles.actionName}>
         {templateTitle}
       </Text>
-      {showDescription && templateDescription && <Markdown>{templateDescription}</Markdown>}
+      {showDescription && templateDescription && <Markdown className={'description'}>{templateDescription}</Markdown>}
     </div>
   );
 };

--- a/libs/designer/src/lib/ui/templates/templateDisplay.tsx
+++ b/libs/designer/src/lib/ui/templates/templateDisplay.tsx
@@ -2,6 +2,7 @@ import type { RootState } from '../../core/state/templates/store';
 import { makeStyles, mergeClasses, Text, tokens } from '@fluentui/react-components';
 import { useSelector } from 'react-redux';
 import { useTemplatesStrings } from './templatesStrings';
+import Markdown from 'react-markdown';
 
 const useStyles = makeStyles({
   actionName: {
@@ -27,7 +28,7 @@ export const TemplateDisplay = ({ titleLabel, showDescription, cssOverrides }: T
       <Text weight="semibold" className={styles.actionName}>
         {templateTitle}
       </Text>
-      {showDescription && <Text>{templateDescription}</Text>}
+      {showDescription && templateDescription && <Markdown>{templateDescription}</Markdown>}
     </div>
   );
 };


### PR DESCRIPTION
## Main Changes

Converted the `TemplateDisplay` description to markdown to match the data coming in from templates.

### Example

![image](https://github.com/user-attachments/assets/1283536e-24ef-4842-a00b-12b2f1a88c5e)
