### PR TITLE
fix(Templates): Refactored `filteredTemplateNames` out of state / into selector 

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/templates.ts
@@ -29,12 +29,7 @@ import { initializeParametersMetadata } from '../../templates/utils/parametershe
 import { initializeNodeOperationInputsData } from '../../state/operation/operationMetadataSlice';
 import { updateAllTemplateParameterDefinitions } from '../../state/templates/templateSlice';
 import { checkWorkflowNameWithRegex, getCurrentWorkflowNames } from '../../templates/utils/helper';
-import {
-  loadGithubManifestNames,
-  setavailableTemplates,
-  setavailableTemplatesNames,
-  setFilteredTemplateNames,
-} from '../../state/templates/manifestSlice';
+import { loadGithubManifestNames, setavailableTemplates, setavailableTemplatesNames } from '../../state/templates/manifestSlice';
 import { clearConnectionCaches } from '../../queries/connections';
 
 export interface WorkflowTemplateData {
@@ -179,7 +174,6 @@ export const reloadTemplates = createAsyncThunk('reloadTemplates', async ({ clea
   if (clear) {
     dispatch(setavailableTemplatesNames(undefined));
     dispatch(setavailableTemplates(undefined));
-    dispatch(setFilteredTemplateNames(undefined));
   }
 
   dispatch(loadGithubManifestNames());

--- a/libs/designer/src/lib/core/state/templates/manifestSlice.ts
+++ b/libs/designer/src/lib/core/state/templates/manifestSlice.ts
@@ -11,7 +11,6 @@ const initialPageNum = 0;
 
 export interface ManifestState {
   availableTemplateNames?: ManifestName[];
-  filteredTemplateNames?: ManifestName[];
   githubTemplateNames?: ManifestName[];
   availableTemplates?: Record<ManifestName, Template.TemplateManifest>;
   filters: {
@@ -68,9 +67,6 @@ export const manifestSlice = createSlice({
     },
     setavailableTemplates: (state, action: PayloadAction<Record<ManifestName, Template.TemplateManifest> | undefined>) => {
       state.availableTemplates = action.payload;
-    },
-    setFilteredTemplateNames: (state, action: PayloadAction<ManifestName[] | undefined>) => {
-      state.filteredTemplateNames = action.payload;
     },
     setPageNum: (state, action: PayloadAction<number>) => {
       state.filters.pageNum = action.payload;
@@ -134,7 +130,6 @@ export const manifestSlice = createSlice({
 export const {
   setavailableTemplatesNames,
   setavailableTemplates,
-  setFilteredTemplateNames,
   setPageNum,
   setKeywordFilter,
   setSortKey,

--- a/libs/designer/src/lib/core/state/templates/templateselectors.ts
+++ b/libs/designer/src/lib/core/state/templates/templateselectors.ts
@@ -3,6 +3,7 @@ import type { RootState } from './store';
 import type { WorkflowTemplateData } from '../../actions/bjsworkflow/templates';
 import type { ConnectionReference } from '../../../common/models/workflow';
 import type { Template } from '@microsoft/logic-apps-shared';
+import { getFilteredTemplates } from '../../templates/utils/helper';
 
 export const useTemplateWorkflows = () => {
   return useSelector((state: RootState) => state.template.workflows ?? {});
@@ -42,4 +43,16 @@ export const useTemplateConnections = (): Record<string, Template.Connection> =>
 
 export const useTemplateParameterDefinitions = (): Record<string, Template.ParameterDefinition> => {
   return useSelector((state: RootState) => state.template?.parameterDefinitions);
+};
+
+export const useFilteredTemplateNames = () => {
+  return useSelector((state: RootState) => {
+    const isConsumption = state.workflow.isConsumption;
+    const availableTemplates = state.manifest.availableTemplates;
+    const filters = state.manifest.filters;
+    if (!availableTemplates) {
+      return undefined;
+    }
+    return getFilteredTemplates(availableTemplates, filters, !!isConsumption);
+  });
 };

--- a/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
+++ b/libs/designer/src/lib/core/templates/TemplatesDataProvider.tsx
@@ -6,13 +6,11 @@ import type { AppDispatch, RootState } from '../state/templates/store';
 import {
   loadGithubManifestNames,
   loadGithubManifests,
-  setFilteredTemplateNames,
   templatesCountPerPage,
   lazyLoadGithubManifests,
 } from '../state/templates/manifestSlice';
 import { type ResourceDetails, setInitialData } from '../state/templates/workflowSlice';
 import type { ConnectionReferences } from '../../common/models/workflow';
-import { getFilteredTemplates } from './utils/helper';
 import { initializeTemplateServices, initializeWorkflowMetadata, reloadTemplates } from '../actions/bjsworkflow/templates';
 import { InitTemplateService, type Template } from '@microsoft/logic-apps-shared';
 import { setEnableResourceSelection, setViewTemplateDetails } from '../state/templates/templateOptionsSlice';
@@ -32,12 +30,10 @@ export interface TemplatesDataProviderProps {
   onResourceChange?: () => void;
 }
 
-const DataProviderInner = ({ isConsumption, children, reload, services }: TemplatesDataProviderProps) => {
+const DataProviderInner = ({ children, reload, services }: TemplatesDataProviderProps) => {
   const dispatch = useDispatch<AppDispatch>();
-  const { githubTemplateNames, availableTemplates, filters, servicesInitialized } = useSelector((state: RootState) => ({
+  const { githubTemplateNames, servicesInitialized } = useSelector((state: RootState) => ({
     githubTemplateNames: state.manifest.githubTemplateNames,
-    availableTemplates: state.manifest.availableTemplates,
-    filters: state.manifest.filters,
     servicesInitialized: state.templateOptions.servicesInitialized,
   }));
 
@@ -63,15 +59,6 @@ const DataProviderInner = ({ isConsumption, children, reload, services }: Templa
       }
     }
   }, [dispatch, githubTemplateNames]);
-
-  useEffect(() => {
-    if (!availableTemplates) {
-      dispatch(setFilteredTemplateNames(undefined));
-      return;
-    }
-    const filteredTemplateNames = getFilteredTemplates(availableTemplates, filters, !!isConsumption);
-    dispatch(setFilteredTemplateNames(filteredTemplateNames));
-  }, [dispatch, availableTemplates, filters, isConsumption]);
 
   return <>{children}</>;
 };

--- a/libs/designer/src/lib/ui/templates/gallery/templatesgallery.tsx
+++ b/libs/designer/src/lib/ui/templates/gallery/templatesgallery.tsx
@@ -6,6 +6,7 @@ import { setPageNum, templatesCountPerPage } from '../../../core/state/templates
 import { Text } from '@fluentui/react-components';
 import { useIntl } from 'react-intl';
 import { css } from '@fluentui/utilities';
+import { useFilteredTemplateNames } from '../../../core/state/templates/templateselectors';
 
 interface TemplatesGalleryProps {
   isLightweight?: boolean;
@@ -24,8 +25,8 @@ export const TemplatesGallery = ({
 }: TemplatesGalleryProps) => {
   const {
     filters: { pageNum },
-    filteredTemplateNames,
   } = useSelector((state: RootState) => state.manifest);
+  const filteredTemplateNames = useFilteredTemplateNames();
   const intl = useIntl();
   const dispatch = useDispatch<AppDispatch>();
   const intlText = {


### PR DESCRIPTION
## Main Changes

Moved `filteredTemplateNames` out of Redux state.
This was being calculated in a useEffect based off of other state values, and sometimes was hitting a race condition causing bugs.
Since we calculate it only using state values, I just moved it to a useSelector hook so that it will always be up to date.