### PR TITLE
fix(designer): Add styles for code tags inside the chat bubble

### DIFF
--- a/libs/designer-ui/src/lib/chatbot/chatbot.less
+++ b/libs/designer-ui/src/lib/chatbot/chatbot.less
@@ -40,6 +40,10 @@
       margin-left: 12px;
     }
   }
+  code {
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
 }
 
 .msla-bubble-footer {


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

- Text for code tags in Markdown component inside the chat bubble was getting overflow

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

- Text for code tags in Markdown component inside the bubbles wraps avoiding overflow

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

### Before

https://github.com/user-attachments/assets/8d756d73-3439-4c70-9278-6c80eb0865b9

### After

https://github.com/user-attachments/assets/13815ca6-91c7-41ec-9afb-6bfbd6a2d8cf

