### PR TITLE
feat(vscode): Add Create New Project option to create custom code/rules engine for existing LA

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/LogicAppNameStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/LogicAppNameStep.ts
@@ -6,23 +6,46 @@ import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
 import * as vscode from 'vscode';
 import * as fse from 'fs-extra';
+import * as path from 'path';
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
-import type { IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
+import { ProjectType, type IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
 import { logicAppNameValidation } from '../../../../constants';
+import { getLogicAppWithoutCustomCode } from '../../../utils/workspace';
+import { isString } from '@microsoft/logic-apps-shared';
 
 export class LogicAppNameStep extends AzureWizardPromptStep<IProjectWizardContext> {
   public async prompt(context: IProjectWizardContext): Promise<void> {
-    context.logicAppName = await context.ui.showInputBox({
-      placeHolder: localize('logicAppNamePlaceHolder', 'Logic App name'),
-      prompt: localize('logicAppNamePrompt', 'Enter a name for your Logic App project'),
-      validateInput: async (input: string): Promise<string | undefined> => await this.validateLogicAppName(input, context),
-    });
+    if (context.projectType === ProjectType.logicApp || context.shouldCreateLogicAppProject) {
+      // For new workspaces or new logic app projects, prompt for a new logic app name
+      context.shouldCreateLogicAppProject = true;
+      context.logicAppName = await this.getLogicAppName(context);
+    } else {
+      // For custom code and rules engine projects, allow users to select from existing logic apps or create new logic app
+      const logicAppFolder = await getLogicAppWithoutCustomCode(context);
+      if (logicAppFolder === undefined) {
+        // This selection indicates that a new logic app should be created
+        context.shouldCreateLogicAppProject = true;
+        context.logicAppName = await this.getLogicAppName(context);
+      } else {
+        // This selection indicates that the custom code/rules engine should be created for an existing logic app project
+        context.shouldCreateLogicAppProject = false;
+        context.logicAppName = isString(logicAppFolder) ? path.basename(logicAppFolder) : logicAppFolder.name;
+      }
+    }
 
     ext.outputChannel.appendLog(localize('logicAppNameSet', `Logic App project name set to ${context.logicAppName}`));
   }
 
   public shouldPrompt(context: IProjectWizardContext): boolean {
     return context.projectType !== undefined;
+  }
+
+  private async getLogicAppName(context: IProjectWizardContext): Promise<string | undefined> {
+    return await context.ui.showInputBox({
+      placeHolder: localize('logicAppNamePlaceHolder', 'Logic App name'),
+      prompt: localize('logicAppNamePrompt', 'Enter a name for your Logic App project'),
+      validateInput: async (input: string): Promise<string | undefined> => await this.validateLogicAppName(input, context),
+    });
   }
 
   private async validateLogicAppName(name: string | undefined, context: IProjectWizardContext): Promise<string | undefined> {

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/WorkspaceSettingsStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/WorkspaceSettingsStep.ts
@@ -69,9 +69,12 @@ export class WorkspaceSettingsStep extends AzureWizardPromptStep<IProjectWizardC
 
     const workspaceFolders = [];
     const logicAppName = context.logicAppName || 'LogicApp';
-    workspaceFolders.push({ name: logicAppName, path: `./${logicAppName}` });
-    const functionsFolder = context.functionAppName;
+    if (context.shouldCreateLogicAppProject) {
+      workspaceFolders.push({ name: logicAppName, path: `./${logicAppName}` });
+    }
+
     if (context.isWorkspaceWithFunctions) {
+      const functionsFolder = context.functionAppName;
       workspaceFolders.push({ name: functionsFolder, path: `./${functionsFolder}` });
     }
 

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/LogicAppNameStep.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/LogicAppNameStep.test.ts
@@ -26,6 +26,7 @@ describe('LogicAppNameStep', () => {
       projectType: ProjectType.logicApp,
       workspaceCustomFilePath: testWorkspaceFile,
       logicAppName: testLogicAppName,
+      shouldCreateLogicAppProject: true,
       ui: {
         showInputBox: vi.fn((options: any) => {
           return options.validateInput(options.testInput).then((validationResult: string | undefined) => {

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/TargetFrameworkStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/createCodeProjectSteps/createFunction/TargetFrameworkStep.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { type IProjectWizardContext, TargetFramework, ProjectType } from '@microsoft/vscode-extension-logic-apps';
-import { localize } from '../../../../../localize';
 import { AzureWizardPromptStep, type IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
+import { localize } from '../../../../../localize';
 import { Platform } from '../../../../../constants';
 
 /**

--- a/apps/vs-code-designer/src/app/commands/createNewProject/createNewProject.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createNewProject.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { createNewProjectInternalBase } from '../createNewCodeProject/CodeProjectBase/CreateNewProjectInternal';
 import { ExistingWorkspaceStep } from './createProjectSteps/ExistingWorkspaceStep';
-import { LogicAppTypeStep } from '../createNewCodeProject/CodeProjectBase/LogicAppTypeStep';
+import { NewProjectLogicAppTypeStep } from './createProjectSteps/NewProjectLogicAppTypeStep';
 import { LogicAppNameStep } from '../createNewCodeProject/CodeProjectBase/LogicAppNameStep';
 import { TargetFrameworkStep } from '../createNewCodeProject/createCodeProjectSteps/createFunction/TargetFrameworkStep';
 import { NewCodeProjectTypeStep } from '../createNewCodeProject/CodeProjectBase/NewCodeProjectTypeStep';
@@ -40,7 +40,7 @@ export async function createNewProjectFromCommand(
       'Create new project',
       [
         new ExistingWorkspaceStep(),
-        new LogicAppTypeStep(),
+        new NewProjectLogicAppTypeStep(),
         new TargetFrameworkStep(),
         new LogicAppNameStep(),
         new NewCodeProjectTypeStep(templateId, functionSettings, false),

--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/NewProjectLogicAppTypeStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/NewProjectLogicAppTypeStep.ts
@@ -7,17 +7,16 @@ import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import type { IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
 import { ProjectType, type IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
 
-export class LogicAppTypeStep extends AzureWizardPromptStep<IProjectWizardContext> {
+export class NewProjectLogicAppTypeStep extends AzureWizardPromptStep<IProjectWizardContext> {
   public async prompt(context: IProjectWizardContext): Promise<void> {
     const picks: IAzureQuickPickItem<ProjectType>[] = [
       { label: localize('logicApp', 'Logic app'), data: ProjectType.logicApp },
-      { label: localize('logicAppCustomCode', 'Logic app with custom code project'), data: ProjectType.customCode },
-      { label: localize('logicAppRulesEngine', 'Logic app with rules engine project (preview)'), data: ProjectType.rulesEngine },
+      { label: localize('logicAppCustomCode', 'Custom code project'), data: ProjectType.customCode },
+      { label: localize('logicAppRulesEngine', 'Rules engine project (preview)'), data: ProjectType.rulesEngine },
     ];
 
-    const placeHolder = localize('logicAppProjectTemplatePlaceHolder', 'Select a project template for your logic app workspace');
+    const placeHolder = localize('logicAppProjectTemplatePlaceHolder', 'Select a template for your new project');
     context.projectType = (await context.ui.showQuickPick(picks, { placeHolder })).data;
-    context.shouldCreateLogicAppProject = true;
     context.isWorkspaceWithFunctions = context.projectType !== ProjectType.logicApp;
   }
 

--- a/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
+++ b/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
@@ -171,6 +171,7 @@ export async function isCustomCodeFunctionsProjectInRoot(
 
 /**
  * Checks workspace root folder for custom code functions project.
+ * TODO - this assumes that all custom code functions projects are in the workspace root folder.
  * @param {IActionContext} context - The action context.
  * @param {WorkspaceFolder | string | undefined} workspaceFolder - The workspace folder.
  * @returns {Promise<string | undefined>} Returns the path to the custom code functions project if found, otherwise returns undefined.

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -16,6 +16,7 @@ import * as vscode from 'vscode';
 import { FileManagement } from '../commands/generateDeploymentScripts/iacGestureHelperFunctions';
 import { ext } from '../../extensionVariables';
 import * as fse from 'fs-extra';
+import { tryGetLogicAppCustomCodeFunctionsProjects } from './customCodeUtils';
 
 /**
  * Checks if the current workspace has a Logic App project.
@@ -126,9 +127,9 @@ export const getWorkspacePath = (workflowFilePath: string): string => {
 /**
  * Gets workspace folder of project.
  * @param {IActionContext} context - Command context.
- * @param {string} message - The message to display to the user.
+ * @param {string} message - The message to display to the user if workspace is not open.
  * @param {string} skipPromptOnMultipleFolders - The boolean to skip prompt to select logic app folder if there are multiple.
- * @returns {Promise<WorkspaceFolder>} Returns either the new project workspace, the already open workspace or the selected workspace.
+ * @returns {Promise<WorkspaceFolder | string | undefined>} Returns either the new project workspace, the already open workspace or the selected workspace.
  */
 export async function getWorkspaceFolder(
   context: IActionContext,
@@ -151,8 +152,8 @@ export async function getWorkspaceFolder(
     if (await isLogicAppProject(workspaceFolderPath)) {
       return workspaceFolder;
     }
-    const folders = await fse.readdir(workspaceFolderPath, { withFileTypes: true });
-    const subFolders = folders.filter((dirent) => dirent.isDirectory()).map((dirent) => path.join(workspaceFolderPath, dirent.name));
+    const folderContents = await fse.readdir(workspaceFolderPath, { withFileTypes: true });
+    const subFolders = folderContents.filter((dirent) => dirent.isDirectory()).map((dirent) => path.join(workspaceFolderPath, dirent.name));
 
     const returnsWorkspaceFolder: boolean = false;
     return await selectLogicAppWorkspaceFolder(context, returnsWorkspaceFolder, subFolders, skipPromptOnMultipleFolders);
@@ -201,6 +202,76 @@ async function selectLogicAppWorkspaceFolder(
   }
 
   return selectedFolder;
+}
+
+/**
+ * Gets user selection of either an existing logic app that isn't associated with a custom code project or new (undefined) logic app project.
+ * @param {IActionContext} context - Command context.
+ * @param {string} message - The message to display to the user if workspace is not open.
+ * @returns {Promise<WorkspaceFolder | string | undefined>} Returns either the selected logic app or undefined for a new logic app.
+ */
+export async function getLogicAppWithoutCustomCode(
+  context: IActionContext,
+  message?: string
+): Promise<vscode.WorkspaceFolder | string | undefined> {
+  const promptMessage: string = message ?? localize('noWorkspaceWarning', 'You must have a workspace open to perform this action.');
+
+  if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+    await promptOpenProjectOrWorkspace(context, promptMessage);
+  }
+
+  if (vscode.workspace.workspaceFolders.length === 1) {
+    const workspaceFolder = vscode.workspace.workspaceFolders[0];
+    const workspaceFolderPath = workspaceFolder.uri.fsPath;
+    if (!(await isLogicAppProject(workspaceFolderPath))) {
+      const folderContents = await fse.readdir(workspaceFolderPath, { withFileTypes: true });
+      const subFolders = folderContents
+        .filter((dirent) => dirent.isDirectory())
+        .map((dirent) => path.join(workspaceFolderPath, dirent.name));
+      return await selectLogicAppWorkspaceFolderWithoutCustomCode(context, false, subFolders);
+    }
+  }
+
+  return await selectLogicAppWorkspaceFolderWithoutCustomCode(context, true, null);
+}
+
+async function selectLogicAppWorkspaceFolderWithoutCustomCode(
+  context: IActionContext,
+  returnsWorkspaceFolder: boolean,
+  subFolders: string[]
+): Promise<vscode.WorkspaceFolder | string> {
+  const logicAppsWorkspaces = [];
+  for (const folder of returnsWorkspaceFolder ? vscode.workspace.workspaceFolders : subFolders) {
+    const projectRoot = await tryGetLogicAppProjectRoot(context, folder);
+    if (projectRoot) {
+      logicAppsWorkspaces.push(projectRoot);
+    }
+  }
+
+  const placeHolder: string = localize('selectProjectFolder', 'Select the folder containing your logic app project');
+  const folderPicksPromises = logicAppsWorkspaces.map(async (projectRoot) => {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.find((folder) => folder.uri.fsPath === projectRoot);
+    const logicAppCustomCodeFunctionsProjects = await tryGetLogicAppCustomCodeFunctionsProjects(projectRoot);
+    if (!logicAppCustomCodeFunctionsProjects || logicAppCustomCodeFunctionsProjects.length === 0) {
+      return {
+        label: path.basename(projectRoot),
+        description: projectRoot,
+        data: returnsWorkspaceFolder ? workspaceFolder : projectRoot,
+      };
+    }
+    return undefined;
+  });
+
+  const folderPicks = (await Promise.all(folderPicksPromises)).filter((item) => item !== undefined);
+
+  folderPicks.push({
+    label: localize('newLogicAppProject', 'Create a new Logic App project...'),
+    description: '',
+    data: undefined,
+  });
+
+  const selectedItem = await context.ui.showQuickPick(folderPicks, { placeHolder });
+  return selectedItem?.data;
 }
 
 /**

--- a/libs/vscode-extension/src/lib/models/project.ts
+++ b/libs/vscode-extension/src/lib/models/project.ts
@@ -79,6 +79,7 @@ export interface IProjectWizardContext extends IActionContext {
   openApiSpecificationFile?: Uri[];
   targetFramework?: TargetFramework;
   projectType?: ProjectType;
+  shouldCreateLogicAppProject?: boolean;
   isWorkspaceWithFunctions?: boolean;
   logicAppName?: string;
   packagePath?: string;


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior

- "Create New Project" options include new LA, new LA with custom code, and new LA with rules engine
- Rules engine generated settings files has undefined target framework

## New Behavior

- Update "Create New Project" options to allow both creating new LA with custom code/rules engine and creating custom code/rules engine for existing LA (max one per LA)
- Fix bug in generated settings file for rules engine (default to .NET framework)

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Added step to existing vendor test to cover "Create New Project" https://msazure.visualstudio.com/One/_workitems/edit/32120152

## Screenshots or Videos (if applicable)

N/A
