### PR TITLE
fix(designer-ui): improve screen reader accessibility for 'Add a trigger' button tooltip

### DIFF
--- a/libs/designer-ui/src/lib/card/addActionCard/__test__/__snapshots__/addActionCard.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/card/addActionCard/__test__/__snapshots__/addActionCard.spec.tsx.snap
@@ -1,0 +1,261 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`lib/card/addActionCard > Basic Rendering > should render as selected 1`] = `
+[
+  <div
+    id="placeholder-node-Trigger-description"
+    style={
+      {
+        "display": "none",
+      }
+    }
+  >
+    Triggers
+    : 
+    Triggers tell your app when to start running. Each workflow needs at least one trigger.
+  </div>,
+  <div
+    className="ms-TooltipHost root-109"
+    onBlurCapture={[Function]}
+    onFocusCapture={[Function]}
+    onKeyDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    role="none"
+  >
+    <div
+      style={
+        {
+          "position": "relative",
+        }
+      }
+    >
+      <div
+        aria-describedby="placeholder-node-Trigger-description"
+        aria-label="Add a trigger"
+        className="msla-panel-card-container msla-panel-card-container-selected"
+        data-automation-id="card-add_a_trigger"
+        data-testid="card-Add a trigger"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        style={
+          {
+            "borderLeft": "4px solid #484F58",
+            "borderRadius": "2px",
+          }
+        }
+        tabIndex={0}
+      >
+        <div
+          className="msla-selection-box selected"
+        />
+        <div
+          className="panel-card-main"
+        >
+          <div
+            className="panel-card-header"
+            role="button"
+          >
+            <div
+              className="panel-card-content-container"
+            >
+              <div
+                className="panel-card-content-gripper-section"
+              />
+              <div
+                className="panel-card-content-icon-section"
+              >
+                <img
+                  alt=""
+                  className="panel-card-icon"
+                  src="/src/lib/card/addActionCard/addNodeIcon.svg"
+                  style={
+                    {
+                      "background": "#484F58",
+                      "height": "16px",
+                      "padding": "4px",
+                      "width": "16px",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="panel-card-top-content"
+              >
+                <div
+                  className="panel-msla-title"
+                >
+                  Add a trigger
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      hidden={true}
+      id="placeholder-node-Trigger"
+      style={
+        {
+          "border": 0,
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": 1,
+        }
+      }
+    >
+      <div
+        style={
+          {
+            "margin": "-8px 12px 0px",
+            "maxWidth": "250px",
+          }
+        }
+      >
+        <h2>
+          Triggers
+        </h2>
+        <p>
+          Triggers tell your app when to start running. Each workflow needs at least one trigger.
+        </p>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`lib/card/addActionCard > Basic Rendering > should render with minimal props 1`] = `
+[
+  <div
+    id="placeholder-node-Trigger-description"
+    style={
+      {
+        "display": "none",
+      }
+    }
+  >
+    Triggers
+    : 
+    Triggers tell your app when to start running. Each workflow needs at least one trigger.
+  </div>,
+  <div
+    className="ms-TooltipHost root-109"
+    onBlurCapture={[Function]}
+    onFocusCapture={[Function]}
+    onKeyDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    role="none"
+  >
+    <div
+      style={
+        {
+          "position": "relative",
+        }
+      }
+    >
+      <div
+        aria-describedby="placeholder-node-Trigger-description"
+        aria-label="Add a trigger"
+        className="msla-panel-card-container"
+        data-automation-id="card-add_a_trigger"
+        data-testid="card-Add a trigger"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        style={
+          {
+            "borderLeft": "4px solid #484F58",
+            "borderRadius": "2px",
+          }
+        }
+        tabIndex={0}
+      >
+        <div
+          className="msla-selection-box"
+        />
+        <div
+          className="panel-card-main"
+        >
+          <div
+            className="panel-card-header"
+            role="button"
+          >
+            <div
+              className="panel-card-content-container"
+            >
+              <div
+                className="panel-card-content-gripper-section"
+              />
+              <div
+                className="panel-card-content-icon-section"
+              >
+                <img
+                  alt=""
+                  className="panel-card-icon"
+                  src="/src/lib/card/addActionCard/addNodeIcon.svg"
+                  style={
+                    {
+                      "background": "#484F58",
+                      "height": "16px",
+                      "padding": "4px",
+                      "width": "16px",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="panel-card-top-content"
+              >
+                <div
+                  className="panel-msla-title"
+                >
+                  Add a trigger
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      hidden={true}
+      id="placeholder-node-Trigger"
+      style={
+        {
+          "border": 0,
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": 1,
+        }
+      }
+    >
+      <div
+        style={
+          {
+            "margin": "-8px 12px 0px",
+            "maxWidth": "250px",
+          }
+        }
+      >
+        <h2>
+          Triggers
+        </h2>
+        <p>
+          Triggers tell your app when to start running. Each workflow needs at least one trigger.
+        </p>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/libs/designer-ui/src/lib/card/addActionCard/__test__/addActionCard.spec.tsx
+++ b/libs/designer-ui/src/lib/card/addActionCard/__test__/addActionCard.spec.tsx
@@ -1,0 +1,269 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setIconOptions } from '@fluentui/react';
+import renderer from 'react-test-renderer';
+import { AddActionCard, ADD_CARD_TYPE } from '../index';
+import type { AddActionCardProps } from '../index';
+import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
+
+describe('lib/card/addActionCard', () => {
+  let defaultProps: AddActionCardProps;
+
+  beforeAll(() => {
+    setIconOptions({
+      disableWarnings: true,
+    });
+  });
+
+  beforeEach(() => {
+    defaultProps = {
+      addCardType: ADD_CARD_TYPE.TRIGGER,
+      onClick: vi.fn(),
+      selected: false,
+    };
+  });
+
+  describe('Basic Rendering', () => {
+    it('should render with minimal props', () => {
+      const tree = renderer.create(<AddActionCard {...defaultProps} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render as trigger card', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.TRIGGER} />);
+      expect(screen.getByText('Add a trigger')).toBeInTheDocument();
+    });
+
+    it('should render as action card', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.ACTION} />);
+      expect(screen.getByText('Add an action')).toBeInTheDocument();
+    });
+
+    it('should render as selected', () => {
+      const tree = renderer.create(<AddActionCard {...defaultProps} selected={true} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('Accessibility - aria-describedby', () => {
+    it('should have aria-describedby pointing to hidden description element for trigger', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.TRIGGER} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      const describedById = card.getAttribute('aria-describedby');
+
+      expect(describedById).toBe('placeholder-node-Trigger-description');
+
+      // Verify the hidden description element exists
+      const descriptionElement = document.getElementById(describedById!);
+      expect(descriptionElement).toBeInTheDocument();
+      expect(descriptionElement).toHaveStyle({ display: 'none' });
+      expect(descriptionElement).toHaveTextContent(
+        'Triggers: Triggers tell your app when to start running. Each workflow needs at least one trigger.'
+      );
+    });
+
+    it('should have aria-describedby pointing to hidden description element for action', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.ACTION} />);
+
+      const card = screen.getByTestId('card-Add an action');
+      const describedById = card.getAttribute('aria-describedby');
+
+      expect(describedById).toBe('placeholder-node-Action-description');
+
+      // Verify the hidden description element exists
+      const descriptionElement = document.getElementById(describedById!);
+      expect(descriptionElement).toBeInTheDocument();
+      expect(descriptionElement).toHaveStyle({ display: 'none' });
+      expect(descriptionElement).toHaveTextContent(
+        'Actions: Actions perform operations on data, communicate between systems, or run other tasks.'
+      );
+    });
+
+    it('should have unique IDs for different card types', () => {
+      const { rerender } = render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.TRIGGER} />);
+
+      const triggerCard = screen.getByTestId('card-Add a trigger');
+      const triggerDescribedBy = triggerCard.getAttribute('aria-describedby');
+
+      rerender(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.ACTION} />);
+
+      const actionCard = screen.getByTestId('card-Add an action');
+      const actionDescribedBy = actionCard.getAttribute('aria-describedby');
+
+      expect(triggerDescribedBy).not.toBe(actionDescribedBy);
+      expect(triggerDescribedBy).toBe('placeholder-node-Trigger-description');
+      expect(actionDescribedBy).toBe('placeholder-node-Action-description');
+    });
+  });
+
+  describe('Screen Reader Compatibility', () => {
+    it('should provide accessible tooltip content for screen readers - trigger', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.TRIGGER} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      const describedById = card.getAttribute('aria-describedby');
+      const descriptionElement = document.getElementById(describedById!);
+
+      // Verify the content is structured for screen readers
+      expect(descriptionElement).toHaveTextContent(
+        'Triggers: Triggers tell your app when to start running. Each workflow needs at least one trigger.'
+      );
+
+      // Verify the element is hidden from visual users but accessible to screen readers
+      expect(descriptionElement).toHaveStyle({ display: 'none' });
+      expect(descriptionElement).not.toHaveAttribute('aria-hidden', 'true');
+      expect(descriptionElement).not.toHaveAttribute('hidden');
+    });
+
+    it('should provide accessible tooltip content for screen readers - action', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.ACTION} />);
+
+      const card = screen.getByTestId('card-Add an action');
+      const describedById = card.getAttribute('aria-describedby');
+      const descriptionElement = document.getElementById(describedById!);
+
+      // Verify the content is structured for screen readers
+      expect(descriptionElement).toHaveTextContent(
+        'Actions: Actions perform operations on data, communicate between systems, or run other tasks.'
+      );
+
+      // Verify the element is hidden from visual users but accessible to screen readers
+      expect(descriptionElement).toHaveStyle({ display: 'none' });
+      expect(descriptionElement).not.toHaveAttribute('aria-hidden', 'true');
+      expect(descriptionElement).not.toHaveAttribute('hidden');
+    });
+  });
+
+  describe('Tooltip Functionality', () => {
+    it('should render tooltip with proper content for trigger', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.TRIGGER} />);
+
+      // The tooltip content should be available in the TooltipHost component
+      // We can't easily test the visible tooltip without user interaction,
+      // but we can verify the structure is correct
+      const card = screen.getByTestId('card-Add a trigger');
+      expect(card).toBeInTheDocument();
+    });
+
+    it('should render tooltip with proper content for action', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.ACTION} />);
+
+      const card = screen.getByTestId('card-Add an action');
+      expect(card).toBeInTheDocument();
+    });
+  });
+
+  describe('Interaction', () => {
+    it('should call onClick when clicked', async () => {
+      const onClickMock = vi.fn();
+      render(<AddActionCard {...defaultProps} onClick={onClickMock} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      await userEvent.click(card);
+
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Note: Keyboard interaction tests for Enter/Space keys are handled by the useCardKeyboardInteraction hook
+    // These are integration tests that would require more complex setup to test the keyboard event handling properly
+
+    it('should stop event propagation on click', () => {
+      const onClickMock = vi.fn();
+      const onParentClick = vi.fn();
+
+      render(
+        <div onClick={onParentClick}>
+          <AddActionCard {...defaultProps} onClick={onClickMock} />
+        </div>
+      );
+
+      const card = screen.getByTestId('card-Add a trigger');
+      fireEvent.click(card);
+
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onParentClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Focus Management', () => {
+    it('should be focusable with tabIndex 0', () => {
+      render(<AddActionCard {...defaultProps} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      expect(card).toHaveAttribute('tabIndex', '0');
+    });
+
+    it('should have proper focus styling when focused', async () => {
+      render(<AddActionCard {...defaultProps} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      card.focus();
+
+      expect(card).toHaveFocus();
+    });
+  });
+
+  describe('Data Attributes', () => {
+    it('should have proper test id for trigger', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.TRIGGER} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      expect(card).toBeInTheDocument();
+    });
+
+    it('should have proper test id for action', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.ACTION} />);
+
+      const card = screen.getByTestId('card-Add an action');
+      expect(card).toBeInTheDocument();
+    });
+
+    it('should have proper automation id for trigger', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.TRIGGER} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      expect(card).toHaveAttribute('data-automation-id', 'card-add_a_trigger');
+    });
+
+    it('should have proper automation id for action', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.ACTION} />);
+
+      const card = screen.getByTestId('card-Add an action');
+      expect(card).toHaveAttribute('data-automation-id', 'card-add_an_action');
+    });
+  });
+
+  describe('Accessibility Labels', () => {
+    it('should have proper aria-label for trigger', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.TRIGGER} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      expect(card).toHaveAttribute('aria-label', 'Add a trigger');
+    });
+
+    it('should have proper aria-label for action', () => {
+      render(<AddActionCard {...defaultProps} addCardType={ADD_CARD_TYPE.ACTION} />);
+
+      const card = screen.getByTestId('card-Add an action');
+      expect(card).toHaveAttribute('aria-label', 'Add an action');
+    });
+  });
+
+  describe('CSS Classes', () => {
+    it('should apply selection styling when selected', () => {
+      render(<AddActionCard {...defaultProps} selected={true} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      expect(card).toHaveClass('msla-panel-card-container-selected');
+    });
+
+    it('should not apply selection styling when not selected', () => {
+      render(<AddActionCard {...defaultProps} selected={false} />);
+
+      const card = screen.getByTestId('card-Add a trigger');
+      expect(card).not.toHaveClass('msla-panel-card-container-selected');
+    });
+  });
+});

--- a/libs/designer-ui/src/lib/card/addActionCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/addActionCard/index.tsx
@@ -85,49 +85,56 @@ export const AddActionCard: React.FC<AddActionCardProps> = ({ addCardType, onCli
   const tooltipHeading = addCardType === ADD_CARD_TYPE.TRIGGER ? triggerTooltipHeading : actionTooltipHeading;
   const tooltipBody = addCardType === ADD_CARD_TYPE.TRIGGER ? triggerTooltipBody : actionTooltipBody;
   const tooltipId = `placeholder-node-${addCardType}`;
+  const tooltipDescriptionId = `${tooltipId}-description`;
 
   return (
-    <TooltipHost
-      id={tooltipId}
-      delay={0}
-      directionalHint={DirectionalHint.rightCenter}
-      calloutProps={{ gapSpace: 8 }}
-      tooltipProps={{
-        onRenderContent: () => (
-          <div style={{ margin: '-8px 12px 0px', maxWidth: '250px' }}>
-            <h2>{tooltipHeading}</h2>
-            <p>{tooltipBody}</p>
-          </div>
-        ),
-      }}
-    >
-      <div style={{ position: 'relative' }}>
-        <div
-          aria-describedby={tooltipId}
-          aria-label={title}
-          className={css('msla-panel-card-container', selected && 'msla-panel-card-container-selected')}
-          style={getCardStyle(brandColor)}
-          data-testid={`card-${title}`}
-          data-automation-id={`card-${replaceWhiteSpaceWithUnderscore(title)}`}
-          onClick={handleClick}
-          onKeyDown={keyboardInteraction.keyDown}
-          onKeyUp={keyboardInteraction.keyUp}
-          tabIndex={0}
-        >
-          <div className={css('msla-selection-box', selected && 'selected')} />
-          <div className="panel-card-main">
-            <div className="panel-card-header" role="button">
-              <div className="panel-card-content-container">
-                <div className={'panel-card-content-gripper-section'} />
-                {cardIcon}
-                <div className="panel-card-top-content">
-                  <div className="panel-msla-title">{title}</div>
+    <>
+      {/* Hidden element for screen readers to access tooltip content */}
+      <div id={tooltipDescriptionId} style={{ display: 'none' }}>
+        {tooltipHeading}: {tooltipBody}
+      </div>
+      <TooltipHost
+        id={tooltipId}
+        delay={0}
+        directionalHint={DirectionalHint.rightCenter}
+        calloutProps={{ gapSpace: 8 }}
+        tooltipProps={{
+          onRenderContent: () => (
+            <div style={{ margin: '-8px 12px 0px', maxWidth: '250px' }}>
+              <h2>{tooltipHeading}</h2>
+              <p>{tooltipBody}</p>
+            </div>
+          ),
+        }}
+      >
+        <div style={{ position: 'relative' }}>
+          <div
+            aria-describedby={tooltipDescriptionId}
+            aria-label={title}
+            className={css('msla-panel-card-container', selected && 'msla-panel-card-container-selected')}
+            style={getCardStyle(brandColor)}
+            data-testid={`card-${title}`}
+            data-automation-id={`card-${replaceWhiteSpaceWithUnderscore(title)}`}
+            onClick={handleClick}
+            onKeyDown={keyboardInteraction.keyDown}
+            onKeyUp={keyboardInteraction.keyUp}
+            tabIndex={0}
+          >
+            <div className={css('msla-selection-box', selected && 'selected')} />
+            <div className="panel-card-main">
+              <div className="panel-card-header" role="button">
+                <div className="panel-card-content-container">
+                  <div className={'panel-card-content-gripper-section'} />
+                  {cardIcon}
+                  <div className="panel-card-top-content">
+                    <div className="panel-msla-title">{title}</div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </TooltipHost>
+      </TooltipHost>
+    </>
   );
 };


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
This PR fixes an accessibility issue where screen readers (NVDA and Narrator) were unable to announce tooltip information when focusing on the "Add a trigger" button in the Logic Apps designer. The root cause was that the `aria-describedby` attribute was pointing to the TooltipHost component rather than an element containing accessible content for screen readers.

The fix adds a hidden element containing the tooltip text that screen readers can access through the `aria-describedby` attribute, while maintaining the existing visual tooltip functionality for sighted users.

## Impact of Change
- **Users**: Screen reader users (NVDA, Narrator) can now hear tooltip information when focusing on "Add a trigger" buttons, improving accessibility compliance
- **Developers**: No API changes; only internal DOM structure updated with hidden accessibility element  
- **System**: Minimal impact - adds one hidden DOM element per AddActionCard component

## Test Plan
- [x] Unit tests added/updated - Added comprehensive test suite (23 tests) covering accessibility, rendering, and interaction
- [ ] E2E tests added/updated - Not needed for this accessibility fix
- [x] Manual testing completed - Verified aria-describedby points to correct hidden element
- [x] Tested in: All existing environments (no visual changes)

## Contributors
Thanks to @Xiaoyu-Huang for reporting the accessibility issue in #7282

## Screenshots/Videos
No visual changes - this is an accessibility-only improvement for screen readers