### PR TITLE
feat(designer): Add "maximumTokenCountReduction" as default in agent settings

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -116,6 +116,7 @@ export default {
                 agentHistoryReductionType: {
                   type: 'string',
                   title: 'Agent history reduction type',
+                  default: 'maximumTokenCountReduction',
                   description: 'Type of agent history reduction to use',
                   'x-ms-editor': 'dropdown',
                   'x-ms-editor-options': {


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [X] Feature
* [ ] Other

This pull request introduces a default value for the `agentHistoryReductionType` property in the `manifest/agentloop.ts` file. The change ensures that the property defaults to `'maximumTokenCountReduction'` if no value is provided.

* **Default value added to `agentHistoryReductionType`:**
  - A default value of `'maximumTokenCountReduction'` was added to the `agentHistoryReductionType` property in the `manifest/agentloop.ts` file to ensure consistent behavior.

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

![CleanShot 2025-04-25 at 16 10 17@2x](https://github.com/user-attachments/assets/d5361785-27e7-49b7-986e-6d7ec11499ba)

