### PR TITLE
fix(vscode): Remove user-facing commands for automated testing

### DIFF
--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -45,7 +45,6 @@ import { startLogicApp } from './startLogicApp';
 import { stopLogicApp } from './stopLogicApp';
 import { swapSlot } from './swapSlot';
 import { viewProperties } from './viewProperties';
-import type { IAzureConnectorsContext } from './workflows/azureConnectorWizard';
 import { configureWebhookRedirectEndpoint } from './workflows/configureWebhookRedirectEndpoint/configureWebhookRedirectEndpoint';
 import { enableAzureConnectors } from './workflows/enableAzureConnectors';
 import { exportLogicApp } from './workflows/exportLogicApp';
@@ -55,10 +54,6 @@ import { openOverview } from './workflows/openOverview';
 import { reviewValidation } from './workflows/reviewValidation';
 import { switchDebugMode } from './workflows/switchDebugMode/switchDebugMode';
 import { switchToDotnetProject } from './workflows/switchToDotnetProject';
-import { createUnitTest } from './workflows/unitTest/createUnitTest';
-import { editUnitTest } from './workflows/unitTest/editUnitTest';
-import { openUnitTestResults } from './workflows/unitTest/openUnitTestResults';
-import { runUnitTest } from './workflows/unitTest/runUnitTest';
 import { useSQLStorage } from './workflows/useSQLStorage';
 import { viewContent } from './workflows/viewContent';
 import { AppSettingsTreeItem, AppSettingTreeItem, registerSiteCommand } from '@microsoft/vscode-azext-azureappservice';
@@ -145,11 +140,4 @@ export function registerCommands(): void {
   // Data Mapper Commands
   registerCommand(extensionCommand.createNewDataMap, (context: IActionContext) => createNewDataMapCmd(context));
   registerCommand(extensionCommand.loadDataMapFile, (context: IActionContext, uri: Uri) => loadDataMapFileCmd(context, uri));
-  // Unit Test Commands
-  registerCommandWithTreeNodeUnwrapping(extensionCommand.createUnitTest, async (context: IAzureConnectorsContext, node: Uri | undefined) =>
-    createUnitTest(context, node)
-  );
-  registerCommandWithTreeNodeUnwrapping(extensionCommand.editUnitTest, editUnitTest);
-  registerCommandWithTreeNodeUnwrapping(extensionCommand.openUnitTestResults, openUnitTestResults);
-  registerCommandWithTreeNodeUnwrapping(extensionCommand.runUnitTest, runUnitTest);
 }

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -180,9 +180,6 @@ export const extensionCommand = {
   dataMapSaveMapXslt: 'azureLogicAppsStandard.dataMap.saveMapXslt',
   createUnitTest: 'azureLogicAppsStandard.createUnitTest',
   saveBlankUnitTest: 'azureLogicAppsStandard.saveBlankUnitTest',
-  editUnitTest: 'azureLogicAppsStandard.editUnitTest',
-  openUnitTestResults: 'azureLogicAppsStandard.openUnitTestResults',
-  runUnitTest: 'azureLogicAppsStandard.runUnitTest',
   vscodeOpenFolder: 'vscode.openFolder',
 } as const;
 export type extensionCommand = (typeof extensionCommand)[keyof typeof extensionCommand];

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -342,33 +342,6 @@
         "when": "resourceExtname in azureLogicAppsStandard.dataMap.setSupportedDataMapDefinitionFileExts"
       },
       {
-        "command": "azureLogicAppsStandard.createUnitTest",
-        "title": "Create unit test",
-        "category": "Azure Logic Apps"
-      },
-      {
-        "command": "azureLogicAppsStandard.openUnitTestResults",
-        "title": "View unit test results",
-        "category": "Azure Logic Apps",
-        "icon": "$(tasklist)"
-      },
-      {
-        "command": "azureLogicAppsStandard.saveBlankUnitTest",
-        "title": "Create blank unit test",
-        "category": "Azure Logic Apps"
-      },
-      {
-        "command": "azureLogicAppsStandard.editUnitTest",
-        "title": "Edit unit test",
-        "category": "Azure Logic Apps",
-        "icon": "$(edit)"
-      },
-      {
-        "command": "azureLogicAppsStandard.runUnitTest",
-        "title": "Run unit test",
-        "category": "Azure Logic Apps"
-      },
-      {
         "command": "azureLogicAppsStandard.parameterizeConnections",
         "title": "Parameterize connections",
         "category": "Azure Logic Apps",
@@ -730,31 +703,6 @@
           "command": "azureLogicAppsStandard.dataMap.loadDataMapFile",
           "group": "navigation",
           "when": "resourceExtname in azureLogicAppsStandard.dataMap.setSupportedDataMapDefinitionFileExts"
-        },
-        {
-          "command": "azureLogicAppsStandard.createUnitTest",
-          "when": "false",
-          "group": "navigation@4"
-        },
-        {
-          "command": "azureLogicAppsStandard.saveBlankUnitTest",
-          "when": "false",
-          "group": "navigation@4"
-        },
-        {
-          "command": "azureLogicAppsStandard.openUnitTestResults",
-          "when": "false",
-          "group": "navigation@5"
-        },
-        {
-          "command": "azureLogicAppsStandard.editUnitTest",
-          "when": "false",
-          "group": "navigation@4"
-        },
-        {
-          "command": "azureLogicAppsStandard.runUnitTest",
-          "when": "false",
-          "group": "navigation@4"
         }
       ],
       "commandPalette": [
@@ -793,26 +741,6 @@
         {
           "command": "azureLogicAppsStandard.createNewProject",
           "when": "never"
-        }
-      ],
-      "testing/item/context": [
-        {
-          "command": "azureLogicAppsStandard.editUnitTest",
-          "group": "inline@3",
-          "when": "false"
-        },
-        {
-          "command": "azureLogicAppsStandard.openUnitTestResults",
-          "group": "inline@4",
-          "when": "false"
-        },
-        {
-          "command": "azureLogicAppsStandard.editUnitTest",
-          "when": "false"
-        },
-        {
-          "command": "azureLogicAppsStandard.openUnitTestResults",
-          "when": "false"
         }
       ]
     },


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

- User-facing commands for run unit test, create unit test, edit unit test, open test results which fail due to not having the logic app context

## New Behavior

- Remove commands

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

No changed behavior

## Screenshots or Videos (if applicable)

N/A
