### PR TITLE
feat(Templates): Removing template bundling from packages

### DIFF
--- a/e2e/templates/app.spec.ts
+++ b/e2e/templates/app.spec.ts
@@ -40,27 +40,6 @@ test.describe(
       await expect(page.getByText('State type')).toBeVisible();
     });
 
-    test('Should contain all templates when templates are loaded from packaged files', async ({ page }) => {
-      await page.goto('/templates');
-
-      await page.getByText('Local', { exact: true }).click();
-      await page.getByLabel('Categories').click();
-      await page.getByText('Automation', { exact: true }).click();
-
-      await page.waitForTimeout(10);
-
-      await page.getByText('Azure Business').click();
-      await page.getByRole('tab', { name: 'Workflow' }).click();
-      await page.getByRole('tab', { name: 'Summary' }).click();
-      await page.getByTestId('template-footer-primary-button').click();
-      await expect(page.getByText('Create a new workflow from template', { exact: true })).toBeVisible();
-      await page.getByRole('button', { name: 'Close' }).click();
-
-      await page.getByPlaceholder('Search').fill('test');
-      await page.waitForTimeout(5);
-      await expect(page.getByText('Test template', { exact: true })).not.toBeVisible();
-    });
-
     test('Should only contain the mock templates when templates are loaded from azure endpoint', async ({ page }) => {
       await page.goto('/templates');
       await page.getByText('Local', { exact: true }).click();

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/template.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/template.ts
@@ -25,43 +25,29 @@ export class BaseTemplateService implements ITemplateService {
     this.options.onAddBlankWorkflow ? this.options.onAddBlankWorkflow() : Promise.resolve();
 
   public getContentPathUrl = (templatePath: string, resourcePath: string): string => {
-    const { endpoint, useEndpointForTemplates } = this.options;
+    const { endpoint } = this.options;
     const resourceName = resourcePath.split('/').pop();
-    return useEndpointForTemplates ? `${endpoint}/${templatePath}/${resourceName}` : resourcePath;
+    return `${endpoint}/${templatePath}/${resourceName}`;
   };
 
   public getAllTemplateNames = async (): Promise<string[]> => {
-    const { httpClient, endpoint, useEndpointForTemplates } = this.options;
-    return useEndpointForTemplates
-      ? httpClient.get<any>({ uri: `${endpoint}/manifest.json`, headers: { 'Access-Control-Allow-Origin': '*' } })
-      : ((await import('./../templates/manifest.json'))?.default as string[]);
+    const { httpClient, endpoint } = this.options;
+    return httpClient.get<any>({ uri: `${endpoint}/manifest.json`, headers: { 'Access-Control-Allow-Origin': '*' } });
   };
 
   public getResourceManifest = async (resourcePath: string): Promise<Template.TemplateManifest | Template.WorkflowManifest> => {
-    const { httpClient, endpoint, useEndpointForTemplates } = this.options;
-    if (useEndpointForTemplates) {
-      return httpClient.get<any>({
-        uri: `${endpoint}/${resourcePath}/manifest.json`,
-        headers: { 'Access-Control-Allow-Origin': '*' },
-      });
-    }
-
-    const paths = resourcePath.split('/');
-
-    return paths.length === 2
-      ? (await import(`./../templates/${paths[0]}/${paths[1]}/manifest.json`)).default
-      : (await import(`./../templates/${resourcePath}/manifest.json`)).default;
+    const { httpClient, endpoint } = this.options;
+    return httpClient.get<any>({
+      uri: `${endpoint}/${resourcePath}/manifest.json`,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+    });
   };
 
   public getWorkflowDefinition = async (templateId: string, workflowId: string): Promise<LogicAppsV2.WorkflowDefinition> => {
-    const { httpClient, endpoint, useEndpointForTemplates } = this.options;
-    if (useEndpointForTemplates) {
-      return httpClient.get<any>({
-        uri: `${endpoint}/${templateId}/${workflowId}/workflow.json`,
-        headers: { 'Access-Control-Allow-Origin': '*' },
-      });
-    }
-
-    return (await import(`./../templates/${templateId}/${workflowId}/workflow.json`)).default;
+    const { httpClient, endpoint } = this.options;
+    return httpClient.get<any>({
+      uri: `${endpoint}/${templateId}/${workflowId}/workflow.json`,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+    });
   };
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   },
   "private": true,
   "scripts": {
-    "postinstall": "pnpm templates",
     "build": "turbo run build",
     "build:lib": "turbo run build:lib",
     "build:extension": "turbo run build:extension",


### PR DESCRIPTION
## Main Changes

Removing template bundling from packages.
We have tested in all clouds and we are able to pull templates from our new storage account, so bundling the templates is no longer needed.

> [!IMPORTANT]
> Risk: Low - We have tested this change in all clouds