### PR TITLE
fix(designer): Fixing standalone+vscode resolving connection references in standalone causing infinite loop

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
@@ -104,16 +104,17 @@ export class WorkflowUtility {
 }
 
 function replaceAllOccurrences(content: string, searchValue: string, value: any): string {
-  while (content.includes(searchValue)) {
-    const tempResult =
-      replaceIfFoundAndVerifyJson(content, `"${searchValue}"`, JSON.stringify(value)) ??
-      replaceIfFoundAndVerifyJson(content, searchValue, `${value}`) ??
-      content.replace(searchValue, '');
-
-    content = tempResult;
+  let result = replaceIfFoundAndVerifyJson(content, `"${searchValue}"`, JSON.stringify(value));
+  if (result) {
+    return result;
   }
 
-  return content;
+  result = replaceIfFoundAndVerifyJson(content, searchValue, `${value}`);
+  if (result) {
+    return result;
+  }
+
+  return content.replaceAll(searchValue, '');
 }
 
 function replaceIfFoundAndVerifyJson(stringifiedJson: string, searchValue: string, value: string): string | undefined {

--- a/apps/vs-code-react/src/app/designer/utilities/workflow.ts
+++ b/apps/vs-code-react/src/app/designer/utilities/workflow.ts
@@ -93,17 +93,17 @@ export const resolveConnectionsReferences = (
 };
 
 function replaceAllOccurrences(content: string, searchValue: string, value: any): string {
-  let currContent = content;
-  while (currContent.includes(searchValue)) {
-    const tempResult =
-      replaceIfFoundAndVerifyJson(currContent, `"${searchValue}"`, JSON.stringify(value)) ??
-      replaceIfFoundAndVerifyJson(currContent, searchValue, `${value}`) ??
-      currContent.replace(searchValue, '');
-
-    currContent = tempResult;
+  let result = replaceIfFoundAndVerifyJson(content, `"${searchValue}"`, JSON.stringify(value));
+  if (result) {
+    return result;
   }
 
-  return currContent;
+  result = replaceIfFoundAndVerifyJson(content, searchValue, `${value}`);
+  if (result) {
+    return result;
+  }
+
+  return content.replaceAll(searchValue, '');
 }
 
 function replaceIfFoundAndVerifyJson(stringifiedJson: string, searchValue: string, value: string): string | undefined {

--- a/libs/vscode-extension/src/lib/services/Workflow.ts
+++ b/libs/vscode-extension/src/lib/services/Workflow.ts
@@ -29,22 +29,23 @@ export const resolveConnectionsReferences = (
 
   try {
     return JSON.parse(result);
-  } catch (error) {
+  } catch (_error) {
     throw new Error('Failure in resolving connection parameterization');
   }
 };
 
 function replaceAllOccurrences(content: string, searchValue: string, value: any): string {
-  while (content.includes(searchValue)) {
-    const tempResult =
-      replaceIfFoundAndVerifyJson(content, `"${searchValue}"`, JSON.stringify(value)) ??
-      replaceIfFoundAndVerifyJson(content, searchValue, `${value}`) ??
-      content.replace(searchValue, '');
-
-    content = tempResult;
+  let result = replaceIfFoundAndVerifyJson(content, `"${searchValue}"`, JSON.stringify(value));
+  if (result) {
+    return result;
   }
 
-  return content;
+  result = replaceIfFoundAndVerifyJson(content, searchValue, `${value}`);
+  if (result) {
+    return result;
+  }
+
+  return content.replaceAll(searchValue, '');
 }
 
 function replaceIfFoundAndVerifyJson(stringifiedJson: string, searchValue: string, value: string): string | undefined {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Previously, we were recursively resolving connection references. While this approach makes sense when repeated replacements (of app settings or parameters) are necessary, it's not ideal in this case. For connectionData, which has a well-defined and fixed structure, recursive resolution isn't needed.

We encountered an ICM where a user mistakenly used an appSetting that referenced itself. Although this is technically a user error, our recursive logic caused an infinite loop, freezing the Designer.

Since we're dealing specifically with connectionData, a single-pass replacement is both safer and more efficient. It avoids potential infinite loops and better aligns with the static nature of the data.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Prevents Designer freezing due to infinite loops caused by improperly configured appSetting values. Improves reliability and user experience loading workflows.
- **Developers**: Simplifies the replacement logic for connectionData by using a one-pass approach instead of recursive resolution. Reduces complexity and risk when debugging connection reference resolution issues.
- **System**: Improves performance and stability by eliminating unnecessary repeated string operations. Reduces risk of unbounded memory or CPU usage in edge cases.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
