### PR TITLE
feat(Templates): Split button for publish for workflow & parameter tabs

### DIFF
--- a/libs/designer-ui/src/lib/templates/templatesPanelFooter.tsx
+++ b/libs/designer-ui/src/lib/templates/templatesPanelFooter.tsx
@@ -55,6 +55,7 @@ export const TemplatesPanelFooter = ({ buttonContents }: TemplatePanelFooterProp
               <Menu key={index} positioning="below-end">
                 <MenuTrigger disableButtonEnhancement>
                   {(triggerProps: MenuButtonProps) => (
+                    // TODO: change back to button, we are not using splitbutton capability
                     <SplitButton
                       style={index < buttonContents.length ? templateFooterItemStyle : {}}
                       menuButton={triggerProps}

--- a/libs/designer-ui/src/lib/templates/templatesPanelFooter.tsx
+++ b/libs/designer-ui/src/lib/templates/templatesPanelFooter.tsx
@@ -60,6 +60,7 @@ export const TemplatesPanelFooter = ({ buttonContents }: TemplatePanelFooterProp
                       menuButton={triggerProps}
                       primaryActionButton={triggerProps}
                       appearance={appreance}
+                      disabled={disabled}
                     >
                       {text}
                     </SplitButton>

--- a/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/configureWorkflowsPanel.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/configureWorkflowsPanel.tsx
@@ -7,13 +7,15 @@ import { useIntl } from 'react-intl';
 import { Panel, PanelType } from '@fluentui/react';
 import { useConfigureWorkflowPanelTabs } from './usePanelTabs';
 import type { WorkflowTemplateData } from '../../../../core';
+import type { Template } from '@microsoft/logic-apps-shared';
 
 export interface ConfigureWorkflowsTabProps {
   hasError?: boolean;
   disabled?: boolean;
   isPrimaryButtonDisabled: boolean;
   isSaving: boolean;
-  onSave?: () => void;
+  onSave?: (status: Template.TemplateEnvironment) => void;
+  status?: Template.TemplateEnvironment;
   selectedWorkflowsList: Record<string, Partial<WorkflowTemplateData>>;
 }
 

--- a/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/tabs/customizeWorkflowsTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/tabs/customizeWorkflowsTab.tsx
@@ -7,9 +7,11 @@ import type { IntlShape } from 'react-intl';
 import type { WorkflowTemplateData } from '../../../../../core';
 import { CustomizeWorkflows } from '../../../workflows/customizeWorkflows';
 import { Spinner } from '@fluentui/react-components';
+import { getSaveMenuButtons } from '../../../../../core/configuretemplate/utils/helper';
 
 export const customizeWorkflowsTab = (
   intl: IntlShape,
+  resources: Record<string, string>,
   dispatch: AppDispatch,
   {
     hasError,
@@ -19,6 +21,7 @@ export const customizeWorkflowsTab = (
     selectedWorkflowsList,
     updateWorkflowDataField,
     onSave,
+    status,
   }: ConfigureWorkflowsTabProps & {
     updateWorkflowDataField: (workflowId: string, workflowData: Partial<WorkflowTemplateData>) => void;
   }
@@ -45,11 +48,10 @@ export const customizeWorkflowsTab = (
             description: 'Button text for saving changes in the configure workflows panel',
           })
         ),
-        onClick: () => {
-          onSave?.();
-        },
+        onClick: () => {},
         appreance: 'primary',
         disabled: isPrimaryButtonDisabled || isSaving,
+        menuItems: getSaveMenuButtons(resources, status ?? 'Development', (newStatus) => onSave?.(newStatus)),
       },
       {
         type: 'button',

--- a/libs/designer/src/lib/ui/configuretemplate/panels/customizeParameterPanel/customizeParameterPanel.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/panels/customizeParameterPanel/customizeParameterPanel.tsx
@@ -8,7 +8,7 @@ import { Panel, PanelType } from '@fluentui/react';
 import { CustomizeParameter } from '../../../configuretemplate/parameters/customizeParameter';
 import { validateParameterDetails } from '../../../../core/state/templates/templateSlice';
 import { useFunctionalState } from '@react-hookz/web';
-import { isUndefinedOrEmptyString, type Template } from '@microsoft/logic-apps-shared';
+import { equals, isUndefinedOrEmptyString, type Template } from '@microsoft/logic-apps-shared';
 import { useParameterDefinition } from '../../../../core/configuretemplate/configuretemplateselectors';
 import { updateWorkflowParameter } from '../../../../core/actions/bjsworkflow/configuretemplate';
 import { getSaveMenuButtons } from '../../../../core/configuretemplate/utils/helper';
@@ -79,20 +79,19 @@ export const CustomizeParameterPanel = () => {
             description: 'Button text for saving changes for parameter in the customize parameter panel',
           }),
           appreance: 'primary',
-          onClick: () => {
-            dispatch(updateWorkflowParameter({ parameterId: parameterId as string, definition: selectedParameterDefinition() }));
-            if (runValidation) {
-              dispatch(validateParameterDetails());
-            }
-          },
+          onClick: () => {},
           disabled: !isDirty || !isUndefinedOrEmptyString(parameterError),
           menuItems: getSaveMenuButtons(resources, currentStatus ?? 'Development', (newStatus) => {
-            // TODO: use this status to perform accordingly
-            console.log('---newStatus :', newStatus);
             if (runValidation) {
               dispatch(validateParameterDetails());
             }
-            dispatch(updateWorkflowParameter({ parameterId: parameterId as string, definition: selectedParameterDefinition() }));
+            dispatch(
+              updateWorkflowParameter({
+                parameterId: parameterId as string,
+                definition: selectedParameterDefinition(),
+                changedStatus: equals(currentStatus, newStatus) ? undefined : newStatus,
+              })
+            );
           }),
         },
         {

--- a/libs/designer/src/lib/ui/configuretemplate/panels/customizeParameterPanel/customizeParameterPanel.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/panels/customizeParameterPanel/customizeParameterPanel.tsx
@@ -8,9 +8,11 @@ import { Panel, PanelType } from '@fluentui/react';
 import { CustomizeParameter } from '../../../configuretemplate/parameters/customizeParameter';
 import { validateParameterDetails } from '../../../../core/state/templates/templateSlice';
 import { useFunctionalState } from '@react-hookz/web';
-import type { Template } from '@microsoft/logic-apps-shared';
+import { isUndefinedOrEmptyString, type Template } from '@microsoft/logic-apps-shared';
 import { useParameterDefinition } from '../../../../core/configuretemplate/configuretemplateselectors';
 import { updateWorkflowParameter } from '../../../../core/actions/bjsworkflow/configuretemplate';
+import { getSaveMenuButtons } from '../../../../core/configuretemplate/utils/helper';
+import { useResourceStrings } from '../../resources';
 
 const layerProps = {
   hostId: 'msla-layer-host',
@@ -20,23 +22,25 @@ const layerProps = {
 export const CustomizeParameterPanel = () => {
   const dispatch = useDispatch<AppDispatch>();
   const intl = useIntl();
-  const { parameterId, runValidation, isOpen, currentPanelView, parameterErrors } = useSelector((state: RootState) => ({
+  const { parameterId, runValidation, isOpen, currentPanelView, parameterErrors, currentStatus } = useSelector((state: RootState) => ({
     parameterId: state.panel.selectedTabId,
     runValidation: state.tab.runValidation,
     isOpen: state.panel.isOpen,
     currentPanelView: state.panel.currentPanelView,
     parameterErrors: state.template.errors.parameters,
+    currentStatus: state.template.status,
   }));
 
   const parameterDefinition = useParameterDefinition(parameterId as string);
 
-  const resources = {
+  const intlText = {
     customizeParamtersTitle: intl.formatMessage({
       defaultMessage: 'Customize parameter',
       id: 'CqN0oM',
       description: 'Panel header title for customizing parameters',
     }),
   };
+  const resources = useResourceStrings();
   const [selectedParameterDefinition, setSelectedParameterDefinition] =
     useFunctionalState<Template.ParameterDefinition>(parameterDefinition);
   const [isDirty, setIsDirty] = useState(false);
@@ -51,16 +55,18 @@ export const CustomizeParameterPanel = () => {
 
   const onRenderHeaderContent = useCallback(
     () => (
-      <TemplatesPanelHeader title={resources.customizeParamtersTitle}>
+      <TemplatesPanelHeader title={intlText.customizeParamtersTitle}>
         <div />
       </TemplatesPanelHeader>
     ),
-    [resources.customizeParamtersTitle]
+    [intlText.customizeParamtersTitle]
   );
 
   const dismissPanel = useCallback(() => {
     dispatch(closePanel());
   }, [dispatch]);
+
+  const parameterError = parameterErrors?.[parameterId as string];
 
   const footerContent: TemplatePanelFooterProps = useMemo(() => {
     return {
@@ -79,7 +85,15 @@ export const CustomizeParameterPanel = () => {
               dispatch(validateParameterDetails());
             }
           },
-          disabled: !isDirty,
+          disabled: !isDirty || !isUndefinedOrEmptyString(parameterError),
+          menuItems: getSaveMenuButtons(resources, currentStatus ?? 'Development', (newStatus) => {
+            // TODO: use this status to perform accordingly
+            console.log('---newStatus :', newStatus);
+            if (runValidation) {
+              dispatch(validateParameterDetails());
+            }
+            dispatch(updateWorkflowParameter({ parameterId: parameterId as string, definition: selectedParameterDefinition() }));
+          }),
         },
         {
           type: 'button',
@@ -94,7 +108,7 @@ export const CustomizeParameterPanel = () => {
         },
       ],
     };
-  }, [dispatch, intl, isDirty, parameterId, runValidation, selectedParameterDefinition]);
+  }, [dispatch, intl, isDirty, parameterId, runValidation, parameterError, currentStatus, resources, selectedParameterDefinition]);
 
   const onRenderFooterContent = useCallback(() => <TemplatesPanelFooter {...footerContent} />, [footerContent]);
 
@@ -113,7 +127,7 @@ export const CustomizeParameterPanel = () => {
       isFooterAtBottom={true}
     >
       <CustomizeParameter
-        parameterError={parameterErrors?.[parameterId as string]}
+        parameterError={parameterError}
         parameterDefinition={selectedParameterDefinition()}
         setParameterDefinition={updateParameterDefinition}
       />

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
@@ -82,7 +82,6 @@ export const useConfigureTemplateWizardTabs = ({
       };
       dispatch(setRunValidation(true));
       const templateId = templateManifest?.id as string;
-      // TODO - error handling, in case of error, onSaveTemplate should be handled accordingly
       await TemplateResourceService().updateTemplate(templateId, manifestToUpdate, newPublishState);
 
       queryClient.removeQueries(['template', templateId.toLowerCase()]);

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/templateresource.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/templateresource.ts
@@ -61,6 +61,23 @@ export class BaseTemplateResourceService implements ITemplateResourceService {
     }
   }
 
+  public async updateState(resourceId: string, state: string) {
+    try {
+      const { baseUrl, apiVersion, httpClient } = this.options;
+      const uri = `${baseUrl}${resourceId}`;
+
+      await httpClient.patch({
+        uri,
+        queryParameters: { 'api-version': apiVersion },
+        content: {
+          properties: { state },
+        },
+      });
+    } catch (error) {
+      throw new Error(error as any);
+    }
+  }
+
   public async updateTemplate(resourceId: string, manifest: Template.TemplateManifest, state?: string) {
     try {
       const { baseUrl, apiVersion, httpClient } = this.options;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/templateresource.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/templateresource.ts
@@ -10,6 +10,7 @@ export interface ITemplateResourceService {
   getTemplate: (id: string) => Promise<ArmResource<any>>;
   getTemplateWorkflows: (id: string) => Promise<ArmResource<any>[]>;
   updateTemplate: (id: string, manifest: Template.TemplateManifest, state?: string) => Promise<void>;
+  updateState: (id: string, state: string) => Promise<void>;
   addWorkflow: (id: string, workflowName: string, data: WorkflowData) => Promise<void>;
   updateWorkflow: (id: string, workflowName: string, manifest: Partial<Template.WorkflowManifest>) => Promise<void>;
   deleteWorkflow: (id: string, workflowName: string) => Promise<void>;


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [X] Feature
* [ ] Other


## Impact of Change
- Using the previously added structure to add split publish buttons for workflows & parameters panels
- for parameter panel, the rollback TODO logic is written

* [ ] **This is a breaking change.**

## Test Plan

## Screenshots or Videos (if applicable)

![image](https://github.com/user-attachments/assets/42620b2b-322a-448a-955d-077b07104bf6)
![image](https://github.com/user-attachments/assets/f7246a2d-cdfb-460a-9719-40a69e469c90)
