### PR TITLE
fix(vscode): .Net 8 custom code debugger fix

### DIFF
--- a/apps/vs-code-designer/src/app/commands/__test__/pickCustomCodeNetHostProcess.test.ts
+++ b/apps/vs-code-designer/src/app/commands/__test__/pickCustomCodeNetHostProcess.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { pickCustomCodeNetHostProcess } from '../pickCustomCodeNetHostProcess';
+import * as validatePreDebug from '../../debug/validatePreDebug';
+import * as customCodeUtils from '../../utils/customCodeUtils';
+import { IRunningFuncTask, runningFuncTaskMap } from '../../utils/funcCoreTools/funcHostTask';
+import * as pickFuncProcessModule from '../pickFuncProcess';
+import { TargetFramework } from '@microsoft/vscode-extension-logic-apps';
+
+vi.mock('vscode', () => ({
+  Uri: {
+    file: (path: string) => ({ path, fsPath: path }),
+  },
+  workspace: {
+    workspaceFolders: [],
+    getWorkspaceFolder: vi.fn(),
+  },
+}));
+
+describe('pickCustomCodeNetHostProcess', () => {
+  const testLogicAppName = 'LogicApp';
+  const testFunctionAppName = 'FunctionApp';
+  const testLogicAppPath = `/path/to/${testLogicAppName}`;
+  const testFunctionAppPath = `/path/to/${testFunctionAppName}`;
+  const testFuncPid = '12345';
+  const testDotnetPid = '67890';
+
+  const testLogicAppWorkspaceFolder: vscode.WorkspaceFolder = {
+    uri: vscode.Uri.file(testLogicAppPath),
+    name: testLogicAppName,
+    index: 0,
+  };
+  const testFunctionAppWorkspaceFolder: vscode.WorkspaceFolder = {
+    uri: vscode.Uri.file(testFunctionAppPath),
+    name: testFunctionAppName,
+    index: 1,
+  };
+  const testDebugConfig: vscode.DebugConfiguration = { type: 'dummy', name: 'dummy', request: 'launch' };
+  const testActionContext = {} as any;
+  const testFunctionsProjectMetadata = {
+    projectPath: `/path/to/${testFunctionAppName}`,
+    functionAppName: testFunctionAppName,
+    logicAppName: testLogicAppName,
+    targetFramework: TargetFramework.Net8,
+    namespace: 'TestNamespace',
+  };
+  const testFuncTask: IRunningFuncTask = {
+    startTime: Date.now(),
+    processId: Number(testFuncPid),
+  };
+
+  beforeEach(() => {
+    (vscode.workspace as any).workspaceFolders = [testLogicAppWorkspaceFolder, testFunctionAppWorkspaceFolder];
+
+    vi.spyOn(validatePreDebug, 'getMatchingWorkspace').mockReturnValue(testLogicAppWorkspaceFolder);
+    vi.spyOn(customCodeUtils, 'getCustomCodeFunctionsProjectMetadata').mockResolvedValue(testFunctionsProjectMetadata);
+    vi.spyOn(pickFuncProcessModule, 'pickChildProcess').mockResolvedValue(testFuncPid);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runningFuncTaskMap.clear();
+  });
+
+  it('should return undefined when no child dotnet process exists on the logic app functions host', async () => {
+    runningFuncTaskMap.set(testLogicAppWorkspaceFolder, testFuncTask);
+    const result = await pickCustomCodeNetHostProcess(testActionContext, testDebugConfig);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return a child process id when a func task for the logic app is running and child dotnet process exists', async () => {
+    runningFuncTaskMap.set(testLogicAppWorkspaceFolder, testFuncTask);
+    vi.spyOn(pickFuncProcessModule, 'getWindowsChildren').mockImplementation((pid: Number) => {
+      if (pid === Number(testFuncPid)) {
+        return Promise.resolve([{ command: 'dotnet.exe', pid: testDotnetPid }]);
+      }
+      return Promise.resolve([]);
+    });
+    vi.spyOn(pickFuncProcessModule, 'getUnixChildren').mockImplementation((pid: Number) => {
+      if (pid === Number(testFuncPid)) {
+        return Promise.resolve([{ command: 'dotnet', pid: testDotnetPid }]);
+      }
+      return Promise.resolve([]);
+    });
+    const result = await pickCustomCodeNetHostProcess(testActionContext, testDebugConfig);
+    expect(result).toBe(testDotnetPid);
+  });
+
+  it('should throw an error when no running task is found', async () => {
+    await expect(pickCustomCodeNetHostProcess(testActionContext, testDebugConfig)).rejects.toThrowError(
+      `Failed to find a running func task for the logic app "${testLogicAppName}" corresponding to the functions project "${testFunctionAppName}".`
+    );
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateNewProjectInternal.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateNewProjectInternal.ts
@@ -26,9 +26,6 @@ export async function createRulesFiles(context: IFunctionWizardContext): Promise
 export async function createLibFolder(context: IFunctionWizardContext): Promise<void> {
   fse.mkdirSync(path.join(context.projectPath, 'lib', 'builtinOperationSdks', 'JAR'), { recursive: true });
   fse.mkdirSync(path.join(context.projectPath, 'lib', 'builtinOperationSdks', 'net472'), { recursive: true });
-  if (context.projectType === ProjectType.customCode) {
-    fse.mkdirSync(path.join(context.projectPath, 'lib', 'custom', context.targetFramework), { recursive: true });
-  }
 }
 
 export async function createNewProjectInternalBase(

--- a/apps/vs-code-designer/src/app/commands/pickCustomCodeNetHostProcess.ts
+++ b/apps/vs-code-designer/src/app/commands/pickCustomCodeNetHostProcess.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { Platform } from '../../constants';
+import { getMatchingWorkspace } from '../debug/validatePreDebug';
+import { runningFuncTaskMap } from '../utils/funcCoreTools/funcHostTask';
+import type { IRunningFuncTask } from '../utils/funcCoreTools/funcHostTask';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import { getUnixChildren, getWindowsChildren, pickChildProcess } from './pickFuncProcess';
+import { getCustomCodeFunctionsProjectMetadata } from '../utils/customCodeUtils';
+import { localize } from '../../localize';
+
+type OSAgnosticProcess = { command: string | undefined; pid: number | string };
+
+export async function pickCustomCodeNetHostProcess(
+  context: IActionContext,
+  debugConfig: vscode.DebugConfiguration
+): Promise<string | undefined> {
+  const workspace: vscode.WorkspaceFolder = getMatchingWorkspace(debugConfig);
+  const functionsProjectMetadata = await getCustomCodeFunctionsProjectMetadata(workspace.uri.fsPath);
+  const logicAppFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders?.find(
+    (workspace) => workspace.name === functionsProjectMetadata.logicAppName
+  );
+
+  const taskInfo: IRunningFuncTask | undefined = runningFuncTaskMap.get(logicAppFolder);
+  if (!taskInfo) {
+    throw new Error(
+      localize(
+        'noFuncTask',
+        'Failed to find a running func task for the logic app "{0}" corresponding to the functions project "{1}". The functions host must be running to attach the debugger.',
+        functionsProjectMetadata.logicAppName,
+        functionsProjectMetadata.functionAppName
+      )
+    );
+  }
+
+  return await pickNetHostChildProcess(taskInfo);
+}
+
+async function pickNetHostChildProcess(taskInfo: IRunningFuncTask): Promise<string | undefined> {
+  const funcPid = Number(await pickChildProcess(taskInfo));
+  if (!funcPid) {
+    return undefined;
+  }
+
+  const children: OSAgnosticProcess[] =
+    process.platform === Platform.windows ? await getWindowsChildren(funcPid) : await getUnixChildren(funcPid);
+  const child: OSAgnosticProcess | undefined = children.reverse().find((c) => /(dotnet)(\.exe|)$/i.test(c.command || ''));
+  return child ? child.pid.toString() : undefined;
+}

--- a/apps/vs-code-designer/src/app/commands/pickFuncProcess.ts
+++ b/apps/vs-code-designer/src/app/commands/pickFuncProcess.ts
@@ -233,7 +233,7 @@ async function startFuncTask(
  * 3. Starting with the .NET 5 worker, Windows sometimes has an inner process we _don't_ want like 'conhost.exe'
  * The only processes we should want to attach to are the "func" process itself or a "dotnet" process running a dll, so we will pick the innermost one of those
  */
-async function pickChildProcess(taskInfo: IRunningFuncTask): Promise<string> {
+export async function pickChildProcess(taskInfo: IRunningFuncTask): Promise<string> {
   // Workaround for https://github.com/microsoft/vscode-azurefunctions/issues/2656
   if (!isRunning(taskInfo.processId) && vscode.window.activeTerminal) {
     const terminalPid = await vscode.window.activeTerminal.processId;
@@ -255,7 +255,7 @@ export async function findChildProcess(processId: number): Promise<string | unde
   return child ? child.pid.toString() : String(processId);
 }
 
-async function getUnixChildren(pid: number): Promise<OSAgnosticProcess[]> {
+export async function getUnixChildren(pid: number): Promise<OSAgnosticProcess[]> {
   const processes: ActualUnixPS[] = await new Promise((resolve, reject): void => {
     unixPsTree(pid, (error: Error | null, result: unixPsTree.PS[]) => {
       if (error) {
@@ -270,7 +270,7 @@ async function getUnixChildren(pid: number): Promise<OSAgnosticProcess[]> {
   });
 }
 
-async function getWindowsChildren(pid: number): Promise<OSAgnosticProcess[]> {
+export async function getWindowsChildren(pid: number): Promise<OSAgnosticProcess[]> {
   const processes: IProcessInfo[] = await getWindowsProcess(pid);
   return (processes || []).map((c) => {
     return { command: c.name, pid: c.pid };

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -63,6 +63,7 @@ import type { FileTreeItem } from '@microsoft/vscode-azext-azureappservice';
 import { registerCommand, registerCommandWithTreeNodeUnwrapping, unwrapTreeNodeCommandCallback } from '@microsoft/vscode-azext-utils';
 import type { AzExtTreeItem, IActionContext, AzExtParentTreeItem } from '@microsoft/vscode-azext-utils';
 import type { Uri } from 'vscode';
+import { pickCustomCodeNetHostProcess } from './pickCustomCodeNetHostProcess';
 
 export function registerCommands(): void {
   registerCommandWithTreeNodeUnwrapping(extensionCommand.openDesigner, openDesigner);
@@ -87,6 +88,7 @@ export function registerCommands(): void {
   registerCommandWithTreeNodeUnwrapping(extensionCommand.stopLogicApp, stopLogicApp);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.restartLogicApp, restartLogicApp);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.pickProcess, pickFuncProcess);
+  registerCommandWithTreeNodeUnwrapping(extensionCommand.pickCustomCodeNetHostProcess, pickCustomCodeNetHostProcess);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.getDebugSymbolDll, getDebugSymbolDll);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.deleteLogicApp, deleteLogicApp);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.openOverview, openOverview);

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as path from 'path';
+import * as fse from 'fs-extra';
 import { RemoteWorkflowTreeItem } from '../../../tree/remoteWorkflowsTree/RemoteWorkflowTreeItem';
 import { getWorkflowNode } from '../../../utils/workspace';
 import type { IAzureConnectorsContext } from '../azureConnectorWizard';
@@ -19,7 +20,10 @@ export async function openDesigner(context: IAzureConnectorsContext, node: Uri |
   if (workflowNode instanceof Uri) {
     try {
       const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
-      await buildCustomCodeFunctionsProject(context, logicAppNode);
+      // Only build custom code projects on open designer if custom code binaries don't already exist in the logic app folder
+      if (!(await fse.pathExists(path.join(logicAppNode.fsPath, 'lib', 'custom')))) {
+        await buildCustomCodeFunctionsProject(context, logicAppNode);
+      }
     } catch {
       // Ignore error if thrown, forego building custom code project
     }

--- a/apps/vs-code-designer/src/app/debug/validatePreDebug.ts
+++ b/apps/vs-code-designer/src/app/debug/validatePreDebug.ts
@@ -70,7 +70,12 @@ export async function preDebugValidate(context: IActionContext, debugConfig: vsc
   return { workspace, shouldContinue };
 }
 
-function getMatchingWorkspace(debugConfig: vscode.DebugConfiguration): vscode.WorkspaceFolder {
+/**
+ * Gets the workspace folder that matches the debug configuration
+ * @param {vscode.DebugConfiguration} debugConfig - The debug configuration to match against
+ * @returns {vscode.WorkspaceFolder} - The workspace folder that matches the debug configuration
+ */
+export function getMatchingWorkspace(debugConfig: vscode.DebugConfiguration): vscode.WorkspaceFolder {
   if (vscode.workspace.workspaceFolders) {
     for (const workspace of vscode.workspace.workspaceFolders) {
       try {
@@ -132,7 +137,7 @@ export async function validateEmulatorIsRunning(
           err ? reject(err) : resolve();
         });
       });
-    } catch (error) {
+    } catch {
       if (!promptWarningMessage) {
         return false;
       }

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -122,6 +122,7 @@ export const extensionCommand = {
   stopLogicApp: 'azureLogicAppsStandard.stopLogicApp',
   restartLogicApp: 'azureLogicAppsStandard.restartLogicApp',
   pickProcess: 'azureLogicAppsStandard.pickProcess',
+  pickCustomCodeNetHostProcess: 'azureLogicAppsStandard.pickCustomCodeNetHostProcess',
   getDebugSymbolDll: 'azureLogicAppsStandard.getDebugSymbolDll',
   deleteLogicApp: 'azureLogicAppsStandard.deleteLogicApp',
   switchToDotnetProject: 'azureLogicAppsStandard.switchToDotnetProject',

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -138,6 +138,11 @@
         "category": "Azure Logic Apps"
       },
       {
+        "command": "azureLogicAppsStandard.pickCustomCodeNetHostProcess",
+        "title": "Pick Custom Code .NET Host Process",
+        "category": "Azure Logic Apps"
+      },
+      {
         "command": "azureLogicAppsStandard.openOverview",
         "title": "Overview",
         "category": "Azure Logic Apps"
@@ -739,6 +744,10 @@
           "when": "never"
         },
         {
+          "command": "azureLogicAppsStandard.pickCustomCodeNetHostProcess",
+          "when": "never"
+        },
+        {
           "command": "azureLogicAppsStandard.openOverview",
           "when": "resourceFilename==workflow.json"
         },
@@ -1018,6 +1027,7 @@
     "onCommand:azureLogicAppsStandard.stopLogicApp",
     "onCommand:azureLogicAppsStandard.restartLogicApp",
     "onCommand:azureLogicAppsStandard.pickProcess",
+    "onCommand:azureLogicAppsStandard.pickCustomCodeNetHostProcess",
     "onCommand:azureLogicAppsStandard.deleteLogicApp",
     "onCommand:azureLogicAppsStandard.openOverview",
     "onCommand:azureLogicAppsStandard.exportLogicApp",


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Launch configuration for .net8 custom code functions project incorrectly targets CustomCodeNetFxWorker

## New Behavior

Update launch config to use new pickCustomCodeNetHostProcess command to pick the dotnet.exe child process of the running func host corresponding to logic app

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Added unit tests for pickCustomCodeNetHostProcess

## Screenshots or Videos (if applicable)

N/A
