### PR TITLE
feat(Templates): Custom Templates Tab Management

### DIFF
--- a/libs/designer-ui/src/lib/templates/model.ts
+++ b/libs/designer-ui/src/lib/templates/model.ts
@@ -5,7 +5,7 @@ export interface TemplateTabProps {
   id: string;
   title: string;
   description?: string | ReactNode;
-  hasError?: boolean;
+  tabStatusIcon?: 'error' | 'success' | 'in-progress' | undefined;
   disabled?: boolean;
   content: React.ReactElement;
   footerContent: TemplatePanelFooterProps;

--- a/libs/designer-ui/src/lib/templates/model.ts
+++ b/libs/designer-ui/src/lib/templates/model.ts
@@ -1,11 +1,13 @@
 import type { TemplatePanelFooterProps } from './templatesPanelFooter';
 import type { ReactNode } from 'react';
 
+export type TemplateTabStatusType = 'error' | 'success' | 'in-progress' | undefined;
+
 export interface TemplateTabProps {
   id: string;
   title: string;
   description?: string | ReactNode;
-  tabStatusIcon?: 'error' | 'success' | 'in-progress' | undefined;
+  tabStatusIcon?: TemplateTabStatusType;
   disabled?: boolean;
   content: React.ReactElement;
   footerContent: TemplatePanelFooterProps;

--- a/libs/designer-ui/src/lib/templates/templatesContent.tsx
+++ b/libs/designer-ui/src/lib/templates/templatesContent.tsx
@@ -1,7 +1,7 @@
-import { TabList, Tab, Text, tokens } from '@fluentui/react-components';
+import { TabList, Tab, Text } from '@fluentui/react-components';
 import type { SelectTabData, SelectTabEvent } from '@fluentui/react-components';
 import type { TemplateTabProps } from './model';
-import { DismissCircleFilled } from '@fluentui/react-icons';
+import { CheckmarkCircleFilled, CircleHintHalfVertical16Filled, DismissCircleFilled } from '@fluentui/react-icons';
 
 export interface TemplateContentProps {
   className?: string;
@@ -27,7 +27,7 @@ export const TemplateContent = ({ tabs = [], selectedTab, selectTab, className }
       {tabs.length > 1 && (
         <>
           <TabList selectedValue={selectedTabId} onTabSelect={onTabSelected} className={tabClass}>
-            {tabs.map(({ id, title, disabled = false, hasError = false }) => (
+            {tabs.map(({ id, title, disabled = false, tabStatusIcon }) => (
               <Tab
                 disabled={disabled}
                 key={id}
@@ -36,7 +36,7 @@ export const TemplateContent = ({ tabs = [], selectedTab, selectTab, className }
                 className="msla-templates-panel-tabName"
                 value={id}
                 role={'tab'}
-                icon={hasError ? <DismissCircleFilled color={tokens.colorStatusDangerForeground1} /> : undefined}
+                icon={TabStatusIcon(tabStatusIcon)}
               >
                 {title}
               </Tab>
@@ -48,4 +48,18 @@ export const TemplateContent = ({ tabs = [], selectedTab, selectTab, className }
       <div className="msla-panel-content-container">{selectedTabProps?.content}</div>
     </div>
   );
+};
+
+const TabStatusIcon = (iconName: 'error' | 'success' | 'in-progress' | undefined) => {
+  switch (iconName) {
+    case 'error':
+      return <DismissCircleFilled />;
+    case 'success':
+      return <CheckmarkCircleFilled />;
+    case 'in-progress':
+      // return <Question16Filled />;
+      return <CircleHintHalfVertical16Filled />;
+    default:
+      return null;
+  }
 };

--- a/libs/designer-ui/src/lib/templates/templatesContent.tsx
+++ b/libs/designer-ui/src/lib/templates/templatesContent.tsx
@@ -1,7 +1,7 @@
 import { TabList, Tab, Text } from '@fluentui/react-components';
 import type { SelectTabData, SelectTabEvent } from '@fluentui/react-components';
 import type { TemplateTabProps } from './model';
-import { CheckmarkCircleFilled, CircleHintHalfVertical16Filled, DismissCircleFilled } from '@fluentui/react-icons';
+import { CheckmarkCircleFilled, CircleHintHalfVerticalFilled, DismissCircleFilled } from '@fluentui/react-icons';
 
 export interface TemplateContentProps {
   className?: string;
@@ -57,8 +57,7 @@ const TabStatusIcon = (iconName: 'error' | 'success' | 'in-progress' | undefined
     case 'success':
       return <CheckmarkCircleFilled />;
     case 'in-progress':
-      // return <Question16Filled />;
-      return <CircleHintHalfVertical16Filled />;
+      return <CircleHintHalfVerticalFilled />;
     default:
       return null;
   }

--- a/libs/designer-ui/src/lib/templates/templatesContent.tsx
+++ b/libs/designer-ui/src/lib/templates/templatesContent.tsx
@@ -1,6 +1,6 @@
 import { TabList, Tab, Text } from '@fluentui/react-components';
 import type { SelectTabData, SelectTabEvent } from '@fluentui/react-components';
-import type { TemplateTabProps } from './model';
+import type { TemplateTabProps, TemplateTabStatusType } from './model';
 import { CheckmarkCircleFilled, CircleHintHalfVerticalFilled, DismissCircleFilled } from '@fluentui/react-icons';
 
 export interface TemplateContentProps {
@@ -50,7 +50,7 @@ export const TemplateContent = ({ tabs = [], selectedTab, selectTab, className }
   );
 };
 
-const TabStatusIcon = (iconName: 'error' | 'success' | 'in-progress' | undefined) => {
+const TabStatusIcon = (iconName: TemplateTabStatusType) => {
   switch (iconName) {
     case 'error':
       return <DismissCircleFilled />;

--- a/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
@@ -49,7 +49,6 @@ import type { WorkflowParameter } from '../../../common/models/workflow';
 import { getAllInputParameters } from '../../utils/parameters/helper';
 import { shouldAddDynamicData } from '../../templates/utils/parametershelper';
 import type { WorkflowState } from '../../state/templates/workflowSlice';
-import { closePanel } from '../../state/templates/panelSlice';
 
 export interface ConfigureTemplateServiceOptions {
   connectionService: IConnectionService;
@@ -145,7 +144,6 @@ export const initializeWorkflowsData = createAsyncThunk(
 
     const parameterDefinitions = await getTemplateParameters(getState() as RootState, mapping);
 
-    dispatch(closePanel()); //TODO: better structure calling this
     return { connections, parameterDefinitions };
   }
 );

--- a/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
@@ -90,7 +90,10 @@ export const initializeConfigureTemplateServices = createAsyncThunk(
 
 export const loadCustomTemplate = createAsyncThunk(
   'loadCustomTemplate',
-  async ({ templateId }: { templateId: string }, { dispatch }): Promise<{ isPublished: boolean; environment: string }> => {
+  async (
+    { templateId }: { templateId: string },
+    { dispatch }
+  ): Promise<{ isPublished: boolean; environment: string; enableWizard: boolean }> => {
     const templateName = getResourceNameFromId(templateId);
     const templateResource = await getTemplate(templateId);
     const manifest = await getTemplateManifest(templateId);
@@ -117,6 +120,7 @@ export const loadCustomTemplate = createAsyncThunk(
     return {
       isPublished: templateResource.properties?.provisioningState === 'Succeeded',
       environment: templateResource.properties?.environment ?? 'Development',
+      enableWizard: allWorkflowsData && Object.keys(allWorkflowsData).length > 0,
     };
   }
 );

--- a/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
@@ -49,6 +49,7 @@ import type { WorkflowParameter } from '../../../common/models/workflow';
 import { getAllInputParameters } from '../../utils/parameters/helper';
 import { shouldAddDynamicData } from '../../templates/utils/parametershelper';
 import type { WorkflowState } from '../../state/templates/workflowSlice';
+import { closePanel } from '../../state/templates/panelSlice';
 
 export interface ConfigureTemplateServiceOptions {
   connectionService: IConnectionService;
@@ -134,6 +135,7 @@ export const initializeWorkflowsData = createAsyncThunk(
     connections: Record<string, Template.Connection>;
     parameterDefinitions: Record<string, Partial<Template.ParameterDefinition>>;
   }> => {
+    dispatch(updateAllWorkflowsData(workflows));
     const { connections, mapping, workflowsWithDefinitions } = await getTemplateConnections(getState() as RootState, dispatch, workflows);
     const operationsData = await getOperationDataInDefinitions(
       workflowsWithDefinitions as Record<string, WorkflowTemplateData>,
@@ -142,6 +144,8 @@ export const initializeWorkflowsData = createAsyncThunk(
     dispatch(initializeNodeOperationInputsData(operationsData));
 
     const parameterDefinitions = await getTemplateParameters(getState() as RootState, mapping);
+
+    dispatch(closePanel()); //TODO: better structure calling this
     return { connections, parameterDefinitions };
   }
 );

--- a/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
@@ -156,6 +156,7 @@ export const deleteWorkflowData = createAsyncThunk(
     connectionKeys: string[];
     parameterKeys: string[];
     parametersToUpdate: Record<string, Partial<Template.ParameterDefinition>>;
+    disableWizard: boolean;
   }> => {
     const combinedConnectionKeys: string[] = [];
     const combinedParameterKeys: string[] = [];
@@ -199,7 +200,8 @@ export const deleteWorkflowData = createAsyncThunk(
       combinedParameterKeys.push(...parameterKeys);
     }
 
-    return { ids, connectionKeys: combinedConnectionKeys, parameterKeys: combinedParameterKeys, parametersToUpdate };
+    const disableWizard = Object.keys(workflows).filter((workflowId) => !ids.includes(workflowId)).length === 0;
+    return { ids, connectionKeys: combinedConnectionKeys, parameterKeys: combinedParameterKeys, parametersToUpdate, disableWizard };
   }
 );
 

--- a/libs/designer/src/lib/core/state/templates/panelSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/panelSlice.ts
@@ -1,6 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { resetTemplatesState } from '../global';
+import { initializeWorkflowsData } from '../../actions/bjsworkflow/configuretemplate';
 
 export const TemplatePanelView = {
   // Template creation panels
@@ -49,6 +50,10 @@ export const panelSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(resetTemplatesState, () => initialState);
+
+    builder.addCase(initializeWorkflowsData.fulfilled, (state) => {
+      state.isOpen = false;
+    });
   },
 });
 

--- a/libs/designer/src/lib/core/state/templates/panelSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/panelSlice.ts
@@ -24,6 +24,12 @@ const initialState: PanelState = {
   selectedTabId: undefined,
 };
 
+const closePanelReducer = (state: typeof initialState) => {
+  state.isOpen = false;
+  state.currentPanelView = undefined;
+  state.selectedTabId = undefined;
+};
+
 export const panelSlice = createSlice({
   name: 'panel',
   initialState,
@@ -42,18 +48,12 @@ export const panelSlice = createSlice({
     selectPanelTab: (state, action: PayloadAction<string | undefined>) => {
       state.selectedTabId = action.payload;
     },
-    closePanel: (state) => {
-      state.isOpen = false;
-      state.currentPanelView = undefined;
-      state.selectedTabId = undefined;
-    },
+    closePanel: closePanelReducer,
   },
   extraReducers: (builder) => {
     builder.addCase(resetTemplatesState, () => initialState);
 
-    builder.addCase(initializeWorkflowsData.fulfilled, (state) => {
-      state.isOpen = false;
-    });
+    builder.addCase(initializeWorkflowsData.fulfilled, closePanelReducer);
   },
 });
 

--- a/libs/designer/src/lib/core/state/templates/tabSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/tabSlice.ts
@@ -6,11 +6,13 @@ import { deleteWorkflowData, initializeWorkflowsData, loadCustomTemplate } from 
 export interface TabState {
   selectedTabId: string | undefined;
   enableWizard: boolean;
+  isWizardUpdating: boolean;
 }
 
 const initialState: TabState = {
   selectedTabId: undefined,
   enableWizard: false,
+  isWizardUpdating: false,
 };
 
 export const tabSlice = createSlice({
@@ -20,19 +22,25 @@ export const tabSlice = createSlice({
     selectWizardTab: (state, action: PayloadAction<string>) => {
       state.selectedTabId = action.payload;
     },
+    setIsWizardUpdating: (state) => {
+      state.isWizardUpdating = true;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(resetTemplatesState, () => initialState);
 
     builder.addCase(loadCustomTemplate.fulfilled, (state, action: PayloadAction<{ enableWizard: boolean }>) => {
+      state.isWizardUpdating = false;
       state.enableWizard = action.payload.enableWizard;
     });
 
     builder.addCase(initializeWorkflowsData.fulfilled, (state) => {
+      state.isWizardUpdating = false;
       state.enableWizard = true;
     });
 
     builder.addCase(deleteWorkflowData.fulfilled, (state, action: PayloadAction<{ disableWizard: boolean }>) => {
+      state.isWizardUpdating = false;
       if (action.payload.disableWizard) {
         state.enableWizard = false;
       }
@@ -40,5 +48,5 @@ export const tabSlice = createSlice({
   },
 });
 
-export const { selectWizardTab } = tabSlice.actions;
+export const { setIsWizardUpdating, selectWizardTab } = tabSlice.actions;
 export default tabSlice.reducer;

--- a/libs/designer/src/lib/core/state/templates/tabSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/tabSlice.ts
@@ -24,9 +24,12 @@ export const tabSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(resetTemplatesState, () => initialState);
 
-    builder.addCase(loadCustomTemplate.fulfilled, (state) => {
-      state.enableWizard = true;
+    builder.addCase(loadCustomTemplate.fulfilled, (state, action: PayloadAction<{ enableWizard: boolean }>) => {
+      state.enableWizard = action.payload.enableWizard;
     });
+
+    //TODO: on initializeWorkflowsData fulfilled, set enableWizard to true after checking workflows length.
+    // TODO: on deleteWorkflowsData fulfilled, set enableWizard to false if workflows length is 0.
   },
 });
 

--- a/libs/designer/src/lib/core/state/templates/tabSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/tabSlice.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { resetTemplatesState } from '../global';
-import { loadCustomTemplate } from '../../actions/bjsworkflow/configuretemplate';
+import { deleteWorkflowData, initializeWorkflowsData, loadCustomTemplate } from '../../actions/bjsworkflow/configuretemplate';
 
 export interface TabState {
   selectedTabId: string | undefined;
@@ -28,8 +28,15 @@ export const tabSlice = createSlice({
       state.enableWizard = action.payload.enableWizard;
     });
 
-    //TODO: on initializeWorkflowsData fulfilled, set enableWizard to true after checking workflows length.
-    // TODO: on deleteWorkflowsData fulfilled, set enableWizard to false if workflows length is 0.
+    builder.addCase(initializeWorkflowsData.fulfilled, (state) => {
+      state.enableWizard = true;
+    });
+
+    builder.addCase(deleteWorkflowData.fulfilled, (state, action: PayloadAction<{ disableWizard: boolean }>) => {
+      if (action.payload.disableWizard) {
+        state.enableWizard = false;
+      }
+    });
   },
 });
 

--- a/libs/designer/src/lib/core/state/templates/tabSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/tabSlice.ts
@@ -22,9 +22,6 @@ export const tabSlice = createSlice({
     selectWizardTab: (state, action: PayloadAction<string>) => {
       state.selectedTabId = action.payload;
     },
-    setIsWizardUpdating: (state) => {
-      state.isWizardUpdating = true;
-    },
   },
   extraReducers: (builder) => {
     builder.addCase(resetTemplatesState, () => initialState);
@@ -34,9 +31,18 @@ export const tabSlice = createSlice({
       state.enableWizard = action.payload.enableWizard;
     });
 
+    builder.addCase(initializeWorkflowsData.pending, (state) => {
+      state.isWizardUpdating = true;
+      state.enableWizard = false;
+    });
+
     builder.addCase(initializeWorkflowsData.fulfilled, (state) => {
       state.isWizardUpdating = false;
       state.enableWizard = true;
+    });
+
+    builder.addCase(deleteWorkflowData.pending, (state) => {
+      state.isWizardUpdating = true;
     });
 
     builder.addCase(deleteWorkflowData.fulfilled, (state, action: PayloadAction<{ disableWizard: boolean }>) => {
@@ -48,5 +54,5 @@ export const tabSlice = createSlice({
   },
 });
 
-export const { setIsWizardUpdating, selectWizardTab } = tabSlice.actions;
+export const { selectWizardTab } = tabSlice.actions;
 export default tabSlice.reducer;

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/connectionsTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/connectionsTab.tsx
@@ -12,7 +12,7 @@ export const connectionsTab = (intl: IntlShape, dispatch: AppDispatch): Template
     id: 'ur+ZvW',
     description: 'The tab label for the monitoring connections tab on the configure template wizard',
   }),
-  hasError: false,
+  tabStatusIcon: undefined,
   content: <TemplateConnectionsList />,
   description: intl.formatMessage({
     defaultMessage: 'Connections for the following connectors would be required during workflow creation from this template.',

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/connectionsTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/connectionsTab.tsx
@@ -4,12 +4,12 @@ import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
 import { TemplateConnectionsList } from '../connections/connectionslist';
-import type { CreateWizardTabProps } from './model';
+import type { TemplateWizardTabProps } from './model';
 
 export const connectionsTab = (
   intl: IntlShape,
   dispatch: AppDispatch,
-  { disabled, tabStatusIcon }: CreateWizardTabProps
+  { disabled, tabStatusIcon }: TemplateWizardTabProps
 ): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.CONNECTIONS,
   title: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/connectionsTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/connectionsTab.tsx
@@ -4,15 +4,21 @@ import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
 import { TemplateConnectionsList } from '../connections/connectionslist';
+import type { CreateWizardTabProps } from './model';
 
-export const connectionsTab = (intl: IntlShape, dispatch: AppDispatch): TemplateTabProps => ({
+export const connectionsTab = (
+  intl: IntlShape,
+  dispatch: AppDispatch,
+  { disabled, tabStatusIcon }: CreateWizardTabProps
+): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.CONNECTIONS,
   title: intl.formatMessage({
     defaultMessage: 'Connections',
     id: 'ur+ZvW',
     description: 'The tab label for the monitoring connections tab on the configure template wizard',
   }),
-  tabStatusIcon: undefined,
+  tabStatusIcon,
+  disabled,
   content: <TemplateConnectionsList />,
   description: intl.formatMessage({
     defaultMessage: 'Connections for the following connectors would be required during workflow creation from this template.',

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/model.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/model.tsx
@@ -1,0 +1,6 @@
+import type { TemplateTabStatusType } from '@microsoft/designer-ui';
+
+export interface CreateWizardTabProps {
+  disabled?: boolean;
+  tabStatusIcon?: TemplateTabStatusType;
+}

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/model.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/model.tsx
@@ -1,6 +1,6 @@
 import type { TemplateTabStatusType } from '@microsoft/designer-ui';
 
-export interface CreateWizardTabProps {
+export interface TemplateWizardTabProps {
   disabled?: boolean;
   tabStatusIcon?: TemplateTabStatusType;
 }

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/parametersTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/parametersTab.tsx
@@ -4,12 +4,12 @@ import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
 import { TemplateParametersList } from '../parameters/parameterslist';
-import type { CreateWizardTabProps } from './model';
+import type { TemplateWizardTabProps } from './model';
 
 export const parametersTab = (
   intl: IntlShape,
   dispatch: AppDispatch,
-  { disabled, tabStatusIcon }: CreateWizardTabProps
+  { disabled, tabStatusIcon }: TemplateWizardTabProps
 ): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.PARAMETERS,
   title: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/parametersTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/parametersTab.tsx
@@ -12,7 +12,7 @@ export const parametersTab = (intl: IntlShape, dispatch: AppDispatch): TemplateT
     id: 'lYAlE9',
     description: 'The tab label for the monitoring parameters tab on the configure template wizard',
   }),
-  hasError: false,
+  tabStatusIcon: undefined,
   content: <TemplateParametersList />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/parametersTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/parametersTab.tsx
@@ -4,15 +4,21 @@ import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
 import { TemplateParametersList } from '../parameters/parameterslist';
+import type { CreateWizardTabProps } from './model';
 
-export const parametersTab = (intl: IntlShape, dispatch: AppDispatch): TemplateTabProps => ({
+export const parametersTab = (
+  intl: IntlShape,
+  dispatch: AppDispatch,
+  { disabled, tabStatusIcon }: CreateWizardTabProps
+): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.PARAMETERS,
   title: intl.formatMessage({
     defaultMessage: 'Parameters',
     id: 'lYAlE9',
     description: 'The tab label for the monitoring parameters tab on the configure template wizard',
   }),
-  tabStatusIcon: undefined,
+  tabStatusIcon,
+  disabled,
   content: <TemplateParametersList />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/profileTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/profileTab.tsx
@@ -12,7 +12,7 @@ export const profileTab = (intl: IntlShape, dispatch: AppDispatch): TemplateTabP
     id: '6ELsbA',
     description: 'The tab label for the monitoring profile tab on the configure template wizard',
   }),
-  hasError: false,
+  tabStatusIcon: undefined,
   content: <TemplateManifestForm />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/profileTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/profileTab.tsx
@@ -4,15 +4,21 @@ import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
 import { TemplateManifestForm } from '../templateprofile/manifestform';
+import type { CreateWizardTabProps } from './model';
 
-export const profileTab = (intl: IntlShape, dispatch: AppDispatch): TemplateTabProps => ({
+export const profileTab = (
+  intl: IntlShape,
+  dispatch: AppDispatch,
+  { disabled, tabStatusIcon }: CreateWizardTabProps
+): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.PROFILE,
   title: intl.formatMessage({
     defaultMessage: 'Profile',
     id: '6ELsbA',
     description: 'The tab label for the monitoring profile tab on the configure template wizard',
   }),
-  tabStatusIcon: undefined,
+  tabStatusIcon,
+  disabled,
   content: <TemplateManifestForm />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/profileTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/profileTab.tsx
@@ -4,12 +4,12 @@ import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
 import { TemplateManifestForm } from '../templateprofile/manifestform';
-import type { CreateWizardTabProps } from './model';
+import type { TemplateWizardTabProps } from './model';
 
 export const profileTab = (
   intl: IntlShape,
   dispatch: AppDispatch,
-  { disabled, tabStatusIcon }: CreateWizardTabProps
+  { disabled, tabStatusIcon }: TemplateWizardTabProps
 ): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.PROFILE,
   title: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/publishTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/publishTab.tsx
@@ -9,6 +9,7 @@ import type { Template } from '@microsoft/logic-apps-shared';
 import { useMemo } from 'react';
 import { type TemplateEnvironment, updateEnvironment, updateTemplateManifest } from '../../../core/state/templates/templateSlice';
 import { getSupportedSkus } from '../../../core/configuretemplate/utils/helper';
+import type { CreateWizardTabProps } from './model';
 
 const TemplateSettings = () => {
   const { manifest, environment, isPublished, connections } = useSelector((state: RootState) => state.template);
@@ -72,7 +73,11 @@ const TemplateSettings = () => {
   );
 };
 
-export const publishTab = (intl: IntlShape, dispatch: AppDispatch): TemplateTabProps => ({
+export const publishTab = (
+  intl: IntlShape,
+  dispatch: AppDispatch,
+  { disabled, tabStatusIcon }: CreateWizardTabProps
+): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.PUBLISH,
   title: intl.formatMessage({
     defaultMessage: 'Settings',
@@ -84,7 +89,8 @@ export const publishTab = (intl: IntlShape, dispatch: AppDispatch): TemplateTabP
     id: 'uOlHLw',
     description: 'The description for the settings tab on the configure template wizard',
   }),
-  tabStatusIcon: undefined,
+  tabStatusIcon,
+  disabled,
   content: <TemplateSettings />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/publishTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/publishTab.tsx
@@ -84,7 +84,7 @@ export const publishTab = (intl: IntlShape, dispatch: AppDispatch): TemplateTabP
     id: 'uOlHLw',
     description: 'The description for the settings tab on the configure template wizard',
   }),
-  hasError: false,
+  tabStatusIcon: undefined,
   content: <TemplateSettings />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/publishTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/publishTab.tsx
@@ -9,7 +9,7 @@ import type { Template } from '@microsoft/logic-apps-shared';
 import { useMemo } from 'react';
 import { type TemplateEnvironment, updateEnvironment, updateTemplateManifest } from '../../../core/state/templates/templateSlice';
 import { getSupportedSkus } from '../../../core/configuretemplate/utils/helper';
-import type { CreateWizardTabProps } from './model';
+import type { TemplateWizardTabProps } from './model';
 
 const TemplateSettings = () => {
   const { manifest, environment, isPublished, connections } = useSelector((state: RootState) => state.template);
@@ -76,7 +76,7 @@ const TemplateSettings = () => {
 export const publishTab = (
   intl: IntlShape,
   dispatch: AppDispatch,
-  { disabled, tabStatusIcon }: CreateWizardTabProps
+  { disabled, tabStatusIcon }: TemplateWizardTabProps
 ): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.PUBLISH,
   title: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/reviewPublishTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/reviewPublishTab.tsx
@@ -4,7 +4,7 @@ import type { TemplateTabProps } from '@microsoft/designer-ui';
 import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
-import type { CreateWizardTabProps } from './model';
+import type { TemplateWizardTabProps } from './model';
 
 export const ReviewPublishTab = () => {
   return <Text>placeholder - show review + publish</Text>;
@@ -14,7 +14,7 @@ export const reviewPublishTab = (
   intl: IntlShape,
   dispatch: AppDispatch,
   onPublish: () => void,
-  { disabled, tabStatusIcon }: CreateWizardTabProps
+  { disabled, tabStatusIcon }: TemplateWizardTabProps
 ): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.REVIEW_AND_PUBLISH,
   title: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/reviewPublishTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/reviewPublishTab.tsx
@@ -16,7 +16,7 @@ export const reviewPublishTab = (intl: IntlShape, dispatch: AppDispatch, onPubli
     id: 'FJQUqL',
     description: 'The tab label for the monitoring review and publish tab on the configure template wizard',
   }),
-  hasError: false,
+  tabStatusIcon: undefined,
   content: <ReviewPublishTab />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/reviewPublishTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/reviewPublishTab.tsx
@@ -4,19 +4,26 @@ import type { TemplateTabProps } from '@microsoft/designer-ui';
 import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
+import type { CreateWizardTabProps } from './model';
 
 export const ReviewPublishTab = () => {
   return <Text>placeholder - show review + publish</Text>;
 };
 
-export const reviewPublishTab = (intl: IntlShape, dispatch: AppDispatch, onPublish: () => void): TemplateTabProps => ({
+export const reviewPublishTab = (
+  intl: IntlShape,
+  dispatch: AppDispatch,
+  onPublish: () => void,
+  { disabled, tabStatusIcon }: CreateWizardTabProps
+): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.REVIEW_AND_PUBLISH,
   title: intl.formatMessage({
     defaultMessage: 'Review + publish',
     id: 'FJQUqL',
     description: 'The tab label for the monitoring review and publish tab on the configure template wizard',
   }),
-  tabStatusIcon: undefined,
+  tabStatusIcon,
+  disabled,
   content: <ReviewPublishTab />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
@@ -18,8 +18,9 @@ export const useConfigureTemplateWizardTabs = ({
   const intl = useIntl();
   const dispatch = useDispatch<AppDispatch>();
 
-  const { enableWizard } = useSelector((state: RootState) => ({
+  const { enableWizard, isWizardUpdating } = useSelector((state: RootState) => ({
     enableWizard: state.tab.enableWizard,
+    isWizardUpdating: state.tab.isWizardUpdating,
   }));
 
   return [
@@ -28,23 +29,23 @@ export const useConfigureTemplateWizardTabs = ({
     }),
     connectionsTab(intl, dispatch, {
       tabStatusIcon: enableWizard ? 'in-progress' : undefined,
-      disabled: !enableWizard,
+      disabled: !enableWizard || isWizardUpdating,
     }),
     parametersTab(intl, dispatch, {
       tabStatusIcon: enableWizard ? 'in-progress' : undefined,
-      disabled: !enableWizard,
+      disabled: !enableWizard || isWizardUpdating,
     }),
     profileTab(intl, dispatch, {
       tabStatusIcon: enableWizard ? 'in-progress' : undefined,
-      disabled: !enableWizard,
+      disabled: !enableWizard || isWizardUpdating,
     }),
     publishTab(intl, dispatch, {
       tabStatusIcon: enableWizard ? 'in-progress' : undefined,
-      disabled: !enableWizard,
+      disabled: !enableWizard || isWizardUpdating,
     }),
     reviewPublishTab(intl, dispatch, onPublish, {
       tabStatusIcon: enableWizard ? 'in-progress' : undefined,
-      disabled: !enableWizard,
+      disabled: !enableWizard || isWizardUpdating,
     }),
   ];
 };

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
@@ -1,6 +1,6 @@
-import type { AppDispatch } from '../../../core/state/templates/store';
+import type { AppDispatch, RootState } from '../../../core/state/templates/store';
 import { useIntl } from 'react-intl';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { workflowsTab } from './workflowsTab';
 import { connectionsTab } from './connectionsTab';
 import { parametersTab } from './parametersTab';
@@ -18,12 +18,33 @@ export const useConfigureTemplateWizardTabs = ({
   const intl = useIntl();
   const dispatch = useDispatch<AppDispatch>();
 
+  const { enableWizard } = useSelector((state: RootState) => ({
+    enableWizard: state.tab.enableWizard,
+  }));
+
   return [
-    workflowsTab(intl, dispatch, onSaveWorkflows),
-    connectionsTab(intl, dispatch),
-    parametersTab(intl, dispatch),
-    profileTab(intl, dispatch),
-    publishTab(intl, dispatch),
-    reviewPublishTab(intl, dispatch, onPublish),
+    workflowsTab(intl, dispatch, onSaveWorkflows, {
+      tabStatusIcon: undefined,
+    }),
+    connectionsTab(intl, dispatch, {
+      tabStatusIcon: enableWizard ? undefined : 'in-progress',
+      disabled: enableWizard,
+    }),
+    parametersTab(intl, dispatch, {
+      tabStatusIcon: enableWizard ? undefined : 'in-progress',
+      disabled: enableWizard,
+    }),
+    profileTab(intl, dispatch, {
+      tabStatusIcon: enableWizard ? undefined : 'in-progress',
+      disabled: enableWizard,
+    }),
+    publishTab(intl, dispatch, {
+      tabStatusIcon: enableWizard ? undefined : 'in-progress',
+      disabled: enableWizard,
+    }),
+    reviewPublishTab(intl, dispatch, onPublish, {
+      tabStatusIcon: enableWizard ? undefined : 'in-progress',
+      disabled: enableWizard,
+    }),
   ];
 };

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
@@ -24,27 +24,27 @@ export const useConfigureTemplateWizardTabs = ({
 
   return [
     workflowsTab(intl, dispatch, onSaveWorkflows, {
-      tabStatusIcon: undefined,
+      tabStatusIcon: 'in-progress',
     }),
     connectionsTab(intl, dispatch, {
-      tabStatusIcon: enableWizard ? undefined : 'in-progress',
-      disabled: enableWizard,
+      tabStatusIcon: enableWizard ? 'in-progress' : undefined,
+      disabled: !enableWizard,
     }),
     parametersTab(intl, dispatch, {
-      tabStatusIcon: enableWizard ? undefined : 'in-progress',
-      disabled: enableWizard,
+      tabStatusIcon: enableWizard ? 'in-progress' : undefined,
+      disabled: !enableWizard,
     }),
     profileTab(intl, dispatch, {
-      tabStatusIcon: enableWizard ? undefined : 'in-progress',
-      disabled: enableWizard,
+      tabStatusIcon: enableWizard ? 'in-progress' : undefined,
+      disabled: !enableWizard,
     }),
     publishTab(intl, dispatch, {
-      tabStatusIcon: enableWizard ? undefined : 'in-progress',
-      disabled: enableWizard,
+      tabStatusIcon: enableWizard ? 'in-progress' : undefined,
+      disabled: !enableWizard,
     }),
     reviewPublishTab(intl, dispatch, onPublish, {
-      tabStatusIcon: enableWizard ? undefined : 'in-progress',
-      disabled: enableWizard,
+      tabStatusIcon: enableWizard ? 'in-progress' : undefined,
+      disabled: !enableWizard,
     }),
   ];
 };

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/workflowsTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/workflowsTab.tsx
@@ -4,13 +4,13 @@ import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
 import { DisplayWorkflows } from '../workflows/workflowslist';
-import type { CreateWizardTabProps } from './model';
+import type { TemplateWizardTabProps } from './model';
 
 export const workflowsTab = (
   intl: IntlShape,
   dispatch: AppDispatch,
   onSaveWorkflows: (isMultiWorkflow: boolean) => void,
-  { disabled, tabStatusIcon }: CreateWizardTabProps
+  { disabled, tabStatusIcon }: TemplateWizardTabProps
 ): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.WORKFLOWS,
   title: intl.formatMessage({

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/workflowsTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/workflowsTab.tsx
@@ -8,7 +8,9 @@ import { DisplayWorkflows } from '../workflows/workflowslist';
 export const workflowsTab = (
   intl: IntlShape,
   dispatch: AppDispatch,
+  // disabled: boolean,
   onSaveWorkflows: (isMultiWorkflow: boolean) => void
+  // { disabled, hasError }
 ): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.WORKFLOWS,
   title: intl.formatMessage({
@@ -16,7 +18,8 @@ export const workflowsTab = (
     id: 'R7VvvJ',
     description: 'The tab label for the monitoring workflows tab on the configure template wizard',
   }),
-  hasError: false,
+  // disabled: disabled,
+  // tabStatusIcon: hasError ? 'error' : undefined,
   content: <DisplayWorkflows onSave={onSaveWorkflows} />,
   footerContent: {
     primaryButtonText: '',

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/workflowsTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/workflowsTab.tsx
@@ -4,13 +4,13 @@ import constants from '../../../common/constants';
 import type { IntlShape } from 'react-intl';
 import { selectWizardTab } from '../../../core/state/templates/tabSlice';
 import { DisplayWorkflows } from '../workflows/workflowslist';
+import type { CreateWizardTabProps } from './model';
 
 export const workflowsTab = (
   intl: IntlShape,
   dispatch: AppDispatch,
-  // disabled: boolean,
-  onSaveWorkflows: (isMultiWorkflow: boolean) => void
-  // { disabled, hasError }
+  onSaveWorkflows: (isMultiWorkflow: boolean) => void,
+  { disabled, tabStatusIcon }: CreateWizardTabProps
 ): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.WORKFLOWS,
   title: intl.formatMessage({
@@ -18,8 +18,8 @@ export const workflowsTab = (
     id: 'R7VvvJ',
     description: 'The tab label for the monitoring workflows tab on the configure template wizard',
   }),
-  // disabled: disabled,
-  // tabStatusIcon: hasError ? 'error' : undefined,
+  disabled: disabled,
+  tabStatusIcon,
   content: <DisplayWorkflows onSave={onSaveWorkflows} />,
   footerContent: {
     primaryButtonText: '',

--- a/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
@@ -28,9 +28,10 @@ import { useResourceStrings } from '../resources';
 
 export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean) => void }) => {
   const intl = useIntl();
-  const { workflows, currentPanelView } = useSelector((state: RootState) => ({
+  const { workflows, currentPanelView, enableWizard } = useSelector((state: RootState) => ({
     workflows: state.template.workflows,
     currentPanelView: state.panel.currentPanelView,
+    enableWizard: state.tab.enableWizard,
   }));
   const dispatch = useDispatch<AppDispatch>();
 
@@ -179,6 +180,7 @@ export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean
           },
         }}
       />
+      {enableWizard ? 'TRUE' : 'FALSE'}
 
       {Object.keys(workflows).length > 0 ? (
         <Table aria-label={resourceStrings.WorkflowsListTableLabel} style={{ minWidth: '550px' }}>

--- a/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
@@ -25,6 +25,7 @@ import { useFunctionalState } from '@react-hookz/web';
 import { Add12Filled } from '@fluentui/react-icons';
 import { deleteWorkflowData } from '../../../core/actions/bjsworkflow/configuretemplate';
 import { useResourceStrings } from '../resources';
+import { setIsWizardUpdating } from '../../../core/state/templates/tabSlice';
 
 export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean) => void }) => {
   const intl = useIntl();
@@ -76,6 +77,7 @@ export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean
         text: intlText.DELETE,
         iconProps: { iconName: 'Trash' },
         onClick: () => {
+          dispatch(setIsWizardUpdating()); //TODO: Found better structure of calling this
           dispatch(deleteWorkflowData({ ids: selectedWorkflowsList() }));
         },
       },

--- a/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
@@ -25,7 +25,6 @@ import { useFunctionalState } from '@react-hookz/web';
 import { Add12Filled } from '@fluentui/react-icons';
 import { deleteWorkflowData } from '../../../core/actions/bjsworkflow/configuretemplate';
 import { useResourceStrings } from '../resources';
-import { setIsWizardUpdating } from '../../../core/state/templates/tabSlice';
 
 export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean) => void }) => {
   const intl = useIntl();
@@ -77,7 +76,6 @@ export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean
         text: intlText.DELETE,
         iconProps: { iconName: 'Trash' },
         onClick: () => {
-          dispatch(setIsWizardUpdating()); //TODO: Found better structure of calling this
           dispatch(deleteWorkflowData({ ids: selectedWorkflowsList() }));
         },
       },

--- a/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
@@ -28,10 +28,9 @@ import { useResourceStrings } from '../resources';
 
 export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean) => void }) => {
   const intl = useIntl();
-  const { workflows, currentPanelView, enableWizard } = useSelector((state: RootState) => ({
+  const { workflows, currentPanelView } = useSelector((state: RootState) => ({
     workflows: state.template.workflows,
     currentPanelView: state.panel.currentPanelView,
-    enableWizard: state.tab.enableWizard,
   }));
   const dispatch = useDispatch<AppDispatch>();
 
@@ -180,8 +179,6 @@ export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean
           },
         }}
       />
-      {enableWizard ? 'TRUE' : 'FALSE'}
-
       {Object.keys(workflows).length > 0 ? (
         <Table aria-label={resourceStrings.WorkflowsListTableLabel} style={{ minWidth: '550px' }}>
           <TableHeader>

--- a/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/tabs/customizeWorkflowsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/tabs/customizeWorkflowsTab.tsx
@@ -29,7 +29,7 @@ export const customizeWorkflowsTab = (
     description: 'The tab label for the monitoring customize workflows tab on the configure template wizard',
   }),
   disabled: disabled,
-  hasError: hasError,
+  tabStatusIcon: hasError ? 'error' : undefined,
   content: <CustomizeWorkflows selectedWorkflowsList={selectedWorkflowsList} updateWorkflowDataField={updateWorkflowDataField} />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/tabs/customizeWorkflowsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/tabs/customizeWorkflowsTab.tsx
@@ -6,6 +6,7 @@ import type { ConfigureWorkflowsTabProps } from '../configureWorkflowsPanel';
 import type { IntlShape } from 'react-intl';
 import type { WorkflowTemplateData } from '../../../../../core';
 import { CustomizeWorkflows } from '../../../../../ui/configuretemplate/workflows/customizeWorkflows';
+import { Spinner } from '@fluentui/react-components';
 
 export const customizeWorkflowsTab = (
   intl: IntlShape,
@@ -32,16 +33,20 @@ export const customizeWorkflowsTab = (
   tabStatusIcon: hasError ? 'error' : undefined,
   content: <CustomizeWorkflows selectedWorkflowsList={selectedWorkflowsList} updateWorkflowDataField={updateWorkflowDataField} />,
   footerContent: {
-    primaryButtonText: intl.formatMessage({
-      defaultMessage: 'Save changes',
-      id: '3jqHdn',
-      description: 'Button text for saving changes in the configure workflows panel',
-    }),
+    primaryButtonText: isSaving ? (
+      <Spinner size="tiny" />
+    ) : (
+      intl.formatMessage({
+        defaultMessage: 'Save changes',
+        id: '3jqHdn',
+        description: 'Button text for saving changes in the configure workflows panel',
+      })
+    ),
     primaryButtonOnClick: () => {
       onSave?.();
-      dispatch(closePanel());
+      // dispatch(closePanel());
     },
-    primaryButtonDisabled: isPrimaryButtonDisabled,
+    primaryButtonDisabled: isPrimaryButtonDisabled || isSaving,
     secondaryButtonText: intl.formatMessage({
       defaultMessage: 'Cancel',
       id: '75zXUl',

--- a/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/tabs/selectWorkflowsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/tabs/selectWorkflowsTab.tsx
@@ -26,6 +26,7 @@ export const selectWorkflowsTab = (
     id: 'vWOWFo',
     description: 'The tab label for the monitoring select workflows tab on the configure template wizard',
   }),
+  disabled: isSaving,
   content: <SelectWorkflows selectedWorkflowsList={selectedWorkflowsList} onWorkflowsSelected={onWorkflowsSelected} />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/usePanelTabs.tsx
@@ -6,10 +6,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from '../../../../core/state/templates/store';
 import { useFunctionalState } from '@react-hookz/web';
 import type { WorkflowTemplateData } from '../../../../core';
-// import { updateAllWorkflowsData } from '../../../../core/state/templates/templateSlice';
 import { getWorkflowsWithDefinitions, initializeWorkflowsData } from '../../../../core/actions/bjsworkflow/configuretemplate';
 import { getResourceNameFromId } from '@microsoft/logic-apps-shared';
-import { setIsWizardUpdating } from '../../../../core/state/templates/tabSlice';
 
 export const useConfigureWorkflowPanelTabs = ({
   onSave,
@@ -57,7 +55,6 @@ export const useConfigureWorkflowPanelTabs = ({
   };
 
   const onSaveChanges = () => {
-    dispatch(setIsWizardUpdating());
     dispatch(initializeWorkflowsData({ workflows: selectedWorkflowsList() }));
     onSave?.(Object.keys(selectedWorkflowsList()).length > 1);
   };

--- a/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/configureTemplatePanel/configureWorkflowsPanel/usePanelTabs.tsx
@@ -6,9 +6,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from '../../../../core/state/templates/store';
 import { useFunctionalState } from '@react-hookz/web';
 import type { WorkflowTemplateData } from '../../../../core';
-import { updateAllWorkflowsData } from '../../../../core/state/templates/templateSlice';
+// import { updateAllWorkflowsData } from '../../../../core/state/templates/templateSlice';
 import { getWorkflowsWithDefinitions, initializeWorkflowsData } from '../../../../core/actions/bjsworkflow/configuretemplate';
 import { getResourceNameFromId } from '@microsoft/logic-apps-shared';
+import { setIsWizardUpdating } from '../../../../core/state/templates/tabSlice';
 
 export const useConfigureWorkflowPanelTabs = ({
   onSave,
@@ -17,13 +18,13 @@ export const useConfigureWorkflowPanelTabs = ({
 }): TemplateTabProps[] => {
   const intl = useIntl();
   const dispatch = useDispatch<AppDispatch>();
-  const { workflowsInTemplate, workflowState } = useSelector((state: RootState) => ({
+  const { isWizardUpdating, workflowsInTemplate, workflowState } = useSelector((state: RootState) => ({
     workflowsInTemplate: state.template.workflows,
+    isWizardUpdating: state.tab.isWizardUpdating,
     workflowState: state.workflow,
   }));
 
   const hasError = false; // Placeholder for actual error state
-  const isSaving = false; // Placeholder for actual saving state
 
   const [selectedWorkflowsList, setSelectedWorkflowsList] =
     useFunctionalState<Record<string, Partial<WorkflowTemplateData>>>(workflowsInTemplate);
@@ -56,7 +57,7 @@ export const useConfigureWorkflowPanelTabs = ({
   };
 
   const onSaveChanges = () => {
-    dispatch(updateAllWorkflowsData(selectedWorkflowsList()));
+    dispatch(setIsWizardUpdating());
     dispatch(initializeWorkflowsData({ workflows: selectedWorkflowsList() }));
     onSave?.(Object.keys(selectedWorkflowsList()).length > 1);
   };
@@ -68,17 +69,17 @@ export const useConfigureWorkflowPanelTabs = ({
 
   return [
     selectWorkflowsTab(intl, dispatch, {
-      isSaving,
       selectedWorkflowsList: selectedWorkflowsList(),
       onWorkflowsSelected,
       onNextButtonClick,
+      isSaving: isWizardUpdating,
       isPrimaryButtonDisabled: isNoWorkflowsSelected,
     }),
     customizeWorkflowsTab(intl, dispatch, {
       hasError,
-      isSaving,
       selectedWorkflowsList: selectedWorkflowsList(),
       updateWorkflowDataField,
+      isSaving: isWizardUpdating,
       disabled: isNoWorkflowsSelected,
       isPrimaryButtonDisabled: missingNameOrDisplayName,
       onSave: onSaveChanges,

--- a/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/tabs/basicsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/tabs/basicsTab.tsx
@@ -25,7 +25,7 @@ export const basicsTab = (
     id: 'sVcvcG',
     description: 'The tab label for the monitoring name and state tab on the create workflow panel',
   }),
-  hasError: hasError,
+  tabStatusIcon: hasError ? 'error' : undefined,
   content: <WorkflowBasics />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/tabs/connectionsTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/tabs/connectionsTab.tsx
@@ -40,7 +40,7 @@ export const connectionsTab = (
     id: 'pqprxZ',
     description: 'An accessibility label that describes the objective of connections tab',
   }),
-  hasError: hasError,
+  tabStatusIcon: hasError ? 'error' : undefined,
   content: <ConnectionsPanel />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/tabs/parametersTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/tabs/parametersTab.tsx
@@ -28,7 +28,7 @@ export const parametersTab = (
     id: 'oxCSqB',
     description: 'An accessibility label that describes the objective of parameters tab',
   }),
-  hasError: hasError,
+  tabStatusIcon: hasError ? 'error' : undefined,
   content: <ParametersPanel />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/tabs/reviewCreateTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/tabs/reviewCreateTab.tsx
@@ -57,7 +57,7 @@ export const reviewCreateTab = (
       description: 'An accessibility label that describes the objective of review and update tab',
     })
   ),
-  hasError: false,
+  tabStatusIcon: undefined,
   content: <ReviewCreatePanel />,
   footerContent: {
     primaryButtonText: isCreating ? (

--- a/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/createWorkflowPanel/usePanelTabs.tsx
@@ -166,6 +166,11 @@ export const useCreateWorkflowPanelTabs = ({
     }
   });
 
+  const nameStateTabItemError = useMemo(
+    () => Object.values(workflows).some((workflowData) => workflowData.errors.kind || workflowData.errors.workflow),
+    [workflows]
+  );
+
   const nameStateTabItem = useMemo(
     () =>
       basicsTab(intl, dispatch, {
@@ -175,7 +180,7 @@ export const useCreateWorkflowPanelTabs = ({
           : parametersExist
             ? Constants.TEMPLATE_PANEL_TAB_NAMES.PARAMETERS
             : Constants.TEMPLATE_PANEL_TAB_NAMES.REVIEW_AND_CREATE,
-        hasError: Object.values(workflows).some((workflowData) => workflowData.errors.kind || workflowData.errors.workflow),
+        hasError: nameStateTabItemError,
         isCreating,
         onClosePanel,
         showCloseButton,
@@ -187,7 +192,7 @@ export const useCreateWorkflowPanelTabs = ({
       isMultiWorkflowTemplate,
       connectionsExist,
       parametersExist,
-      workflows,
+      nameStateTabItemError,
       isCreating,
       onClosePanel,
       showCloseButton,
@@ -260,7 +265,7 @@ export const useCreateWorkflowPanelTabs = ({
         isCreateView: !!isCreateView,
         errorMessage,
         hasError: false,
-        isPrimaryButtonDisabled: nameStateTabItem.hasError || !!connectionsError || hasParametersValidationErrors,
+        isPrimaryButtonDisabled: nameStateTabItemError || !!connectionsError || hasParametersValidationErrors,
         previousTabId: parametersExist
           ? Constants.TEMPLATE_PANEL_TAB_NAMES.PARAMETERS
           : connectionsExist
@@ -281,7 +286,7 @@ export const useCreateWorkflowPanelTabs = ({
       isCreating,
       isCreateView,
       errorMessage,
-      nameStateTabItem.hasError,
+      nameStateTabItemError,
       connectionsError,
       hasParametersValidationErrors,
       parametersExist,

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/summaryTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/summaryTab.tsx
@@ -160,7 +160,7 @@ export const summaryTab = (
     id: 'mgD2ZT',
     description: 'The tab label for the monitoring parameters tab on the operation panel',
   }),
-  hasError: false,
+  tabStatusIcon: undefined,
   content: <SummaryPanel workflowId={workflowId} />,
   footerContent: {
     primaryButtonText: intl.formatMessage({

--- a/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/workflowTab.tsx
+++ b/libs/designer/src/lib/ui/panel/templatePanel/quickViewPanel/tabs/workflowTab.tsx
@@ -38,7 +38,7 @@ export const workflowTab = (
     id: 'lFWXhc',
     description: 'The tab label for the monitoring parameters tab on the operation panel',
   }),
-  hasError: false,
+  tabStatusIcon: undefined,
   content: <WorkflowPanel workflowId={workflowId} />,
   footerContent: {
     primaryButtonText: intl.formatMessage({


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [X] Feature
* [ ] Other

## Current Behavior
Tab will only be enabled when 1. enableWizard is true and 2. isWizardUpdating is not true.
- enableWizard is true when there are selected workflows, meaning tabs will be disabled when no workflows are selected
- isWizardUpdating is used to determine temporarily disabling tabs or setting spinner/disabling panel until initialization or deletion is complete
To be coming: With each tab validation, we may turn the tab status to error

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

## Test Plan
- UI elements are still to be polished (i.e. tab icons will not be always in progress once validation is implemented)
- Validation tests will be added along with validation logic & UI in the next PR (error tab status is not fixed yet)

## Screenshots or Videos (if applicable)

https://github.com/user-attachments/assets/ff3c4d17-8c25-4092-8c38-4b3c02aaf601

