### PR TITLE
fix(designer): Agentic Loops - Agent parameter button styling fix

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/editor.less
+++ b/libs/designer-ui/src/lib/editor/base/editor.less
@@ -126,14 +126,6 @@
     height: 31px;
     border-radius: 0px 4px 4px 0px;
     box-shadow: none;
-    border-bottom: 1px solid @primary_border_blue;
-    border-right: 1px solid @primary_border_blue;
-    border-top: 1px solid @primary_border_blue;
-
-    &:hover {
-      background-color: @primary_hover_blue;
-      color: @defaultButtonTextColor;
-    }
   }
 }
 

--- a/libs/designer-ui/src/lib/editor/base/plugins/tokenpickerbutton/agentParameterButton.tsx
+++ b/libs/designer-ui/src/lib/editor/base/plugins/tokenpickerbutton/agentParameterButton.tsx
@@ -33,6 +33,7 @@ export const AgentParameterButton = ({ openTokenPicker, shifted }: AgentParamete
       <Tooltip content={agentParameterButtonText} relationship="label">
         <Button
           icon={<SparkleIcon />}
+          appearance="primary"
           className={'msla-agent-parameter-entrypoint-button'}
           onClick={() => {
             LoggerService().log({


### PR DESCRIPTION
## Main Changes

Used built-in `appearance` prop instead of style overrides for agent parameter button

### BUG
https://github.com/user-attachments/assets/1bad953c-4d15-41ef-8327-68e680f33eda

### FIX
https://github.com/user-attachments/assets/6e2056b5-b01f-4946-8ce1-f87c94395106

