### PR TITLE
fix(designer): Load agent run data from general run data

### DIFF
--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -833,17 +833,18 @@ const addActionsInstanceMetaData = (
     const runIndex = isAgent && isRunning ? (nodeRunData?.iterationCount ? nodeRunData.iterationCount - 1 : 0) : 0;
 
     if (!isNullOrUndefined(nodeRunData)) {
-      const repetitionRunData = isNullOrUndefined(nodeRunData.repetitionCount)
-        ? {
-            runData: {
-              ...nodeRunData,
-              duration: getDurationStringPanelMode(
-                Date.parse(nodeRunData.endTime) - Date.parse(nodeRunData.startTime),
-                /* abbreviated */ true
-              ),
-            },
-          }
-        : {};
+      const repetitionRunData =
+        isNullOrUndefined(nodeRunData.repetitionCount) || isAgent
+          ? {
+              runData: {
+                ...nodeRunData,
+                duration: getDurationStringPanelMode(
+                  Date.parse(nodeRunData.endTime) - Date.parse(nodeRunData.startTime),
+                  /* abbreviated */ true
+                ),
+              },
+            }
+          : {};
 
       updatedNodesData[key] = {
         ...node,


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

- First load wasn't setting the metadata from the general run data as iteration count is not undefined

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

- New behavior now load the data from the general run data

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

### Before

![CleanShot 2025-04-17 at 16 07 21@2x](https://github.com/user-attachments/assets/baf7dab4-5768-49c2-80ee-7a0891a15294)


### After
![CleanShot 2025-04-17 at 16 00 57@2x](https://github.com/user-attachments/assets/9d7e8c8c-bb20-4a21-94b0-1e83812a04bb)
