### PR TITLE
fix(vscode): prompt appearing when empty workspace opened

### DIFF
--- a/apps/vs-code-designer/src/app/commands/__test__/parameterizeConnections.test.ts
+++ b/apps/vs-code-designer/src/app/commands/__test__/parameterizeConnections.test.ts
@@ -98,7 +98,7 @@ describe('parameterizeConnections', () => {
   it('should parameterize connections for all logic apps in the workspace when no project path is provided', async () => {
     const paramSpy = vi.spyOn(parameterizerUtil, 'areAllConnectionsParameterized').mockReturnValue(false);
     await parameterizeConnections(testContext);
-    expect(workspaceUtil.getWorkspaceLogicAppFolders).toHaveBeenCalledWith(testContext);
+    expect(workspaceUtil.getWorkspaceLogicAppFolders).toHaveBeenCalled();
     expect(connectionUtil.getConnectionsJson).toHaveBeenCalledTimes(2);
     expect(connectionUtil.getConnectionsJson).toHaveBeenCalledWith(testLogicAppProjectPath1);
     expect(connectionUtil.getConnectionsJson).toHaveBeenCalledWith(testLogicAppProjectPath2);

--- a/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
+++ b/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
@@ -97,7 +97,7 @@ export async function validateAndInstallBinaries(context: IActionContext) {
             'https://dotnet.microsoft.com/en-us/download/dotnet',
             dotnetDependencies
           );
-          await setDotNetCommand(context);
+          await setDotNetCommand();
         });
         ext.outputChannel.appendLog(
           localize(

--- a/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -49,7 +49,7 @@ export async function validateFuncCoreToolsIsLatestBinaries(majorVersion?: strin
         context.telemetry.properties.outOfDateFunc = 'true';
         stopAllDesignTimeApis();
         await installFuncCoreToolsBinaries(context, majorVersion);
-        await startAllDesignTimeApis(context);
+        await startAllDesignTimeApis();
       }
     } else {
       await installFuncCoreToolsBinaries(context, majorVersion);

--- a/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
+++ b/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
@@ -42,7 +42,7 @@ export async function promptParameterizeConnections(context: IActionContext): Pr
     }
 
     if (shouldParameterizeConnections) {
-      const projectPaths = await getWorkspaceLogicAppFolders(context);
+      const projectPaths = await getWorkspaceLogicAppFolders();
       await Promise.all(projectPaths.map((projectPath) => parameterizeConnections(context, projectPath)));
     }
   }
@@ -57,7 +57,7 @@ export async function promptParameterizeConnections(context: IActionContext): Pr
 export async function parameterizeConnections(context: IActionContext, projectPath?: string): Promise<void> {
   if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
     if (!projectPath) {
-      const workspaceLogicAppFolders = await getWorkspaceLogicAppFolders(context);
+      const workspaceLogicAppFolders = await getWorkspaceLogicAppFolders();
       await Promise.all(workspaceLogicAppFolders.map((projectPath) => parameterizeConnections(context, projectPath)));
       return;
     }

--- a/apps/vs-code-designer/src/app/utils/__test__/workspace.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/workspace.test.ts
@@ -200,7 +200,6 @@ describe('workspaceUtils.getWorkspaceFolder', () => {
   });
 
   describe('workspaceUtils.getWorkspaceLogicAppFolders', () => {
-    const mockContext: any = {};
     const testLogicAppProjectPath1 = path.join('test', 'project', 'LogicApp1');
     const testLogicAppProjectPath2 = path.join('test', 'project', 'LogicApp2');
     const testWorkspaceFolders = [
@@ -216,14 +215,21 @@ describe('workspaceUtils.getWorkspaceFolder', () => {
       vi.restoreAllMocks();
     });
 
-    it('should prompt to open project if no workspace folders are open', async () => {
+    it('should return an empty array if no workspace folders are open', async () => {
       (vscode.workspace as any).workspaceFolders = [];
-      const promptOpenProjectOrWorkspaceSpy = vi.fn((context, promptMessage) => {});
-      (promptOpenProjectOrWorkspace as Mock).mockImplementation(promptOpenProjectOrWorkspaceSpy);
+      const tryGetAllLogicAppProjectRootsSpy = vi.fn(async (folder: vscode.WorkspaceFolder) => {
+        if (folder.uri.fsPath === testLogicAppProjectPath1) {
+          return [folder];
+        } else if (folder.uri.fsPath === testLogicAppProjectPath2) {
+          return ['root2a', 'root2b'];
+        }
+        return [];
+      });
 
-      await workspaceUtils.getWorkspaceLogicAppFolders(mockContext, 'Custom warning message');
+      const result = await workspaceUtils.getWorkspaceLogicAppFolders();
 
-      expect(promptOpenProjectOrWorkspaceSpy).toHaveBeenCalledWith(mockContext, 'Custom warning message');
+      expect(tryGetAllLogicAppProjectRootsSpy).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
     });
 
     it('should collect logic app roots from each workspace folder', async () => {
@@ -237,7 +243,7 @@ describe('workspaceUtils.getWorkspaceFolder', () => {
       });
       (tryGetAllLogicAppProjectRoots as Mock).mockImplementation(tryGetAllLogicAppProjectRootsSpy);
 
-      const result = await workspaceUtils.getWorkspaceLogicAppFolders(mockContext);
+      const result = await workspaceUtils.getWorkspaceLogicAppFolders();
 
       expect(tryGetAllLogicAppProjectRootsSpy).toHaveBeenCalledTimes(2);
       expect(result).toEqual([testLogicAppProjectPath1, 'root2a', 'root2b']);
@@ -249,7 +255,7 @@ describe('workspaceUtils.getWorkspaceFolder', () => {
       });
       (tryGetAllLogicAppProjectRoots as Mock).mockImplementation(tryGetAllLogicAppProjectRootsSpy);
 
-      const result = await workspaceUtils.getWorkspaceLogicAppFolders(mockContext);
+      const result = await workspaceUtils.getWorkspaceLogicAppFolders();
 
       expect(tryGetAllLogicAppProjectRootsSpy).toHaveBeenCalledTimes(2);
       expect(result).toEqual([]);

--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -305,12 +305,11 @@ export function stopDesignTimeApi(projectPath: string): void {
 
 /**
  * Starts the design-time API for all Logic Apps in the workspace.
- * @param {IActionContext} context - The action context.
  * @returns {Promise<void>} A promise that resolves when each design-time API is in the starting state.
  */
-export async function startAllDesignTimeApis(context: IActionContext): Promise<void> {
+export async function startAllDesignTimeApis(): Promise<void> {
   if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-    const logicAppFolders = await getWorkspaceLogicAppFolders(context);
+    const logicAppFolders = await getWorkspaceLogicAppFolders();
     await Promise.all(logicAppFolders.map(startDesignTimeApi));
   }
 }
@@ -322,7 +321,7 @@ export async function startAllDesignTimeApis(context: IActionContext): Promise<v
  */
 export async function promptStartDesignTimeOption(context: IActionContext) {
   if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-    const logicAppFolders = await getWorkspaceLogicAppFolders(context);
+    const logicAppFolders = await getWorkspaceLogicAppFolders();
     const showStartDesignTimeMessage = !!getWorkspaceSetting<boolean>(showStartDesignTimeMessageSetting);
     let autoStartDesignTime = !!getWorkspaceSetting<boolean>(autoStartDesignTimeSetting);
 

--- a/apps/vs-code-designer/src/app/utils/dotnet/dotnet.ts
+++ b/apps/vs-code-designer/src/app/utils/dotnet/dotnet.ts
@@ -224,7 +224,7 @@ export function getDotNetCommand(): string {
   return command;
 }
 
-export async function setDotNetCommand(context: IActionContext): Promise<void> {
+export async function setDotNetCommand(): Promise<void> {
   const binariesLocation = getGlobalSetting<string>(autoRuntimeDependenciesPathSettingKey);
   const dotNetBinariesPath = path.join(binariesLocation, dotnetDependencyName);
   const binariesExist = fs.existsSync(dotNetBinariesPath);
@@ -239,7 +239,7 @@ export async function setDotNetCommand(context: IActionContext): Promise<void> {
     fs.chmodSync(dotNetBinariesPath, 0o777);
 
     try {
-      const workspaceLogicAppFolders = await getWorkspaceLogicAppFolders(context);
+      const workspaceLogicAppFolders = await getWorkspaceLogicAppFolders();
       for (const projectPath of workspaceLogicAppFolders) {
         const pathEnv = {
           PATH: newPath,

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -130,15 +130,11 @@ export const getWorkspacePath = (workflowFilePath: string): string => {
 
 /**
  * Gets the logic app roots from all workspace folders.
- * @param {IActionContext} context - Command context.
- * @param {string} message - The message to display to the user.
  * @returns {Promise<(vscode.WorkspaceFolder | string)[]>} Returns an array of logic app roots.
  */
-export async function getWorkspaceLogicAppFolders(context: IActionContext, message?: string): Promise<string[]> {
-  const promptMessage: string = message ?? localize('noWorkspaceWarning', 'You must have a workspace open to perform this action.');
-
+export async function getWorkspaceLogicAppFolders(): Promise<string[]> {
   if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-    await promptOpenProjectOrWorkspace(context, promptMessage);
+    return [];
   }
 
   const logicAppRoots: (vscode.WorkspaceFolder | string)[] = [];

--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestBlankClassFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestBlankClassFile
@@ -46,7 +46,7 @@ namespace <%= LogicAppName %>.Tests
 
             // ACT
             // Create an instance of UnitTestExecutor, and run the workflow with the mock data.
-           var testMock = new TestMockDefinition(
+            var testMock = new TestMockDefinition(
                 triggerMock: triggerMock,
                 actionMocks: new Dictionary<string, ActionMock>()
                 {


### PR DESCRIPTION

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

- When the user opens an empty workspace a prompt appears "You must have a workspace open to perform this action."

## New Behavior

- Avoid unintended prompt by removing prompt from getWorkspaceLogicAppFolders and returning empty array if workspace is empty

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

N/A

## Screenshots or Videos (if applicable)

N/A
