### PR TITLE
fix(designer): Reset id replacements when reset designer dirty state 

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -524,6 +524,7 @@ const DesignerEditor = () => {
                   }}
                   switchViews={handleSwitchView}
                   saveWorkflowFromCode={saveWorkflowFromCode}
+                  setWorkflow={setWorkflow}
                 />
                 {designerView ? <Designer /> : <CodeViewEditor ref={codeEditorRef} workflowKind={workflow?.kind} />}
                 <CombineInitializeVariableDialog />

--- a/libs/designer/src/lib/core/state/global.ts
+++ b/libs/designer/src/lib/core/state/global.ts
@@ -1,6 +1,6 @@
 import { resetCustomCode } from './customcode/customcodeSlice';
 import { useIsWorkflowDirty } from './workflow/workflowSelectors';
-import { setIsWorkflowDirty } from './workflow/workflowSlice';
+import { resetIdReplacements, setIsWorkflowDirty } from './workflow/workflowSlice';
 import { setIsWorkflowParametersDirty } from './workflowparameters/workflowparametersSlice';
 import { useIsWorkflowParametersDirty } from './workflowparameters/workflowparametersselector';
 import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
@@ -22,4 +22,5 @@ export const resetDesignerDirtyState = createAsyncThunk('resetDesignerDirtyState
   dispatch(setIsWorkflowDirty(false));
   dispatch(setIsWorkflowParametersDirty(false));
   dispatch(resetCustomCode());
+  dispatch(resetIdReplacements());
 });

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -671,6 +671,10 @@ export const workflowSlice = createSlice({
       }
       state.hostData.errorMessages[action.payload.level] = action.payload.errorMessages;
     },
+    // on save we want to remove all id replacements
+    resetIdReplacements: (state) => {
+      state.idReplacements = {};
+    },
   },
   extraReducers: (builder) => {
     // Add reducers for additional action types here, and handle loading state as needed
@@ -770,6 +774,7 @@ export const {
   updateAgenticMetadata,
   setFocusElement,
   clearFocusElement,
+  resetIdReplacements,
 } = workflowSlice.actions;
 
 export default workflowSlice.reducer;


### PR DESCRIPTION
Cherry-pick of the following PR:
- https://github.com/Azure/LogicAppsUX/pull/7105
