### PR TITLE
fix(templates): Moving workflow metadata initialization in templatesdataprovider

### DIFF
--- a/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
+++ b/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
@@ -13,7 +13,7 @@ import {
 import { type ResourceDetails, setInitialData } from '../state/templates/workflowSlice';
 import type { ConnectionReferences } from '../../common/models/workflow';
 import { getFilteredTemplates } from './utils/helper';
-import { initializeTemplateServices, reloadTemplates } from '../actions/bjsworkflow/templates';
+import { initializeTemplateServices, initializeWorkflowMetadata, reloadTemplates } from '../actions/bjsworkflow/templates';
 import { InitTemplateService, type Template } from '@microsoft/logic-apps-shared';
 import { setEnableResourceSelection, setViewTemplateDetails } from '../state/templates/templateOptionsSlice';
 import { changeCurrentTemplateName } from '../state/templates/templateSlice';
@@ -79,12 +79,13 @@ const DataProviderInner = ({ isConsumption, children, reload, services }: Templa
 export const TemplatesDataProvider = (props: TemplatesDataProviderProps) => {
   const wrapped = useContext(TemplatesWrappedContext);
   const dispatch = useDispatch<AppDispatch>();
-  const { servicesInitialized, subscriptionId, resourceGroup, location, workflowAppName } = useSelector((state: RootState) => ({
+  const { servicesInitialized, subscriptionId, resourceGroup, location, workflowAppName, manifest } = useSelector((state: RootState) => ({
     servicesInitialized: state.templateOptions.servicesInitialized,
     subscriptionId: state.workflow.subscriptionId,
     resourceGroup: state.workflow.resourceGroup,
     location: state.workflow.location,
     workflowAppName: state.workflow.workflowAppName,
+    manifest: state.template.manifest,
   }));
   const {
     services,
@@ -138,6 +139,12 @@ export const TemplatesDataProvider = (props: TemplatesDataProviderProps) => {
       onResourceChange();
     }
   }, [onResourceChange, subscriptionId, resourceGroup, location, workflowAppName]);
+
+  useEffect(() => {
+    if (manifest) {
+      dispatch(initializeWorkflowMetadata());
+    }
+  }, [dispatch, manifest]);
 
   if (!servicesInitialized) {
     return null;

--- a/libs/designer/src/lib/ui/templates/gallery/templatesgallerywithsearch.tsx
+++ b/libs/designer/src/lib/ui/templates/gallery/templatesgallerywithsearch.tsx
@@ -1,9 +1,5 @@
-import type { AppDispatch, RootState } from '../../../core/state/templates/store';
-import { useDispatch, useSelector } from 'react-redux';
 import type { TemplateSearchAndFilterProps } from '../filters/templatesearchfilters';
 import { TemplateSearchAndFilters } from '../filters/templatesearchfilters';
-import { useEffect } from 'react';
-import { initializeWorkflowMetadata } from '../../../core/actions/bjsworkflow/templates';
 import { TemplatesGallery } from './templatesgallery';
 import type { TemplateSelectHandler } from '../cards/templateCard';
 
@@ -24,16 +20,6 @@ export const TemplatesGalleryWithSearch = ({
   cssOverrides,
   onTemplateSelect,
 }: TemplatesGalleryWithSearchProps) => {
-  const dispatch = useDispatch<AppDispatch>();
-
-  const { manifest } = useSelector((state: RootState) => state.template);
-
-  useEffect(() => {
-    if (manifest) {
-      dispatch(initializeWorkflowMetadata());
-    }
-  }, [dispatch, manifest]);
-
   return (
     <>
       <TemplateSearchAndFilters {...searchAndFilterProps} />

--- a/libs/designer/src/lib/ui/templates/templateview.tsx
+++ b/libs/designer/src/lib/ui/templates/templateview.tsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import type { CreateWorkflowHandler } from './TemplatesDesigner';
 import type { AppDispatch, RootState } from '../../core/state/templates/store';
-import { initializeWorkflowMetadata, isMultiWorkflowTemplate, loadTemplate } from '../../core/actions/bjsworkflow/templates';
+import { isMultiWorkflowTemplate, loadTemplate } from '../../core/actions/bjsworkflow/templates';
 import { useEffect } from 'react';
 import { TemplateOverview } from './templateoverview';
 import { setLayerHostSelector, Spinner, SpinnerSize, Text } from '@fluentui/react';
@@ -33,12 +33,6 @@ export const TemplatesView = (props: TemplateViewProps) => {
       dispatch(loadTemplate({ preLoadedManifest: undefined }));
     }
   }, [dispatch, templateName]);
-
-  useEffect(() => {
-    if (manifest) {
-      dispatch(initializeWorkflowMetadata());
-    }
-  }, [dispatch, manifest]);
 
   if (!manifest) {
     return templateName ? (


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Change

Since this is tied to a component, when component unmounts this was not getting called so moved this so data provider, since it is data initialization.
