### PR TITLE
fix(vscode): Unit Test Array Object Name

### DIFF
--- a/apps/vs-code-designer/src/app/utils/__test__/unitTestUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/unitTestUtils.test.ts
@@ -268,6 +268,106 @@ describe('generateCSharpClasses - HTTP Action', () => {
     expect(classCode).toContain('this.StatusCode = HttpStatusCode.OK;');
     expect(classCode).toContain('this.Key1 = string.Empty;');
   });
+
+  it('should generate C# class code from a class definition HTTP action with schema', () => {
+    const workflowName = 'TestWorkflow';
+    const mockType = 'Action';
+    const mockClassName = 'MockClass';
+    const classCode = generateCSharpClasses(
+      'NamespaceName',
+      'RootClass',
+      workflowName,
+      mockType,
+      mockClassName,
+      {
+        body: {
+          orderId: {
+            nestedTypeProperty: 'string',
+            title: 'orderId',
+          },
+          customerId: {
+            nestedTypeProperty: 'string',
+            title: 'customerId',
+          },
+          region: {
+            nestedTypeProperty: 'string',
+            title: 'region',
+          },
+          orderDetails: {
+            '[*]': {
+              productId: {
+                nestedTypeProperty: 'string',
+                title: 'productId',
+              },
+              productName: {
+                nestedTypeProperty: 'string',
+                title: 'productName',
+              },
+              quantity: {
+                nestedTypeProperty: 'integer',
+                title: 'quantity',
+              },
+              unitPrice: {
+                nestedTypeProperty: 'integer',
+                title: 'unitPrice',
+              },
+              nestedTypeProperty: 'object',
+              title: 'Item',
+            },
+            nestedTypeProperty: 'array',
+            title: 'orderDetails',
+          },
+          nestedTypeProperty: 'object',
+          title: 'Body',
+        },
+        headers: {
+          nestedTypeProperty: 'object',
+          title: 'Headers',
+        },
+        relativePathParameters: {
+          nestedTypeProperty: 'object',
+          title: 'Path Parameters',
+        },
+        queries: {
+          nestedTypeProperty: 'object',
+          title: 'Queries',
+        },
+      },
+      true
+    );
+
+    expect(classCode).toContain('public class RootClass');
+    expect(classCode).toContain('public HttpStatusCode StatusCode {get; set;}');
+    expect(classCode).toContain('public RootClassBody Body { get; set; }');
+
+    expect(classCode).toContain('public RootClass()');
+    expect(classCode).toContain('this.StatusCode = HttpStatusCode.OK;');
+    expect(classCode).toContain('this.Body = new RootClassBody();');
+
+    expect(classCode).toContain('public class RootClassBody');
+    expect(classCode).toContain('public string OrderId { get; set; }');
+    expect(classCode).toContain('public string CustomerId { get; set; }');
+    expect(classCode).toContain('public string Region { get; set; }');
+    expect(classCode).toContain('public List<OrderDetailsItem> OrderDetails { get; set; }');
+
+    expect(classCode).toContain('public RootClassBody()');
+    expect(classCode).toContain('this.OrderId = string.Empty;');
+    expect(classCode).toContain('this.CustomerId = string.Empty;');
+    expect(classCode).toContain('this.Region = string.Empty;');
+    expect(classCode).toContain('this.OrderDetails = new List<OrderDetailsItem>();');
+
+    expect(classCode).toContain('public class OrderDetailsItem');
+    expect(classCode).toContain('public string ProductId { get; set; }');
+    expect(classCode).toContain('public string ProductName { get; set; }');
+    expect(classCode).toContain('public int Quantity { get; set; }');
+    expect(classCode).toContain('public int UnitPrice { get; set; }');
+
+    expect(classCode).toContain('public OrderDetailsItem()');
+    expect(classCode).toContain('this.ProductId = string.Empty;');
+    expect(classCode).toContain('this.ProductName = string.Empty;');
+    expect(classCode).toContain('this.Quantity = 0;');
+    expect(classCode).toContain('this.UnitPrice = 0;');
+  });
 });
 
 describe('generateCSharpClasses - non HTTP', () => {

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -844,7 +844,8 @@ export function buildClassDefinition(className: string, node: any): ClassDefinit
       if (subNode?.nestedTypeProperty === 'array') {
         isObject = true;
         const arrayItemNode = subNode['[*]'];
-        const arrayItemClassName = subNode?.description ? toPascalCase(subNode?.description.replace(/\s+/g, '')) : ''; // Remove spaces from description
+        let arrayItemClassName = subNode?.description ? toPascalCase(subNode?.description.replace(/\s+/g, '')) : ''; // Remove spaces from description
+        arrayItemClassName = arrayItemClassName === '' ? `${propName}${arrayItemNode.title}` : `${propName}Item`;
         const arrayItemDef = buildClassDefinition(arrayItemClassName, arrayItemNode);
 
         // If there are child properties then use the newly created object, otherwise use JObject


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Updating buildClassDefinition such that array objects always have a name. It is currently possible that an array object have a empty name which results in invalid mock output c# files.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->Mock output files will now be generated correctly when http action schema with arrays are passed in.
- **Developers**: <!-- API changes, new patterns, etc. -->None.
- **System**: <!-- Performance, architecture, dependencies -->None.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
