### PR TITLE
feat(vscode): New debug config provider for logic app project with custom code

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateNewProjectInternal.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateNewProjectInternal.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../constants';
 import { localize } from '../../../../localize';
 import { createArtifactsFolder } from '../../../utils/codeless/artifacts';
-import { getCustomCodeFunctionsProjects } from '../../../utils/customCodeUtils';
+import { getAllCustomCodeFunctionsProjects } from '../../../utils/customCodeUtils';
 import { addLocalFuncTelemetry, tryGetLocalFuncVersion, tryParseFuncVersion } from '../../../utils/funcCoreTools/funcVersion';
 import { getGlobalSetting, getWorkspaceSetting } from '../../../utils/vsCodeConfig/settings';
 import { FolderListStep } from '../../createNewProject/createProjectSteps/FolderListStep';
@@ -85,7 +85,7 @@ export async function createNewProjectInternalBase(
   await wizard.execute();
 
   if (wizardContext.isWorkspaceWithFunctions) {
-    commands.executeCommand('setContext', extensionCommand.customCodeSetFunctionsFolders, await getCustomCodeFunctionsProjects(context));
+    commands.executeCommand('setContext', extensionCommand.customCodeSetFunctionsFolders, await getAllCustomCodeFunctionsProjects(context));
   }
 
   window.showInformationMessage(localize('finishedCreating', 'Finished creating project.'));

--- a/apps/vs-code-designer/src/app/commands/debugLogicApp.ts
+++ b/apps/vs-code-designer/src/app/commands/debugLogicApp.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { pickFuncProcessInternal } from './pickFuncProcess';
+import { localize } from '../../localize';
+import { tryGetLogicAppProjectRoot } from '../utils/verifyIsProject';
+import { pickCustomCodeNetHostProcessInternal } from './pickCustomCodeNetHostProcess';
+
+export async function debugLogicApp(
+  context: IActionContext,
+  debugConfig: vscode.DebugConfiguration,
+  workspaceFolder: vscode.WorkspaceFolder | undefined
+): Promise<void> {
+  const projectPath: string | undefined = await tryGetLogicAppProjectRoot(context, workspaceFolder);
+  if (!projectPath) {
+    const errorMessage = 'Failed to find a logic app project in the workspace folder "{0}".';
+    context.telemetry.properties.result = 'Failed';
+    context.telemetry.properties.error = errorMessage.replace('{0}', workspaceFolder?.uri?.fsPath);
+    throw new Error(localize('noLogicAppProject', errorMessage, workspaceFolder?.uri?.fsPath));
+  }
+  const logicAppName = path.basename(projectPath);
+
+  const funcProcessId = await pickFuncProcessInternal(context, debugConfig, workspaceFolder, projectPath);
+  const logicAppLaunchConfig = {
+    name: localize('attachToNetFunc', `Debug logic app ${logicAppName}`),
+    type: debugConfig.funcRuntime,
+    request: 'attach',
+    processId: funcProcessId,
+  };
+  await vscode.debug.startDebugging(workspaceFolder, logicAppLaunchConfig);
+
+  if (debugConfig.customCodeRuntime) {
+    let functionLaunchConfig: vscode.DebugConfiguration;
+    if (debugConfig.customCodeRuntime === 'coreclr') {
+      const customCodeNetHostProcessId = await pickCustomCodeNetHostProcessInternal(context, workspaceFolder, projectPath);
+      functionLaunchConfig = {
+        name: localize('attachToCustomCodeFunc', 'Debug local function'),
+        type: debugConfig.customCodeRuntime,
+        request: 'attach',
+        processId: customCodeNetHostProcessId,
+      };
+    } else if (debugConfig.customCodeRuntime === 'clr') {
+      functionLaunchConfig = {
+        name: localize('attachToFunc', 'Debug local function'),
+        type: debugConfig.customCodeRuntime,
+        request: 'attach',
+        processName: 'Microsoft.Azure.Workflows.Functions.CustomCodeNetFxWorker.exe',
+      };
+    } else {
+      const errorMessage = 'Unsupported custom code runtime "{0}".';
+      context.telemetry.properties.result = 'Failed';
+      context.telemetry.properties.error = errorMessage.replace('{0}', debugConfig.customCodeRuntime);
+      throw new Error(localize('unsupportedCustomCodeRuntime', errorMessage, debugConfig.customCodeRuntime));
+    }
+
+    await vscode.debug.startDebugging(workspaceFolder, functionLaunchConfig);
+    context.telemetry.properties.result = 'Succeeded';
+  }
+}

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -64,6 +64,7 @@ import { registerCommand, registerCommandWithTreeNodeUnwrapping, unwrapTreeNodeC
 import type { AzExtTreeItem, IActionContext, AzExtParentTreeItem } from '@microsoft/vscode-azext-utils';
 import type { Uri } from 'vscode';
 import { pickCustomCodeNetHostProcess } from './pickCustomCodeNetHostProcess';
+import { debugLogicApp } from './debugLogicApp';
 
 export function registerCommands(): void {
   registerCommandWithTreeNodeUnwrapping(extensionCommand.openDesigner, openDesigner);
@@ -147,4 +148,5 @@ export function registerCommands(): void {
   // Custom code commands
   registerCommandWithTreeNodeUnwrapping(extensionCommand.buildCustomCodeFunctionsProject, buildCustomCodeFunctionsProject);
   registerCommand(extensionCommand.createCustomCodeFunction, createCustomCodeFunctionFromCommand);
+  registerCommand(extensionCommand.debugLogicApp, debugLogicApp);
 }

--- a/apps/vs-code-designer/src/app/utils/__test__/customCodeUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/customCodeUtils.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   CustomCodeFunctionsProjectMetadata,
   getCustomCodeFunctionsProjectMetadata,
-  getCustomCodeFunctionsProjects,
+  getAllCustomCodeFunctionsProjects,
   isCustomCodeFunctionsProject,
   isCustomCodeFunctionsProjectInRoot,
   tryGetCustomCodeFunctionsProjects,
@@ -131,7 +131,7 @@ describe('customCodeUtils', () => {
     vi.restoreAllMocks();
   });
 
-  describe('getCustomCodeFunctionsProjects', () => {
+  describe('getAllCustomCodeFunctionsProjects', () => {
     const testContext: any = {};
     const testWorkspaceRoot = path.join('test', 'workspace');
 
@@ -142,7 +142,7 @@ describe('customCodeUtils', () => {
 
     it('should return an empty array if workspace root is undefined', async () => {
       vi.spyOn(workspaceUtils, 'getWorkspaceRoot').mockResolvedValue(undefined);
-      const result = await getCustomCodeFunctionsProjects(testContext);
+      const result = await getAllCustomCodeFunctionsProjects(testContext);
       expect(result).toEqual([]);
     });
 
@@ -169,7 +169,7 @@ describe('customCodeUtils', () => {
         return '';
       });
 
-      const result = await getCustomCodeFunctionsProjects(testContext);
+      const result = await getAllCustomCodeFunctionsProjects(testContext);
       expect(result).toEqual([path.join(testWorkspaceRoot, 'proj1'), path.join(testWorkspaceRoot, 'proj2')]);
     });
 
@@ -193,7 +193,7 @@ describe('customCodeUtils', () => {
         return '';
       });
 
-      const result = await getCustomCodeFunctionsProjects(testContext);
+      const result = await getAllCustomCodeFunctionsProjects(testContext);
       expect(result).toEqual([]);
     });
   });

--- a/apps/vs-code-designer/src/app/utils/azurite/activateAzurite.ts
+++ b/apps/vs-code-designer/src/app/utils/azurite/activateAzurite.ts
@@ -27,10 +27,12 @@ import type { MessageItem } from 'vscode';
  * Overrides default Azurite location to new default location.
  * User can specify location.
  */
-export async function activateAzurite(context: IActionContext): Promise<void> {
+export async function activateAzurite(context: IActionContext, projectPath?: string): Promise<void> {
   if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-    const workspaceFolder = await getWorkspaceFolder(context, undefined, true);
-    const projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
+    if (!projectPath) {
+      const workspaceFolder = await getWorkspaceFolder(context, undefined, true);
+      projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder);
+    }
 
     if (projectPath) {
       const globalAzuriteLocationSetting: string = getWorkspaceSetting<string>(azuriteLocationSetting, projectPath, azuriteExtensionPrefix);

--- a/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
+++ b/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
@@ -17,7 +17,7 @@ export interface CustomCodeFunctionsProjectMetadata {
   namespace: string;
 }
 
-export async function getCustomCodeFunctionsProjects(context: IActionContext): Promise<string[]> {
+export async function getAllCustomCodeFunctionsProjects(context: IActionContext): Promise<string[]> {
   const workspaceRoot: string | undefined = await getWorkspaceRoot(context);
 
   if (isNullOrUndefined(workspaceRoot)) {

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -185,6 +185,7 @@ export const extensionCommand = {
   createUnitTest: 'azureLogicAppsStandard.createUnitTest',
   saveBlankUnitTest: 'azureLogicAppsStandard.saveBlankUnitTest',
   vscodeOpenFolder: 'vscode.openFolder',
+  debugLogicApp: 'azureLogicAppsStandard.debugLogicApp',
 } as const;
 export type extensionCommand = (typeof extensionCommand)[keyof typeof extensionCommand];
 

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -994,6 +994,30 @@
           }
         }
       }
+    ],
+    "debuggers": [
+      {
+        "type": "logicapp",
+        "label": "Debug Logic App",
+        "configurationAttributes": {
+          "launch": {
+            "required": ["funcRuntime"],
+            "properties": {
+              "funcRuntime": {
+                "type": "string",
+                "description": "The runtime to use for the Azure Functions host process.",
+                "enum": ["coreclr", "clr"],
+                "default": "coreclr"
+              },
+              "customCodeRuntime": {
+                "type": "string",
+                "description": "The runtime to use for the .NET custom code host process.",
+                "enum": ["coreclr", "clr"]
+              }
+            }
+          }
+        }
+      }
     ]
   },
   "extensionDependencies": [


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior

- Logic app projects with custom code require starting two separate debuggers for the logic app and local custom code function

## New Behavior

- Add new 'logicapp' debug configuration provider which has 'funcRuntime' and 'customCodeRuntime' properties and starts two debuggers for logic app and custom code function simultaneously

## Impact of Change

* [ ] **This is a breaking change.**

## Test Plan

TODO

