### PR TITLE
fix(designer-ui): make About tab scrollable content keyboard accessible

### DIFF
--- a/libs/designer-ui/src/lib/panel/panel.less
+++ b/libs/designer-ui/src/lib/panel/panel.less
@@ -206,6 +206,11 @@
           flex: 1;
           padding: 15px;
           overflow-y: auto;
+          
+          &[tabindex="0"]:focus {
+            outline: 2px solid @panel-mode-panel-border-color-dark;
+            outline-offset: -2px;
+          }
         }
       }
 

--- a/libs/designer-ui/src/lib/panel/panelcontent.tsx
+++ b/libs/designer-ui/src/lib/panel/panelcontent.tsx
@@ -50,7 +50,6 @@ export const PanelContent = ({ nodeId, tabs = [], selectedTab, selectTab }: Pane
     id: 'PP63jY',
     description: 'This is a label to access the overflowed panels',
   });
-
   return (
     <div id={`msla-node-details-panel-${nodeId}`} className="msla-node-details-panel">
       <Overflow aria-label={overflowLabel}>
@@ -68,7 +67,14 @@ export const PanelContent = ({ nodeId, tabs = [], selectedTab, selectTab }: Pane
           <OverflowMenu tabs={tabs} onTabSelect={selectTab} />
         </TabList>
       </Overflow>
-      <div className="msla-panel-content-container">{tabs.find((tab) => tab.id === selectedTabId)?.content}</div>
+      <div
+        className="msla-panel-content-container"
+        tabIndex={selectedTabId === 'ABOUT' ? 0 : undefined}
+        role={selectedTabId === 'ABOUT' ? 'region' : undefined}
+        aria-label={selectedTabId === 'ABOUT' ? tabs.find((tab) => tab.id === selectedTabId)?.title : undefined}
+      >
+        {tabs.find((tab) => tab.id === selectedTabId)?.content}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
This PR fixes an accessibility issue where scrollable content in the "About" tab was not accessible by keyboard navigation. The issue prevented users who rely on keyboard navigation from accessing the full content within the About tab, violating WCAG 2.1.1 requirements.

Fixes #7280

## Impact of Change
- **Users**: Improves accessibility for keyboard-only users who can now navigate and scroll through content in the About tab using their keyboard
- **Developers**: No API changes - only adds conditional keyboard accessibility attributes to the panel content container
- **System**: No performance impact - only adds tabIndex and ARIA attributes when the About tab is selected

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Local development environment

### Manual Testing Steps:
1. Navigate to any workflow action panel
2. Switch to the "About" tab
3. Press Tab to focus the scrollable content area
4. Use arrow keys to scroll through the content
5. Verify the focus outline appears when the container is focused
6. Verify other tabs do not have keyboard-focusable scroll containers

## Contributors
Thanks to @Xiaoyu-Huang for reporting this accessibility issue

## Screenshots/Videos
My airplane internet doesn't want to upload a video but it works

