### PR TITLE
fix(scripts): Add ES module __dirname equivalent for update-versions.js

### DIFF
--- a/scripts/update-versions.js
+++ b/scripts/update-versions.js
@@ -2,6 +2,10 @@
 /* eslint-env node */
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const version = process.argv[2];
 if (!version) {


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
The update-versions.js script was recently converted to ES modules (using import instead of require), but it still used the CommonJS `__dirname` variable. This causes a runtime error during the GitHub Actions workflow:

```
ReferenceError: __dirname is not defined in ES module scope
```

This fix adds the ES module equivalent of `__dirname` using `fileURLToPath(import.meta.url)` and `path.dirname()`.

## Impact of Change
- **Users**: No direct user impact - this is internal release tooling
- **Developers**: Release workflow will no longer fail at the "update version in package files" step
- **System**: Fixes broken version update functionality in release pipeline

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Local verification of ES module syntax and path resolution

The fix follows the standard ES module pattern for recreating `__dirname`:
- Uses `import.meta.url` to get current module URL
- Converts to file path with `fileURLToPath()`
- Extracts directory with `path.dirname()`

## Contributors
None

## Screenshots/Videos
N/A - Backend script fix only