### PR TITLE
fix(templates): Removing publish buttons from non summary tabs

### DIFF
--- a/libs/designer/src/lib/core/configuretemplate/ConfigureTemplateWizard.tsx
+++ b/libs/designer/src/lib/core/configuretemplate/ConfigureTemplateWizard.tsx
@@ -65,7 +65,7 @@ export const ConfigureTemplateWizard = ({
     }
   };
 
-  const onSaveTemplate = (prevStatus: Template.TemplateEnvironment, newStatus: Template.TemplateEnvironment) => {
+  const onSaveTemplate = (prevStatus: Template.TemplateEnvironment, newStatus?: Template.TemplateEnvironment) => {
     const isNewStatusPublished = equals(newStatus, 'Production') || equals(newStatus, 'Testing');
     setToasterData({
       title: isNewStatusPublished

--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -642,7 +642,9 @@ export const operationMetadataSlice = createSlice({
     builder.addCase(setStateAfterUndoRedo, (_, action: PayloadAction<UndoRedoPartialRootState>) => action.payload.operations);
     builder.addCase(deleteWorkflowData.fulfilled, (state, action: PayloadAction<{ ids: string[] }>) => {
       for (const id of action.payload.ids) {
-        const nodeIds = Object.keys(state.operationInfo).filter((nodeId) => nodeId.startsWith(`${id}${delimiter}`));
+        const nodeIds = Object.keys(state.operationInfo).filter((nodeId) =>
+          nodeId.toLowerCase().startsWith(`${id.toLowerCase()}${delimiter}`)
+        );
 
         for (const nodeId of nodeIds) {
           delete state.inputParameters[nodeId];

--- a/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/configureWorkflowsPanel.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/configureWorkflowsPanel.tsx
@@ -16,7 +16,7 @@ export interface ConfigureWorkflowsTabProps {
   disabled?: boolean;
   isPrimaryButtonDisabled: boolean;
   isSaving: boolean;
-  onSave?: (status: Template.TemplateEnvironment) => void;
+  onSave?: () => void;
   onClose?: () => void;
   status?: Template.TemplateEnvironment;
   selectedWorkflowsList: Record<string, Partial<WorkflowTemplateData>>;

--- a/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/tabs/customizeWorkflowsTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/tabs/customizeWorkflowsTab.tsx
@@ -7,7 +7,6 @@ import type { IntlShape } from 'react-intl';
 import type { WorkflowTemplateData } from '../../../../../core';
 import { CustomizeWorkflows } from '../../../workflows/customizeWorkflows';
 import { Spinner } from '@fluentui/react-components';
-import { getSaveMenuButtons } from '../../../../../core/configuretemplate/utils/helper';
 
 export const customizeWorkflowsTab = (
   intl: IntlShape,
@@ -22,7 +21,6 @@ export const customizeWorkflowsTab = (
     updateWorkflowDataField,
     onSave,
     duplicateIds,
-    status,
     onClose,
   }: ConfigureWorkflowsTabProps & {
     duplicateIds: string[];
@@ -58,10 +56,9 @@ export const customizeWorkflowsTab = (
             description: 'Button text for saving changes in the configure workflows panel',
           })
         ),
-        onClick: () => {},
+        onClick: () => onSave?.(),
         appearance: 'primary',
         disabled: isPrimaryButtonDisabled || isSaving,
-        menuItems: getSaveMenuButtons(resources, status ?? 'Development', (newStatus) => onSave?.(newStatus)),
       },
       {
         type: 'action',

--- a/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/panels/configureWorkflowsPanel/usePanelTabs.tsx
@@ -11,7 +11,7 @@ import {
   initializeAndSaveWorkflowsData,
   saveWorkflowsData,
 } from '../../../../core/actions/bjsworkflow/configuretemplate';
-import { getResourceNameFromId, equals, isUndefinedOrEmptyString, getUniqueName, type Template, clone } from '@microsoft/logic-apps-shared';
+import { getResourceNameFromId, equals, isUndefinedOrEmptyString, getUniqueName, clone } from '@microsoft/logic-apps-shared';
 import { checkWorkflowNameWithRegex, validateWorkflowData } from '../../../../core/templates/utils/helper';
 import { useMemo, useCallback } from 'react';
 import { useResourceStrings } from '../../resources';
@@ -136,7 +136,7 @@ export const useConfigureWorkflowPanelTabs = ({
 
   const onSaveCompleted = useCallback(() => onSave?.(Object.keys(selectedWorkflowsList()).length > 1), [onSave, selectedWorkflowsList]);
 
-  const onSaveChanges = (newPublishState: Template.TemplateEnvironment) => {
+  const onSaveChanges = () => {
     // 1. Update the workflowId with user-input id (For newly selected workflow)
     setSelectedWorkflowsList((prevSelectedWorkflows) => {
       for (const [workflowId, workflowData] of Object.entries(prevSelectedWorkflows)) {
@@ -165,9 +165,9 @@ export const useConfigureWorkflowPanelTabs = ({
 
     // TODO: change below logic to API call then modify state
     if (hasWorkflowListChanged) {
-      dispatch(initializeAndSaveWorkflowsData({ workflows: selectedWorkflowsList(), publishState: newPublishState, onSaveCompleted }));
+      dispatch(initializeAndSaveWorkflowsData({ workflows: selectedWorkflowsList(), onSaveCompleted }));
     } else {
-      dispatch(saveWorkflowsData({ workflows: selectedWorkflowsList(), publishState: newPublishState, onSaveCompleted }));
+      dispatch(saveWorkflowsData({ workflows: selectedWorkflowsList(), onSaveCompleted }));
     }
   };
 

--- a/libs/designer/src/lib/ui/configuretemplate/panels/customizeParameterPanel/customizeParameterPanel.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/panels/customizeParameterPanel/customizeParameterPanel.tsx
@@ -8,11 +8,9 @@ import { Panel, PanelType } from '@fluentui/react';
 import { CustomizeParameter } from '../../../configuretemplate/parameters/customizeParameter';
 import { validateParameterDetails } from '../../../../core/state/templates/templateSlice';
 import { useFunctionalState } from '@react-hookz/web';
-import { equals, isUndefinedOrEmptyString, type Template } from '@microsoft/logic-apps-shared';
+import { isUndefinedOrEmptyString, type Template } from '@microsoft/logic-apps-shared';
 import { useParameterDefinition } from '../../../../core/configuretemplate/configuretemplateselectors';
 import { updateWorkflowParameter } from '../../../../core/actions/bjsworkflow/configuretemplate';
-import { getSaveMenuButtons } from '../../../../core/configuretemplate/utils/helper';
-import { useResourceStrings } from '../../resources';
 
 const layerProps = {
   hostId: 'msla-layer-host',
@@ -22,13 +20,12 @@ const layerProps = {
 export const CustomizeParameterPanel = () => {
   const dispatch = useDispatch<AppDispatch>();
   const intl = useIntl();
-  const { parameterId, runValidation, isOpen, currentPanelView, parameterErrors, currentStatus } = useSelector((state: RootState) => ({
+  const { parameterId, runValidation, isOpen, currentPanelView, parameterErrors } = useSelector((state: RootState) => ({
     parameterId: state.panel.selectedTabId,
     runValidation: state.tab.runValidation,
     isOpen: state.panel.isOpen,
     currentPanelView: state.panel.currentPanelView,
     parameterErrors: state.template.errors.parameters,
-    currentStatus: state.template.status,
   }));
 
   const parameterDefinition = useParameterDefinition(parameterId as string);
@@ -40,7 +37,6 @@ export const CustomizeParameterPanel = () => {
       description: 'Panel header title for customizing parameters',
     }),
   };
-  const resources = useResourceStrings();
   const [selectedParameterDefinition, setSelectedParameterDefinition] =
     useFunctionalState<Template.ParameterDefinition>(parameterDefinition);
   const [isDirty, setIsDirty] = useState(false);
@@ -81,9 +77,7 @@ export const CustomizeParameterPanel = () => {
             description: 'Button text for saving changes for parameter in the customize parameter panel',
           }),
           appearance: 'primary',
-          onClick: () => {},
-          disabled: !isDirty || isDisplayNameEmpty,
-          menuItems: getSaveMenuButtons(resources, currentStatus ?? 'Development', (newStatus) => {
+          onClick: () => {
             if (runValidation) {
               dispatch(validateParameterDetails());
             }
@@ -91,10 +85,10 @@ export const CustomizeParameterPanel = () => {
               updateWorkflowParameter({
                 parameterId: parameterId as string,
                 definition: selectedParameterDefinition(),
-                changedStatus: equals(currentStatus, newStatus) ? undefined : newStatus,
               })
             );
-          }),
+          },
+          disabled: !isDirty || isDisplayNameEmpty,
         },
         {
           type: 'action',
@@ -109,7 +103,7 @@ export const CustomizeParameterPanel = () => {
         },
       ],
     };
-  }, [dispatch, intl, isDirty, parameterId, runValidation, currentStatus, resources, selectedParameterDefinition]);
+  }, [dispatch, intl, isDirty, parameterId, runValidation, selectedParameterDefinition]);
 
   const onRenderFooterContent = useCallback(() => <TemplatesPanelFooter {...footerContent} />, [footerContent]);
 

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/model.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/model.tsx
@@ -4,6 +4,6 @@ import type { Template } from '@microsoft/logic-apps-shared';
 export interface TemplateWizardTabProps {
   disabled?: boolean;
   tabStatusIcon?: TemplateTabStatusType;
-  onSave?: (status: Template.TemplateEnvironment) => void;
+  onSave?: () => void;
   status?: Template.TemplateEnvironment;
 }

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/profileTab.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/profileTab.tsx
@@ -5,13 +5,12 @@ import { selectWizardTab } from '../../../core/state/templates/tabSlice';
 import { TemplateManifestForm } from '../templateprofile/manifestform';
 import type { TemplateWizardTabProps } from './model';
 import type { IntlShape } from 'react-intl';
-import { getSaveMenuButtons } from '../../../core/configuretemplate/utils/helper';
 
 export const profileTab = (
   intl: IntlShape,
   resources: Record<string, string>,
   dispatch: AppDispatch,
-  { disabled, tabStatusIcon, onSave, status, isSaveButtonDisabled }: TemplateWizardTabProps & { isSaveButtonDisabled: boolean }
+  { disabled, tabStatusIcon, onSave, isSaveButtonDisabled }: TemplateWizardTabProps & { isSaveButtonDisabled: boolean }
 ): TemplateTabProps => ({
   id: constants.CONFIGURE_TEMPLATE_WIZARD_TAB_NAMES.PROFILE,
   title: resources.ProfileTabLabel,
@@ -38,9 +37,8 @@ export const profileTab = (
         type: 'action',
         text: resources.SaveButtonText,
         appearance: 'primary',
-        onClick: () => {},
+        onClick: () => onSave?.(),
         disabled: isSaveButtonDisabled,
-        menuItems: getSaveMenuButtons(resources, status ?? 'Development', (newStatus) => onSave?.(newStatus)),
       },
     ],
   },

--- a/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/tabs/useWizardTabs.tsx
@@ -26,7 +26,7 @@ export const useConfigureTemplateWizardTabs = ({
   onSaveTemplate,
 }: {
   onSaveWorkflows: (isMultiWorkflow: boolean) => void;
-  onSaveTemplate: (prevStatus: Template.TemplateEnvironment, newStatus: Template.TemplateEnvironment) => void;
+  onSaveTemplate: (prevStatus: Template.TemplateEnvironment, newStatus?: Template.TemplateEnvironment) => void;
 }) => {
   const intl = useIntl();
   const dispatch = useDispatch<AppDispatch>();
@@ -76,7 +76,7 @@ export const useConfigureTemplateWizardTabs = ({
   }, [dispatch, selectedTabId]);
 
   const handleSaveTemplate = useCallback(
-    async (newPublishState: Template.TemplateEnvironment) => {
+    async (newPublishState?: Template.TemplateEnvironment) => {
       dispatch(setRunValidation(true));
       dispatch(
         saveTemplateData({


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
This removes the buttons to publish the templates from workflows, profile and parameters tab and now it can only be published from summary tab.
When workflows are being added we also move the template to development state now to prevent validation errors.
This was needed because it was creating incorrect data while saving data in other tabs and resulting in errors and not letting users move forward.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users would be able to add new workflows in template which is already published and save changes correctly
- **Developers**: No new changes
- **System**: No new changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@divyaswarnkar @bonica-ayala @Elaina-Lee 

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/58e4d488-a06e-4034-9b9b-0d2c913a3588)
