### PR TITLE
fix(Template): Template parameter definition not updating on resource

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/configuretemplate.ts
@@ -231,8 +231,15 @@ export const updateWorkflowParameter = createAsyncThunk(
     const {
       template: { manifest, parameterDefinitions },
     } = getState() as RootState;
-    const parameter = parameterDefinitions[parameterId];
-    const allParameters = Object.values(parameterDefinitions);
+    const modifiedParameterDefinition = {
+      ...parameterDefinitions,
+      [parameterId]: {
+        ...parameterDefinitions?.[parameterId],
+        ...definition,
+      },
+    };
+    const parameter = modifiedParameterDefinition[parameterId];
+    const allParameters = Object.values(modifiedParameterDefinition);
     const associatedWorkflows = (parameter?.associatedWorkflows as string[]) ?? [];
     const promises: Promise<void>[] = [];
     const existingWorkflows = await getWorkflowResourcesInTemplate(manifest?.id as string);


### PR DESCRIPTION
## Type of Change

* [X] Bug fix
* [ ] Feature
* [ ] Other

## Fix
Parameter definition was only being updated in the state and not in the resource API call

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

* [ ] **This is a breaking change.**
