### PR TITLE
feat(Templates): Move summary tab before workflow tab

### DIFF
--- a/libs/designer/src/lib/core/templates/utils/helper.ts
+++ b/libs/designer/src/lib/core/templates/utils/helper.ts
@@ -20,12 +20,11 @@ export const getQuickViewTabs = (
   onCloseButtonClick?: () => void
 ) => {
   return [
-    workflowTab(
+    summaryTab(
       intl,
       dispatch,
       workflowId,
       showCreate,
-      undefined,
       {
         templateId,
         workflowAppName,
@@ -33,11 +32,12 @@ export const getQuickViewTabs = (
       },
       onCloseButtonClick
     ),
-    summaryTab(
+    workflowTab(
       intl,
       dispatch,
       workflowId,
       showCreate,
+      undefined,
       {
         templateId,
         workflowAppName,


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [X] Feature
* [ ] Other

## New Behavior
Changed the order of summary tab and workflow tab, so that the information of the workflow will open up first for accessibility purposes as per discussed with the templates team

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)
![image](https://github.com/user-attachments/assets/06b5a301-7e73-4630-b8ec-bb4193d3535d)