### PR TITLE
fix(vscode): Add unit test name validation check for existing test/folder with same name

### DIFF
--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -41,8 +41,8 @@ export const saveUnitTestDefinition = async (
     await vscode.window.withProgress(options, async () => {
       const projectName = path.basename(projectPath);
       const testsDirectory = getTestsDirectory(projectPath);
-      const unitTestsPath = getUnitTestsPath(testsDirectory.fsPath, projectName, workflowName, unitTestName);
-      const workflowTestsPath = getWorkflowTestsPath(testsDirectory.fsPath, projectName, workflowName);
+      const unitTestsPath = path.join(projectPath, projectName, workflowName, `${unitTestName}${unitTestsFileName}`);
+      const workflowTestsPath = path.join(testsDirectory.fsPath, projectName, workflowName);
 
       if (!fse.existsSync(workflowTestsPath)) {
         fse.mkdirSync(workflowTestsPath, { recursive: true });
@@ -85,27 +85,6 @@ export const getTestsDirectory = (projectPath: string) => {
   const workspacePath = path.dirname(projectPath);
   const testsDirectory = vscode.Uri.file(path.join(workspacePath, testsDirectoryName));
   return testsDirectory;
-};
-
-/**
- * Returns the path of a unit test file for a given project, workflow, and unit test name.
- * @param {string} projectPath - The path of the project.
- * @param {string} workflowName - The name of the workflow.
- * @param {string} unitTestName - The name of the unit test.
- * @returns The path of the unit test file.
- */
-const getUnitTestsPath = (projectPath: string, projectName: string, workflowName: string, unitTestName: string) => {
-  return path.join(projectPath, projectName, workflowName, `${unitTestName}${unitTestsFileName}`);
-};
-
-/**
- * Returns the path to the a workflow tests directory.
- * @param {string} projectPath - The path to the project directory.
- * @param {string} workflowName - The name of the workflow.
- * @returns The path to the workflow tests directory.
- */
-const getWorkflowTestsPath = (projectPath: string, projectName: string, workflowName: string) => {
-  return path.join(projectPath, projectName, workflowName);
 };
 
 /**
@@ -601,28 +580,14 @@ export const validateUnitTestName = async (
 
   const testsFolderPath = getTestsDirectory(projectPath);
   const logicAppName = path.basename(projectPath);
-  if (fse.existsSync(path.join(testsFolderPath.fsPath, logicAppName, workflowName, name))) {
-    return localize('unitTestNameExists', 'A unit test with this name already exists in the test project.');
+  const testPath = path.join(testsFolderPath.fsPath, logicAppName, workflowName, name);
+  if (fse.existsSync(testPath)) {
+    if ((await fse.readdir(testPath)).includes(`${name}.cs`)) {
+      return localize('unitTestExists', 'A unit test with this name already exists in the test project.');
+    }
+    return localize('unitTestFolderNameExists', 'Another folder with this name already exists in the test project.');
   }
 
-  return await validateUnitTestNameCore(projectPath, workflowName, name);
-};
-
-/**
- * Validates the unit test name for a given project, workflow, and name.
- * @param {string} projectPath - The path of the project.
- * @param {string} workflowName - The name of the workflow.
- * @param {string} name - The name of the unit test.
- * @returns A string representing an error message if a unit test with the same name already exists, otherwise undefined.
- */
-const validateUnitTestNameCore = async (projectPath: string, workflowName: string, name: string): Promise<string | undefined> => {
-  const projectName = path.basename(projectPath);
-  const testsDirectory = getTestsDirectory(projectPath);
-  const workflowTestsPath = getWorkflowTestsPath(testsDirectory.fsPath, projectName, workflowName);
-
-  if (await fse.pathExists(path.join(workflowTestsPath, `${name}${unitTestsFileName}`))) {
-    return localize('existingUnitTestError', 'A unit test with the name "{0}" already exists.', name);
-  }
   return undefined;
 };
 


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

- Check for existing test with matching name does not work as expected

## New Behavior

- Fix existing check, also check for other folders in Tests/logicAppName/workflowName with matching name

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Added unit tests for validateUnitTestName

## Screenshots or Videos (if applicable)

N/A
