### PR TITLE
fix(vscode): Delete statusCode from root def 

### DIFF
--- a/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
@@ -188,6 +188,40 @@ describe('parseErrorBeforeTelemetry', () => {
   });
 });
 
+describe('generateCSharpClasses - StatusCode Removal', () => {
+  it('should remove the redundant StatusCode property from the generated class definition', () => {
+    // Simulate JSON output with a redundant StatusCode property.
+    const dataWithStatusCode = {
+      nestedTypeProperty: 'object',
+      Body: { nestedTypeProperty: 'object', description: 'Response body' },
+      StatusCode: { nestedTypeProperty: 'integer', description: 'The status code' },
+    };
+
+    const classCode = generateCSharpClasses('TestNamespace', 'TestClass', 'WorkflowName', 'Action', 'MockClass', dataWithStatusCode);
+
+    // The generated code should include the constructor setting the base's StatusCode.
+    expect(classCode).toContain('this.StatusCode = HttpStatusCode.OK;');
+    // It should not contain a separate integer property for StatusCode in the class body.
+    expect(classCode).not.toContain('public int StatusCode { get; set; }');
+    // Optionally, check that other properties are still generated correctly.
+    expect(classCode).toContain('public JObject Body { get; set; }');
+  });
+
+  it('should not remove properties other than StatusCode', () => {
+    const dataWithoutStatusCode = {
+      nestedTypeProperty: 'object',
+      Key1: { nestedTypeProperty: 'string', description: 'Test key description' },
+    };
+
+    const classCode = generateCSharpClasses('TestNamespace', 'TestClass', 'WorkflowName', 'Action', 'MockClass', dataWithoutStatusCode);
+
+    // Ensure that a valid property is generated.
+    expect(classCode).toContain('public string Key1 { get; set; }');
+    // And still the base class initialization for StatusCode should be present.
+    expect(classCode).toContain('this.StatusCode = HttpStatusCode.OK;');
+  });
+});
+
 describe('generateCSharpClasses', () => {
   it('should generate C# class code from a class definition', () => {
     const workflowName = 'TestWorkflow';

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -1138,6 +1138,10 @@ export function generateCSharpClasses(
     ...data, // Merge the data (including "description", subfields, etc.)
   });
 
+  if (rootDef.properties && Array.isArray(rootDef.properties)) {
+    rootDef.properties = rootDef.properties.filter((prop) => prop.propertyName !== 'StatusCode');
+  }
+
   rootDef.inheritsFrom = 'MockOutput';
 
   const sanitizedWorkflowName = workflowName.replace(/-/g, '_');


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Currently, when generating C# class definitions for action mocks, any output property named "StatusCode" is included in the generated class. Because the base class (`MockOutput`) already defines a `StatusCode` property (with a different type, e.g. `HttpStatusCode?`), this duplicate declaration leads to a type mismatch during unit test validation. For example, actions such as `Call_External_API` result in errors like:

> *"The workflow '' associated with unit test '' has action mock 'Call_External_API' that has 'outputs' that has status code of invalid type. Expected type: 'string', Actual type : 'Integer'"*

## New Behavior

With this fix, we now filter out any property where `propertyName` equals `"StatusCode"` from the generated class definition. This ensures that the only `StatusCode` in the output is the one inherited from the base class (`MockOutput`), eliminating type conflicts and ensuring the unit test framework receives the expected type.

## Impact of Change

* [ ] **This is a breaking change.**

This change is not breaking since it only affects the internal generation of mock classes for unit tests. Downstream consumers will see more consistent behavior from the mock outputs.

## Test Plan

Unit tests added in **apps\vs-code-designer\src\app\utils\__test__\UnitTesting\unitTestUtils.test.ts** - no updates needed. 

## Screenshots or Videos (if applicable)
The MockOutput in the SDK is defined as:

![image](https://github.com/user-attachments/assets/b64d4032-e151-48d5-a1c9-51daf5d34771)

code before bug fix:
![image](https://github.com/user-attachments/assets/222d3fb0-59f4-4d30-8bed-720e0045122d)

code after bug fis: 
![image](https://github.com/user-attachments/assets/a39c60b8-8ea1-42a3-aa27-02048aa3176d)

