### PR TITLE
fix(designer): Array Editor Bugfixes

### DIFF
--- a/libs/designer-ui/src/lib/agentinstruction/index.tsx
+++ b/libs/designer-ui/src/lib/agentinstruction/index.tsx
@@ -84,7 +84,7 @@ export const AgentInstructionEditor = ({
         <NavigateIcon style={{ position: 'relative', top: '2px' }} />
       </Link>
       <div className="msla-agent-instruction-editors">
-        <Label text={systemPromptLabel} />
+        <Label text={systemPromptLabel} isRequiredField />
         <StringEditor
           {...props}
           className={css(className, 'msla-agent-instruction-system-editor editor-custom')}
@@ -95,6 +95,7 @@ export const AgentInstructionEditor = ({
         <Label text={userItemLabel} />
         <ArrayEditor
           {...props}
+          isRequired={false}
           label={userItemLabel}
           placeholder={userPlaceholder}
           itemSchema={{ key: 'userMessage', type: 'string' }}

--- a/libs/designer-ui/src/lib/arrayeditor/expandedsimplearray.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/expandedsimplearray.tsx
@@ -41,6 +41,7 @@ export interface ExpandedSimpleArrayProps {
   tokenMapping?: Record<string, ValueSegment>;
   loadParameterValueFromString?: loadParameterValueFromStringHandler;
   isDynamic?: boolean;
+  isRequired?: boolean;
 }
 
 export const ExpandedSimpleArray = ({
@@ -54,6 +55,7 @@ export const ExpandedSimpleArray = ({
   readonly,
   options,
   isDynamic,
+  isRequired,
   ...props
 }: ExpandedSimpleArrayProps): JSX.Element => {
   const intl = useIntl();
@@ -84,7 +86,7 @@ export const ExpandedSimpleArray = ({
         return (
           <div key={item.key + index} className="msla-array-item">
             <div className="msla-array-item-header">
-              {renderLabel(index, labelProps.text, true)}
+              {renderLabel(index, labelProps.text, isRequired)}
               <div className="msla-array-item-commands">
                 <ItemMenuButton
                   disabled={!!readonly}

--- a/libs/designer-ui/src/lib/arrayeditor/index.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/index.tsx
@@ -94,6 +94,7 @@ export const ArrayEditor: React.FC<ArrayEditorProps> = ({
   castParameter,
   ...baseEditorProps
 }): JSX.Element => {
+  console.log(initialValue);
   const [collapsed, setCollapsed] = useState<boolean>(initialMode === InitialMode.Array);
   const [collapsedValue, setCollapsedValue] = useState<ValueSegment[]>(initialValue);
   const [items, setItems] = useState<ComplexArrayItems[] | SimpleArrayItem[]>([]);

--- a/libs/designer-ui/src/lib/arrayeditor/index.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/index.tsx
@@ -94,7 +94,6 @@ export const ArrayEditor: React.FC<ArrayEditorProps> = ({
   castParameter,
   ...baseEditorProps
 }): JSX.Element => {
-  console.log(initialValue);
   const [collapsed, setCollapsed] = useState<boolean>(initialMode === InitialMode.Array);
   const [collapsedValue, setCollapsedValue] = useState<ValueSegment[]>(initialValue);
   const [items, setItems] = useState<ComplexArrayItems[] | SimpleArrayItem[]>([]);

--- a/libs/designer-ui/src/lib/arrayeditor/index.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/index.tsx
@@ -211,6 +211,7 @@ export const ArrayEditor: React.FC<ArrayEditorProps> = ({
       ) : (
         <ExpandedSimpleArray
           {...baseEditorProps}
+          isRequired={isRequired}
           placeholder={placeholder}
           valueType={itemSchema.type}
           itemEnum={itemSchema.enum}

--- a/libs/designer-ui/src/lib/dictionary/dictionaryeditor.less
+++ b/libs/designer-ui/src/lib/dictionary/dictionaryeditor.less
@@ -113,7 +113,7 @@
             position: absolute;
             text-overflow: ellipsis;
             margin-top: -25px;
-            margin-left: 5px;
+            margin-left: 6px;
             font-size: 15px;
             user-select: none;
             display: inline-block;

--- a/libs/designer/src/lib/core/utils/parameters/__test__/segment.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/segment.spec.ts
@@ -70,17 +70,19 @@ describe('core/utils/parameters/segment', () => {
       expectOutputTokenSegment(segments[1], 'b', OutputSource.Body, 'bar', 'outputs.$.body.bar', undefined, true);
     });
 
-    it('should not have double quote for single non interpolated token.', () => {
+    it('should have double quote for single non interpolated token.', () => {
       const convertor = new ValueSegmentConvertor();
       const segments = convertor.convertToValueSegments({
         foo: '@triggerBody().foo',
       });
-      expect(segments.length).toEqual(5);
+      expect(segments.length).toEqual(7);
       expectLiteralSegment(segments[0], '{\n  ');
       expectLiteralSegment(segments[1], '"foo"');
       expectLiteralSegment(segments[2], ': ');
-      expectOutputTokenSegment(segments[3], undefined, OutputSource.Body, 'foo', 'outputs.$.body.foo', undefined, true);
-      expectLiteralSegment(segments[4], '\n}');
+      expectLiteralSegment(segments[3], '"');
+      expectOutputTokenSegment(segments[4], undefined, OutputSource.Body, 'foo', 'outputs.$.body.foo', undefined, true);
+      expectLiteralSegment(segments[5], '"');
+      expectLiteralSegment(segments[6], '\n}');
     });
 
     it('should add @ if the string starts with @ when raw mode is enabled.', () => {
@@ -179,7 +181,7 @@ describe('core/utils/parameters/segment', () => {
         interpolation: "@{triggerBody().foo}@{variables('v')}",
         expression: '@triggerBody().foo',
       });
-      expect(segments.length).toEqual(18);
+      expect(segments.length).toEqual(20);
       expectLiteralSegment(segments[0], '{\n  ');
       expectLiteralSegment(segments[1], '"boolean"');
       expectLiteralSegment(segments[2], ': false,\n  ');
@@ -196,8 +198,10 @@ describe('core/utils/parameters/segment', () => {
       expectLiteralSegment(segments[13], ',\n  ');
       expectLiteralSegment(segments[14], '"expression"');
       expectLiteralSegment(segments[15], ': ');
-      expectOutputTokenSegment(segments[16], undefined, OutputSource.Body, 'foo', 'outputs.$.body.foo', undefined, true);
-      expectLiteralSegment(segments[17], '\n}');
+      expectLiteralSegment(segments[16], '"');
+      expectOutputTokenSegment(segments[17], undefined, OutputSource.Body, 'foo', 'outputs.$.body.foo', undefined, true);
+      expectLiteralSegment(segments[18], '"');
+      expectLiteralSegment(segments[19], '\n}');
     });
 
     it('should convert FX token expression to token segment successfully.', () => {

--- a/libs/designer/src/lib/core/utils/parameters/__test__/uncast.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/uncast.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { UncastingUtility } from '../uncast';
+import constants from '../../../../common/constants';
+
+describe('core/utils/parameters/uncast', () => {
+  describe('isCastableFormat', () => {
+    it('should return true for "binary"', () => {
+      expect(UncastingUtility.isCastableFormat(constants.SWAGGER.FORMAT.BINARY)).toBe(true);
+    });
+
+    it('should return true for "BYTE" (case-insensitive)', () => {
+      expect(UncastingUtility.isCastableFormat(constants.SWAGGER.FORMAT.BYTE.toUpperCase())).toBe(true);
+    });
+
+    it('should return true for "datauri"', () => {
+      expect(UncastingUtility.isCastableFormat(constants.SWAGGER.FORMAT.DATAURI)).toBe(true);
+    });
+
+    it('should return false for uncastable format like "uuid"', () => {
+      expect(UncastingUtility.isCastableFormat(constants.SWAGGER.FORMAT.UUID)).toBe(false);
+    });
+
+    it('should return false for undefined format', () => {
+      expect(UncastingUtility.isCastableFormat(undefined)).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(UncastingUtility.isCastableFormat('')).toBe(false);
+    });
+  });
+});

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -169,6 +169,7 @@ import type {
 import { createAsyncThunk, type Dispatch } from '@reduxjs/toolkit';
 import { getInputDependencies } from '../../actions/bjsworkflow/initialize';
 import { getAllVariables } from '../variables';
+import { UncastingUtility } from './uncast';
 
 // import { debounce } from 'lodash';
 
@@ -920,7 +921,7 @@ export function loadParameterValue(parameter: InputParameter): ValueSegment[] {
 
   let valueSegments = convertToValueSegments(
     valueObject,
-    !parameter.suppressCasting && !!parameter?.format,
+    !parameter.suppressCasting && UncastingUtility.isCastableFormat(parameter?.format),
     parameter.type,
     parameter.schema
   );

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -79,7 +79,6 @@ export class ValueSegmentConvertor {
   }
 
   private _convertJsonToValueSegments(json: string, parameterSchema?: any): ValueSegment[] {
-    console.log(json);
     const sections = new JsonSplitter(json).split();
     const segments: ValueSegment[] = [];
 
@@ -106,7 +105,6 @@ export class ValueSegmentConvertor {
       });
     };
 
-    console.log(sections);
     for (const section of sections) {
       for (const segment of this._convertJsonSectionToSegments(section)) {
         if (hasFormatProperty(section)) {
@@ -129,11 +127,8 @@ export class ValueSegmentConvertor {
       const expression = ExpressionParser.parseTemplateExpression(value);
       const segments = this._convertTemplateExpressionToValueSegments(expression);
 
-      // Note: If an non-interpolated expression is turned into a signle TOKEN, we don't surround with double quote. Otherwise,
-      // double quotes are added to surround the expression. This is the existing behaviour.
-      if (segments.length === 1 && isTokenValueSegment(segments[0]) && !isStringInterpolation(expression)) {
-        return segments;
-      }
+      // Note: Previously if there was a non-interpolated single expression, we wouldn't surround with double quotes.
+      // However, this just complicates the logic on deserialization/serialization when it can be managed by the interpolated expression.
       const escapedSegments = segments.map((segment) => {
         // Note: All literal segments must be escaped since they are inside a JSON string.
         if (isLiteralValueSegment(segment)) {

--- a/libs/designer/src/lib/core/utils/parameters/segment.ts
+++ b/libs/designer/src/lib/core/utils/parameters/segment.ts
@@ -79,6 +79,7 @@ export class ValueSegmentConvertor {
   }
 
   private _convertJsonToValueSegments(json: string, parameterSchema?: any): ValueSegment[] {
+    console.log(json);
     const sections = new JsonSplitter(json).split();
     const segments: ValueSegment[] = [];
 
@@ -99,9 +100,13 @@ export class ValueSegmentConvertor {
         ...(schema.anyOf ?? []),
       ].filter(Boolean); // Remove undefined values
 
-      return possibleSchemas.some((s) => s.properties?.[sectionKey]?.format || s.additionalProperties?.format);
+      return possibleSchemas.some((s) => {
+        const format = s.properties?.[sectionKey]?.format ?? s.additionalProperties?.format;
+        return UncastingUtility.isCastableFormat(format);
+      });
     };
 
+    console.log(sections);
     for (const section of sections) {
       for (const segment of this._convertJsonSectionToSegments(section)) {
         if (hasFormatProperty(section)) {

--- a/libs/designer/src/lib/core/utils/parameters/uncast.ts
+++ b/libs/designer/src/lib/core/utils/parameters/uncast.ts
@@ -1,5 +1,6 @@
 import type { Expression, ExpressionFunction } from '@microsoft/logic-apps-shared';
 import { isFunction, isStringLiteral, equals } from '@microsoft/logic-apps-shared';
+import constants from '../../../common/constants';
 
 export interface UncastResult {
   expression: Expression;
@@ -98,8 +99,8 @@ export class UncastingUtility {
    * @return {boolean} - True if the format is uncastable, false otherwise.
    */
   public static isCastableFormat(format?: string): boolean {
-    const uncastableFormats = new Set(['binary', 'byte', 'datauri']);
-    return !!format && uncastableFormats.has(format.toLowerCase());
+    const castableFormats = new Set([constants.SWAGGER.FORMAT.BINARY, constants.SWAGGER.FORMAT.BYTE, constants.SWAGGER.FORMAT.DATAURI]);
+    return !!format && castableFormats.has(format.toLowerCase());
   }
 
   private _uncastOnce(expression: Expression): UncastResult[] | null {
@@ -110,13 +111,13 @@ export class UncastingUtility {
         case 'CONCAT':
           return this._uncastConcat(expression);
         case 'BASE64TOBINARY':
-          return this._uncastSingleFunction(expression, 'byte');
+          return this._uncastSingleFunction(expression, constants.SWAGGER.FORMAT.BYTE);
         case 'BASE64TOSTRING':
-          return this._uncastSingleFunction(expression, 'byte');
+          return this._uncastSingleFunction(expression, constants.SWAGGER.FORMAT.BYTE);
         case 'ENCODEURICOMPONENT':
           return this._uncastSingleFunction(expression, '');
         case 'DECODEDATAURI':
-          return this._uncastSingleFunction(expression, 'datauri');
+          return this._uncastSingleFunction(expression, constants.SWAGGER.FORMAT.DATAURI);
         default:
           return null;
       }
@@ -136,7 +137,7 @@ export class UncastingUtility {
           return concatArguments.map((argument) => ({ expression: argument, format: '' }));
         }
       } else {
-        return functionArguments.map((argument) => ({ expression: argument, format: 'binary' }));
+        return functionArguments.map((argument) => ({ expression: argument, format: constants.SWAGGER.FORMAT.BINARY }));
       }
     }
 
@@ -153,7 +154,7 @@ export class UncastingUtility {
         switch (value.toUpperCase()) {
           case 'DATA:APPLICATION/OCTET-STREAM;BASE64,':
           case 'DATA:;BASE64,': {
-            format = 'byte';
+            format = constants.SWAGGER.FORMAT.BYTE;
             break;
           }
           case 'DATA:APPLICATION/OCTET-STREAM,':

--- a/libs/designer/src/lib/core/utils/parameters/uncast.ts
+++ b/libs/designer/src/lib/core/utils/parameters/uncast.ts
@@ -92,6 +92,16 @@ export class UncastingUtility {
     return result;
   }
 
+  /**
+   * Checks if the format is uncastable.
+   * @param {string} format - The format to check.
+   * @return {boolean} - True if the format is uncastable, false otherwise.
+   */
+  public static isCastableFormat(format?: string): boolean {
+    const uncastableFormats = new Set(['binary', 'byte', 'datauri']);
+    return !!format && uncastableFormats.has(format.toLowerCase());
+  }
+
   private _uncastOnce(expression: Expression): UncastResult[] | null {
     if (isFunction(expression)) {
       switch (expression.name.toUpperCase()) {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -74,7 +74,14 @@ export default {
         input: {
           type: 'Request',
           default: {
-            'inputs.$.schema': '{"properties": {"prompt": {"type": "string"}}, "type": "object"}',
+            'inputs.$.schema': `{
+  "type": "object",
+  "properties": {
+    "prompt": {
+      "type": "string"
+    }
+  }
+}`,
           },
         },
         output: {


### PR DESCRIPTION
1. Fixes an issue where using a token in complex array editor ends up deserializing in collapsed form and is unable to change back to expanded form (removes quotes around the token)
2. Fixes an issue where casting was happening on ever parameter with format instead of specific format types
3. Fixed a bug where simple array editor was always showing required label
4. Cosmetic format default agent parameter channel schema