### PR TITLE
fix(templates): Fixing logic to append workflow identifier in connection names in definition

### DIFF
--- a/apps/Standalone/src/configuretemplate/app/LocalConfigureTemplate.tsx
+++ b/apps/Standalone/src/configuretemplate/app/LocalConfigureTemplate.tsx
@@ -22,7 +22,7 @@ import { ArmParser } from '../../designer/app/AzureLogicAppsDesigner/Utilities/A
 import { useCurrentTenantId } from '../../designer/app/AzureLogicAppsDesigner/Services/WorkflowAndArtifacts';
 
 const testTemplateId =
-  '/subscriptions/f34b22a3-2202-4fb1-b040-1332bd928c84/resourceGroups/TestACSRG/providers/microsoft.logic/templates/bonicatemplate';
+  '/subscriptions/f34b22a3-2202-4fb1-b040-1332bd928c84/resourceGroups/TestACSRG/providers/microsoft.logic/templates/pritichecktemplate';
 export const LocalConfigureTemplate = () => {
   const { theme, resourcePath } = useSelector((state: RootState) => ({
     theme: state.configureTemplateLoader.theme,

--- a/libs/designer/src/lib/core/configuretemplate/utils/helper.ts
+++ b/libs/designer/src/lib/core/configuretemplate/utils/helper.ts
@@ -455,7 +455,8 @@ export const suffixConnectionsWithIdentifier = (
           result.connections[updatedConnectionKey] = connections[connectionKey];
         }
 
-        updatedDefinition = replaceAllStringInWorkflowDefinition(updatedDefinition, connectionKey, updatedConnectionKey);
+        updatedDefinition = replaceAllStringInWorkflowDefinition(updatedDefinition, `"${connectionKey}"`, `"${updatedConnectionKey}"`);
+        updatedDefinition = replaceAllStringInWorkflowDefinition(updatedDefinition, `'${connectionKey}'`, `'${updatedConnectionKey}'`);
       }
     }
 


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
We were incorrectly replace a connection key name in the definition, just fixed that logic to be more precise to only connection name references in teh definition

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

