### PR TITLE
fix(designer): Fixed issue with \ in Dictionary editor serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ __azurite_db_queue_extent__.json
 
 # ARM Token
 **/armToken.json
+**/subscriptionIds.json
 
 # Generated Docusaurus files
 .docusaurus/

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureConsumptionLogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureConsumptionLogicAppSelector.tsx
@@ -22,7 +22,7 @@ const resourceIdValidation =
   /^\/subscriptions\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/resourceGroups\/[a-zA-Z0-9](?:[a-zA-Z0-9-_]*[a-zA-Z0-9])?\/providers\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_./]+$/;
 
 export const AzureConsumptionLogicAppSelector = () => {
-  const { data: appList, isLoading: isAppsLoading } = useFetchConsumptionApps();
+  const { data: appList, isLoading: isAppsLoading } = useFetchConsumptionApps(environment.subscriptionIds);
   const dispatch = useDispatch<AppDispatch>();
 
   const appId = useAppId();

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector.tsx
@@ -28,7 +28,7 @@ export const AzureStandardLogicAppSelector = () => {
   const runId = useRunId();
   const isMonitoringView = useIsMonitoringView();
   const hostingPlan = useHostingPlan();
-  const standardList = useFetchStandardApps();
+  const standardList = useFetchStandardApps(environment.subscriptionIds);
   const hybridList = useFetchHybridApps();
   const { data: appList, isLoading: isAppsLoading } = hostingPlan === 'hybrid' ? hybridList : standardList;
   const validApp = appId ? resourceIdValidation.test(appId) : false;

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Queries/FetchConsumptionApps.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Queries/FetchConsumptionApps.ts
@@ -1,18 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
 import { environment } from '../../../../environments/environment';
 import type { Data as FetchLogicAppsData } from '../Models/LogicAppAppTypes';
 import { fetchAppsByQuery } from '../Utilities/resourceUtilities';
-import { useQuery } from '@tanstack/react-query';
 
-export const useFetchConsumptionApps = () => {
+const buildQuery = (subscriptionId?: string) => {
+  const baseQuery = `
+    resources
+    | where ${subscriptionId ? `subscriptionId == '${subscriptionId}' and` : ''}
+      (type =~ 'microsoft.logic/workflows' or (type =~ 'microsoft.web/sites' and kind contains 'workflowapp'))
+    | extend plan = case(kind contains 'workflowapp', 'Standard', 'Consumption')
+    | where plan =~ 'consumption'
+  `;
+  return baseQuery;
+};
+
+export const useFetchConsumptionApps = (subscriptionIds?: string[]) => {
   return useQuery<FetchLogicAppsData[]>(
-    ['listAllLogicApps', 'consumption'],
+    ['listAllLogicApps', 'consumption', subscriptionIds ?? 'all'],
     async () => {
       if (!environment.armToken) {
         return [];
       }
-      const query = `resources | where type =~ 'microsoft.logic/workflows' or (type =~ 'microsoft.web/sites' and kind contains 'workflowapp') | extend plan = case(kind contains 'workflowapp', 'Standard', 'Consumption') | where (plan =~ ('consumption'))`;
-      const data = await fetchAppsByQuery(query);
-      return data.map((item: any) => ({
+
+      const queries = subscriptionIds?.length
+        ? subscriptionIds.map((id) => fetchAppsByQuery(buildQuery(id)))
+        : [fetchAppsByQuery(buildQuery())];
+
+      const results = await Promise.all(queries);
+
+      return results.flat().map((item: any) => ({
         id: item[0],
         name: item[1],
         location: item[5],
@@ -22,6 +38,7 @@ export const useFetchConsumptionApps = () => {
       }));
     },
     {
+      enabled: !!environment.armToken,
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Queries/FetchStandardApps.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Queries/FetchStandardApps.ts
@@ -1,18 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
 import { environment } from '../../../../environments/environment';
 import type { Data as FetchLogicAppsData } from '../Models/LogicAppAppTypes';
 import { fetchAppsByQuery } from '../Utilities/resourceUtilities';
-import { useQuery } from '@tanstack/react-query';
 
-export const useFetchStandardApps = () => {
+const buildStandardQuery = (subscriptionId?: string) => `
+  resources
+  | where ${subscriptionId ? `subscriptionId == '${subscriptionId}' and` : ''}
+    type == 'microsoft.web/sites' and kind contains 'workflowapp'
+  | extend plan = 'Standard'
+`;
+
+export const useFetchStandardApps = (subscriptionIds?: string[]) => {
   return useQuery<FetchLogicAppsData[]>(
-    ['listAllLogicApps', 'standard'],
+    ['listAllLogicApps', 'standard', subscriptionIds ?? 'all'],
     async () => {
       if (!environment.armToken) {
         return [];
       }
-      const query = `resources | where type == "microsoft.web/sites" and kind contains "workflowapp"`;
-      const data = await fetchAppsByQuery(query);
-      return data.map((item: any) => ({
+
+      const queries = subscriptionIds?.length
+        ? subscriptionIds.map((id) => fetchAppsByQuery(buildStandardQuery(id)))
+        : [fetchAppsByQuery(buildStandardQuery())];
+
+      const results = await Promise.all(queries);
+
+      return results.flat().map((item: any) => ({
         id: item[0],
         name: item[1],
         location: item[5],
@@ -22,6 +34,7 @@ export const useFetchStandardApps = () => {
       }));
     },
     {
+      enabled: !!environment.armToken,
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,

--- a/apps/Standalone/src/designer/app/DesignerShell/designer.tsx
+++ b/apps/Standalone/src/designer/app/DesignerShell/designer.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { loadToken } from '../../../environments/environment';
+import { loadSubscriptionIds, loadToken } from '../../../environments/environment';
 import { SettingsBox } from '../../components/settings_box';
 import { useHostingPlan, useIsLocal, useQueryCachePersist, useResourcePath } from '../../state/workflowLoadingSelectors';
 import LogicAppsDesignerStandard from '../AzureLogicAppsDesigner/laDesigner';
@@ -10,6 +10,7 @@ import { useQuery } from '@tanstack/react-query';
 
 const LoadWhenArmTokenIsLoaded = ({ children }: { children: ReactNode }) => {
   const { isLoading } = useQuery(['armToken'], loadToken);
+  useQuery(['subcriptionIds'], loadSubscriptionIds);
   return isLoading ? null : <>{children}</>;
 };
 export const DesignerWrapper = () => {

--- a/apps/Standalone/src/environments/environment.ts
+++ b/apps/Standalone/src/environments/environment.ts
@@ -16,6 +16,7 @@ const getAccessToken = async (fileName: string): Promise<string | undefined> => 
 export interface EnvironmentVars {
   production: boolean;
   armToken?: string;
+  subscriptionIds?: string[];
   chatbotEndpoint?: string;
 }
 
@@ -27,4 +28,29 @@ export const loadToken = async () => {
   const token = await getAccessToken('armToken');
   environment.armToken = token;
   return token ?? null;
+};
+
+// place a subscriptionIds.json file in /public
+// with the following format:
+// {
+//   "subscriptionIds": ["subscriptionId1", "subscriptionId2"]
+// }
+
+const getSubscriptionIds = async (): Promise<string[] | undefined> => {
+  try {
+    const res = await fetch('/subscriptionIds.json');
+    if (!res.ok) {
+      throw new Error('File not found');
+    }
+    const subData = await res.json();
+    return subData?.subscriptionIds;
+  } catch (_e) {
+    return undefined;
+  }
+};
+
+export const loadSubscriptionIds = async () => {
+  const subs = await getSubscriptionIds();
+  environment.subscriptionIds = subs;
+  return subs ?? [];
 };

--- a/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
+++ b/libs/designer-ui/src/lib/editor/base/utils/keyvalueitem.ts
@@ -3,7 +3,7 @@ import { isEmpty } from '../../../dictionary/expandeddictionary';
 import type { ValueSegment } from '../../models/parameter';
 import { containsTokenSegments, createLiteralValueSegment, insertQutationForStringType } from './helper';
 import { convertSegmentsToString } from './parsesegments';
-import { escapeString } from '@microsoft/logic-apps-shared';
+import { escapeBackslash } from '@microsoft/logic-apps-shared';
 
 export interface KeyValueItem {
   id: string;
@@ -29,7 +29,7 @@ export const convertKeyValueItemToSegments = (items: KeyValueItem[], keyType?: s
     const updatedKey = key.map((segment) => {
       return {
         ...segment,
-        value: convertedKeyType !== constants.SWAGGER.TYPE.STRING ? segment.value : escapeString(segment.value),
+        value: convertedKeyType !== constants.SWAGGER.TYPE.STRING ? segment.value : escapeBackslash(segment.value),
       };
     });
 
@@ -37,7 +37,12 @@ export const convertKeyValueItemToSegments = (items: KeyValueItem[], keyType?: s
     const updatedValue = value.map((segment) => {
       return {
         ...segment,
-        value: convertedValueType !== constants.SWAGGER.TYPE.STRING ? segment.value : escapeString(segment.value),
+        value:
+          convertedValueType !== constants.SWAGGER.TYPE.STRING
+            ? segment.value
+            : typeof segment.value === 'string'
+              ? escapeBackslash(segment.value)
+              : JSON.stringify(segment.value),
       };
     });
 

--- a/libs/designer-ui/src/lib/flyout2/__test__/flyout2.spec.tsx
+++ b/libs/designer-ui/src/lib/flyout2/__test__/flyout2.spec.tsx
@@ -1,7 +1,8 @@
+import React from 'react';
 import type { Flyout2Props } from '../index';
 import { Flyout2 } from '../index';
 import renderer from 'react-test-renderer';
-import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
+import { describe, beforeEach, it, expect } from 'vitest';
 describe('lib/flyout2', () => {
   let minimal: Flyout2Props;
 

--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -389,7 +389,9 @@ export function TokenPicker({
                   setExpression={setExpression}
                   getValueSegmentFromToken={getValueSegmentFromToken}
                   tokenClickedCallback={tokenClickedCallback}
-                  noDynamicContent={!isDynamicContentAvailable(filteredTokenGroup ?? [])}
+                  noDynamicContent={
+                    !isDynamicContentAvailable((selectedMode === TokenPickerMode.TOKEN ? filteredTokenGroup : tokenGroup) ?? [])
+                  }
                   expressionEditorCurrentHeight={expressionEditorCurrentHeight}
                 />
                 {isExpression ? (

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -139,6 +139,10 @@ export const escapeString = (input: string, requireSingleQuotesWrap?: boolean): 
   });
 };
 
+export const escapeBackslash = (s: string): string => {
+  return s.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
+};
+
 /**
  * Converts a string to PascalCase.
  * Assumes the input string has been cleaned of invalid characters.


### PR DESCRIPTION
Fixed an issue where dictionary editor was throwing a validation error when using \, so extending our escape character to all instances of \.

Giving standalone users an optional hidden subscriptionIds.json file, so they developers filter which workflows to load by sub (mostly because if there are a lot of flows, it can take a while to load them all)

Fixed an issue where we would show no dynamic options in the Expression editor even though there were tokens available