### PR TITLE
fix(vscode): fix "Use connectors from Azure" for workspace with multiple logic apps

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/enableAzureConnectors.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/enableAzureConnectors.ts
@@ -18,9 +18,9 @@ import { isString } from '@microsoft/logic-apps-shared';
 /**
  * Enables Azure connectors for the project containing workflow node.
  * @param {IActionContext} context - The action context for the command.
- * @param {vscode.Uri} node - The URI of the workflow node.
+ * @param {vscode.Uri | undefined} node - The URI of the workflow node.
  */
-export async function enableAzureConnectors(context: IActionContext, node: vscode.Uri): Promise<void> {
+export async function enableAzureConnectors(context: IActionContext, node: vscode.Uri | undefined): Promise<void> {
   const projectRoot = node !== undefined ? await getLogicAppProjectRoot(context, node.fsPath) : await getWorkspaceFolder(context);
   const projectPath = isString(projectRoot) ? projectRoot : projectRoot.uri.fsPath;
   const localSettingsFilePath: string = path.join(projectPath, localSettingsFileName);

--- a/apps/vs-code-designer/src/app/commands/workflows/enableAzureConnectors.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/enableAzureConnectors.ts
@@ -7,31 +7,39 @@ import { localize } from '../../../localize';
 import type { IAzureConnectorsContext } from '../../commands/workflows/azureConnectorWizard';
 import { createAzureWizard } from '../../commands/workflows/azureConnectorWizard';
 import { getLocalSettingsJson } from '../../utils/appSettings/localSettings';
-import { getLocalSettingsFile } from '../appSettings/getLocalSettingsFile';
 import type { AzureWizard, IActionContext } from '@microsoft/vscode-azext-utils';
 import type { ILocalSettingsJson } from '@microsoft/vscode-extension-logic-apps';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { getLogicAppProjectRoot } from '../../utils/codeless/connection';
+import { getWorkspaceFolder } from '../../utils/workspace';
+import { isString } from '@microsoft/logic-apps-shared';
 
-export async function enableAzureConnectors(context: IActionContext): Promise<void> {
-  const message: string = localize('selectLocalSettings', 'Select your local settings file.');
-  const localSettingsFile: string = await getLocalSettingsFile(context, message);
-  const projectPath: string = path.dirname(localSettingsFile);
+/**
+ * Enables Azure connectors for the project containing workflow node.
+ * @param {IActionContext} context - The action context for the command.
+ * @param {vscode.Uri} node - The URI of the workflow node.
+ */
+export async function enableAzureConnectors(context: IActionContext, node: vscode.Uri): Promise<void> {
+  const projectRoot = node !== undefined ? await getLogicAppProjectRoot(context, node.fsPath) : await getWorkspaceFolder(context);
+  const projectPath = isString(projectRoot) ? projectRoot : projectRoot.uri.fsPath;
   const localSettingsFilePath: string = path.join(projectPath, localSettingsFileName);
   const localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, localSettingsFilePath);
-  const connectorsContext: IAzureConnectorsContext = context as IAzureConnectorsContext;
   const subscriptionId: string = localSettings.Values[workflowSubscriptionIdKey];
 
   if (subscriptionId === undefined || subscriptionId === '') {
+    const connectorsContext: IAzureConnectorsContext = context as IAzureConnectorsContext;
     const wizard: AzureWizard<IAzureConnectorsContext> = createAzureWizard(connectorsContext, projectPath);
     await wizard.prompt();
     await wizard.execute();
-    vscode.window.showInformationMessage(
-      localize(
-        'logicapp.azureConnectorsEnabledForProject',
-        'Azure connectors are enabled for the project. Reload the designer panel to start using the connectors.'
-      )
-    );
+    if (connectorsContext.enabled) {
+      vscode.window.showInformationMessage(
+        localize(
+          'logicapp.azureConnectorsEnabledForProject',
+          'Azure connectors are enabled for the project. Reload the designer panel to start using the connectors.'
+        )
+      );
+    }
   } else {
     await vscode.window.showInformationMessage(
       localize('logicapp.azureConnectorsEnabledForWorkflow', 'Azure connectors are enabled for the workflow.')


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Fix for #6782. "Use connectors from Azure" command does not prompt for subscription/resource group and update local.settings.json in some scenarios in workspaces with multiple logic apps, fixed to work as intended.

## Impact of Change
- **Users**: Working "Use connectors from Azure" command for multi-logic app projects

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
- Andrew Eldridge (andrew-eldridge)
