### PR TITLE
fix(designer): Browse Action Spotlight to Local Storage

### DIFF
--- a/libs/designer-ui/src/lib/panel/recommendationpanel/recommendation.less
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/recommendation.less
@@ -176,9 +176,10 @@
 .msla-recommendation-panel-spotlight-section-header {
   display: flex;
   align-items: center;
-  .msla-recommendation-panel-spotlight-section-header-button {
-    & button {
-      padding: 0;
-    }
+}
+
+.msla-recommendation-panel-spotlight-section-header-button {
+  & button {
+    padding: 0;
   }
 }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -197,9 +197,10 @@ export default {
     outputs: {
       type: 'object',
       properties: {
-        messages: {
+        lastAssistantMessage: {
           type: 'object',
-          title: 'Messages',
+          title: 'Last Assitant Message',
+          description: 'This is the final message returned by the model',
         },
       },
     },

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/localStorage.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/localStorage.ts
@@ -5,4 +5,5 @@ export const LOCAL_STORAGE_KEYS = {
   MIXED_INPUT_TOGGLE: 'msla-mixedInputEditor-toggle',
   COMBINE_INITIALIZE_VARIABLES: 'msla-combine-initialize-variables',
   IGNORE_EMPTY_TRIGGER_DESCRIPTION: 'msla-ignore-empty-trigger-description',
+  ACTION_SPOTLIGHT_OPEN_ITEMS: 'msla-action-spotlight-open-items',
 };


### PR DESCRIPTION
1. Persist user saving Browse Action Spotlight expand/collapse in Local Storage
2. lastAssistantMessage output in Agent Loop