### PR TITLE
fix(designer): Fix panel resize

### DIFF
--- a/libs/designer-ui/src/lib/panel/panelResizer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelResizer.tsx
@@ -27,10 +27,11 @@ const useStyles = makeStyles({
 interface PanelResizerProps {
   minWidth?: number;
   updatePanelWidth: (width: string) => void;
+  panelRef?: React.RefObject<HTMLDivElement>;
 }
 
 export const PanelResizer = (props: PanelResizerProps): JSX.Element => {
-  const { minWidth = 400, updatePanelWidth } = props;
+  const { minWidth = 400, updatePanelWidth, panelRef } = props;
   const styles = useStyles();
   const [isResizing, setIsResizing] = useState(false);
   const startResizing = useCallback(() => setIsResizing(true), []);
@@ -44,10 +45,18 @@ export const PanelResizer = (props: PanelResizerProps): JSX.Element => {
       }
       e.preventDefault();
       const { clientX } = e;
-      animationFrame.current = requestAnimationFrame(() => {
-        const newWidth = Math.max(window.innerWidth - clientX, minWidth);
-        updatePanelWidth(`${newWidth.toString()}px`);
-      });
+
+      if (panelRef?.current) {
+        const panelRefRect = panelRef.current.getBoundingClientRect();
+        // Calculate width as the distance from the mouse to the container's right edge
+        const newWidth = Math.max(panelRefRect.right - clientX, minWidth);
+        updatePanelWidth(`${newWidth}px`);
+      } else {
+        animationFrame.current = requestAnimationFrame(() => {
+          const newWidth = Math.max(window.innerWidth - clientX, minWidth);
+          updatePanelWidth(`${newWidth.toString()}px`);
+        });
+      }
     },
     [isResizing, minWidth, updatePanelWidth]
   );

--- a/libs/designer-ui/src/lib/panel/panelcontainer.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontainer.tsx
@@ -11,7 +11,7 @@ import {
   MessageBarTitle,
 } from '@fluentui/react-components';
 import { ChevronDoubleRightFilled } from '@fluentui/react-icons';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { EmptyContent } from '../card/emptycontent';
 import type { PageActionTelemetryData } from '../telemetry/models';
@@ -84,6 +84,7 @@ export const PanelContainer = ({
   const isRight = panelLocation === PanelLocation.Right;
   const pinnedNodeId = pinnedNode?.nodeId;
   const pinnedNodeIfDifferent = pinnedNode && pinnedNode.nodeId !== node?.nodeId ? pinnedNode : undefined;
+  const panelRef = useRef<HTMLDivElement>(null);
 
   const drawerWidth = isCollapsed
     ? PanelSize.Auto
@@ -215,6 +216,7 @@ export const PanelContainer = ({
         element: mountNode,
       }}
       open={true}
+      ref={panelRef}
       position={isRight ? 'end' : 'start'}
       style={{ position: 'relative', maxWidth: '100%', width: drawerWidth, height: '100%' }}
     >
@@ -251,7 +253,7 @@ export const PanelContainer = ({
               </>
             )}
           </div>
-          {canResize ? <PanelResizer minWidth={minWidth} updatePanelWidth={setOverrideWidth} /> : null}
+          {canResize ? <PanelResizer minWidth={minWidth} panelRef={panelRef} updatePanelWidth={setOverrideWidth} /> : null}
         </>
       )}
     </Drawer>

--- a/libs/designer/src/lib/ui/panel/agentChat/agentChat.tsx
+++ b/libs/designer/src/lib/ui/panel/agentChat/agentChat.tsx
@@ -1,6 +1,5 @@
-import type { ConversationItem } from '@microsoft/designer-ui';
-import { ConversationItemType, PanelLocation, PanelResizer, PanelSize } from '@microsoft/designer-ui';
-import { useEffect, useMemo, useState } from 'react';
+import { ConversationItemType, PanelLocation, PanelResizer, PanelSize, type ConversationItem } from '@microsoft/designer-ui';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { type IntlShape, useIntl } from 'react-intl';
 import { defaultChatbotPanelWidth, ChatbotContent } from '@microsoft/logic-apps-chatbot';
 import { type ChatHistory, useChatHistory } from '../../../core/queries/runs';
@@ -175,11 +174,12 @@ export const AgentChat = ({
   const [isCollapsed, setIsCollapsed] = useState(false);
   const panelContainerElement = panelContainerRef.current as HTMLElement;
   const { isFetching: isChatHistoryFetching, data: chatHistoryData } = useChatHistory(!!isMonitoringView, agentOperations, runInstance?.id);
-  const [overrideWidth, setOverrideWidth] = useState<string | undefined>();
+  const [overrideWidth, setOverrideWidth] = useState<string | undefined>(chatbotWidth);
   const isChatInputEnabled = useIsChatInputEnabled(conversation.length > 0 ? conversation[0].metadata?.parentId : undefined);
   const dispatch = useDispatch<AppDispatch>();
   const agentsNumber = Object.keys(agentLastOperations).length;
-  const drawerWidth = isCollapsed ? PanelSize.Auto : (overrideWidth ?? chatbotWidth);
+  const drawerWidth = isCollapsed ? PanelSize.Auto : overrideWidth;
+  const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!isNullOrUndefined(chatHistoryData)) {
@@ -275,6 +275,7 @@ export const AgentChat = ({
       }}
       open={true}
       position={'end'}
+      ref={panelRef}
       style={{
         position: 'relative',
         maxWidth: '100%',
@@ -327,7 +328,7 @@ export const AgentChat = ({
               setFocus: setFocus,
             }}
           />
-          <PanelResizer minWidth={undefined} updatePanelWidth={setOverrideWidth} />
+          <PanelResizer updatePanelWidth={setOverrideWidth} panelRef={panelRef} />
         </>
       )}
     </Drawer>


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

- Innermost panel wasn't rendering and sizing in a right way since the chat panel was introduced

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

- Now panel resize rely on the drawer reference rather than relying on the window width

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

No breaking changes

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->



### Before


https://github.com/user-attachments/assets/c614f7f1-e9b8-4466-a4a2-3322ab74a069



### After


https://github.com/user-attachments/assets/5d2d6daf-20fe-4621-9f55-5ed37c2eff39

