### PR TITLE
fix(Designer): Modified connector icon error log as warning

### DIFF
--- a/libs/designer-ui/src/lib/panel/recommendationpanel/connectorAvatar/index.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/connectorAvatar/index.tsx
@@ -30,7 +30,7 @@ export const ConnectorAvatar = ({
         // We don't want to log custom connector image failures since it is provided by users and is a user error
         if (!isCustomApi) {
           LoggerService().log({
-            level: LogEntryLevel.Error,
+            level: LogEntryLevel.Warning,
             area: 'ConnectorAvatar.onError',
             message: 'Connector image failed to load.',
             args: [iconUri, connectorId],


### PR DESCRIPTION
## Main Changes

Modified connector icon log to be a warning instead of an error.

Fixes https://github.com/Azure/LogicAppsUX/issues/7402