### PR TITLE
fix(vscode): logic app name validation misses duplicate name

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetLogicAppNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetLogicAppNameStep.ts
@@ -9,7 +9,6 @@ import * as fse from 'fs-extra';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
 import { logicAppNameValidation } from '../../../../constants';
-import * as path from 'path';
 
 export class SetLogicAppName extends AzureWizardPromptStep<IProjectWizardContext> {
   public async prompt(context: IProjectWizardContext): Promise<void> {
@@ -35,8 +34,8 @@ export class SetLogicAppName extends AzureWizardPromptStep<IProjectWizardContext
       const workspaceFileContent = await vscode.workspace.fs.readFile(vscode.Uri.file(context.workspaceCustomFilePath));
       const workspaceFileJson = JSON.parse(workspaceFileContent.toString());
 
-      if (workspaceFileJson.folders && workspaceFileJson.folders.some((folder: { path: string }) => folder.path === path.join('.', name))) {
-        return localize('logicAppNameExists', 'A logic app with this name already exists in the workspace');
+      if (workspaceFileJson.folders && workspaceFileJson.folders.some((folder: { name: string }) => folder.name === name)) {
+        return localize('logicAppNameExists', 'A project with this name already exists in the workspace');
       }
     }
 

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/SetLogicAppNameStep.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/SetLogicAppNameStep.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach, test } from 'vitest';
+import * as fse from 'fs-extra';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { SetLogicAppName } from '../SetLogicAppNameStep';
+import { ext } from '../../../../../extensionVariables';
+import { localize } from '../../../../../localize';
+import { ProjectType } from '@microsoft/vscode-extension-logic-apps';
+
+describe('SetLogicAppName', () => {
+  const testLogicAppName = 'LogicApp';
+  const testWorkspaceName = 'TestWorkspace';
+  const testWorkspaceFile = path.join('path', 'to', `${testWorkspaceName}.code-workspace`);
+  const testWorkspace = {
+    folders: [{ name: testLogicAppName }],
+  };
+  let step: SetLogicAppName;
+  let testContext: any;
+  let existsSyncSpy: any;
+  let readFileSpy: any;
+  let appendLogSpy: any;
+
+  beforeEach(() => {
+    step = new SetLogicAppName();
+    testContext = {
+      projectType: ProjectType.logicApp,
+      workspaceCustomFilePath: testWorkspaceFile,
+      logicAppName: testLogicAppName,
+      ui: {
+        showInputBox: vi.fn((options: any) => {
+          return options.validateInput(options.testInput).then((validationResult: string | undefined) => {
+            if (validationResult) {
+              return Promise.reject(new Error(validationResult));
+            }
+            return Promise.resolve(options.testInput);
+          });
+        }),
+      },
+    };
+
+    appendLogSpy = vi.spyOn(ext.outputChannel, 'appendLog').mockImplementation(() => {});
+    existsSyncSpy = vi.spyOn(fse, 'existsSync').mockReturnValue(false);
+    readFileSpy = vi.spyOn(vscode.workspace.fs, 'readFile').mockResolvedValue(Buffer.from(JSON.stringify(testWorkspace)));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('shouldPrompt', () => {
+    it('returns true when projectType is defined', () => {
+      expect(step.shouldPrompt(testContext)).toBe(true);
+    });
+
+    it('returns false when projectType is undefined', () => {
+      testContext.projectType = undefined;
+      expect(step.shouldPrompt(testContext)).toBe(false);
+    });
+  });
+
+  describe('prompt', () => {
+    it('sets context.logicAppName and logs output for valid input', async () => {
+      const validName = 'ValidProject';
+      testContext.ui.showInputBox = vi.fn((options: any) => {
+        options.testInput = validName;
+        return options.validateInput(options.testInput).then((result: string | undefined) => {
+          if (result) {
+            return Promise.reject(new Error(result));
+          }
+          return Promise.resolve(validName);
+        });
+      });
+      await step.prompt(testContext);
+      expect(testContext.logicAppName).toBe(validName);
+      expect(appendLogSpy).toHaveBeenCalledWith(localize('logicAppNameSet', `Logic App project name set to ${validName}`));
+    });
+
+    it('rejects when input is invalid (empty)', async () => {
+      const emptyName = '';
+      testContext.ui.showInputBox = vi.fn((options: any) => {
+        options.testInput = emptyName;
+        return options.validateInput(options.testInput).then((result: string | undefined) => {
+          if (result) {
+            return Promise.reject(new Error(result));
+          }
+          return Promise.resolve(emptyName);
+        });
+      });
+      await expect(step.prompt(testContext)).rejects.toThrow(localize('logicAppNameEmpty', 'Logic app name cannot be empty'));
+    });
+  });
+
+  describe('validateLogicAppName (private method)', () => {
+    const callValidate = (name: string | undefined, context: any) => (step as any).validateLogicAppName(name, context);
+
+    it('returns error message when name is empty', async () => {
+      const res = await callValidate('', testContext);
+      expect(res).toBe(localize('logicAppNameEmpty', 'Logic app name cannot be empty'));
+    });
+
+    it('returns error when name already exists in the workspace file', async () => {
+      existsSyncSpy.mockReturnValue(true);
+
+      const res = await callValidate(testLogicAppName, testContext);
+      expect(res).toBe(localize('logicAppNameExists', 'A project with this name already exists in the workspace'));
+    });
+
+    it('returns error when name does not pass regex validation', async () => {
+      const invalidName = '1InvalidName';
+      const res = await callValidate(invalidName, testContext);
+      expect(res).toBe(
+        localize('logicAppNameInvalidMessage', 'Logic app name must start with a letter and can only contain letters, digits, "_" and "-".')
+      );
+    });
+
+    it('returns undefined for a valid name', async () => {
+      const validName = 'My_Valid-Name123';
+      const res = await callValidate(validName, testContext);
+      expect(res).toBeUndefined();
+    });
+  });
+});

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -52,6 +52,7 @@ vi.mock('fs-extra', () => ({
   readFile: vi.fn(() => Promise.resolve()),
   pathExists: vi.fn(() => Promise.resolve()),
   readdir: vi.fn(() => Promise.resolve()),
+  existsSync: vi.fn(() => {}),
 }));
 
 vi.mock('child_process');
@@ -68,6 +69,9 @@ vi.mock('vscode', () => ({
   workspace: {
     workspaceFolders: [],
     updateWorkspaceFolders: vi.fn(), // <-- This ensures the method exists.
+    fs: {
+      readFile: vi.fn(),
+    },
   },
   Uri: {
     file: (p: string) => ({ fsPath: p, toString: () => p }),
@@ -78,4 +82,12 @@ vi.mock('vscode', () => ({
   EventEmitter: vi.fn().mockImplementation(() => ({
     getUser: vi.fn(),
   })),
+}));
+
+vi.mock('./src/extensionVariables', () => ({
+  ext: {
+    outputChannel: {
+      appendLog: vi.fn(),
+    },
+  },
 }));


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Fixes #6822
Logic app name validation in create project flow does not catch duplicate logic app name in workspace

## New Behavior

Fix validation to catch duplicate LA name

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan

Added unit tests for SetLogicAppNameStep (prompt/validate)

## Screenshots or Videos (if applicable)

N/A
