### PR TITLE
fix(templates): Fixing query cache for template workflows to allow correct data saving

### DIFF
--- a/apps/Standalone/src/configuretemplate/app/LocalConfigureTemplate.tsx
+++ b/apps/Standalone/src/configuretemplate/app/LocalConfigureTemplate.tsx
@@ -22,7 +22,7 @@ import { ArmParser } from '../../designer/app/AzureLogicAppsDesigner/Utilities/A
 import { useCurrentTenantId } from '../../designer/app/AzureLogicAppsDesigner/Services/WorkflowAndArtifacts';
 
 const testTemplateId =
-  '/subscriptions/f34b22a3-2202-4fb1-b040-1332bd928c84/resourceGroups/TestACSRG/providers/microsoft.logic/templates/pritichecktemplate';
+  '/subscriptions/f34b22a3-2202-4fb1-b040-1332bd928c84/resourceGroups/TestACSRG/providers/microsoft.logic/templates/pritichecktemplate1';
 export const LocalConfigureTemplate = () => {
   const { theme, resourcePath } = useSelector((state: RootState) => ({
     theme: state.configureTemplateLoader.theme,

--- a/e2e/templates/app.spec.ts
+++ b/e2e/templates/app.spec.ts
@@ -40,7 +40,7 @@ test.describe(
       await expect(page.getByText('State type')).toBeVisible();
     });
 
-    test('Should only contain the mock templates when templates are loaded from azure endpoint', async ({ page }) => {
+    test('Should only contain the mock templates when templates are loaded from azure endpoint.', async ({ page }) => {
       await page.goto('/templates');
       await page.getByText('Local', { exact: true }).click();
       await page.getByLabel('Categories').click();

--- a/libs/designer/src/lib/core/configuretemplate/utils/queries.ts
+++ b/libs/designer/src/lib/core/configuretemplate/utils/queries.ts
@@ -65,10 +65,10 @@ export const useTemplate = (templateId: string, enabled = true): UseQueryResult<
   });
 };
 
-export const useTemplateWorkflows = (templateId: string, enabled = true): UseQueryResult<ArmResource<any>[], unknown> => {
+export const useTemplateWorkflowResources = (templateId: string, enabled = true): UseQueryResult<ArmResource<any>[], unknown> => {
   return useQuery(
     ['templateworkflowresources', templateId?.toLowerCase()],
-    async () => TemplateResourceService().getTemplateWorkflows(templateId),
+    async () => TemplateResourceService().getTemplateWorkflows(templateId, /* rawData */ true),
     {
       cacheTime: 1000 * 60 * 60 * 24,
       refetchOnMount: false,

--- a/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/workflows/workflowslist.tsx
@@ -39,7 +39,7 @@ import { ConfigureWorkflowsPanel } from '../panels/configureWorkflowsPanel/confi
 import { DescriptionWithLink, tableHeaderStyle, ErrorBar } from '../common';
 import { workflowsHaveErrors } from '../../../core/configuretemplate/utils/errors';
 import EBookIcon from '../../../common/images/templates/openbook.svg';
-import { useTemplateWorkflows } from '../../../core/configuretemplate/utils/queries';
+import { useTemplateWorkflowResources } from '../../../core/configuretemplate/utils/queries';
 import { getDateTimeString } from '../../../core/configuretemplate/utils/helper';
 
 export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean) => void }) => {
@@ -53,7 +53,7 @@ export const DisplayWorkflows = ({ onSave }: { onSave: (isMultiWorkflow: boolean
     templateId: state.template.manifest?.id as string,
   }));
   const hasErrors = useMemo(() => saveErrors || workflowsHaveErrors(apiErrors, workflows), [apiErrors, saveErrors, workflows]);
-  const { data: workflowResources, isLoading: workflowResourcesLoading } = useTemplateWorkflows(templateId);
+  const { data: workflowResources, isLoading: workflowResourcesLoading } = useTemplateWorkflowResources(templateId);
   const dispatch = useDispatch<AppDispatch>();
   const isMultiWorkflow = Object.keys(workflows).length > 1;
 

--- a/libs/designer/src/lib/ui/templates/gallery/templatesfullgalleryview.tsx
+++ b/libs/designer/src/lib/ui/templates/gallery/templatesfullgalleryview.tsx
@@ -1,7 +1,7 @@
 import type { AppDispatch, RootState } from '../../../core/state/templates/store';
 import { useDispatch, useSelector } from 'react-redux';
 import { TemplateCard } from '../cards/templateCard';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { setLayerHostSelector } from '@fluentui/react';
 import type { CreateWorkflowHandler, TemplatesDesignerProps } from '../TemplatesDesigner';
 import { QuickViewPanel } from '../../panel/templatePanel/quickViewPanel/quickViewPanel';
@@ -19,10 +19,10 @@ export const TemplatesFullGalleryView = ({ detailFilters, createWorkflowCall, is
     filters: { detailFilters: appliedDetailFilters },
   } = useSelector((state: RootState) => state.manifest);
 
-  const selectedTabId = appliedDetailFilters?.[tabFilterKey]?.[0]?.value;
-
-  const blankTemplateCard =
-    selectedTabId !== 'Custom' ? <TemplateCard blankWorkflowProps={{ isWorkflowEmpty }} templateName="#blank#" /> : undefined;
+  const blankTemplateCard = useMemo(() => {
+    const selectedTabId = appliedDetailFilters?.[tabFilterKey]?.[0]?.value;
+    return selectedTabId === undefined ? <TemplateCard blankWorkflowProps={{ isWorkflowEmpty }} templateName="#blank#" /> : undefined;
+  }, [appliedDetailFilters, isWorkflowEmpty]);
   const onTemplateSelect = (_templateName: string, isSingleWorkflow: boolean) => {
     if (isSingleWorkflow) {
       dispatch(openPanelView({ panelView: TemplatePanelView.QuickView }));

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/template.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/template.ts
@@ -37,12 +37,11 @@ export class BaseTemplateService implements ITemplateService {
     return httpClient.get<any>({ uri: `${endpoint}/manifest.json`, headers: { 'Access-Control-Allow-Origin': '*' } });
   };
 
-  public getCustomTemplates = async (subscriptionId: string, resourceGroup: string): Promise<CustomTemplateResource[]> => {
+  public getCustomTemplates = async (subscriptionId: string, _resourceGroup: string): Promise<CustomTemplateResource[]> => {
     const { httpClient, baseUrl } = this.options;
 
-    const uri = `${baseUrl}/providers/Microsoft.ResourceGraph/resources?api-version=2019-04-01`;
-    const query = `resources | where type =~ "microsoft.logic/templates" and resourceGroup =~ "${resourceGroup.toLowerCase()}"
-    | where properties.state !~ "Development" | project id, name, manifest = properties.manifest, state = properties.state`;
+    const uri = `${baseUrl}/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01`;
+    const query = `resources | where type =~ "microsoft.logic/templates" | where properties.state !~ "Development" | project id, name, manifest = properties.manifest, state = properties.state`;
     const response = await fetchAppsByQuery(httpClient, uri, query, [subscriptionId]);
 
     return response


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Fixes three critical issues: 
(1) Custom template queries now pull from the subscription level, not just resource group,
(2) the blank template appears only in the 'All' tab as intended,
(3) query cache now correctly stores raw template workflows.

All of these were blockers for the release because they prevented users from saving and viewing templates correctly.

## Impact of Change
- Users: Users will now see and save templates correctly, resolving previous blockers for release.
- Developers: Ensure cache key usage is consistent going forward; downstream code may need to consider this update.
- System: None expected, but verify if broader system-level template flows may be indirectly affected due to query or cache logic changes.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@bonica-ayala @divyaswarnkar 

## Screenshots/Videos
NA
