### PR TITLE
fix(desinger): Move Hybrid Api versions to a single location in Libraries

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector.tsx
@@ -11,7 +11,7 @@ import axios from 'axios';
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';
-import { HybridAppUtility } from '../Utilities/HybridAppUtilities';
+import { HybridAppUtility, hybridApiVersion } from '../Utilities/HybridAppUtilities';
 
 const columnProps: Partial<IStackProps> = {
   tokens: { childrenGap: 15 },
@@ -41,7 +41,7 @@ export const AzureStandardLogicAppSelector = () => {
 
     const getWorkflowUrl =
       hostingPlan === 'hybrid'
-        ? `https://management.azure.com${HybridAppUtility.getHybridAppBaseRelativeUrl(appId)}/workflows?api-version=2024-02-02-preview`
+        ? `https://management.azure.com${HybridAppUtility.getHybridAppBaseRelativeUrl(appId)}/workflows?api-version=${hybridApiVersion}`
         : `https://management.azure.com${appId}/workflows?api-version=2018-11-01`;
 
     const results = await axios.get<WorkflowList>(getWorkflowUrl, {

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/WorkflowAndArtifacts.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/WorkflowAndArtifacts.tsx
@@ -12,13 +12,12 @@ import { useQuery } from '@tanstack/react-query';
 import { isSuccessResponse } from './HttpClient';
 import { fetchFileData, fetchFilesFromFolder } from './vfsService';
 import type { CustomCodeFileNameMapping } from '@microsoft/logic-apps-designer';
-import { HybridAppUtility } from '../Utilities/HybridAppUtilities';
+import { HybridAppUtility, hybridApiVersion } from '../Utilities/HybridAppUtilities';
 import type { HostingPlanTypes } from '../../../state/workflowLoadingSlice';
 import { ArmParser } from '../Utilities/ArmParser';
 
 const baseUrl = 'https://management.azure.com';
 const standardApiVersion = '2020-06-01';
-const hybridApiVersion = '2024-02-02-preview';
 const consumptionApiVersion = '2019-05-01';
 
 export const useConnectionsData = (appId?: string) => {
@@ -330,7 +329,7 @@ export const useAppSettings = (siteResourceId: string) => {
 export const getAppSettings = async (siteResourceId: string) => {
   if (HybridAppUtility.isHybridLogicApp(siteResourceId)) {
     const containerAppInfo = (
-      await axios.get(`${baseUrl}${siteResourceId}?api-version=2024-02-02-preview`, {
+      await axios.get(`${baseUrl}${siteResourceId}?api-version=${hybridApiVersion}`, {
         headers: {
           Authorization: `Bearer ${environment.armToken}`,
         },

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Utilities/HybridAppUtilities.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Utilities/HybridAppUtilities.ts
@@ -15,7 +15,7 @@ export class HybridAppUtility {
     appName.pop();
 
     return (
-      await axios.post<T>(`${baseUri}providers/Microsoft.App/logicapps/${appName.pop()}/invoke?api-version=2024-02-02-preview`, data, {
+      await axios.post<T>(`${baseUri}providers/Microsoft.App/logicapps/${appName.pop()}/invoke?api-version=${hybridApiVersion}`, data, {
         headers: {
           ...headers,
           'x-ms-logicapps-proxy-path': `${path}`,
@@ -30,7 +30,7 @@ export class HybridAppUtility {
     const splitUri = uri.split('/hostruntime/');
     const appName = splitUri[0].split('/').pop();
     return (
-      await axios.post<T>(`${splitUri[0]}/providers/Microsoft.App/logicapps/${appName}/invoke?api-version=2024-02-02-preview`, data, {
+      await axios.post<T>(`${splitUri[0]}/providers/Microsoft.App/logicapps/${appName}/invoke?api-version=${hybridApiVersion}`, data, {
         headers: {
           ...headers,
           'x-ms-logicapps-proxy-path': `/${splitUri[1]}`,
@@ -45,7 +45,7 @@ export class HybridAppUtility {
     const [baseUri, path] = uri.split('/hostruntime/');
     const appName = baseUri.split('/').pop();
 
-    return await axios.post<T>(`${baseUri}/providers/Microsoft.App/logicapps/${appName}/invoke?api-version=2024-02-02-preview`, data, {
+    return await axios.post<T>(`${baseUri}/providers/Microsoft.App/logicapps/${appName}/invoke?api-version=${hybridApiVersion}`, data, {
       headers: {
         ...headers,
         'x-ms-logicapps-proxy-path': `${path}/`,
@@ -59,3 +59,5 @@ export class HybridAppUtility {
     return uri.toLowerCase().includes('microsoft.app');
   }
 }
+
+export const hybridApiVersion = '2024-02-02-preview';

--- a/apps/vs-code-designer/src/app/commands/deploy/hybridLogicApp/cleanResources.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/hybridLogicApp/cleanResources.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { localize } from '../../../../localize';
 import { executeCommand } from '../../../utils/funcCoreTools/cpUtils';
-import { azurePublicBaseUrl, Platform } from '../../../../constants';
+import { azurePublicBaseUrl, Platform, hybridAppApiVersion } from '../../../../constants';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { isSuccessResponse } from '@microsoft/vscode-extension-logic-apps';
@@ -11,7 +11,7 @@ import { isSuccessResponse } from '@microsoft/vscode-extension-logic-apps';
  * @returns A Promise that resolves when the hybrid app is created.
  */
 export const cleanSMB = async (connectedEnvironmentId: string, storageName: string, accessToken: string): Promise<void> => {
-  const url = `${azurePublicBaseUrl}/${connectedEnvironmentId}/storages/${storageName}?api-version=2024-02-02-preview`;
+  const url = `${azurePublicBaseUrl}/${connectedEnvironmentId}/storages/${storageName}?api-version=${hybridAppApiVersion}`;
   try {
     const response = await axios.delete(url, {
       headers: { authorization: accessToken },

--- a/apps/vs-code-designer/src/app/commands/deploy/hybridLogicApp/index.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/hybridLogicApp/index.ts
@@ -10,7 +10,7 @@ import { updateSMBConnectedEnvironment } from '../../../utils/codeless/hybridLog
 import path from 'path';
 import { getAuthorizationToken } from '../../../utils/codeless/getAuthorizationToken';
 import { getWorkspaceSetting } from '../../../utils/vsCodeConfig/settings';
-import { azurePublicBaseUrl, driveLetterSMBSetting } from '../../../../constants';
+import { azurePublicBaseUrl, driveLetterSMBSetting, hybridAppApiVersion } from '../../../../constants';
 import axios from 'axios';
 import { isSuccessResponse } from '@microsoft/vscode-extension-logic-apps';
 
@@ -112,7 +112,7 @@ const getSMBDetails = async (context: IActionContext, node: SlotTreeItem) => {
 const getStorageInfoForConnectedEnv = async (connectedEnvId: string, storageName: string, context: IActionContext, node: SlotTreeItem) => {
   const accessToken = await getAuthorizationToken();
 
-  const url = `${azurePublicBaseUrl}/${connectedEnvId}/storages/${storageName}?api-version=2024-02-02-preview`;
+  const url = `${azurePublicBaseUrl}/${connectedEnvId}/storages/${storageName}?api-version=${hybridAppApiVersion}`;
 
   try {
     const response = await axios.get(url, { headers: { authorization: accessToken } });

--- a/apps/vs-code-designer/src/app/utils/codeless/hybridLogicApp/connectedEnvironment.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/hybridLogicApp/connectedEnvironment.ts
@@ -1,7 +1,7 @@
 import { type FileShare, isSuccessResponse } from '@microsoft/vscode-extension-logic-apps';
 import axios from 'axios';
 import { localize } from '../../../../localize';
-import { azurePublicBaseUrl } from '../../../../constants';
+import { azurePublicBaseUrl, hybridAppApiVersion } from '../../../../constants';
 
 export const updateSMBConnectedEnvironment = async (
   accessToken: string,
@@ -10,7 +10,7 @@ export const updateSMBConnectedEnvironment = async (
   siteName: string,
   fileShare: FileShare
 ) => {
-  const url = `${azurePublicBaseUrl}/${connectedEnvironmentId}/storages/${siteName}?api-version=2024-02-02-preview`;
+  const url = `${azurePublicBaseUrl}/${connectedEnvironmentId}/storages/${siteName}?api-version=${hybridAppApiVersion}`;
   let domain: string = null;
   let username: string = null;
   if (fileShare.userName.includes('\\')) {

--- a/apps/vs-code-designer/src/app/utils/codeless/hybridLogicApp/hybridApp.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/hybridLogicApp/hybridApp.ts
@@ -7,6 +7,7 @@ import {
   appKindSetting,
   azurePublicBaseUrl,
   extensionVersionKey,
+  hybridAppApiVersion,
   localSettingsFileName,
   logicAppKind,
   sqlConnectionStringSecretName,
@@ -140,7 +141,7 @@ export const createOrUpdateHybridApp = async (context: IActionContext, accessTok
         },
       };
 
-  const url = `${azurePublicBaseUrl}/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${siteName}?api-version=2024-02-02-preview`;
+  const url = `${azurePublicBaseUrl}/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${siteName}?api-version=${hybridAppApiVersion}`;
 
   try {
     const method = hybridApp ? HTTP_METHODS.PATCH : HTTP_METHODS.PUT;
@@ -171,7 +172,7 @@ export const createOrUpdateHybridApp = async (context: IActionContext, accessTok
  * @throws An error if there is an issue in getting the connection.
  */
 export const createLogicAppExtension = async (context: ILogicAppWizardContext, accessToken: string) => {
-  const url = `${azurePublicBaseUrl}/subscriptions/${context.subscriptionId}/resourceGroups/${context.resourceGroup.name}/providers/Microsoft.App/containerApps/${context.newSiteName}/providers/Microsoft.App/logicApps/${context.newSiteName}?api-version=2024-02-02-preview`;
+  const url = `${azurePublicBaseUrl}/subscriptions/${context.subscriptionId}/resourceGroups/${context.resourceGroup.name}/providers/Microsoft.App/containerApps/${context.newSiteName}/providers/Microsoft.App/logicApps/${context.newSiteName}?api-version=${hybridAppApiVersion}`;
 
   try {
     const response = await axios.put(

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -73,6 +73,7 @@ export const workflowSubscriptionIdKey = 'WORKFLOWS_SUBSCRIPTION_ID';
 export const workflowTenantIdKey = 'WORKFLOWS_TENANT_ID';
 export const workflowManagementBaseURIKey = 'WORKFLOWS_MANAGEMENT_BASE_URI';
 export const workflowAppApiVersion = '2018-11-01';
+export const hybridAppApiVersion = '2024-02-02-preview';
 export const azureWebJobsStorageKey = 'AzureWebJobsStorage';
 export const azureWebJobsSecretStorageTypeKey = 'AzureWebJobsSecretStorageType';
 export const workflowappRuntime = 'node|18';

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
@@ -25,7 +25,7 @@ import { LoggerService } from '../logger';
 import { LogEntryLevel, Status } from '../logging/logEntry';
 import type { IOAuthPopup } from '../oAuth';
 import { OAuthService } from '../oAuth';
-import { getHybridAppBaseRelativeUrl, isHybridLogicApp } from './hybrid';
+import { getHybridAppBaseRelativeUrl, hybridApiVersion, isHybridLogicApp } from './hybrid';
 import { validateRequiredServiceArguments } from '../../../utils/src/lib/helpers/functions';
 import agentloopConnector from '../standard/manifest/agentLoopConnector';
 
@@ -164,7 +164,7 @@ export class StandardConnectionService extends BaseConnectionService implements 
       let response = null;
       if (isHybridLogicApp(baseUrl)) {
         response = await httpClient.post<any, null>({
-          uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=2024-02-02-preview`,
+          uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=${hybridApiVersion}`,
           headers: {
             'x-ms-logicapps-proxy-path': `/runtime/webhooks/workflow/api/management/operationGroups/${connectorId.split('/').at(-1)}/`,
             'x-ms-logicapps-proxy-method': 'GET',
@@ -611,7 +611,7 @@ export class StandardConnectionService extends BaseConnectionService implements 
 
       if (isHybridLogicApp(uri)) {
         const [baseUri, proxyPath] = uri.split('/hostruntime');
-        uri = `${getHybridAppBaseRelativeUrl(baseUri)}/invoke?api-version=2024-02-02-preview`;
+        uri = `${getHybridAppBaseRelativeUrl(baseUri)}/invoke?api-version=${hybridApiVersion}`;
         queryParameters = {};
         headers = {
           'x-ms-logicapps-proxy-path': proxyPath || '',

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connector.ts
@@ -5,7 +5,7 @@ import type { BaseConnectorServiceOptions } from '../base';
 import { BaseConnectorService } from '../base';
 import type { ListDynamicValue, ManagedIdentityRequestProperties, TreeDynamicExtension, TreeDynamicValue } from '../connector';
 import { pathCombine } from '../helpers';
-import { getHybridAppBaseRelativeUrl, isHybridLogicApp } from './hybrid';
+import { getHybridAppBaseRelativeUrl, hybridApiVersion, isHybridLogicApp } from './hybrid';
 
 type GetConfigurationFunction = (connectionId: string) => Promise<Record<string, any>>;
 
@@ -70,7 +70,7 @@ export class StandardConnectorService extends BaseConnectorService {
     let response = null;
     if (isHybridLogicApp(uri)) {
       response = await httpClient.post({
-        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=2024-02-02-preview`,
+        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=${hybridApiVersion}`,
         headers: {
           'x-ms-logicapps-proxy-path': `/runtime/webhooks/workflow/api/management/operationGroups/${connectorId
             .split('/')
@@ -123,7 +123,7 @@ export class StandardConnectorService extends BaseConnectorService {
     let response = null;
     if (isHybridLogicApp(uri)) {
       response = await httpClient.post({
-        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=2024-02-02-preview`,
+        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=${hybridApiVersion}`,
         headers: {
           'x-ms-logicapps-proxy-path': `/runtime/webhooks/workflow/api/management/operationGroups/${connectorId
             .split('/')

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/hybrid.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/hybrid.ts
@@ -14,3 +14,5 @@ export const getHybridAppBaseRelativeUrl = (appId: string | undefined): string =
 
   return `${appId}/providers/Microsoft.App/logicApps/${appId.split('/').pop()}`;
 };
+
+export const hybridApiVersion = '2024-02-02-preview';

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/operationmanifest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/operationmanifest.ts
@@ -3,7 +3,7 @@ import { ConnectionType, equals } from '../../../utils/src';
 import { BaseOperationManifestService } from '../base';
 import type { BaseOperationManifestServiceOptions } from '../base/operationmanifest';
 import { getBuiltInOperationInfo, isBuiltInOperation, supportedBaseManifestObjects } from '../base/operationmanifest';
-import { getHybridAppBaseRelativeUrl, isHybridLogicApp } from './hybrid';
+import { getHybridAppBaseRelativeUrl, hybridApiVersion, isHybridLogicApp } from './hybrid';
 import { getClientBuiltInConnectors } from '../base/search';
 
 export interface StandardOperationManifestServiceOptions extends BaseOperationManifestServiceOptions {
@@ -71,7 +71,7 @@ export class StandardOperationManifestService extends BaseOperationManifestServi
     let response = null;
     if (isHybridLogicApp(baseUrl)) {
       response = await httpClient.post<any, null>({
-        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=2024-02-02-preview`,
+        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=${hybridApiVersion}`,
         headers: {
           'x-ms-logicapps-proxy-path': `/runtime/webhooks/workflow/api/management/operationGroups/${connectorName}/operations/${operationName}?$expand=properties/manifest`,
           'x-ms-logicapps-proxy-method': 'GET',
@@ -116,7 +116,7 @@ export class StandardOperationManifestService extends BaseOperationManifestServi
       let response = null;
       if (isHybridLogicApp(baseUrl)) {
         response = await httpClient.post<any, null>({
-          uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=2024-02-02-preview`,
+          uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=${hybridApiVersion}`,
           headers: {
             'x-ms-logicapps-proxy-path': `/runtime/webhooks/workflow/api/management/operationGroups/${connectorName}/operations/${operationName}?$expand=properties/manifest`,
             'x-ms-logicapps-proxy-method': 'GET',

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
@@ -12,7 +12,7 @@ import {
   isNullOrUndefined,
   validateRequiredServiceArguments,
 } from '../../../utils/src';
-import { isHybridLogicApp } from './hybrid';
+import { hybridApiVersion, isHybridLogicApp } from './hybrid';
 import { LogEntryLevel } from '../logging/logEntry';
 import { LoggerService } from '../logger';
 
@@ -101,7 +101,7 @@ export class StandardRunService implements IRunService {
     const appName = baseUri.split('/');
     appName.pop();
     return {
-      uri: `${baseUri}/providers/Microsoft.App/logicapps/${appName.pop()}/invoke?api-version=2024-02-02-preview`,
+      uri: `${baseUri}/providers/Microsoft.App/logicapps/${appName.pop()}/invoke?api-version=${hybridApiVersion}`,
       headerPath: path,
     };
   }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/search.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/search.ts
@@ -12,7 +12,7 @@ import type { AzureOperationsFetchResponse, BaseSearchServiceOptions } from '../
 import { getClientBuiltInOperations, getClientBuiltInConnectors } from '../base/search';
 import type { ContinuationTokenResponse } from '../common/azure';
 import type { QueryParameters } from '../httpClient';
-import { getHybridAppBaseRelativeUrl, isHybridLogicApp } from './hybrid';
+import { getHybridAppBaseRelativeUrl, hybridApiVersion, isHybridLogicApp } from './hybrid';
 import * as ClientOperationsData from '../base/operations';
 
 const ISE_RESOURCE_ID = 'properties/integrationServiceEnvironmentResourceId';
@@ -59,7 +59,7 @@ export class StandardSearchService extends BaseSearchService {
     let response = null;
     if (isHybridLogicApp(uri)) {
       response = await httpClient.post<AzureOperationsFetchResponse, null>({
-        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=2024-02-02-preview`,
+        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=${hybridApiVersion}`,
         headers: {
           'x-ms-logicapps-proxy-path': `/runtime/webhooks/workflow/api/management/operations/?workflowKind=${
             showStatefulOperations ? 'Stateful' : 'Stateless'
@@ -154,7 +154,7 @@ export class StandardSearchService extends BaseSearchService {
     let response = null;
     if (isHybridLogicApp(uri)) {
       response = await httpClient.post<{ value: Connector[] }, null>({
-        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=2024-02-02-preview`,
+        uri: `${getHybridAppBaseRelativeUrl(baseUrl.split('hostruntime')[0])}/invoke?api-version=${hybridApiVersion}`,
         headers: {
           'x-ms-logicapps-proxy-path': '/runtime/webhooks/workflow/api/management/operationGroups/',
           'x-ms-logicapps-proxy-method': 'GET',


### PR DESCRIPTION
The backend version will be updating the hybrid api versions soon, so this prevents us from having to update the version in every place that uses it