### PR TITLE
fix(Templates): Fixed query issue in Templates

### DIFF
--- a/libs/designer/src/lib/core/templates/utils/queries.ts
+++ b/libs/designer/src/lib/core/templates/utils/queries.ts
@@ -18,7 +18,7 @@ export const useConnectorInfo = (
   enabled = true
 ): UseQueryResult<ConnectorInfo | undefined, unknown> => {
   return useQuery(
-    ['apiInfo', { connectorId }],
+    ['templateQueries', 'apiInfo', { connectorId }],
     async () => {
       if (!connectorId) {
         return null;
@@ -55,7 +55,7 @@ export const useConnectorInfo = (
 
 export const useSubscriptions = (): UseQueryResult<Resource[], unknown> => {
   return useQuery(
-    ['subscriptions'],
+    ['templateQueries', 'subscriptions'],
     async () => {
       return ResourceService().listSubscriptions();
     },
@@ -70,7 +70,7 @@ export const useSubscriptions = (): UseQueryResult<Resource[], unknown> => {
 
 export const useResourceGroups = (subscriptionId: string): UseQueryResult<Resource[], unknown> => {
   return useQuery(
-    ['resourcegroups', subscriptionId],
+    ['templateQueries', 'resourcegroups', subscriptionId],
     async () => {
       return ResourceService().listResourceGroups(subscriptionId);
     },
@@ -86,7 +86,7 @@ export const useResourceGroups = (subscriptionId: string): UseQueryResult<Resour
 
 export const useLocations = (subscriptionId: string): UseQueryResult<Resource[], unknown> => {
   return useQuery(
-    ['locations', subscriptionId],
+    ['templateQueries', 'locations', subscriptionId],
     async () => {
       return ResourceService().listLocations(subscriptionId);
     },
@@ -106,7 +106,7 @@ export const useLogicApps = (
   enabled: boolean
 ): UseQueryResult<LogicAppResource[], unknown> => {
   return useQuery(
-    ['logicapps', subscriptionId, resourceGroup],
+    ['templateQueries', 'logicapps', subscriptionId, resourceGroup],
     async () => {
       return ResourceService().listLogicApps(subscriptionId, resourceGroup);
     },
@@ -122,7 +122,10 @@ export const useLogicApps = (
 
 export const getCustomTemplates = async (subscriptionId: string, resourceGroup: string) => {
   const queryClient = getReactQueryClient();
-  return queryClient.fetchQuery(['customtemplates', subscriptionId.toLowerCase(), resourceGroup.toLowerCase()], async () => {
-    return (await TemplateService()?.getCustomTemplates?.(subscriptionId, resourceGroup)) ?? [];
-  });
+  return queryClient.fetchQuery(
+    ['templateQueries', 'customtemplates', subscriptionId.toLowerCase(), resourceGroup.toLowerCase()],
+    async () => {
+      return (await TemplateService()?.getCustomTemplates?.(subscriptionId, resourceGroup)) ?? [];
+    }
+  );
 };

--- a/libs/designer/src/lib/ui/templates/review/ResourceDisplay.tsx
+++ b/libs/designer/src/lib/ui/templates/review/ResourceDisplay.tsx
@@ -1,10 +1,10 @@
 import { mergeClasses, Text } from '@fluentui/react-components';
 import { Spinner, SpinnerSize } from '@fluentui/react';
-import { useSubscriptions } from '../../../core/state/connection/connectionSelector';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useTemplatesStrings } from '../templatesStrings';
 import type { RootState } from '../../../core/state/templates/store';
+import { useSubscriptions } from '../../../core/templates/utils/queries';
 
 export type ResourceDisplayProps = {
   invertBolds?: boolean;


### PR DESCRIPTION
## Main Changes

Fixed the `useSubscriptions` import in the `ResourceDisplay` component.
Added an extra query key to template queries to prevent overlap with other queries.

Cherry-pick of https://github.com/Azure/LogicAppsUX/pull/7192