### PR TITLE
docs(verdaccio): Add registry config for verdaccio development

### DIFF
--- a/apps/docs/docs/Development/portal.mdx
+++ b/apps/docs/docs/Development/portal.mdx
@@ -97,6 +97,16 @@ This can also be done on the .npmrc of the repo levels if preferred.
 npm set registry http://localhost:4873/
 ```
 
+For Logic Apps Portal repo, you can also set the following at the top of the file in `.../Client/React/.npmrc` (this complements the command above)
+
+```bash 
+# This will resolve the @microsoft packages for to the private registry
+@microsoft:registry=http://localhost:4873/
+//localhost:4873/:_authToken="PUT_YOUR_TOKEN_HERE"
+
+# Leave the rest of the file content below. This will resolve the rest of packages to the global registry
+```
+
 :::note
 
 1-4 are one time setup steps. You can now publish packages to verdaccio and install them from there.
@@ -108,5 +118,6 @@ from the LAUX repo root:
 pnpm turbo run publish:local
 ```
 
-6. Install the package from verdaccio
+6. Install the package from verdaccio 
+
 Just go to the target app and update the versions of the package.json to the current versions published to verdaccio. Then run npm install noramlly.


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [ ] Feature
* [X] Other

This pull request updates the documentation for setting up and using a private npm registry with Verdaccio in the Logic Apps Portal repository. The changes clarify configuration steps and improve instructions for package installation.

### Documentation Updates for Private Registry Setup:

* Added instructions for configuring an `.npmrc` file in the `Client/React` directory to resolve `@microsoft` packages to the private registry while maintaining global registry settings for other packages.

* Clarified the process for installing packages from Verdaccio by updating the `package.json` versions and running `npm install`.

## Impact of Change



Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
