### PR TITLE
feat(Designer): Exported 2 extra state methods for templates

### DIFF
--- a/libs/designer/src/lib/core/index.ts
+++ b/libs/designer/src/lib/core/index.ts
@@ -94,7 +94,13 @@ export { storeStateToUndoRedoHistory, onUndoClick, onRedoClick } from './actions
 export { useCanUndo, useCanRedo } from './state/undoRedo/undoRedoSelectors';
 export { resetDesignerView } from './state/designerView/designerViewSlice';
 export * from './queries/runs';
-export { reloadTemplates, resetStateOnResourceChange, type WorkflowTemplateData } from './actions/bjsworkflow/templates';
+export * from './queries/template';
+export {
+  reloadTemplates,
+  resetStateOnResourceChange,
+  type WorkflowTemplateData,
+  validateWorkflowsBasicInfo,
+} from './actions/bjsworkflow/templates';
 export type { AppDispatch as TemplatesAppDispatch, RootState as TemplatesRootState } from './state/templates/store';
 export type { TemplateServiceOptions } from './templates/TemplatesDesignerContext';
 export { ConfigureTemplateWizard } from './configuretemplate/ConfigureTemplateWizard';


### PR DESCRIPTION
## Main Changes

Exported `validateWorkflowsBasicInfo` and `useExistingWorkflowNames` for use in templates flow outside designer.