### PR TITLE
fix(Designer): Refactored `useLayout` as a context provider 

### DIFF
--- a/libs/designer/src/lib/core/DesignerProvider.tsx
+++ b/libs/designer/src/lib/core/DesignerProvider.tsx
@@ -12,6 +12,7 @@ import { IntlProvider } from '@microsoft/logic-apps-shared';
 import type React from 'react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { Provider as ReduxProvider, useDispatch } from 'react-redux';
+import { LayoutProvider } from './graphlayout';
 
 export interface DesignerProviderProps {
   key?: string;
@@ -51,21 +52,23 @@ export const DesignerProvider = ({ id, locale = 'en', options, children }: Desig
         <ProviderWrappedContext.Provider value={options.services}>
           <ThemeProvider theme={azTheme} style={{ height: 'inherit' }}>
             <FluentProvider theme={webTheme} style={{ height: 'inherit' }}>
-              <div
-                data-color-scheme={themeName}
-                className={`msla-theme-${themeName}`}
-                style={{ display: 'flex', flexDirection: 'column', height: 'inherit', overflow: 'hidden' }}
-              >
-                <IntlProvider
-                  locale={locale}
-                  defaultLocale={locale}
-                  stringOverrides={options.hostOptions.stringOverrides}
-                  onError={onError}
+              <LayoutProvider>
+                <div
+                  data-color-scheme={themeName}
+                  className={`msla-theme-${themeName}`}
+                  style={{ display: 'flex', flexDirection: 'column', height: 'inherit', overflow: 'hidden' }}
                 >
-                  <ReduxReset id={id} />
-                  {children}
-                </IntlProvider>
-              </div>
+                  <IntlProvider
+                    locale={locale}
+                    defaultLocale={locale}
+                    stringOverrides={options.hostOptions.stringOverrides}
+                    onError={onError}
+                  >
+                    <ReduxReset id={id} />
+                    {children}
+                  </IntlProvider>
+                </div>
+              </LayoutProvider>
             </FluentProvider>
           </ThemeProvider>
         </ProviderWrappedContext.Provider>

--- a/libs/designer/src/lib/core/graphlayout/elklayout.tsx
+++ b/libs/designer/src/lib/core/graphlayout/elklayout.tsx
@@ -42,7 +42,7 @@ const readOnlyOptions: Record<string, string> = {
 };
 
 const elk = new ELK();
-const defaultEdgeType = WORKFLOW_EDGE_TYPES.TRANSITION_EDGE;
+const defaultEdgeType = WORKFLOW_EDGE_TYPES.BUTTON_EDGE;
 const defaultNodeType = WORKFLOW_NODE_TYPES.OPERATION_NODE;
 
 const elkLayout = async (graph: ElkNode, readOnly?: boolean) => {
@@ -55,7 +55,7 @@ const elkLayout = async (graph: ElkNode, readOnly?: boolean) => {
   return layout;
 };
 
-const convertElkGraphToReactFlow = (graph: ElkNode): [Node[], Edge[], number[]] => {
+const convertElkGraphToReactFlow = (graph: ElkNode): LayoutContextType => {
   const nodes: Node[] = [];
   const edges: Edge[] = [];
 

--- a/libs/designer/src/lib/core/graphlayout/index.ts
+++ b/libs/designer/src/lib/core/graphlayout/index.ts
@@ -1,1 +1,1 @@
-export { useLayout } from './elklayout';
+export { useLayout, LayoutProvider } from './elklayout';


### PR DESCRIPTION
## Main Changes

Refactored our `useLayout` hook as a context provider.
I noticed some of our simple layouting changes were taking a while to update, and I found that our `useLayout` hook was recalculating individually for each instance of the hook (we had 4 separate instances).
This all happened at the same time so in addition to happening 4x instead of 1x, it seemed to bottleneck and lead to slower execution on each instance.

I've taken some perf timings for before and after my changes on just our `All Scope Nodes` test flow.

| [5 test averages] | Before | After | % Change |
|-------------------|--------|-------|----------|
| Initial load      | 1700ms | 300ms | -82%     |
| Collapse all      | 80ms   | 15ms  | -82%     |
| Expand all        | 625ms  | 50ms  | -92%     |