### PR TITLE
fix(vscode): Auto update function core tools for major version difference

### DIFF
--- a/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/apps/vs-code-designer/src/app/commands/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -46,10 +46,13 @@ export async function validateFuncCoreToolsIsLatestBinaries(majorVersion?: strin
       const newestVersion: string | undefined = await getLatestFunctionCoreToolsVersion(context, majorVersion);
       const isLocalVersionMissing = localVersion === null;
 
-      const isLocalVersionOutdated =
-        !isLocalVersionMissing && semver.major(newestVersion) === semver.major(localVersion) && semver.gt(newestVersion, localVersion);
+      const isLocalVersionOutdated = !isLocalVersionMissing && semver.gt(newestVersion, localVersion);
 
-      if (isLocalVersionMissing || isLocalVersionOutdated) {
+      if (isLocalVersionMissing) {
+        context.telemetry.properties.localVersion = 'null';
+        await installFuncCoreToolsBinaries(context, majorVersion);
+        context.telemetry.properties.binaryCommand = `${getFunctionsCommand()}`;
+      } else if (isLocalVersionMissing || isLocalVersionOutdated) {
         context.telemetry.properties.localVersion = localVersion ?? 'null';
         context.telemetry.properties.outOfDateFunc = 'true';
         stopAllDesignTimeApis();


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

- Check for outdated function core tools, but only installs it if the major version between local installation and newest is the same

## New Behavior

- Now if the major version between the newest and local version is different, it will mark it as outdated and will install it

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

- Not a breaking change
- 
## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

![CleanShot 2025-05-21 at 10 44 35@2x](https://github.com/user-attachments/assets/5b902701-b33d-408a-a924-2f5d95f487c6)
