### PR TITLE
fix(vscode): Bypass isMockable check for trigger mocks

### DIFF
--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -1057,7 +1057,7 @@ export async function getOperationMockClassContent(
     const isTrigger = operationName === triggerName;
 
     // Only proceed if this operation type is mockable (using the new async isMockable)
-    if (await isMockable(type)) {
+    if (isTrigger || (await isMockable(type))) {
       const isMockableHttpType = await isMockableHttp(type);
       // Set operationName as className
       const cleanedOperationName = removeInvalidCharacters(operationName);


### PR DESCRIPTION
## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Other

## Current Behavior

Trigger types (e.g. Recurrence) missing from ListMockableOperations response. All triggers should be mockable

## New Behavior

Skip this check for triggers
