### PR TITLE
feat(vscode) : Updated unit test to use cloud.settings.json

### DIFF
--- a/apps/vs-code-designer/src/assets/UnitTestTemplates/TestExecutorFile
+++ b/apps/vs-code-designer/src/assets/UnitTestTemplates/TestExecutorFile
@@ -42,7 +42,7 @@ namespace <%= LogicAppName %>.Tests
             var workflowDefinitionPath = Path.Combine(this.rootDirectory, this.logicAppName, this.workflow, "workflow.json");
             var connectionsPath = Path.Combine(this.rootDirectory, this.logicAppName, "connections.json");
             var parametersPath = Path.Combine(this.rootDirectory, this.logicAppName, "parameters.json");
-            var localSettingsPath = Path.Combine(this.rootDirectory, this.logicAppName, "local.settings.json");
+            var localSettingsPath = Path.Combine(this.rootDirectory, this.logicAppName, "cloud.settings.json");
             
             return new UnitTestExecutor(
                 workflowFilePath: workflowDefinitionPath,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
There is a reliance on having local.settings.json available to do execute unit tests. This is fine when users run test in vscode. However, users will be blocked from doing this as local.settings.json is not a source controlled file and has settings that should not be committed to a repository. We have now created cloud.settings.json, which has sanitized settings and should allow users to run unit tests in CI/CD environments. We are simply changing the reference in the TestExecutorFile to cloud.settings.json.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any --> This is a first pass that should get users closer to being able to run unit tests they create in CI/CD environments.
- **Developers**: <!-- API changes, new patterns, etc. --> None
- **System**: <!-- Performance, architecture, dependencies --> None

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
