### PR TITLE
chore(pipelines): Add write permissions for auto merge PR check

### DIFF
--- a/.github/workflows/loc-auto-merge.yml
+++ b/.github/workflows/loc-auto-merge.yml
@@ -2,6 +2,7 @@ name: 'Auto-merge Validation'
 
 permissions:
   pull-requests: write
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [X] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [X] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->

- Looks like the Auto-merge Validation pipeline for automation and CSIGS PR's is not able to auto assign the label for the PR, therefore it can't go through the next step of auto merging those PR's

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No user facing changes
- **Developers**: No abrupt changes, just added the permission to write on the specific PR for the github action pipeline. 
- **System**: No changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [X] Tested in: Will test it in the pending PR's to automerge CSIGS

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->


## Screenshots/Videos
<!-- Visual changes only -->
