### PR TITLE
fix(designer): Prevent Uncast from ocurring by default

### DIFF
--- a/libs/designer-ui/src/lib/querybuilder/Row.tsx
+++ b/libs/designer-ui/src/lib/querybuilder/Row.tsx
@@ -269,7 +269,7 @@ export const Row = ({
           editorBlur={handleKeySave}
           tokenPickerButtonProps={{
             location: TokenPickerButtonLocation.Left,
-            newlineVerticalOffset: 16,
+            newlineVerticalOffset: isSimpleQueryBuilder ? 16.5 : 16,
             horizontalOffSet: isSimpleQueryBuilder ? undefined /* uses default of 38*/ : 33,
           }}
           {...baseEditorProps}
@@ -284,7 +284,11 @@ export const Row = ({
           getTokenPicker={getTokenPicker}
           editorBlur={handleValueSave}
           clearEditorOnTokenInsertion={clearEditorOnTokenInsertion}
-          tokenPickerButtonProps={{ location: TokenPickerButtonLocation.Left, newlineVerticalOffset: 16, horizontalOffSet: 33 }}
+          tokenPickerButtonProps={{
+            location: TokenPickerButtonLocation.Left,
+            newlineVerticalOffset: isSimpleQueryBuilder ? 16.5 : 16,
+            horizontalOffSet: 33,
+          }}
           {...baseEditorProps}
         />
       </div>

--- a/libs/designer/src/lib/common/constants.ts
+++ b/libs/designer/src/lib/common/constants.ts
@@ -81,6 +81,7 @@ export default {
     TRUE: 'true',
     FALSE: 'false',
   },
+  PARAMETER_NULL_VALUE: 'null',
   CONTENT_SIZE_MAX: 262144, // 2^18
   API_CATEGORIES: {
     APP_SERVICES: 'Microsoft.Web/sites',

--- a/libs/designer/src/lib/core/utils/__test__/segment.spec.ts
+++ b/libs/designer/src/lib/core/utils/__test__/segment.spec.ts
@@ -10,46 +10,31 @@ describe('convertToValueSegments', () => {
   });
   it('properly converts string segment to Value Segment', () => {
     const stringValue = 'test';
-    const result = convertor.convertToValueSegments(
-      stringValue,
-      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.STRING })
-    );
+    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.STRING);
     expect(result[0].value).toEqual(createLiteralValueSegment(stringValue).value);
   });
 
   it('properly wraps string boolean with quotes if of type any', () => {
     const stringValue = 'true';
-    const result = convertor.convertToValueSegments(
-      stringValue,
-      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.ANY })
-    );
+    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.ANY);
     expect(result[0].value).toEqual('"true"');
   });
 
   it('properly wraps string number with quotes if of type any', () => {
     const stringValue = '14';
-    const result = convertor.convertToValueSegments(
-      stringValue,
-      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.ANY })
-    );
+    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.ANY);
     expect(result[0].value).toEqual('"14"');
   });
 
   it('properly wraps null with quotes if of type any', () => {
     const stringValue = 'null';
-    const result = convertor.convertToValueSegments(
-      stringValue,
-      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.ANY })
-    );
+    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.ANY);
     expect(result[0].value).toEqual('"null"');
   });
 
   it('does not wrap string primitive segment with quotes if of types other than any', () => {
     const stringValue = 'true';
-    const result = convertor.convertToValueSegments(
-      stringValue,
-      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.STRING })
-    );
+    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.STRING);
     expect(result[0].value).toEqual('true');
   });
 });

--- a/libs/designer/src/lib/core/utils/__test__/segment.spec.ts
+++ b/libs/designer/src/lib/core/utils/__test__/segment.spec.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { createLiteralValueSegment, ValueSegmentConvertor, ValueSegmentConvertorOptions } from '../parameters/segment';
 import constants from '../../../common/constants';
+import { convertStringToInputParameter } from '../parameters/helper';
 
 describe('convertToValueSegments', () => {
   const convertor = new ValueSegmentConvertor({
@@ -9,31 +10,46 @@ describe('convertToValueSegments', () => {
   });
   it('properly converts string segment to Value Segment', () => {
     const stringValue = 'test';
-    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.STRING);
+    const result = convertor.convertToValueSegments(
+      stringValue,
+      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.STRING })
+    );
     expect(result[0].value).toEqual(createLiteralValueSegment(stringValue).value);
   });
 
   it('properly wraps string boolean with quotes if of type any', () => {
     const stringValue = 'true';
-    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.ANY);
+    const result = convertor.convertToValueSegments(
+      stringValue,
+      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.ANY })
+    );
     expect(result[0].value).toEqual('"true"');
   });
 
   it('properly wraps string number with quotes if of type any', () => {
     const stringValue = '14';
-    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.ANY);
+    const result = convertor.convertToValueSegments(
+      stringValue,
+      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.ANY })
+    );
     expect(result[0].value).toEqual('"14"');
   });
 
   it('properly wraps null with quotes if of type any', () => {
     const stringValue = 'null';
-    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.ANY);
+    const result = convertor.convertToValueSegments(
+      stringValue,
+      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.ANY })
+    );
     expect(result[0].value).toEqual('"null"');
   });
 
   it('does not wrap string primitive segment with quotes if of types other than any', () => {
     const stringValue = 'true';
-    const result = convertor.convertToValueSegments(stringValue, constants.SWAGGER.TYPE.STRING);
+    const result = convertor.convertToValueSegments(
+      stringValue,
+      convertStringToInputParameter(stringValue, { parameterType: constants.SWAGGER.TYPE.STRING })
+    );
     expect(result[0].value).toEqual('true');
   });
 });

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -918,7 +918,7 @@ export function loadParameterValue(parameter: InputParameter): ValueSegment[] {
     }
   }
 
-  let valueSegments = convertToValueSegments(valueObject, !parameter.suppressCasting /* shouldUncast */, parameter.type);
+  let valueSegments = convertToValueSegments(valueObject, !parameter.suppressCasting && !!parameter?.format, parameter);
 
   valueSegments = compressSegments(valueSegments);
 
@@ -971,13 +971,13 @@ export function convertToTokenExpression(value: any): string {
   return value.toString();
 }
 
-export function convertToValueSegments(value: any, shouldUncast: boolean, parameterType?: string): ValueSegment[] {
+export function convertToValueSegments(value: any, shouldUncast: boolean, parameter: InputParameter): ValueSegment[] {
   try {
     const convertor = new ValueSegmentConvertor({
       shouldUncast,
       rawModeEnabled: true,
     });
-    return convertor.convertToValueSegments(value, parameterType);
+    return convertor.convertToValueSegments(value, parameter);
   } catch {
     return [createLiteralValueSegment(typeof value === 'string' ? value : JSON.stringify(value, null, 2))];
   }

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -918,7 +918,12 @@ export function loadParameterValue(parameter: InputParameter): ValueSegment[] {
     }
   }
 
-  let valueSegments = convertToValueSegments(valueObject, !parameter.suppressCasting && !!parameter?.format, parameter);
+  let valueSegments = convertToValueSegments(
+    valueObject,
+    !parameter.suppressCasting && !!parameter?.format,
+    parameter.type,
+    parameter.schema
+  );
 
   valueSegments = compressSegments(valueSegments);
 
@@ -971,13 +976,13 @@ export function convertToTokenExpression(value: any): string {
   return value.toString();
 }
 
-export function convertToValueSegments(value: any, shouldUncast: boolean, parameter: InputParameter): ValueSegment[] {
+export function convertToValueSegments(value: any, shouldUncast: boolean, parameterType?: string, parameterSchema?: any): ValueSegment[] {
   try {
     const convertor = new ValueSegmentConvertor({
       shouldUncast,
       rawModeEnabled: true,
     });
-    return convertor.convertToValueSegments(value, parameter);
+    return convertor.convertToValueSegments(value, parameterType, parameterSchema);
   } catch {
     return [createLiteralValueSegment(typeof value === 'string' ? value : JSON.stringify(value, null, 2))];
   }

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -538,7 +538,7 @@ export const loadParameterValueFromString = (
   return loadParameterValue(inputParameter);
 };
 
-const convertStringToInputParameter = (value: string, options: LoadParamteerValueFromStringOptions): InputParameter => {
+export const convertStringToInputParameter = (value: string, options: LoadParamteerValueFromStringOptions): InputParameter => {
   const { removeQuotesFromExpression, trimExpression, convertIfContainsExpression, parameterType } = options ?? {};
   if (typeof value !== 'string') {
     return { key: guid(), name: value, type: parameterType ?? typeof value, hideInUI: false, value };
@@ -555,7 +555,7 @@ const convertStringToInputParameter = (value: string, options: LoadParamteerValu
   return {
     key: guid(),
     name: newValue,
-    type: constants.SWAGGER.TYPE.STRING,
+    type: parameterType ?? typeof newValue,
     hideInUI: false,
     value: newValue,
     suppressCasting: true,

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -28,6 +28,7 @@ import {
   startsWith,
   UnsupportedException,
   wrapStringInQuotes,
+  unwrapQuotesFromString,
 } from '@microsoft/logic-apps-shared';
 
 /**
@@ -83,10 +84,9 @@ export class ValueSegmentConvertor {
 
     for (const section of sections) {
       for (const segment of this._convertJsonSectionToSegments(section)) {
-        // console.log(section);
-        // if (parameter.schema?.items?.properties?.[section]?.format) {
-        //   this._options.shouldUncast = false;
-        // }
+        if (parameter.schema?.items?.properties?.[unwrapQuotesFromString(section)]?.format) {
+          this._options.shouldUncast = true;
+        }
 
         segments.push(segment);
       }

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -14,7 +14,7 @@ import { TokenSegmentConvertor } from './tokensegment';
 import { UncastingUtility } from './uncast';
 import { TokenType, ValueSegmentType } from '@microsoft/designer-ui';
 import type { Token, ValueSegment } from '@microsoft/designer-ui';
-import type { Expression, ExpressionFunction, ExpressionLiteral, InputParameter } from '@microsoft/logic-apps-shared';
+import type { Expression, ExpressionFunction, ExpressionLiteral } from '@microsoft/logic-apps-shared';
 import {
   ExpressionParser,
   ExpressionType,
@@ -68,23 +68,23 @@ export class ValueSegmentConvertor {
    * @arg {any} value - The value.
    * @return {ValueSegment[]}
    */
-  public convertToValueSegments(value: any, parameter: InputParameter): ValueSegment[] {
+  public convertToValueSegments(value: any, parameterType?: string, parameterSchema?: any): ValueSegment[] {
     if (isNullOrUndefined(value)) {
       return [createLiteralValueSegment('')];
     }
     if (typeof value === 'string') {
-      return this._convertStringToValueSegments(value, parameter);
+      return this._convertStringToValueSegments(value, parameterType);
     }
-    return this._convertJsonToValueSegments(JSON.stringify(value, null, 2), parameter);
+    return this._convertJsonToValueSegments(JSON.stringify(value, null, 2), parameterSchema);
   }
 
-  private _convertJsonToValueSegments(json: string, parameter: InputParameter): ValueSegment[] {
+  private _convertJsonToValueSegments(json: string, parameterSchema?: any): ValueSegment[] {
     const sections = new JsonSplitter(json).split();
     const segments: ValueSegment[] = [];
 
     const hasFormatProperty = (section: string): boolean => {
       const sectionKey = unwrapQuotesFromString(section);
-      const schema = parameter?.schema;
+      const schema = parameterSchema;
 
       if (!schema) {
         return false;
@@ -142,7 +142,7 @@ export class ValueSegmentConvertor {
     return [this._createLiteralValueSegment(section)];
   }
 
-  private _convertStringToValueSegments(value: string, parameter: InputParameter): ValueSegment[] {
+  private _convertStringToValueSegments(value: string, parameterType?: string): ValueSegment[] {
     if (isTemplateExpression(value)) {
       const expression = ExpressionParser.parseTemplateExpression(value);
       return this._convertTemplateExpressionToValueSegments(expression);
@@ -151,7 +151,7 @@ export class ValueSegmentConvertor {
     const isSpecialValue =
       [constants.BOOLEAN_PARAMETER_VALUE.TRUE, constants.BOOLEAN_PARAMETER_VALUE.FALSE, constants.PARAMETER_NULL_VALUE].includes(value) ||
       /^-?\d+$/.test(value);
-    const stringValue = parameter?.type === constants.SWAGGER.TYPE.ANY && isSpecialValue ? wrapStringInQuotes(value) : value;
+    const stringValue = parameterType === constants.SWAGGER.TYPE.ANY && isSpecialValue ? wrapStringInQuotes(value) : value;
     return [this._createLiteralValueSegment(stringValue)];
   }
 

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -22,6 +22,13 @@ export const wrapTokenValue = (s: string) => `@{${s}}`;
 
 export const wrapStringInQuotes = (s: string) => `"${s}"`;
 
+export const unwrapQuotesFromString = (s: string) => {
+  if (s.startsWith('"') && s.endsWith('"')) {
+    return s.slice(1, -1);
+  }
+  return s;
+};
+
 export const wrapStringifiedTokenSegments = (jsonString: string): string => {
   const tokenRegex = /:\s?(@{?(?:[^,}\s]+}?))/g;
 

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -20,6 +20,8 @@ export const normalizeAutomationId = (s: string) => s.replace(/\W/g, '-');
 
 export const wrapTokenValue = (s: string) => `@{${s}}`;
 
+export const wrapStringInQuotes = (s: string) => `"${s}"`;
+
 export const wrapStringifiedTokenSegments = (jsonString: string): string => {
   const tokenRegex = /:\s?(@{?(?:[^,}\s]+}?))/g;
 


### PR DESCRIPTION
We're uncasting on all parameters unless explicitly defined in the swagger to suppressCasting. However, it causes issues such as:
https://github.com/Azure/LogicAppsUX/issues/6896 where if users use expressions with base64, encodeUri, etc it ends up not showing on deserialization. Worse, if the editor is then changed later on, during serialization, the cast is lost altogether.

This is meant so we only uncast when the format is explicitly defined in the parameter. Thus, it should only uncast on editors that are casted on serialization