### PR TITLE
fix(vscode): Add fallback for function core tools installation

### DIFF
--- a/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -44,8 +44,13 @@ export async function validateFuncCoreToolsIsLatestBinaries(majorVersion?: strin
       const localVersion: string | null = await getLocalFuncCoreToolsVersion();
       context.telemetry.properties.localVersion = localVersion;
       const newestVersion: string | undefined = await getLatestFunctionCoreToolsVersion(context, majorVersion);
+      const isLocalVersionMissing = localVersion === null;
 
-      if (semver.major(newestVersion) === semver.major(localVersion) && semver.gt(newestVersion, localVersion)) {
+      const isLocalVersionOutdated =
+        !isLocalVersionMissing && semver.major(newestVersion) === semver.major(localVersion) && semver.gt(newestVersion, localVersion);
+
+      if (isLocalVersionMissing || isLocalVersionOutdated) {
+        context.telemetry.properties.localVersion = localVersion ?? 'null';
         context.telemetry.properties.outOfDateFunc = 'true';
         stopAllDesignTimeApis();
         await installFuncCoreToolsBinaries(context, majorVersion);

--- a/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -17,7 +17,7 @@ import { installFuncCoreToolsBinaries } from './installFuncCoreTools';
 import { uninstallFuncCoreTools } from './uninstallFuncCoreTools';
 import { updateFuncCoreTools } from './updateFuncCoreTools';
 import { HTTP_METHODS } from '@microsoft/logic-apps-shared';
-import { callWithTelemetryAndErrorHandling, DialogResponses, openUrl, parseError } from '@microsoft/vscode-azext-utils';
+import { callWithTelemetryAndErrorHandling, DialogResponses, parseError } from '@microsoft/vscode-azext-utils';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { FuncVersion } from '@microsoft/vscode-extension-logic-apps';
 import * as semver from 'semver';
@@ -71,10 +71,7 @@ export async function validateFuncCoreToolsIsLatestSystem(): Promise<void> {
     const showMultiCoreToolsWarningKey = 'showMultiCoreToolsWarning';
     const showMultiCoreToolsWarning = !!getWorkspaceSetting<boolean>(showMultiCoreToolsWarningKey);
 
-    const showCoreToolsWarningKey = 'showCoreToolsWarning';
-    const showCoreToolsWarning = !!getWorkspaceSetting<boolean>(showCoreToolsWarningKey);
-
-    if (showCoreToolsWarning || showMultiCoreToolsWarning) {
+    if (showMultiCoreToolsWarning) {
       const packageManagers: PackageManager[] = await getFuncPackageManagers(true /* isFuncInstalled */);
       let packageManager: PackageManager;
 
@@ -101,50 +98,27 @@ export async function validateFuncCoreToolsIsLatestSystem(): Promise<void> {
 
         return;
       }
+      const localVersion: string | null = await getLocalFuncCoreToolsVersion();
+      if (!localVersion) {
+        return;
+      }
+      context.telemetry.properties.localVersion = localVersion;
 
-      if (showCoreToolsWarning) {
-        const localVersion: string | null = await getLocalFuncCoreToolsVersion();
-        if (!localVersion) {
-          return;
-        }
-        context.telemetry.properties.localVersion = localVersion;
+      const versionFromSetting: FuncVersion | undefined = tryParseFuncVersion(localVersion);
+      if (versionFromSetting === undefined) {
+        return;
+      }
 
-        const versionFromSetting: FuncVersion | undefined = tryParseFuncVersion(localVersion);
-        if (versionFromSetting === undefined) {
-          return;
-        }
+      const newestVersion: string | undefined = await getNewestFunctionRuntimeVersion(packageManager, versionFromSetting, context);
+      if (!newestVersion) {
+        return;
+      }
 
-        const newestVersion: string | undefined = await getNewestFunctionRuntimeVersion(packageManager, versionFromSetting, context);
-        if (!newestVersion) {
-          return;
-        }
-
-        if (semver.major(newestVersion) === semver.major(localVersion) && semver.gt(newestVersion, localVersion)) {
-          context.telemetry.properties.outOfDateFunc = 'true';
-          const message: string = localize(
-            'outdatedFunctionRuntime',
-            'Update your Azure Functions Core Tools ({0}) to the latest ({1}) for the best experience.',
-            localVersion,
-            newestVersion
-          );
-
-          const update: MessageItem = { title: localize('update', 'Update') };
-          let result: MessageItem;
-
-          do {
-            result =
-              packageManager !== undefined
-                ? await context.ui.showWarningMessage(message, update, DialogResponses.learnMore, DialogResponses.dontWarnAgain)
-                : await context.ui.showWarningMessage(message, DialogResponses.learnMore, DialogResponses.dontWarnAgain);
-            if (result === DialogResponses.learnMore) {
-              await openUrl('https://aka.ms/azFuncOutdated');
-            } else if (result === update) {
-              await updateFuncCoreTools(context, packageManager, versionFromSetting);
-            } else if (result === DialogResponses.dontWarnAgain) {
-              await updateGlobalSetting(showCoreToolsWarningKey, false);
-            }
-          } while (result === DialogResponses.learnMore);
-        }
+      if (semver.major(newestVersion) === semver.major(localVersion) && semver.gt(newestVersion, localVersion)) {
+        context.telemetry.properties.outOfDateFunc = 'true';
+        stopAllDesignTimeApis();
+        await updateFuncCoreTools(context, packageManager, versionFromSetting);
+        await startAllDesignTimeApis();
       }
     }
   });

--- a/apps/vs-code-designer/src/app/commands/nodeJs/validateNodeJsIsLatest.ts
+++ b/apps/vs-code-designer/src/app/commands/nodeJs/validateNodeJsIsLatest.ts
@@ -27,10 +27,13 @@ export async function validateNodeJsIsLatest(majorVersion?: string): Promise<voi
       context.telemetry.properties.binaryCommand = `${getNodeJsCommand()}`;
     } else if (showNodeJsWarning) {
       context.telemetry.properties.binaryCommand = `${getNodeJsCommand()}`;
-      const localVersion: string | null = await getLocalNodeJsVersion();
+      const localVersion: string | null = await getLocalNodeJsVersion(context);
       context.telemetry.properties.localVersion = localVersion;
       const newestVersion: string | undefined = await getLatestNodeJsVersion(context, majorVersion);
-      if (semver.major(newestVersion) === semver.major(localVersion) && semver.gt(newestVersion, localVersion)) {
+
+      if (localVersion === null) {
+        await installNodeJs(context, majorVersion);
+      } else if (semver.major(newestVersion) === semver.major(localVersion) && semver.gt(newestVersion, localVersion)) {
         context.telemetry.properties.outOfDateDotNet = 'true';
         const message: string = localize(
           'outdatedNodeJsRuntime',

--- a/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
@@ -200,7 +200,7 @@ describe('binaries', () => {
 
       expect(result).toBe(DependencyVersion.funcCoreTools);
       expect(showErrorMessage).toHaveBeenCalled();
-      expect(context.telemetry.properties.getLatestFunctionCoreToolsVersion).toBe('fallback');
+      expect(context.telemetry.properties.latestVersionSource).toBe('fallback');
     });
 
     it('should return the fallback Function Core Tools version when no major version is sent', async () => {
@@ -208,7 +208,7 @@ describe('binaries', () => {
       const result = await getLatestFunctionCoreToolsVersion(context);
 
       expect(result).toBe(DependencyVersion.funcCoreTools);
-      expect(context.telemetry.properties.getLatestFunctionCoreToolsVersion).toBe('fallback');
+      expect(context.telemetry.properties.latestVersionSource).toBe('fallback');
     });
   });
 

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -34,7 +34,7 @@ import * as semver from 'semver';
 import * as vscode from 'vscode';
 
 import AdmZip = require('adm-zip');
-import { isNullOrUndefined } from '@microsoft/logic-apps-shared';
+import { isNullOrUndefined, isString } from '@microsoft/logic-apps-shared';
 import { setFunctionsCommand } from './funcCoreTools/funcVersion';
 import { startAllDesignTimeApis } from './codeless/startDesignTimeApi';
 
@@ -131,9 +131,18 @@ const getFunctionCoreToolVersionFromGithub = async (context: IActionContext, maj
     if (checkMajorVersion(latestVersion, majorVersion)) {
       return latestVersion;
     }
+    throw new Error(
+      localize(
+        'latestVersionNotFound',
+        'Latest version of Azure Functions Core Tools not found for major version {0}. Latest version is {1}.',
+        majorVersion,
+        latestVersion
+      )
+    );
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : isString(error) ? error : 'Unknown error';
     context.telemetry.properties.latestVersionSource = 'fallback';
-    context.telemetry.properties.errorLatestFunctionCoretoolsVersion = `Error getting latest function core tools version from github: ${error}`;
+    context.telemetry.properties.errorLatestFunctionCoretoolsVersion = `Error getting latest function core tools version from github: ${errorMessage}`;
     return DependencyVersion.funcCoreTools;
   }
 };

--- a/apps/vs-code-designer/src/app/utils/nodeJs/nodeJsVersion.ts
+++ b/apps/vs-code-designer/src/app/utils/nodeJs/nodeJsVersion.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
 import { isString } from '@microsoft/logic-apps-shared';
+import { binariesExist } from '../binaries';
 
 /**
  * Executes nodejs version command and gets it from cli.
@@ -37,9 +38,9 @@ export async function getLocalNodeJsVersion(context: IActionContext): Promise<st
 export function getNpmCommand(): string {
   const binariesLocation = getGlobalSetting<string>(autoRuntimeDependenciesPathSettingKey);
   const nodeJsBinariesPath = path.join(binariesLocation, nodeJsDependencyName);
-  const binariesExist = fs.existsSync(nodeJsBinariesPath);
+  const binaries = binariesExist(nodeJsDependencyName);
   let command = ext.npmCliPath;
-  if (binariesExist) {
+  if (binaries) {
     // windows the executable is at root folder, linux & macos its in the bin
     command = path.join(nodeJsBinariesPath, ext.npmCliPath);
     if (process.platform !== Platform.windows) {

--- a/apps/vs-code-designer/src/app/utils/nodeJs/nodeJsVersion.ts
+++ b/apps/vs-code-designer/src/app/utils/nodeJs/nodeJsVersion.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { Platform, autoRuntimeDependenciesPathSettingKey, nodeJsBinaryPathSettingKey, nodeJsDependencyName } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { executeCommand } from '../funcCoreTools/cpUtils';
@@ -9,12 +10,13 @@ import { getGlobalSetting, updateGlobalSetting } from '../vsCodeConfig/settings'
 import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
+import { isString } from '@microsoft/logic-apps-shared';
 
 /**
  * Executes nodejs version command and gets it from cli.
  * @returns {Promise<string | null>} Functions core tools version.
  */
-export async function getLocalNodeJsVersion(): Promise<string | null> {
+export async function getLocalNodeJsVersion(context: IActionContext): Promise<string | null> {
   try {
     const output: string = await executeCommand(undefined, undefined, `${getNodeJsCommand()}`, '--version');
     const version: string | null = semver.clean(output);
@@ -23,6 +25,8 @@ export async function getLocalNodeJsVersion(): Promise<string | null> {
     }
     return null;
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : isString(error) ? error : 'Unknown error';
+    context.telemetry.properties.error = errorMessage;
     return null;
   }
 }

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -274,7 +274,7 @@ export const defaultDataMapperVersion = 1;
 // Fallback Dependency Versions
 export const DependencyVersion = {
   dotnet6: '6.0.413',
-  funcCoreTools: '4.0.5455',
+  funcCoreTools: '4.0.7030',
   nodeJs: '18.17.1',
 } as const;
 export type DependencyVersion = (typeof DependencyVersion)[keyof typeof DependencyVersion];


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

- Current behavior just choose from nodejs or github to get the latest version of function core tools. If the nodejs fails the installation fails in general

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

- Now latest version is user has nodejs falls on the npm installation, if this fails it falls into github to get the lates version

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

- Not a breaking change

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
