### PR TITLE
fix(vscode): Test authoring fixes

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetWorkspaceSettings.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/SetWorkspaceSettings.ts
@@ -7,6 +7,7 @@ import { type IProjectWizardContext, ProjectLanguage, WorkflowProjectType } from
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { OpenBehavior } from '@microsoft/vscode-extension-logic-apps';
+import { testsDirectoryName } from '../../../../constants';
 
 export class SetWorkspaceSettings extends AzureWizardPromptStep<IProjectWizardContext> {
   // Hide the step count in the wizard UI
@@ -128,6 +129,13 @@ export class SetWorkspaceSettings extends AzureWizardPromptStep<IProjectWizardCo
     workspaceFolders.push({ name: logicAppName, path: `./${logicAppName}` });
 
     workspaceContent.folders = [...workspaceContent.folders, ...workspaceFolders];
+
+    // Move the tests folder to the end of the workspace folders
+    const testsIndex = workspaceContent.folders.findIndex((folder) => folder.name === testsDirectoryName);
+    if (testsIndex !== -1 && testsIndex !== workspaceContent.folders.length - 1) {
+      const [testsFolder] = workspaceContent.folders.splice(testsIndex, 1);
+      workspaceContent.folders.push(testsFolder);
+    }
 
     await fs.writeJSON(context.workspaceCustomFilePath, workspaceContent, { spaces: 2 });
   }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/__test__/saveBlankUnitTest.test.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/__test__/saveBlankUnitTest.test.ts
@@ -4,8 +4,6 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as util from 'util';
 import * as childProcess from 'child_process';
-
-// Import the function under test and the utility modules
 import { saveBlankUnitTest } from '../saveBlankUnitTest';
 import * as workspaceUtils from '../../../../utils/workspace';
 import * as projectRootUtils from '../../../../utils/verifyIsProject';
@@ -45,12 +43,22 @@ describe('saveBlankUnitTest', () => {
     logicAppName: 'LogicApp1',
     logicAppTestFolderPath: '/fake/project/myLogicApp',
     workflowTestFolderPath: path.join(dummyProjectPath, 'workflows', dummyWorkflowName),
+    mocksFolderPath: path.join(dummyProjectPath, 'workflows', dummyWorkflowName, 'MockOutputs'),
     testsDirectory: path.join(dummyProjectPath, 'tests'),
   };
 
-  const dummyMockOperations: { foundActionMocks: Record<string, string>; foundTriggerMocks: Record<string, string> } = {
+  const dummyMockOperations: {
+    mockClassContent: Record<string, string>;
+    foundActionMocks: Record<string, string>;
+    foundTriggerMocks: Record<string, string>;
+  } = {
+    mockClassContent: {
+      TestOperationTriggerOutput: 'dummy class content',
+    },
     foundActionMocks: {},
-    foundTriggerMocks: {},
+    foundTriggerMocks: {
+      Test_operation: 'TestOperationTriggerOutput',
+    },
   };
 
   let updateSolutionWithProjectSpy: any;
@@ -64,7 +72,7 @@ describe('saveBlankUnitTest', () => {
     vi.spyOn(unitTestUtils, 'promptForUnitTestName').mockResolvedValue(dummyUnitTestName);
     vi.spyOn(unitTestUtils, 'validateWorkflowPath').mockResolvedValue();
     vi.spyOn(unitTestUtils, 'getUnitTestPaths').mockReturnValue(dummyPaths);
-    vi.spyOn(unitTestUtils, 'processAndWriteMockableOperations').mockResolvedValue(dummyMockOperations);
+    vi.spyOn(unitTestUtils, 'getOperationMockClassContent').mockResolvedValue(dummyMockOperations);
 
     // Stub directory creation
     vi.spyOn(fs, 'ensureDir').mockResolvedValue();
@@ -88,13 +96,13 @@ describe('saveBlankUnitTest', () => {
     });
 
     // Stub methods used within generateBlankCodefulUnitTest
-    vi.spyOn(unitTestUtils, 'createCsFile').mockResolvedValue();
+    vi.spyOn(unitTestUtils, 'createTestCsFile').mockResolvedValue();
     vi.spyOn(unitTestUtils, 'ensureCsproj').mockResolvedValue();
     vi.spyOn(workspaceUtils, 'ensureDirectoryInWorkspace').mockResolvedValue();
     vi.spyOn(ext.outputChannel, 'appendLog').mockImplementation(() => {});
 
     // Stub the methods used in updateSolutionWithProject
-    updateSolutionWithProjectSpy = vi.spyOn(unitTestUtils, 'updateSolutionWithProject');
+    updateSolutionWithProjectSpy = vi.spyOn(unitTestUtils, 'updateTestsSln');
     vi.spyOn(util, 'promisify').mockImplementation((fn) => fn);
     vi.spyOn(childProcess, 'exec').mockResolvedValue(new childProcess.ChildProcess());
   });
@@ -106,13 +114,9 @@ describe('saveBlankUnitTest', () => {
   test('should successfully create a blank unit test', async () => {
     await saveBlankUnitTest(dummyContext, dummyNode, dummyUnitTestDefinition);
 
-    // Verify that telemetry was logged indicating a successful process
     expect(unitTestUtils.logTelemetry).toHaveBeenCalledWith(dummyContext, expect.objectContaining({ unitTestSaveStatus: 'Success' }));
-    // Verify that the unit test name was prompted
     expect(unitTestUtils.promptForUnitTestName).toHaveBeenCalledTimes(1);
-    // Verify that required directories were ensured to exist
     expect(fs.ensureDir).toHaveBeenCalled();
-    // Verify that the backend process was invoked via callWithTelemetryAndErrorHandling
     expect(azextUtils.callWithTelemetryAndErrorHandling).toHaveBeenCalled();
 
     expect(updateSolutionWithProjectSpy).toHaveBeenCalledOnce();

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -20,7 +20,7 @@ import {
   getOperationMockClassContent,
   promptForUnitTestName,
   selectWorkflowNode,
-  updateSolutionWithProject,
+  updateTestsSln,
   validateWorkflowPath,
 } from '../../../utils/unitTests';
 import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
@@ -308,7 +308,7 @@ async function generateUnitTestFromRun(
       const csprojFilePath = path.join(paths.logicAppTestFolderPath, `${paths.logicAppName}.csproj`);
 
       ext.outputChannel.appendLog(`Updating solution in tests folder: ${paths.testsDirectory}`);
-      await updateSolutionWithProject(paths.testsDirectory, csprojFilePath);
+      await updateTestsSln(paths.testsDirectory, csprojFilePath);
     } catch (solutionError) {
       ext.outputChannel.appendLog(`Failed to update solution: ${solutionError}`);
     }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/createUnitTest.ts
@@ -6,7 +6,7 @@
 import { localize } from '../../../../localize';
 import { ConvertToWorkspace } from '../../createNewCodeProject/CodeProjectBase/ConvertToWorkspace';
 import {
-  createCsFile,
+  createTestCsFile,
   createTestExecutorFile,
   createTestSettingsConfigFile,
   ensureCsproj,
@@ -17,7 +17,7 @@ import {
   logTelemetry,
   parseErrorBeforeTelemetry,
   parseUnitTestOutputs,
-  processAndWriteMockableOperations,
+  getOperationMockClassContent,
   promptForUnitTestName,
   selectWorkflowNode,
   updateSolutionWithProject,
@@ -29,7 +29,7 @@ import type { IAzureConnectorsContext } from '../azureConnectorWizard';
 import { type IActionContext, callWithTelemetryAndErrorHandling, parseError } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as fs from 'fs-extra';
+import * as fse from 'fs-extra';
 import axios from 'axios';
 import { ext } from '../../../../extensionVariables';
 import { unzipLogicAppArtifacts } from '../../../utils/taskUtils';
@@ -202,27 +202,24 @@ async function generateUnitTestFromRun(
     }
 
     const paths = getUnitTestPaths(projectPath, workflowName, unitTestName);
-    await fs.ensureDir(paths.unitTestFolderPath);
-    const { foundActionMocks, foundTriggerMocks } = await processAndWriteMockableOperations(
+    const { mockClassContent, foundActionMocks, foundTriggerMocks } = await getOperationMockClassContent(
       operationInfo,
       outputParameters,
       workflowPath,
-      paths.workflowTestFolderPath,
       workflowName,
       paths.logicAppName
     );
+    if (!foundTriggerMocks || Object.keys(foundTriggerMocks).length === 0) {
+      throw new Error(localize('noTriggersFound', 'No trigger found in the workflow. Unit tests must include a mocked trigger.'));
+    }
 
     // Get cleaned versions of strings
     const cleanedUnitTestName = unitTestName.replace(/-/g, '_');
     const cleanedWorkflowName = workflowName.replace(/-/g, '_');
     const cleanedLogicAppName = paths.logicAppName.replace(/-/g, '_');
 
-    // Create the testSettings.config file for the unit test
-    ext.outputChannel.appendLog(localize('creatingTestSettingsConfig', 'Creating testSettings.config file for unit test...'));
-    await createTestSettingsConfigFile(paths.workflowTestFolderPath, workflowName, paths.logicAppName);
-    await createTestExecutorFile(paths.logicAppTestFolderPath, cleanedLogicAppName);
-
     try {
+      await fse.ensureDir(paths.unitTestFolderPath);
       ext.outputChannel.appendLog(localize('unzippingFiles', `Unzipping Mock.json into: ${paths.unitTestFolderPath}`));
       await unzipLogicAppArtifacts(zipBuffer, paths.unitTestFolderPath);
       logTelemetry(context, { filesUnzipped: 'true', processStage: 'Files Unzipped' });
@@ -235,14 +232,26 @@ async function generateUnitTestFromRun(
     }
 
     try {
-      // Get the first actionMock in foundActionMocks
+      // Create the testSettings.config and TestExecutor.cs files
+      ext.outputChannel.appendLog(localize('creatingTestSettingsConfig', 'Creating testSettings.config file for unit test...'));
+      await createTestSettingsConfigFile(paths.workflowTestFolderPath, workflowName, paths.logicAppName);
+      await createTestExecutorFile(paths.logicAppTestFolderPath, cleanedLogicAppName);
+
       const [actionName, actionOutputClassName] = Object.entries(foundActionMocks)[0] || [];
-      // Get the first actionMock in foundActionMocks
       const [, triggerOutputClassName] = Object.entries(foundTriggerMocks)[0] || [];
+
       // Create actionMockClassName by replacing "Output" with "Mock" in actionOutputClassName
       const actionMockClassName = actionOutputClassName?.replace(/(.*)Output$/, '$1Mock');
       const triggerMockClassName = triggerOutputClassName.replace(/(.*)Output$/, '$1Mock');
-      await createCsFile(
+
+      await fse.ensureDir(paths.mocksFolderPath);
+      for (const [mockClassName, classContent] of Object.entries(mockClassContent)) {
+        const mockFilePath = path.join(paths.mocksFolderPath, `${mockClassName}.cs`);
+        await fse.writeFile(mockFilePath, classContent, 'utf-8');
+        ext.outputChannel.appendLog(localize('csMockFileCreated', 'Created .cs file for mock at: {0}', mockFilePath));
+      }
+
+      await createTestCsFile(
         paths.unitTestFolderPath!,
         unitTestName,
         cleanedUnitTestName,

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/saveBlankUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/saveBlankUnitTest.ts
@@ -18,7 +18,7 @@ import {
   promptForUnitTestName,
   selectWorkflowNode,
   getOperationMockClassContent,
-  updateSolutionWithProject,
+  updateTestsSln,
   validateWorkflowPath,
 } from '../../../utils/unitTests';
 import { tryGetLogicAppProjectRoot } from '../../../utils/verifyIsProject';
@@ -169,10 +169,10 @@ export async function saveBlankUnitTest(
     });
 
     try {
-      // Construct the path for the .csproj file using the logic app test folder
       const csprojFilePath = path.join(logicAppTestFolderPath, `${logicAppName}.csproj`);
+
       ext.outputChannel.appendLog(`Updating solution in tests folder: ${unitTestFolderPath}`);
-      await updateSolutionWithProject(testsDirectory, csprojFilePath);
+      await updateTestsSln(testsDirectory, csprojFilePath);
     } catch (solutionError) {
       ext.outputChannel.appendLog(`Failed to update solution: ${solutionError}`);
     }

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/saveBlankUnitTest.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/saveBlankUnitTest.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { localize } from '../../../../localize';
 import {
-  createCsFile,
+  createTestCsFile,
   createTestSettingsConfigFile,
   createTestExecutorFile,
   ensureCsproj,
@@ -17,7 +17,7 @@ import {
   parseUnitTestOutputs,
   promptForUnitTestName,
   selectWorkflowNode,
-  processAndWriteMockableOperations,
+  getOperationMockClassContent,
   updateSolutionWithProject,
   validateWorkflowPath,
 } from '../../../utils/unitTests';
@@ -27,7 +27,7 @@ import type { IAzureConnectorsContext } from '../azureConnectorWizard';
 import { type IActionContext, callWithTelemetryAndErrorHandling, parseError } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as fs from 'fs-extra';
+import * as fse from 'fs-extra';
 import { ext } from '../../../../extensionVariables';
 import { ConvertToWorkspace } from '../../createNewCodeProject/CodeProjectBase/ConvertToWorkspace';
 
@@ -131,23 +131,20 @@ export async function saveBlankUnitTest(
       workflowName,
       unitTestName
     );
-    // Retrieve necessary paths
-    // Indicate that we resolved the folder path
     logTelemetry(context, {
       workflowTestFolderPathResolved: workflowTestFolderPath ? 'true' : 'false',
     });
 
-    // Ensure required directories exist
-    await fs.ensureDir(unitTestFolderPath);
-    await fs.ensureDir(workflowTestFolderPath);
-    const { foundActionMocks, foundTriggerMocks } = await processAndWriteMockableOperations(
+    const { mockClassContent, foundActionMocks, foundTriggerMocks } = await getOperationMockClassContent(
       operationInfo,
       outputParameters,
       workflowNode.fsPath,
-      workflowTestFolderPath,
       workflowName,
       logicAppName
     );
+    if (!foundTriggerMocks || Object.keys(foundTriggerMocks).length === 0) {
+      throw new Error(localize('noTriggersFound', 'No trigger found in the workflow. Unit tests must include a mocked trigger.'));
+    }
 
     // Log telemetry before proceeding
     logTelemetry(context, { workflowName, unitTestName });
@@ -155,13 +152,22 @@ export async function saveBlankUnitTest(
     // Save the unit test
     await callWithTelemetryAndErrorHandling('logicApp.saveBlankUnitTest', async (telemetryContext: IActionContext) => {
       Object.assign(telemetryContext, context);
-      await generateBlankCodefulUnitTest(context, projectPath, workflowName, unitTestName, foundActionMocks, foundTriggerMocks);
+      await generateBlankCodefulUnitTest(
+        context,
+        projectPath,
+        workflowName,
+        unitTestName,
+        mockClassContent,
+        foundActionMocks,
+        foundTriggerMocks
+      );
     });
 
     logTelemetry(context, {
       unitTestSaveStatus: 'Success',
       unitTestProcessingTimeMs: (Date.now() - startTime).toString(),
     });
+
     try {
       // Construct the path for the .csproj file using the logic app test folder
       const csprojFilePath = path.join(logicAppTestFolderPath, `${logicAppName}.csproj`);
@@ -186,6 +192,9 @@ export async function saveBlankUnitTest(
  * @param {string} projectPath - The path to the project directory.
  * @param {string} workflowName - The name of the workflow for which the test is being created.
  * @param {string} unitTestName - The name of the unit test to be created.
+ * @param {Record<string, string>} mockClassContent - The content of the mock classes.
+ * @param {Record<string, string>} foundActionMocks - The action mocks found in the workflow.
+ * @param {Record<string, string>} foundTriggerMocks - The trigger mocks found in the workflow.
  * @returns {Promise<void>} - A promise that resolves when the unit test has been generated.
  */
 async function generateBlankCodefulUnitTest(
@@ -193,16 +202,14 @@ async function generateBlankCodefulUnitTest(
   projectPath: string,
   workflowName: string,
   unitTestName: string,
+  mockClassContent: Record<string, string>,
   foundActionMocks: Record<string, string>,
   foundTriggerMocks: Record<string, string>
 ): Promise<void> {
   try {
     // Get required paths
-    const { testsDirectory, logicAppName, logicAppTestFolderPath, workflowTestFolderPath, unitTestFolderPath } = getUnitTestPaths(
-      projectPath,
-      workflowName,
-      unitTestName
-    );
+    const { testsDirectory, logicAppName, logicAppTestFolderPath, workflowTestFolderPath, mocksFolderPath, unitTestFolderPath } =
+      getUnitTestPaths(projectPath, workflowName, unitTestName);
 
     ext.outputChannel.appendLog(
       localize(
@@ -220,23 +227,34 @@ async function generateBlankCodefulUnitTest(
 
     // Ensure directories exist
     ext.outputChannel.appendLog(localize('ensuringDirectories', 'Ensuring required directories exist...'));
-    await Promise.all([fs.ensureDir(logicAppTestFolderPath), fs.ensureDir(workflowTestFolderPath), fs.ensureDir(unitTestFolderPath)]);
+    await Promise.all([
+      fse.ensureDir(logicAppTestFolderPath),
+      fse.ensureDir(workflowTestFolderPath),
+      fse.ensureDir(unitTestFolderPath),
+      fse.ensureDir(mocksFolderPath),
+    ]);
 
-    // Create the testSettings.config file for the unit test
+    // Create the testSettings.config and TestExecutor.cs files
     ext.outputChannel.appendLog(localize('creatingTestSettingsConfig', 'Creating testSettings.config file for unit test...'));
     await createTestSettingsConfigFile(workflowTestFolderPath, workflowName, logicAppName);
     await createTestExecutorFile(logicAppTestFolderPath, cleanedLogicAppName);
 
-    // Get the first actionMock in foundActionMocks
     const [actionName, actionOutputClassName] = Object.entries(foundActionMocks)[0] || [];
-    // Get the first actionMock in foundActionMocks
     const [, triggerOutputClassName] = Object.entries(foundTriggerMocks)[0] || [];
+
     // Create actionMockClassName by replacing "Output" with "Mock" in actionOutputClassName
     const actionMockClassName = actionOutputClassName?.replace(/(.*)Output$/, '$1Mock');
     const triggerMockClassName = triggerOutputClassName.replace(/(.*)Output$/, '$1Mock');
+
+    // Create the mock files
+    for (const [mockClassName, classContent] of Object.entries(mockClassContent)) {
+      const mockFilePath = path.join(mocksFolderPath, `${mockClassName}.cs`);
+      await fse.writeFile(mockFilePath, classContent, 'utf-8');
+      ext.outputChannel.appendLog(localize('csMockFileCreated', 'Created .cs file for mock at: {0}', mockFilePath));
+    }
+
     // Create the .cs file for the unit test
-    ext.outputChannel.appendLog(localize('creatingCsFile', 'Creating .cs file for unit test...'));
-    await createCsFile(
+    await createTestCsFile(
       unitTestFolderPath,
       unitTestName,
       cleanedUnitTestName,
@@ -284,12 +302,11 @@ async function generateBlankCodefulUnitTest(
     vscode.window.showInformationMessage(
       localize('info.generateCodefulUnitTest', 'Generated unit test "{0}" in "{1}"', unitTestName, unitTestFolderPath)
     );
-    // Log success and notify the user
+
     const successMessage = localize('info.generateCodefulUnitTest', 'Generated unit test "{0}" in "{1}"', unitTestName, unitTestFolderPath);
     logSuccess(context, 'unitTestGenerationStatus', successMessage);
     vscode.window.showInformationMessage(successMessage);
   } catch (error: any) {
-    // Log the error using helper functions
     logError(context, error, 'generateBlankCodefulUnitTest');
   }
 }

--- a/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
@@ -909,7 +909,7 @@ namespace <%= LogicAppName %>.Tests
             var triggerMock = new <%= TriggerMockClassName %>(outputs: triggerMockOutput);
 
             // Generate mock action data.
-            // OPTION 1 : defining a callback class
+            // OPTION 1 : defining a callback function
             var actionMock = new <%= ActionMockClassName %>(name: "<%= ActionMockName %>", onGetActionMock: <%= ActionMockClassName %>OutputCallback);
             // OPTION 2: defining inline using a lambda
             /*var actionMock = new <%= ActionMockClassName %>(name: "<%= ActionMockName %>", onGetActionMock: (testExecutionContext) =>
@@ -1050,7 +1050,7 @@ namespace <%= LogicAppName %>.Tests
             // Generate mock action and trigger data.
             var mockData = this.GetTestMockDefinition();
             var sampleActionMock = mockData.ActionMocks["<%= ActionMockName %>"];
-            sampleActionMock.Outputs["your-property-name"] = "your-property-value";
+            // sampleActionMock.Outputs["your-property-name"] = "your-property-value";
 
             // ACT
             // Create an instance of UnitTestExecutor, and run the workflow with the mock data.
@@ -1074,7 +1074,7 @@ namespace <%= LogicAppName %>.Tests
             // PREPARE
             // Generate mock action and trigger data.
             var mockData = this.GetTestMockDefinition();
-            // OPTION 1 : defining a callback class
+            // OPTION 1 : defining a callback function
             mockData.ActionMocks["<%= ActionMockName %>"] = new <%= ActionMockClassName %>(name: "<%= ActionMockName %>", onGetActionMock: <%= ActionMockClassName %>OutputCallback);
             // OPTION 2: defining inline using a lambda
             mockData.ActionMocks["<%= ActionMockName %>"] = new <%= ActionMockClassName %>(name: "<%= ActionMockName %>", onGetActionMock: (testExecutionContext) =>
@@ -1347,7 +1347,7 @@ namespace <%= LogicAppName %>.Tests
             // PREPARE Mock
             // Generate mock action and trigger data.
             var mockData = this.GetTestMockDefinition();
-            mockData.TriggerMock.Outputs["your-property-name"] = "your-property-value";
+            // mockData.TriggerMock.Outputs["your-property-name"] = "your-property-value";
 
             // ACT
             // Create an instance of UnitTestExecutor, and run the workflow with the mock data.

--- a/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/UnitTesting/unitTestUtils.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import axios from 'axios';
 import * as fse from 'fs-extra';
-import * as childProcess from 'child_process';
 import * as util from 'util';
 import path from 'path';
 import * as localizeModule from '../../../../localize';
+import * as vscodeConfigSettings from '../../../utils/vsCodeConfig/settings';
+import * as cpUtils from '../../../utils/funcCoreTools/cpUtils';
 import { ext } from '../../../../extensionVariables';
 import type { IAzureConnectorsContext } from '../../../commands/workflows/azureConnectorWizard';
 import {
@@ -15,15 +16,15 @@ import {
   generateCSharpClasses,
   generateClassCode,
   logTelemetry,
-  processAndWriteMockableOperations,
+  getOperationMockClassContent,
   buildClassDefinition,
   mapJsonTypeToCSharp,
   createCsprojFile,
   updateCsprojFile,
-  createCsFile,
+  createTestCsFile,
   createTestExecutorFile,
   createTestSettingsConfigFile,
-  updateSolutionWithProject,
+  updateTestsSln,
   validateWorkflowPath,
   validateUnitTestName,
 } from '../../unitTests';
@@ -384,14 +385,10 @@ describe('logTelemetry function', () => {
   });
 });
 
-describe('processAndWriteMockableOperations with no actions', () => {
-  let writeFileSpy: any;
-  let ensureDirSpy: any;
+describe('getOperationMockClassContent with no actions', () => {
   let readFileSpy: any;
 
   beforeEach(() => {
-    writeFileSpy = vi.spyOn(fse, 'writeFile').mockResolvedValue();
-    ensureDirSpy = vi.spyOn(fse, 'ensureDir').mockResolvedValue();
     readFileSpy = vi.spyOn(fse, 'readFile').mockResolvedValue(
       JSON.stringify({
         definition: {
@@ -418,7 +415,7 @@ describe('processAndWriteMockableOperations with no actions', () => {
     vi.restoreAllMocks();
   });
 
-  it('should gracefully handle workflows with no actions by not creating any files', async () => {
+  it('should gracefully handle workflows with no actions', async () => {
     const operationInfo = {
       When_a_HTTP_request_is_received: { type: 'Request', operationId: 'When_a_HTTP_request_is_received' },
     };
@@ -429,27 +426,24 @@ describe('processAndWriteMockableOperations with no actions', () => {
         },
       },
     };
-    const { foundActionMocks, foundTriggerMocks } = await processAndWriteMockableOperations(
+    const { mockClassContent, foundActionMocks, foundTriggerMocks } = await getOperationMockClassContent(
       operationInfo,
       outputParameters,
-      projectPath,
       projectPath,
       'workflowName',
       fakeLogicAppName
     );
+    expect(Object.keys(mockClassContent).length).toEqual(1);
+    expect(mockClassContent['WhenAHTTPRequestIsReceivedTriggerOutput']).toContain('public class WhenAHTTPRequestIsReceivedTriggerOutput');
     expect(Object.keys(foundActionMocks).length).toEqual(0);
     expect(Object.keys(foundTriggerMocks).length).toEqual(1);
   });
 });
 
-describe('processAndWriteMockableOperations', () => {
-  let writeFileSpy: any;
-  let ensureDirSpy: any;
+describe('getOperationMockClassContent', () => {
   let readFileSpy: any;
 
   beforeEach(() => {
-    writeFileSpy = vi.spyOn(fse, 'writeFile').mockResolvedValue();
-    ensureDirSpy = vi.spyOn(fse, 'ensureDir').mockResolvedValue();
     readFileSpy = vi.spyOn(fse, 'readFile').mockResolvedValue(
       JSON.stringify({
         definition: {
@@ -503,7 +497,6 @@ describe('processAndWriteMockableOperations', () => {
       })
     );
     ext.outputChannel = { appendLog: vi.fn() } as any;
-    // Set designTimePort and stub axios.get so isMockable works without error
     ext.designTimePort = 1234;
     vi.spyOn(axios, 'get').mockResolvedValue({ data: ['Http'] });
   });
@@ -512,7 +505,39 @@ describe('processAndWriteMockableOperations', () => {
     vi.restoreAllMocks();
   });
 
-  it('should create a C# file in the "MockOutputs" folder with standardized naming for an action', async () => {
+  it('should throw an error when no trigger exists in the workflow is provided', async () => {
+    readFileSpy = vi.spyOn(fse, 'readFile').mockResolvedValue(
+      JSON.stringify({
+        definition: {
+          $schema: 'https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#',
+          actions: {
+            Complete_the_message_in_a_queue: {
+              type: 'ApiConnection',
+              inputs: {
+                host: {
+                  connection: {
+                    referenceName: 'servicebus',
+                  },
+                },
+                method: 'delete',
+                path: "/@{encodeURIComponent(encodeURIComponent('test'))}/messages/complete",
+                queries: {
+                  lockToken: "@triggerBody()?['LockToken']",
+                  queueType: 'Main',
+                  sessionId: '',
+                },
+              },
+              runAfter: {},
+            },
+          },
+          contentVersion: '1.0.0.0',
+          outputs: {},
+          triggers: {},
+        },
+        kind: 'Stateful',
+      })
+    );
+
     const operationInfo = {
       ReadAResourceGroup: { type: 'Http', operationId: 'ReadAResourceGroup' },
     };
@@ -523,18 +548,49 @@ describe('processAndWriteMockableOperations', () => {
         },
       },
     };
-    await processAndWriteMockableOperations(operationInfo, outputParameters, projectPath, projectPath, 'workflowName', fakeLogicAppName);
-    const expectedMockOutputsFolder = path.join(projectPath, 'MockOutputs');
-    expect(ensureDirSpy).toHaveBeenCalledWith(expectedMockOutputsFolder);
-    const expectedFileName = 'ReadAResourceGroupActionOutput.cs';
-    const expectedFilePath = path.join(expectedMockOutputsFolder, expectedFileName);
-    expect(writeFileSpy).toHaveBeenCalledWith(expectedFilePath, expect.any(String), 'utf-8');
+
+    expect(
+      getOperationMockClassContent(operationInfo, outputParameters, projectPath, 'workflowName', fakeLogicAppName)
+    ).rejects.toThrowError();
   });
 
-  it('should not create duplicate C# classes for identical operations', async () => {
+  it('should return mock action/trigger class contents for each operation in the workflow', async () => {
+    const operationInfo = {
+      ReadAResourceGroup: { type: 'Http', operationId: 'ReadAResourceGroup' },
+      WhenAHTTPRequestIsReceived: { type: 'HttpWebhook', operationId: 'WhenAHTTPRequestIsReceived' },
+    };
+    const outputParameters = {
+      ReadAResourceGroup: {
+        outputs: {
+          'outputs.$.dummy': { type: 'string', description: 'dummy description' },
+        },
+      },
+      WhenAHTTPRequestIsReceived: {
+        outputs: {
+          'outputs.$.dummy': { type: 'string', description: 'dummy trigger description' },
+        },
+      },
+    };
+    const { mockClassContent, foundActionMocks, foundTriggerMocks } = await getOperationMockClassContent(
+      operationInfo,
+      outputParameters,
+      projectPath,
+      'workflowName',
+      fakeLogicAppName
+    );
+    expect(mockClassContent).toHaveProperty('ReadAResourceGroupActionOutput');
+    expect(mockClassContent).toHaveProperty('WhenAHTTPRequestIsReceivedTriggerOutput');
+    expect(mockClassContent['ReadAResourceGroupActionOutput']).toContain('public class ReadAResourceGroupActionOutput');
+    expect(mockClassContent['WhenAHTTPRequestIsReceivedTriggerOutput']).toContain('public class WhenAHTTPRequestIsReceivedTriggerOutput');
+    expect(Object.keys(foundActionMocks).length).toEqual(1);
+    expect(Object.keys(foundTriggerMocks).length).toEqual(1);
+  });
+
+  it('should return a single copy of mock class contents for identical operations', async () => {
     const operationInfo = {
       ReadAResourceGroup: { type: 'Http', operationId: 'ReadAResourceGroup' },
       ReadAResourceGroupDuplicate: { type: 'Http', operationId: 'ReadAResourceGroup' },
+      WhenAHTTPRequestIsReceived: { type: 'HttpWebhook', operationId: 'WhenAHTTPRequestIsReceived' },
     };
     const outputParameters = {
       ReadAResourceGroup: {
@@ -547,27 +603,22 @@ describe('processAndWriteMockableOperations', () => {
           'outputs.$.dummy': { type: 'string', description: 'duplicate dummy description' },
         },
       },
-    };
-    await processAndWriteMockableOperations(operationInfo, outputParameters, projectPath, projectPath, 'workflowName', fakeLogicAppName);
-    expect(writeFileSpy.mock.calls.length).toBe(1);
-  });
-
-  it('should apply standardized naming conventions for trigger operations', async () => {
-    const operationInfo = {
-      WhenAHTTPRequestIsReceived: { type: 'HttpWebhook', operationId: 'WhenAHTTPRequestIsReceived' },
-    };
-    const outputParameters = {
       WhenAHTTPRequestIsReceived: {
         outputs: {
           'outputs.$.dummy': { type: 'string', description: 'dummy trigger description' },
         },
       },
     };
-    await processAndWriteMockableOperations(operationInfo, outputParameters, projectPath, projectPath, 'workflowName', fakeLogicAppName);
-    const expectedMockOutputsFolder = path.join(projectPath, 'MockOutputs');
-    const expectedFileName = 'WhenAHTTPRequestIsReceivedTriggerOutput.cs';
-    const expectedFilePath = path.join(expectedMockOutputsFolder, expectedFileName);
-    expect(writeFileSpy).toHaveBeenCalledWith(expectedFilePath, expect.any(String), 'utf-8');
+    const { mockClassContent, foundActionMocks, foundTriggerMocks } = await getOperationMockClassContent(
+      operationInfo,
+      outputParameters,
+      projectPath,
+      'workflowName',
+      fakeLogicAppName
+    );
+    expect(Object.keys(mockClassContent).length).toEqual(2);
+    expect(Object.keys(foundActionMocks).length).toEqual(1);
+    expect(Object.keys(foundTriggerMocks).length).toEqual(1);
   });
 });
 
@@ -803,7 +854,7 @@ describe('updateCsprojFile', () => {
   });
 });
 
-describe('createCsFile', () => {
+describe('createTestCsFile', () => {
   const unitTestFolderPath: string = 'unitTestFolderPath';
   const unitTestName: string = 'TestBlankClass';
   const workflowName: string = 'MyWorkflow';
@@ -972,7 +1023,7 @@ namespace <%= LogicAppName %>.Tests
     const cleanedWorkflowName = workflowName.replace(/-/g, '_');
     const cleanedLogicAppName = logicAppName.replace(/-/g, '_');
 
-    await createCsFile(
+    await createTestCsFile(
       unitTestFolderPath,
       unitTestName,
       cleanedUnitTestName,
@@ -1164,7 +1215,7 @@ namespace <%= LogicAppName %>.Tests
     const cleanedWorkflowName = workflowName.replace(/-/g, '_');
     const cleanedLogicAppName = logicAppName.replace(/-/g, '_');
 
-    await createCsFile(
+    await createTestCsFile(
       unitTestFolderPath,
       unitTestName,
       cleanedUnitTestName,
@@ -1270,7 +1321,7 @@ namespace <%= LogicAppName %>.Tests
     const cleanedWorkflowName = workflowName.replace(/-/g, '_');
     const cleanedLogicAppName = logicAppName.replace(/-/g, '_');
 
-    await createCsFile(
+    await createTestCsFile(
       unitTestFolderPath,
       unitTestName,
       cleanedUnitTestName,
@@ -1407,7 +1458,7 @@ namespace <%= LogicAppName %>.Tests
     const cleanedWorkflowName = workflowName.replace(/-/g, '_');
     const cleanedLogicAppName = logicAppName.replace(/-/g, '_');
 
-    await createCsFile(
+    await createTestCsFile(
       unitTestFolderPath,
       unitTestName,
       cleanedUnitTestName,
@@ -1602,13 +1653,15 @@ describe('createTestSettingsConfig', () => {
 });
 
 describe('updateSolutionWithProject', () => {
+  const testDotnetBinaryPath = path.join('test', 'path', 'to', 'dotnet');
   let pathExistsSpy: any;
-  let execSpy: any;
+  let executeCommandSpy: any;
 
   beforeEach(() => {
     vi.spyOn(ext.outputChannel, 'appendLog').mockImplementation(() => {});
     vi.spyOn(util, 'promisify').mockImplementation((fn) => fn);
-    execSpy = vi.spyOn(childProcess, 'exec').mockResolvedValue(new childProcess.ChildProcess());
+    vi.spyOn(vscodeConfigSettings, 'getGlobalSetting').mockReturnValue(testDotnetBinaryPath);
+    executeCommandSpy = vi.spyOn(cpUtils, 'executeCommand').mockResolvedValue('');
   });
 
   afterEach(() => {
@@ -1621,12 +1674,13 @@ describe('updateSolutionWithProject', () => {
     const testsDirectory = path.join(projectPath, 'Tests');
     const logicAppCsprojPath = path.join(testsDirectory, `${fakeLogicAppName}.csproj`);
 
-    await updateSolutionWithProject(testsDirectory, logicAppCsprojPath);
+    await updateTestsSln(testsDirectory, logicAppCsprojPath);
 
-    expect(execSpy).toHaveBeenCalledTimes(1);
-    expect(execSpy).toHaveBeenCalledWith(
-      `dotnet sln "${path.join(testsDirectory, 'Tests.sln')}" add "${fakeLogicAppName}.csproj"`,
-      expect.anything()
+    expect(executeCommandSpy).toHaveBeenCalledTimes(1);
+    expect(executeCommandSpy).toHaveBeenCalledWith(
+      ext.outputChannel,
+      testsDirectory,
+      `${testDotnetBinaryPath} sln "${path.join(testsDirectory, 'Tests.sln')}" add "${fakeLogicAppName}.csproj"`
     );
   });
 
@@ -1636,13 +1690,14 @@ describe('updateSolutionWithProject', () => {
     const testsDirectory = path.join(projectPath, 'Tests');
     const logicAppCsprojPath = path.join(testsDirectory, `${fakeLogicAppName}.csproj`);
 
-    await updateSolutionWithProject(testsDirectory, logicAppCsprojPath);
+    await updateTestsSln(testsDirectory, logicAppCsprojPath);
 
-    expect(execSpy).toHaveBeenCalledTimes(2);
-    expect(execSpy).toHaveBeenCalledWith('dotnet new sln -n Tests', expect.anything());
-    expect(execSpy).toHaveBeenCalledWith(
-      `dotnet sln "${path.join(testsDirectory, 'Tests.sln')}" add "${fakeLogicAppName}.csproj"`,
-      expect.anything()
+    expect(executeCommandSpy).toHaveBeenCalledTimes(2);
+    expect(executeCommandSpy).toHaveBeenCalledWith(ext.outputChannel, testsDirectory, `${testDotnetBinaryPath} new sln -n Tests`);
+    expect(executeCommandSpy).toHaveBeenCalledWith(
+      ext.outputChannel,
+      testsDirectory,
+      `${testDotnetBinaryPath} sln "${path.join(testsDirectory, 'Tests.sln')}" add "${fakeLogicAppName}.csproj"`
     );
   });
 });

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { exec } from 'child_process';
 import axios from 'axios';
 import * as fse from 'fs-extra';
 import * as path from 'path';
@@ -11,12 +10,20 @@ import * as xml2js from 'xml2js';
 import { type IActionContext, callWithTelemetryAndErrorHandling, type IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
 import type { UnitTestResult } from '@microsoft/vscode-extension-logic-apps';
 import { toPascalCase } from '@microsoft/logic-apps-shared';
-import { saveUnitTestEvent, testMockOutputsDirectory, testsDirectoryName, unitTestsFileName, workflowFileName } from '../../constants';
+import {
+  dotNetBinaryPathSettingKey,
+  saveUnitTestEvent,
+  testMockOutputsDirectory,
+  testsDirectoryName,
+  unitTestsFileName,
+  workflowFileName,
+} from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { getWorkflowsInLocalProject } from './codeless/common';
 import type { IAzureConnectorsContext } from '../commands/workflows/azureConnectorWizard';
-import { promisify } from 'util';
+import { executeCommand } from './funcCoreTools/cpUtils';
+import { getGlobalSetting } from './vsCodeConfig/settings';
 
 /**
  * Saves the unit test definition for a workflow.
@@ -1049,14 +1056,13 @@ export async function getOperationMockClassContent(
     if (await isMockable(type)) {
       // Set operationName as className
       const cleanedOperationName = removeInvalidCharacters(operationName);
-      let className = toPascalCase(cleanedOperationName);
+      let mockOutputClassName = toPascalCase(cleanedOperationName);
       let mockClassName = toPascalCase(cleanedOperationName);
 
       // Append suffix based on whether it's a trigger
-      className += isTrigger ? 'TriggerOutput' : 'ActionOutput';
-
+      mockOutputClassName += isTrigger ? 'TriggerOutput' : 'ActionOutput';
       const mockType = isTrigger ? 'TriggerMock' : 'ActionMock';
-      mockClassName += isTrigger ? 'TriggerMock' : 'ActionMock';
+      mockClassName += mockType;
 
       // Transform the output parameters for this operation
       const outputs = outputParameters[operationName]?.outputs;
@@ -1065,14 +1071,21 @@ export async function getOperationMockClassContent(
       const sanitizedLogicAppName = logicAppName.replace(/-/g, '_');
 
       // Generate C# class content
-      const classContent = generateCSharpClasses(sanitizedLogicAppName, className, workflowName, mockType, mockClassName, outputs);
-      mockClassContent[className] = classContent;
+      const classContent = generateCSharpClasses(
+        sanitizedLogicAppName,
+        mockOutputClassName,
+        workflowName,
+        mockType,
+        mockClassName,
+        outputs
+      );
+      mockClassContent[mockOutputClassName] = classContent;
 
       // Store the operation name and class name in the appropriate dictionary
       if (isTrigger) {
-        foundTriggerMocks[operationName] = className;
+        foundTriggerMocks[operationName] = mockOutputClassName;
       } else {
-        foundActionMocks[operationName] = className;
+        foundActionMocks[operationName] = mockOutputClassName;
       }
     }
   }
@@ -1209,7 +1222,7 @@ export async function isMockable(type: string): Promise<boolean> {
 }
 
 /**
- * Creates a new solution file and adds the specified Logic App .csproj to it.
+ * Creates a new solution file if one doesn't exist and adds the specified Logic App .csproj to it.
  *
  * This function performs the following steps in the tests directory:
  * 1. Runs 'dotnet new sln -n Tests' to create a new solution file named Tests.sln.
@@ -1219,10 +1232,10 @@ export async function isMockable(type: string): Promise<boolean> {
  * @param testsDirectory - The absolute path to the tests directory root.
  * @param logicAppCsprojPath - The absolute path to the Logic App's .csproj file.
  */
-export async function updateSolutionWithProject(testsDirectory: string, logicAppCsprojPath: string): Promise<void> {
+export async function updateTestsSln(testsDirectory: string, logicAppCsprojPath: string): Promise<void> {
   const solutionName = 'Tests'; // This will create "Tests.sln"
   const solutionFile = path.join(testsDirectory, `${solutionName}.sln`);
-  const execAsync = promisify(exec);
+  const dotnetBinaryPath = getGlobalSetting(dotNetBinaryPathSettingKey);
 
   try {
     // Create a new solution file if it doesn't already exist.
@@ -1230,14 +1243,14 @@ export async function updateSolutionWithProject(testsDirectory: string, logicApp
       ext.outputChannel.appendLog(`Solution file already exists at ${solutionFile}.`);
     } else {
       ext.outputChannel.appendLog(`Creating new solution file at ${solutionFile}...`);
-      await execAsync(`dotnet new sln -n ${solutionName}`, { cwd: testsDirectory });
+      await executeCommand(ext.outputChannel, testsDirectory, `${dotnetBinaryPath} new sln -n ${solutionName}`);
       ext.outputChannel.appendLog(`Solution file created: ${solutionFile}`);
     }
 
     // Compute the relative path from the tests directory to the Logic App .csproj.
     const relativeProjectPath = path.relative(testsDirectory, logicAppCsprojPath);
     ext.outputChannel.appendLog(`Adding project '${relativeProjectPath}' to solution '${solutionFile}'...`);
-    await execAsync(`dotnet sln "${solutionFile}" add "${relativeProjectPath}"`, { cwd: testsDirectory });
+    await executeCommand(ext.outputChannel, testsDirectory, `${dotnetBinaryPath} sln "${solutionFile}" add "${relativeProjectPath}"`);
     ext.outputChannel.appendLog('Project added to solution successfully.');
   } catch (err) {
     ext.outputChannel.appendLog(`Error updating solution: ${err}`);

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestBlankClassFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestBlankClassFile
@@ -77,7 +77,7 @@ namespace <%= LogicAppName %>.Tests
             var triggerMock = new <%= TriggerMockClassName %>(outputs: triggerMockOutput);
 
             // Generate mock action data.
-            // OPTION 1 : defining a callback class
+            // OPTION 1 : defining a callback function
             var actionMock = new <%= ActionMockClassName %>(name: "<%= ActionMockName %>", onGetActionMock: <%= ActionMockClassName %>OutputCallback);
             // OPTION 2: defining inline using a lambda
             /*var actionMock = new <%= ActionMockClassName %>(name: "<%= ActionMockName %>", onGetActionMock: (testExecutionContext) =>

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFile
@@ -40,7 +40,7 @@ namespace <%= LogicAppName %>.Tests
             // Generate mock action and trigger data.
             var mockData = this.GetTestMockDefinition();
             var sampleActionMock = mockData.ActionMocks["<%= ActionMockName %>"];
-            sampleActionMock.Outputs["your-property-name"] = "your-property-value";
+            // sampleActionMock.Outputs["your-property-name"] = "your-property-value";
 
             // ACT
             // Create an instance of UnitTestExecutor, and run the workflow with the mock data.
@@ -64,7 +64,7 @@ namespace <%= LogicAppName %>.Tests
             // PREPARE
             // Generate mock action and trigger data.
             var mockData = this.GetTestMockDefinition();
-            // OPTION 1 : defining a callback class
+            // OPTION 1 : defining a callback function
             mockData.ActionMocks["<%= ActionMockName %>"] = new <%= ActionMockClassName %>(name: "<%= ActionMockName %>", onGetActionMock: <%= ActionMockClassName %>OutputCallback);
             // OPTION 2: defining inline using a lambda
             mockData.ActionMocks["<%= ActionMockName %>"] = new <%= ActionMockClassName %>(name: "<%= ActionMockName %>", onGetActionMock: (testExecutionContext) =>

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFileWithoutActions
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFileWithoutActions
@@ -58,7 +58,7 @@ namespace <%= LogicAppName %>.Tests
         /// This method shows how to set up mock data, execute the workflow, and assert the outcome.
         /// </summary>
         [TestMethod]
-        public async Task <%= WorkflowName %>_<%= UnitTestName %>_ExecuteWorkflow_FAILED_Sample3()
+        public async Task <%= WorkflowName %>_<%= UnitTestName %>_ExecuteWorkflow_FAILED_Sample2()
         {
             // PREPARE
             // Generate mock action and trigger data.

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFileWithoutActions
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestClassFileWithoutActions
@@ -39,7 +39,7 @@ namespace <%= LogicAppName %>.Tests
             // PREPARE Mock
             // Generate mock action and trigger data.
             var mockData = this.GetTestMockDefinition();
-            mockData.TriggerMock.Outputs["your-property-name"] = "your-property-value";
+            // mockData.TriggerMock.Outputs["your-property-name"] = "your-property-value";
 
             // ACT
             // Create an instance of UnitTestExecutor, and run the workflow with the mock data.

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -35,6 +35,7 @@ export const schemasDirectory = 'Schemas';
 // Folder names
 export const designTimeDirectoryName = 'workflow-designtime';
 export const testsDirectoryName = 'Tests';
+export const testMockOutputsDirectory = 'MockOutputs';
 export const testResultsDirectoryName = '.testResults';
 export const vscodeFolderName = '.vscode';
 


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

- The Tests folder is not always at the end of the workspace (e.g. when new projects are added)
- Partial creation of unit tests from invalid workflows is possible
- Workflows missing trigger do not fail gracefully on create unit test
- Using user's local dotnet installation to run some commands

## New Behavior

- Update create new project behavior to always push Tests folder to end of workspace
- Move all ensure directory and create file statements to end of create test functions to avoid partial test creation
- Add error handling for workflows missing trigger
- Use extension dotnet binaries for commands

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

Updated relevant unit tests for test authoring

## Screenshots or Videos (if applicable)

N/A
