### PR TITLE
fix(designer): Fix C Sharp Custom Code Unable to Save Due to #

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/initialize.ts
@@ -585,7 +585,8 @@ export const initializeCustomCodeDataInInputs = (parameter: ParameterInfo, nodeI
     const fileData = generateDefaultCustomCodeValue(language);
     if (fileData) {
       const fileExtension = getFileExtensionName(language);
-      const fileName = replaceWhiteSpaceWithUnderscore(nodeId) + fileExtension;
+      const fileName = replaceWhiteSpaceWithUnderscore(nodeId.replace(/#/g, 'sharp')) + fileExtension;
+
       parameter.editorViewModel = {
         customCodeData: { fileData, fileName, fileExtension },
       };

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -2,7 +2,7 @@ export const idDisplayCase = (s: string) => removeIdTag(labelCase(s));
 export const labelCase = (label: string) => label?.replace(/_/g, ' ');
 
 export const replaceWhiteSpaceWithUnderscore = (uiElementName: string): string => {
-  return uiElementName?.replace(/[^a-zA-Z0-9_#]/g, '_')?.toLowerCase();
+  return uiElementName?.replace(/\W/g, '_')?.toLowerCase();
 };
 
 export const containsIdTag = (id: string) => id?.includes('-#');


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Revert previous change on replaceWhiteSpaceWithUnderscore and instead to make it so by default c# custom code file is execute_csharp_script_code

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
