### PR TITLE
fix(vscode): bug in function name/function app name/function app namespace input validation, update context when creating new functions project

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createCustomCodeFunction/createCustomCodeFunction.ts
+++ b/apps/vs-code-designer/src/app/commands/createCustomCodeFunction/createCustomCodeFunction.ts
@@ -2,8 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as vscode from 'vscode';
-import { extensionCommand } from '../../../constants';
 import { ExistingWorkspaceStep } from '../createNewProject/createProjectSteps/ExistingWorkspaceStep';
 import { isString } from '@microsoft/logic-apps-shared';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -15,11 +13,7 @@ import { localize } from '../../../localize';
 import { type Uri, window } from 'vscode';
 import { FunctionNameStep } from './createCustomCodeFunctionSteps/FunctionNameStep';
 import { FunctionFilesStep } from './createCustomCodeFunctionSteps/FunctionFilesStep';
-import {
-  getCustomCodeFunctionsProjectMetadata,
-  getCustomCodeFunctionsProjects,
-  isCustomCodeFunctionsProject,
-} from '../../utils/customCodeUtils';
+import { getCustomCodeFunctionsProjectMetadata, isCustomCodeFunctionsProject } from '../../utils/customCodeUtils';
 
 /**
  * Creates a new function in a custom code functions project.
@@ -37,6 +31,7 @@ export async function createCustomCodeFunctionFromCommand(context: IActionContex
 
     const wizardContext: Partial<IFunctionWizardContext> & IActionContext = Object.assign(context, options);
     wizardContext.projectType = ProjectType.customCode;
+    wizardContext.functionFolderPath = options.folderPath;
     wizardContext.isWorkspaceWithFunctions = true;
     if (!options.folderPath || !(await isCustomCodeFunctionsProject(options.folderPath))) {
       window.showErrorMessage(
@@ -99,11 +94,5 @@ export async function createCustomCodeFunctionFromCommand(context: IActionContex
     });
 
     await wizard.prompt();
-
-    vscode.commands.executeCommand(
-      'setContext',
-      extensionCommand.customCodeSetFunctionsFolders,
-      await getCustomCodeFunctionsProjects(context)
-    );
   }
 }

--- a/apps/vs-code-designer/src/app/commands/createCustomCodeFunction/createCustomCodeFunctionSteps/FunctionNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createCustomCodeFunction/createCustomCodeFunctionSteps/FunctionNameStep.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
 import * as vscode from 'vscode';
 import * as fse from 'fs-extra';
@@ -17,6 +18,8 @@ export class FunctionNameStep extends AzureWizardPromptStep<IProjectWizardContex
       prompt: localize('functionNamePrompt', 'Provide a function name'),
       validateInput: async (input: string): Promise<string | undefined> => await this.validateFunctionName(input, context),
     });
+
+    ext.outputChannel.appendLog(localize('functionNameSet', `Function name set to ${context.customCodeFunctionName}`));
   }
 
   public shouldPrompt(): boolean {
@@ -24,9 +27,10 @@ export class FunctionNameStep extends AzureWizardPromptStep<IProjectWizardContex
   }
 
   private async validateFunctionName(name: string | undefined, context: IProjectWizardContext): Promise<string | undefined> {
-    if (!name) {
-      return localize('emptyTemplateNameError', `Can't have an empty function name.`);
+    if (!name || name.length === 0) {
+      return localize('emptyFunctionNameError', `Can't have an empty function name.`);
     }
+
     if (!/^[a-z][a-z\d_]*$/i.test(name)) {
       return localize(
         'functionNameInvalidMessage',
@@ -38,7 +42,7 @@ export class FunctionNameStep extends AzureWizardPromptStep<IProjectWizardContex
       return localize('functionNameSameAsProjectNameError', `Can't use the same name for the function and the logic app project.`);
     }
 
-    if (fse.existsSync(context.workspaceCustomFilePath)) {
+    if (context.functionFolderPath && fse.existsSync(context.functionFolderPath)) {
       const functionAppFiles = await vscode.workspace.fs.readDirectory(vscode.Uri.file(context.functionFolderPath));
       const functionFileNames = functionAppFiles
         .map((file) => file[0])

--- a/apps/vs-code-designer/src/app/commands/createCustomCodeFunction/createCustomCodeFunctionSteps/FunctionNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createCustomCodeFunction/createCustomCodeFunctionSteps/FunctionNameStep.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 import * as fse from 'fs-extra';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
-import * as path from 'path';
 
 export class FunctionNameStep extends AzureWizardPromptStep<IProjectWizardContext> {
   public hideStepCount = true;
@@ -40,11 +39,14 @@ export class FunctionNameStep extends AzureWizardPromptStep<IProjectWizardContex
     }
 
     if (fse.existsSync(context.workspaceCustomFilePath)) {
-      const workspaceFileContent = await vscode.workspace.fs.readFile(vscode.Uri.file(context.workspaceCustomFilePath));
-      const workspaceFileJson = JSON.parse(workspaceFileContent.toString());
+      const functionAppFiles = await vscode.workspace.fs.readDirectory(vscode.Uri.file(context.functionFolderPath));
+      const functionFileNames = functionAppFiles
+        .map((file) => file[0])
+        .filter((fileName) => fileName.endsWith('.cs'))
+        .map((functionFile) => functionFile.split('.')[0]);
 
-      if (workspaceFileJson.folders && workspaceFileJson.folders.some((folder: { path: string }) => folder.path === path.join('.', name))) {
-        return localize('functionNameExistsInWorkspaceError', 'A function with this name already exists in the workspace.');
+      if (functionFileNames && functionFileNames.includes(name)) {
+        return localize('functionNameExistsInFunctionsProjectError', 'A function with this name already exists in the functions project.');
       }
     }
   }

--- a/apps/vs-code-designer/src/app/commands/createCustomCodeFunction/createCustomCodeFunctionSteps/__test__/FunctionNameStep.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createCustomCodeFunction/createCustomCodeFunctionSteps/__test__/FunctionNameStep.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fse from 'fs-extra';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { FunctionNameStep } from '../FunctionNameStep';
+import { ext } from '../../../../../extensionVariables';
+import { localize } from '../../../../../localize';
+import { IProjectWizardContext, ProjectType } from '@microsoft/vscode-extension-logic-apps';
+
+describe('FunctionNameStep', () => {
+  const existingFunctionName = 'Func1';
+  const validFunctionName = 'Valid_Func_';
+  const invalidFunctionName = 'Invalid-Func';
+
+  const testLogicAppName = 'LogicApp1';
+  const testFunctionFolderPath = path.join('path', 'to', existingFunctionName);
+  const testFunctionFolderDirectory: [string, vscode.FileType][] = [
+    [`${existingFunctionName}.cs`, vscode.FileType.File],
+    [`${existingFunctionName}.csproj`, vscode.FileType.File],
+    [`${existingFunctionName}.sln`, vscode.FileType.File],
+    ['.vscode', vscode.FileType.Directory],
+  ];
+  let functionNameStep: FunctionNameStep;
+  let testContext: any;
+  let existsSyncSpy: any;
+  let appendLogSpy: any;
+  let readFileSpy: any;
+
+  beforeEach(() => {
+    functionNameStep = new FunctionNameStep();
+    testContext = {
+      projectType: ProjectType.customCode,
+      functionFolderPath: testFunctionFolderPath,
+      logicAppName: testLogicAppName,
+      ui: {
+        showInputBox: vi.fn((options: any) => {
+          return options.validateInput(options.testInput).then((validationResult: string | undefined) => {
+            if (validationResult) {
+              return Promise.reject(new Error(validationResult));
+            }
+            return Promise.resolve(options.testInput);
+          });
+        }),
+      },
+    };
+
+    appendLogSpy = vi.spyOn(ext.outputChannel, 'appendLog').mockImplementation(() => {});
+    existsSyncSpy = vi.spyOn(fse, 'existsSync').mockReturnValue(true);
+    readFileSpy = vi.spyOn(vscode.workspace.fs, 'readDirectory').mockResolvedValue(testFunctionFolderDirectory);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('prompt', () => {
+    it('sets context.customCodeFunctionName and logs output for valid input', async () => {
+      testContext.ui.showInputBox = vi.fn((options: any) => {
+        options.testInput = validFunctionName;
+        return options.validateInput(options.testInput).then((result: string | undefined) => {
+          if (result) {
+            return Promise.reject(new Error(result));
+          }
+          return Promise.resolve(options.testInput);
+        });
+      });
+      await functionNameStep.prompt(testContext);
+      expect(testContext.customCodeFunctionName).toBe(validFunctionName);
+      expect(appendLogSpy).toHaveBeenCalledWith(localize('functionNameSet', `Function name set to ${validFunctionName}`));
+    });
+
+    it('rejects when input is invalid (empty)', async () => {
+      const emptyName = '';
+      testContext.ui.showInputBox = vi.fn((options: any) => {
+        options.testInput = emptyName;
+        return options.validateInput(options.testInput).then((result: string | undefined) => {
+          if (result) {
+            return Promise.reject(new Error(result));
+          }
+          return Promise.resolve(emptyName);
+        });
+      });
+      await expect(functionNameStep.prompt(testContext)).rejects.toThrow(
+        localize('emptyFunctionNameError', `Can't have an empty function name.`)
+      );
+    });
+  });
+
+  describe('validateFunctionName', () => {
+    const callValidateFunctionName = (name: string | undefined, context: IProjectWizardContext) =>
+      (functionNameStep as any).validateFunctionName(name, context);
+
+    it('returns error for empty function name', async () => {
+      const emptyName = '';
+      const result = await callValidateFunctionName(emptyName, testContext);
+      expect(result).toBe(localize('emptyFunctionNameError', `Can't have an empty function name.`));
+    });
+
+    it('returns error when function name is same as logic app name', async () => {
+      const result = await callValidateFunctionName(testLogicAppName, testContext);
+      expect(result).toBe(
+        localize('functionNameSameAsProjectNameError', `Can't use the same name for the function and the logic app project.`)
+      );
+    });
+
+    it('returns error when function name already exists in functions project', async () => {
+      const result = await callValidateFunctionName(existingFunctionName, testContext);
+      expect(result).toBe(
+        localize('functionNameExistsInFunctionsProjectError', 'A function with this name already exists in the functions project.')
+      );
+    });
+
+    it('returns error when function name does not pass regex validation', async () => {
+      const result = await callValidateFunctionName(invalidFunctionName, testContext);
+      expect(result).toBe(
+        localize(
+          'functionNameInvalidMessage',
+          'The function name must start with a letter and can only contain letters, digits, or underscores ("_").'
+        )
+      );
+    });
+
+    it('returns undefined for valid function name', async () => {
+      const result = await callValidateFunctionName(validFunctionName, testContext);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateNewProjectInternal.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateNewProjectInternal.ts
@@ -1,6 +1,13 @@
-import { funcVersionSetting, projectLanguageSetting, projectOpenBehaviorSetting, projectTemplateKeySetting } from '../../../../constants';
+import {
+  extensionCommand,
+  funcVersionSetting,
+  projectLanguageSetting,
+  projectOpenBehaviorSetting,
+  projectTemplateKeySetting,
+} from '../../../../constants';
 import { localize } from '../../../../localize';
 import { createArtifactsFolder } from '../../../utils/codeless/artifacts';
+import { getCustomCodeFunctionsProjects } from '../../../utils/customCodeUtils';
 import { addLocalFuncTelemetry, tryGetLocalFuncVersion, tryParseFuncVersion } from '../../../utils/funcCoreTools/funcVersion';
 import { getGlobalSetting, getWorkspaceSetting } from '../../../utils/vsCodeConfig/settings';
 import { FolderListStep } from '../../createNewProject/createProjectSteps/FolderListStep';
@@ -11,7 +18,7 @@ import { latestGAVersion, OpenBehavior, ProjectType } from '@microsoft/vscode-ex
 import type { ICreateFunctionOptions, IFunctionWizardContext, ProjectLanguage } from '@microsoft/vscode-extension-logic-apps';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { window } from 'vscode';
+import { window, commands } from 'vscode';
 
 export async function createRulesFiles(context: IFunctionWizardContext): Promise<void> {
   if (context.projectType === ProjectType.rulesEngine) {
@@ -69,6 +76,10 @@ export async function createNewProjectInternalBase(
   await createArtifactsFolder(context as IFunctionWizardContext);
   await createRulesFiles(context as IFunctionWizardContext);
   await createLibFolder(context as IFunctionWizardContext);
+
+  if (wizardContext.isWorkspaceWithFunctions) {
+    commands.executeCommand('setContext', extensionCommand.customCodeSetFunctionsFolders, await getCustomCodeFunctionsProjects(context));
+  }
 
   window.showInformationMessage(localize('finishedCreating', 'Finished creating project.'));
 }

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/LogicAppNameStep.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/LogicAppNameStep.test.ts
@@ -1,27 +1,27 @@
-import { describe, it, expect, vi, beforeEach, afterEach, test } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fse from 'fs-extra';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { LogicAppNameStep } from '../LogicAppNameStep';
 import { ext } from '../../../../../extensionVariables';
 import { localize } from '../../../../../localize';
-import { ProjectType } from '@microsoft/vscode-extension-logic-apps';
+import { IProjectWizardContext, ProjectType } from '@microsoft/vscode-extension-logic-apps';
 
-describe('SetLogicAppName', () => {
+describe('LogicAppNameStep', () => {
   const testLogicAppName = 'LogicApp';
   const testWorkspaceName = 'TestWorkspace';
   const testWorkspaceFile = path.join('path', 'to', `${testWorkspaceName}.code-workspace`);
   const testWorkspace = {
     folders: [{ name: testLogicAppName }],
   };
-  let step: LogicAppNameStep;
+  let logicAppNameStep: LogicAppNameStep;
   let testContext: any;
   let existsSyncSpy: any;
   let readFileSpy: any;
   let appendLogSpy: any;
 
   beforeEach(() => {
-    step = new LogicAppNameStep();
+    logicAppNameStep = new LogicAppNameStep();
     testContext = {
       projectType: ProjectType.logicApp,
       workspaceCustomFilePath: testWorkspaceFile,
@@ -49,12 +49,12 @@ describe('SetLogicAppName', () => {
 
   describe('shouldPrompt', () => {
     it('returns true when projectType is defined', () => {
-      expect(step.shouldPrompt(testContext)).toBe(true);
+      expect(logicAppNameStep.shouldPrompt(testContext)).toBe(true);
     });
 
     it('returns false when projectType is undefined', () => {
       testContext.projectType = undefined;
-      expect(step.shouldPrompt(testContext)).toBe(false);
+      expect(logicAppNameStep.shouldPrompt(testContext)).toBe(false);
     });
   });
 
@@ -70,7 +70,7 @@ describe('SetLogicAppName', () => {
           return Promise.resolve(validName);
         });
       });
-      await step.prompt(testContext);
+      await logicAppNameStep.prompt(testContext);
       expect(testContext.logicAppName).toBe(validName);
       expect(appendLogSpy).toHaveBeenCalledWith(localize('logicAppNameSet', `Logic App project name set to ${validName}`));
     });
@@ -86,28 +86,29 @@ describe('SetLogicAppName', () => {
           return Promise.resolve(emptyName);
         });
       });
-      await expect(step.prompt(testContext)).rejects.toThrow(localize('logicAppNameEmpty', 'Logic app name cannot be empty'));
+      await expect(logicAppNameStep.prompt(testContext)).rejects.toThrow(localize('logicAppNameEmpty', 'Logic app name cannot be empty'));
     });
   });
 
   describe('validateLogicAppName (private method)', () => {
-    const callValidate = (name: string | undefined, context: any) => (step as any).validateLogicAppName(name, context);
+    const callValidateLogicAppName = (name: string | undefined, context: IProjectWizardContext) =>
+      (logicAppNameStep as any).validateLogicAppName(name, context);
 
     it('returns error message when name is empty', async () => {
-      const res = await callValidate('', testContext);
+      const res = await callValidateLogicAppName('', testContext);
       expect(res).toBe(localize('logicAppNameEmpty', 'Logic app name cannot be empty'));
     });
 
     it('returns error when name already exists in the workspace file', async () => {
       existsSyncSpy.mockReturnValue(true);
 
-      const res = await callValidate(testLogicAppName, testContext);
+      const res = await callValidateLogicAppName(testLogicAppName, testContext);
       expect(res).toBe(localize('logicAppNameExists', 'A project with this name already exists in the workspace'));
     });
 
     it('returns error when name does not pass regex validation', async () => {
       const invalidName = '1InvalidName';
-      const res = await callValidate(invalidName, testContext);
+      const res = await callValidateLogicAppName(invalidName, testContext);
       expect(res).toBe(
         localize('logicAppNameInvalidMessage', 'Logic app name must start with a letter and can only contain letters, digits, "_" and "-".')
       );
@@ -115,7 +116,7 @@ describe('SetLogicAppName', () => {
 
     it('returns undefined for a valid name', async () => {
       const validName = 'My_Valid-Name123';
-      const res = await callValidate(validName, testContext);
+      const res = await callValidateLogicAppName(validName, testContext);
       expect(res).toBeUndefined();
     });
   });

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionAppNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionAppNameStep.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 import * as fse from 'fs-extra';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
-import * as path from 'path';
 
 export class FunctionAppNameStep extends AzureWizardPromptStep<IProjectWizardContext> {
   public hideStepCount = true;
@@ -25,9 +24,10 @@ export class FunctionAppNameStep extends AzureWizardPromptStep<IProjectWizardCon
   }
 
   private async validateFunctionName(name: string | undefined, context: IProjectWizardContext): Promise<string | undefined> {
-    if (!name) {
+    if (!name || name.length === 0) {
       return localize('emptyTemplateNameError', `Can't have an empty function name.`);
     }
+
     if (!/^[a-z][a-z\d_]*$/i.test(name)) {
       return localize(
         'functionNameInvalidMessage',
@@ -43,7 +43,7 @@ export class FunctionAppNameStep extends AzureWizardPromptStep<IProjectWizardCon
       const workspaceFileContent = await vscode.workspace.fs.readFile(vscode.Uri.file(context.workspaceCustomFilePath));
       const workspaceFileJson = JSON.parse(workspaceFileContent.toString());
 
-      if (workspaceFileJson.folders && workspaceFileJson.folders.some((folder: { path: string }) => folder.path === path.join('.', name))) {
+      if (workspaceFileJson.folders && workspaceFileJson.folders.some((folder: { name: string }) => folder.name === name)) {
         return localize('functionNameExistsInWorkspaceError', 'A function with this name already exists in the workspace.');
       }
     }

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionAppNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionAppNameStep.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../../../../extensionVariables';
 import { localize } from '../../../../../localize';
 import * as vscode from 'vscode';
 import * as fse from 'fs-extra';
@@ -17,6 +18,8 @@ export class FunctionAppNameStep extends AzureWizardPromptStep<IProjectWizardCon
       prompt: localize('functionNamePrompt', 'Provide a function name for functions app project'),
       validateInput: async (input: string): Promise<string | undefined> => await this.validateFunctionName(input, context),
     });
+
+    ext.outputChannel.appendLog(localize('functionAppNameSet', `Function App project name set to ${context.functionAppName}`));
   }
 
   public shouldPrompt(): boolean {
@@ -25,7 +28,7 @@ export class FunctionAppNameStep extends AzureWizardPromptStep<IProjectWizardCon
 
   private async validateFunctionName(name: string | undefined, context: IProjectWizardContext): Promise<string | undefined> {
     if (!name || name.length === 0) {
-      return localize('emptyTemplateNameError', `Can't have an empty function name.`);
+      return localize('emptyFunctionNameError', "Can't have an empty function name.");
     }
 
     if (!/^[a-z][a-z\d_]*$/i.test(name)) {

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionAppNamespaceStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionAppNamespaceStep.ts
@@ -13,10 +13,24 @@ export class FunctionAppNamespaceStep extends AzureWizardPromptStep<IProjectWiza
     context.functionAppNamespace = await context.ui.showInputBox({
       placeHolder: localize('setNamespace', 'namespace'),
       prompt: localize('methodNamePrompt', 'Provide a namespace for functions project'),
+      validateInput: async (input: string): Promise<string | undefined> => await this.validateNamespace(input),
     });
   }
 
   public shouldPrompt(_context: IProjectWizardContext): boolean {
     return true;
+  }
+
+  private async validateNamespace(namespace: string | undefined): Promise<string | undefined> {
+    if (!namespace) {
+      return localize('emptyNamespaceError', `Can't have an empty namespace.`);
+    }
+
+    if (!/^[a-zA-Z][a-zA-Z\d_]*$/i.test(namespace)) {
+      return localize(
+        'namespaceInvalidMessage',
+        'The namespace must start with a letter and can only contain letters, digits, or underscores ("_").'
+      );
+    }
   }
 }

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionAppNamespaceStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/FunctionAppNamespaceStep.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../../../../extensionVariables';
 import { localize } from '../../../../../localize';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import type { IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
@@ -15,6 +16,10 @@ export class FunctionAppNamespaceStep extends AzureWizardPromptStep<IProjectWiza
       prompt: localize('methodNamePrompt', 'Provide a namespace for functions project'),
       validateInput: async (input: string): Promise<string | undefined> => await this.validateNamespace(input),
     });
+
+    ext.outputChannel.appendLog(
+      localize('functionAppNamespaceSet', `Function App project namespace set to ${context.functionAppNamespace}`)
+    );
   }
 
   public shouldPrompt(_context: IProjectWizardContext): boolean {

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/__test__/FunctionAppNameStep.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/__test__/FunctionAppNameStep.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fse from 'fs-extra';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { FunctionAppNameStep } from '../FunctionAppNameStep';
+import { ext } from '../../../../../../extensionVariables';
+import { localize } from '../../../../../../localize';
+import { IProjectWizardContext, ProjectType } from '@microsoft/vscode-extension-logic-apps';
+
+describe('FunctionAppNameStep', () => {
+  const existingFunctionAppName = 'Func1';
+  const validFunctionAppName = 'Valid_Func_';
+  const invalidFunctionAppName = 'Invalid-Func';
+
+  const testLogicAppName = 'LogicApp1';
+  const testWorkspaceName = 'TestWorkspace';
+  const testWorkspaceFile = path.join('path', 'to', `${testWorkspaceName}.code-workspace`);
+  const testWorkspace = {
+    folders: [{ name: existingFunctionAppName }],
+  };
+  let functionAppNameStep: FunctionAppNameStep;
+  let testContext: any;
+  let existsSyncSpy: any;
+  let appendLogSpy: any;
+  let readFileSpy: any;
+
+  beforeEach(() => {
+    functionAppNameStep = new FunctionAppNameStep();
+    testContext = {
+      projectType: ProjectType.customCode,
+      workspaceCustomFilePath: testWorkspaceFile,
+      logicAppName: testLogicAppName,
+      ui: {
+        showInputBox: vi.fn((options: any) => {
+          return options.validateInput(options.testInput).then((validationResult: string | undefined) => {
+            if (validationResult) {
+              return Promise.reject(new Error(validationResult));
+            }
+            return Promise.resolve(options.testInput);
+          });
+        }),
+      },
+    };
+
+    appendLogSpy = vi.spyOn(ext.outputChannel, 'appendLog').mockImplementation(() => {});
+    existsSyncSpy = vi.spyOn(fse, 'existsSync').mockReturnValue(true);
+    readFileSpy = vi.spyOn(vscode.workspace.fs, 'readFile').mockResolvedValue(Buffer.from(JSON.stringify(testWorkspace)));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('prompt', () => {
+    it('sets context.functionAppName and logs output for valid input', async () => {
+      testContext.ui.showInputBox = vi.fn((options: any) => {
+        options.testInput = validFunctionAppName;
+        return options.validateInput(options.testInput).then((result: string | undefined) => {
+          if (result) {
+            return Promise.reject(new Error(result));
+          }
+          return Promise.resolve(options.testInput);
+        });
+      });
+      await functionAppNameStep.prompt(testContext);
+      expect(testContext.functionAppName).toBe(validFunctionAppName);
+      expect(appendLogSpy).toHaveBeenCalledWith(localize('functionAppNameSet', `Function App project name set to ${validFunctionAppName}`));
+    });
+
+    it('rejects when input is invalid (empty)', async () => {
+      const emptyName = '';
+      testContext.ui.showInputBox = vi.fn((options: any) => {
+        options.testInput = emptyName;
+        return options.validateInput(options.testInput).then((result: string | undefined) => {
+          if (result) {
+            return Promise.reject(new Error(result));
+          }
+          return Promise.resolve(emptyName);
+        });
+      });
+      await expect(functionAppNameStep.prompt(testContext)).rejects.toThrow(
+        localize('emptyFunctionNameError', "Can't have an empty function name.")
+      );
+    });
+  });
+
+  describe('validateFunctionName', () => {
+    const callValidateFunctionName = (name: string | undefined, context: IProjectWizardContext) =>
+      (functionAppNameStep as any).validateFunctionName(name, context);
+
+    it('returns error for empty function name', async () => {
+      const emptyName = '';
+      const result = await callValidateFunctionName(emptyName, testContext);
+      expect(result).toBe(localize('emptyFunctionNameError', "Can't have an empty function name."));
+    });
+
+    it('returns error when function name is same as logic app name', async () => {
+      const result = await callValidateFunctionName(testLogicAppName, testContext);
+      expect(result).toBe(
+        localize('functionNameSameAsProjectNameError', `Can't use the same name for the function and the logic app project.`)
+      );
+    });
+
+    it('returns error when function name already exists in workspace', async () => {
+      const result = await callValidateFunctionName(existingFunctionAppName, testContext);
+      expect(result).toBe(localize('functionNameExistsInWorkspaceError', 'A function with this name already exists in the workspace.'));
+    });
+
+    it('returns error when function name does not pass regex validation', async () => {
+      const result = await callValidateFunctionName(invalidFunctionAppName, testContext);
+      expect(result).toBe(
+        localize(
+          'functionNameInvalidMessage',
+          'The function name must start with a letter and can only contain letters, digits, or underscores ("_").'
+        )
+      );
+    });
+
+    it('returns undefined for valid function name', async () => {
+      const result = await callValidateFunctionName(validFunctionAppName, testContext);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/__test__/FunctionAppNamespaceStep.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/__test__/FunctionAppNamespaceStep.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FunctionAppNamespaceStep } from '../FunctionAppNamespaceStep';
+import { ProjectType } from '@microsoft/vscode-extension-logic-apps';
+import { ext } from '../../../../../../extensionVariables';
+
+describe('FunctionAppNamespaceStep', () => {
+  const validFunctionAppNamespace = 'Valid_Namespace1';
+  const invalidFunctionAppNamespace = 'Invalid-Namespace';
+
+  let functionAppNamespaceStep: FunctionAppNamespaceStep;
+  let testContext: any;
+  let appendLogSpy: any;
+
+  beforeEach(() => {
+    functionAppNamespaceStep = new FunctionAppNamespaceStep();
+    testContext = {
+      projectType: ProjectType.customCode,
+      ui: {
+        showInputBox: vi.fn((options: any) => {
+          return options.validateInput(options.testInput).then((validationResult: string | undefined) => {
+            if (validationResult) {
+              return Promise.reject(new Error(validationResult));
+            }
+            return Promise.resolve(options.testInput);
+          });
+        }),
+      },
+    };
+    appendLogSpy = vi.spyOn(ext.outputChannel, 'appendLog').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('prompt', () => {
+    it('sets context.functionAppNamespace and logs output for valid input', async () => {
+      testContext.ui.showInputBox = vi.fn((options: any) => {
+        options.testInput = validFunctionAppNamespace;
+        return options.validateInput(options.testInput).then((result: string | undefined) => {
+          if (result) {
+            return Promise.reject(new Error(result));
+          }
+          return Promise.resolve(options.testInput);
+        });
+      });
+
+      await functionAppNamespaceStep.prompt(testContext);
+      expect(testContext.functionAppNamespace).toBe(validFunctionAppNamespace);
+      expect(appendLogSpy).toHaveBeenCalledWith(`Function App project namespace set to ${validFunctionAppNamespace}`);
+    });
+
+    it('rejects when input is invalid (empty)', async () => {
+      const emptyNamespace = '';
+      testContext.ui.showInputBox = vi.fn((options: any) => {
+        options.testInput = emptyNamespace;
+        return options.validateInput(options.testInput).then((result: string | undefined) => {
+          if (result) {
+            return Promise.reject(new Error(result));
+          }
+          return Promise.resolve(emptyNamespace);
+        });
+      });
+
+      await expect(functionAppNamespaceStep.prompt(testContext)).rejects.toThrowError(`Can't have an empty namespace.`);
+    });
+  });
+
+  describe('validateNamespace', () => {
+    const callValidateNamespace = (name: string | undefined) => (functionAppNamespaceStep as any).validateNamespace(name);
+
+    it('returns error for empty namespace', async () => {
+      const result = await callValidateNamespace('');
+      expect(result).toBe(`Can't have an empty namespace.`);
+    });
+
+    it('returns error when namespace does not pass regex validation', async () => {
+      const result = await callValidateNamespace(invalidFunctionAppNamespace);
+      expect(result).toBe('The namespace must start with a letter and can only contain letters, digits, or underscores ("_").');
+    });
+
+    it('returns undefined for valid namespace', async () => {
+      const result = await callValidateNamespace(validFunctionAppNamespace);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -76,6 +76,7 @@ vi.mock('vscode', () => ({
     updateWorkspaceFolders: vi.fn(), // <-- This ensures the method exists.
     fs: {
       readFile: vi.fn(),
+      readDirectory: vi.fn(),
     },
   },
   Uri: {
@@ -87,6 +88,10 @@ vi.mock('vscode', () => ({
   EventEmitter: vi.fn().mockImplementation(() => ({
     getUser: vi.fn(),
   })),
+  FileType: {
+    File: 'file',
+    Directory: 'directory',
+  },
 }));
 
 vi.mock('./src/extensionVariables', () => ({


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

- Function app name input validation doesn't check for other function apps in workspace with same name
- Function name input validation doesn't check for other functions in the same function app with same name
- Context storing functions projects for workspace isn't updated after creating new project with functions

## New Behavior

All above bugs fixed

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Added unit tests for FunctionAppNameStep/FunctionNameStep/FuncationAppNamespaceStep validation

## Screenshots or Videos (if applicable)

N/A
