### PR TITLE
fix(vscode): Add noAuth to run trigger

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
@@ -320,7 +320,7 @@ export class StandardRunService implements IRunService {
     }
 
     try {
-      await this.getHttpRequestByMethod(httpClient, method, { uri });
+      await this.getHttpRequestByMethod(httpClient, method, { uri, noAuth: true });
     } catch (e: any) {
       throw new Error(`${e.status} ${e?.data?.error?.message}`);
     }


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

Fixes #7367 

## Current Behavior

- When running a workflow in overview page in vscode was sending the auth token in the POST API call causing a 400 error

![image](https://github.com/user-attachments/assets/a3f8eab9-4708-4dd4-9ddd-9756fb578d16)


## New Behavior

Now run trigger api call doesn't include bearer token

- Tested in local and remote workflows

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Not a breaking change
- Portal uses a different approach to run the workflows. This only affects vscode

## Test Plan

<!-- Please post how this change has been tested and will be tested going forward --> 

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->
