### PR TITLE
fix(vscode): use correct tenant in getAuthorizationToken

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ConnectEnvironmentStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/ConnectEnvironmentStep.ts
@@ -27,7 +27,7 @@ export class ConnectEnvironmentStep extends AzureWizardExecuteStep<ILogicAppWiza
       const message: string = localize('linkingSMBEnvironment', 'Linking SMB to connected environment  "{0}"...', context.newSiteName);
       ext.outputChannel.appendLog(message);
       progress.report({ message });
-      const accessToken = await getAuthorizationToken();
+      const accessToken = await getAuthorizationToken(context.tenantId);
 
       await updateSMBConnectedEnvironment(
         accessToken,

--- a/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/HybridAppCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createLogicApp/createLogicAppSteps/HybridLogicAppsSteps/HybridAppCreateStep.ts
@@ -20,7 +20,7 @@ export class HybridAppCreateStep extends AzureWizardExecuteStep<ILogicAppWizardC
       ext.outputChannel.appendLog(message);
       progress.report({ message });
 
-      const accessToken = await getAuthorizationToken();
+      const accessToken = await getAuthorizationToken(context.tenantId);
 
       const hybridAppOptions = {
         sqlConnectionString: context.sqlConnectionString,

--- a/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
@@ -407,11 +407,11 @@ async function getProjectPathToDeploy(
     for (const referenceKey of Object.keys(connectionsData.managedApiConnections)) {
       try {
         const connection = resolvedConnections.managedApiConnections[referenceKey].connection;
-        await createAclInConnectionIfNeeded(identityWizardContext, connection.id, node.site);
+        await createAclInConnectionIfNeeded(identityWizardContext, connection.id, node);
 
         if (node.site.isSlot) {
           const parentTreeItem = node.parent?.parent as SlotTreeItem;
-          await createAclInConnectionIfNeeded(identityWizardContext, connection.id, parentTreeItem.site);
+          await createAclInConnectionIfNeeded(identityWizardContext, connection.id, parentTreeItem);
         }
       } catch (error) {
         throw new Error(`Error in creating access policy for connection in reference - '${referenceKey}'. ${error}`);

--- a/apps/vs-code-designer/src/app/commands/deploy/hybridLogicApp/index.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/hybridLogicApp/index.ts
@@ -8,7 +8,7 @@ import { getRandomHexString } from '../../../utils/fs';
 import { createOrUpdateHybridApp, patchAppSettings } from '../../../utils/codeless/hybridLogicApp/hybridApp';
 import { updateSMBConnectedEnvironment } from '../../../utils/codeless/hybridLogicApp/connectedEnvironment';
 import path from 'path';
-import { getAuthorizationToken } from '../../../utils/codeless/getAuthorizationToken';
+import { getAuthorizationTokenFromNode } from '../../../utils/codeless/getAuthorizationToken';
 import { getWorkspaceSetting } from '../../../utils/vsCodeConfig/settings';
 import {
   azurePublicBaseUrl,
@@ -42,7 +42,7 @@ export const deployHybridLogicApp = async (context: IActionContext, node: SlotTr
 
         const newSmbFolderName = `${node.hybridSite.name}-${getRandomHexString(32 - node.hybridSite.name.length - 1)}`.toLowerCase();
 
-        const accessToken = await getAuthorizationToken(node.subscription?.tenantId);
+        const accessToken = await getAuthorizationTokenFromNode(node);
 
         progress.report({ increment: 16, message: 'Connecting to SMB and uploading files' });
 
@@ -155,7 +155,7 @@ export const zipDeployHybridLogicApp = async (context: IActionContext, node: Slo
         if (!logicAppsContext.isCreate) {
           progress.report({ increment: 80, message: 'Updating app settings' });
 
-          await patchAppSettings(hybridAppOptions, context, await getAuthorizationToken(node.subscription?.tenantId));
+          await patchAppSettings(hybridAppOptions, context, await getAuthorizationTokenFromNode(node));
         }
 
         progress.report({ increment: 100, message: 'Deployment completed successfully' });
@@ -315,7 +315,7 @@ const getSMBDetails = async (context: IActionContext, node: SlotTreeItem) => {
 };
 
 const getStorageInfoForConnectedEnv = async (connectedEnvId: string, storageName: string, context: IActionContext, node: SlotTreeItem) => {
-  const accessToken = await getAuthorizationToken(node.subscription?.tenantId);
+  const accessToken = await getAuthorizationTokenFromNode(node);
 
   const url = `${azurePublicBaseUrl}/${connectedEnvId}/storages/${storageName}?api-version=${hybridAppApiVersion}`;
 

--- a/apps/vs-code-designer/src/app/commands/deploy/hybridLogicApp/index.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/hybridLogicApp/index.ts
@@ -42,7 +42,7 @@ export const deployHybridLogicApp = async (context: IActionContext, node: SlotTr
 
         const newSmbFolderName = `${node.hybridSite.name}-${getRandomHexString(32 - node.hybridSite.name.length - 1)}`.toLowerCase();
 
-        const accessToken = await getAuthorizationToken();
+        const accessToken = await getAuthorizationToken(node.subscription?.tenantId);
 
         progress.report({ increment: 16, message: 'Connecting to SMB and uploading files' });
 
@@ -155,7 +155,7 @@ export const zipDeployHybridLogicApp = async (context: IActionContext, node: Slo
         if (!logicAppsContext.isCreate) {
           progress.report({ increment: 80, message: 'Updating app settings' });
 
-          await patchAppSettings(hybridAppOptions, context, await getAuthorizationToken());
+          await patchAppSettings(hybridAppOptions, context, await getAuthorizationToken(node.subscription?.tenantId));
         }
 
         progress.report({ increment: 100, message: 'Deployment completed successfully' });
@@ -315,7 +315,7 @@ const getSMBDetails = async (context: IActionContext, node: SlotTreeItem) => {
 };
 
 const getStorageInfoForConnectedEnv = async (connectedEnvId: string, storageName: string, context: IActionContext, node: SlotTreeItem) => {
-  const accessToken = await getAuthorizationToken();
+  const accessToken = await getAuthorizationToken(node.subscription?.tenantId);
 
   const url = `${azurePublicBaseUrl}/${connectedEnvId}/storages/${storageName}?api-version=${hybridAppApiVersion}`;
 

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
@@ -8,7 +8,6 @@ import {
   getStandardAppData,
   getWorkflowManagementBaseURI,
 } from '../../../utils/codeless/common';
-import { getAuthorizationToken } from '../../../utils/codeless/getAuthorizationToken';
 import type { IAzureConnectorsContext } from '../azureConnectorWizard';
 import { OpenDesignerBase } from './openDesignerBase';
 import type { IWorkflowFileContent, IDesignerPanelMetadata } from '@microsoft/vscode-extension-logic-apps';
@@ -16,6 +15,7 @@ import { ExtensionCommand, ProjectName } from '@microsoft/vscode-extension-logic
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { Uri } from 'vscode';
+import { getAuthorizationTokenFromNode } from '../../../utils/codeless/getAuthorizationToken';
 
 export class OpenDesignerForAzureResource extends OpenDesignerBase {
   private readonly node: RemoteWorkflowTreeItem;
@@ -112,7 +112,7 @@ export class OpenDesignerForAzureResource extends OpenDesignerBase {
   }
 
   private async getDesignerPanelMetadata(): Promise<IDesignerPanelMetadata> {
-    const accessToken: string = await getAuthorizationToken(this.node.subscription?.tenantId);
+    const accessToken = await getAuthorizationTokenFromNode(this.node);
 
     return {
       panelId: this.panelName,

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
@@ -112,7 +112,7 @@ export class OpenDesignerForAzureResource extends OpenDesignerBase {
   }
 
   private async getDesignerPanelMetadata(): Promise<IDesignerPanelMetadata> {
-    const accessToken: string = await getAuthorizationToken();
+    const accessToken: string = await getAuthorizationToken(this.node.subscription?.tenantId);
 
     return {
       panelId: this.panelName,

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
@@ -165,7 +165,7 @@ export default class openMonitoringViewForAzureResource extends OpenMonitoringVi
   }
 
   private async getDesignerPanelMetadata(): Promise<IDesignerPanelMetadata> {
-    const accessToken: string = await getAuthorizationToken();
+    const accessToken: string = await getAuthorizationToken(this.node.subscription?.tenantId);
 
     return {
       panelId: this.panelName,

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForAzureResource.ts
@@ -13,7 +13,6 @@ import {
   getWorkflowManagementBaseURI,
   getStandardAppData,
 } from '../../../utils/codeless/common';
-import { getAuthorizationToken } from '../../../utils/codeless/getAuthorizationToken';
 import { sendAzureRequest } from '../../../utils/requestUtils';
 import type { IAzureConnectorsContext } from '../azureConnectorWizard';
 import { OpenMonitoringViewBase } from './openMonitoringViewBase';
@@ -24,6 +23,7 @@ import { ExtensionCommand, ProjectName } from '@microsoft/vscode-extension-logic
 import * as vscode from 'vscode';
 import type { WebviewPanel } from 'vscode';
 import { Uri, ViewColumn } from 'vscode';
+import { getAuthorizationTokenFromNode } from '../../../utils/codeless/getAuthorizationToken';
 
 export default class openMonitoringViewForAzureResource extends OpenMonitoringViewBase {
   private node: RemoteWorkflowTreeItem;
@@ -165,7 +165,7 @@ export default class openMonitoringViewForAzureResource extends OpenMonitoringVi
   }
 
   private async getDesignerPanelMetadata(): Promise<IDesignerPanelMetadata> {
-    const accessToken: string = await getAuthorizationToken(this.node.subscription?.tenantId);
+    const accessToken: string = await getAuthorizationTokenFromNode(this.node);
 
     return {
       panelId: this.panelName,

--- a/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
@@ -143,7 +143,7 @@ export async function openOverview(context: IAzureConnectorsContext, node: vscod
         // Just shipping the access Token every 5 seconds is easier and more
         // performant that asking for it every time and waiting.
         interval = setInterval(async () => {
-          const updatedAccessToken = await getAuthorizationToken();
+          const updatedAccessToken = await getAuthorizationToken(context.tenantId);
 
           if (updatedAccessToken !== accessToken) {
             accessToken = updatedAccessToken;

--- a/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import type { LogicAppsV2 } from '@microsoft/logic-apps-shared';
 import { getRequestTriggerName, getTriggerName, HTTP_METHODS, isNullOrUndefined } from '@microsoft/logic-apps-shared';
-import { localSettingsFileName, managementApiPrefix, workflowAppApiVersion } from '../../../constants';
+import { localSettingsFileName, managementApiPrefix, workflowAppApiVersion, workflowTenantIdKey } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { RemoteWorkflowTreeItem } from '../../tree/remoteWorkflowsTree/RemoteWorkflowTreeItem';
@@ -17,7 +17,7 @@ import {
   tryGetWebviewPanel,
 } from '../../utils/codeless/common';
 import { getLogicAppProjectRoot } from '../../utils/codeless/connection';
-import { getAuthorizationToken } from '../../utils/codeless/getAuthorizationToken';
+import { getAuthorizationToken, getAuthorizationTokenFromNode } from '../../utils/codeless/getAuthorizationToken';
 import { getWebViewHTML } from '../../utils/codeless/getWebViewHTML';
 import { sendRequest } from '../../utils/requestUtils';
 import { getWorkflowNode } from '../../utils/workspace';
@@ -40,6 +40,7 @@ export async function openOverview(context: IAzureConnectorsContext, node: vscod
   let baseUrl: string;
   let apiVersion: string;
   let accessToken: string;
+  let getAccessToken: () => Promise<string>;
   let isLocal: boolean;
   let callbackInfo: ICallbackUrlResponse | undefined;
   let panelName = '';
@@ -58,18 +59,18 @@ export async function openOverview(context: IAzureConnectorsContext, node: vscod
     baseUrl = `http://localhost:${ext.workflowRuntimePort}${managementApiPrefix}`;
     apiVersion = '2019-10-01-edge-preview';
     isLocal = true;
-    accessToken = '';
     triggerName = getTriggerName(workflowContent.definition);
     callbackInfo = await getLocalWorkflowCallbackInfo(context, workflowContent.definition, baseUrl, workflowName, triggerName, apiVersion);
 
     const projectPath = await getLogicAppProjectRoot(context, workflowFilePath);
     localSettings = projectPath ? (await getLocalSettingsJson(context, join(projectPath, localSettingsFileName))).Values || {} : {};
+    getAccessToken = async () => await getAuthorizationToken(localSettings[workflowTenantIdKey]);
     isWorkflowRuntimeRunning = !isNullOrUndefined(ext.workflowRuntimePort);
   } else if (workflowNode instanceof RemoteWorkflowTreeItem) {
     workflowName = workflowNode.name;
     panelName = `${workflowNode.id}-${workflowName}-overview`;
     workflowContent = workflowNode.workflowFileContent;
-    accessToken = await workflowNode.subscription.credentials.getToken();
+    getAccessToken = async () => await getAuthorizationTokenFromNode(workflowNode);
     baseUrl = getWorkflowManagementBaseURI(workflowNode);
     apiVersion = workflowAppApiVersion;
     triggerName = getTriggerName(workflowContent.definition);
@@ -77,7 +78,11 @@ export async function openOverview(context: IAzureConnectorsContext, node: vscod
     corsNotice = localize('CorsNotice', 'To view runs, set "*" to allowed origins in the CORS setting.');
     isLocal = false;
     isWorkflowRuntimeRunning = true;
+  } else {
+    throw new Error(localize('noWorkflowNode', 'No workflow node provided.'));
   }
+
+  accessToken = await getAccessToken();
 
   const existingPanel: vscode.WebviewPanel | undefined = tryGetWebviewPanel(panelGroupKey, panelName);
 
@@ -143,7 +148,7 @@ export async function openOverview(context: IAzureConnectorsContext, node: vscod
         // Just shipping the access Token every 5 seconds is easier and more
         // performant that asking for it every time and waiting.
         interval = setInterval(async () => {
-          const updatedAccessToken = await getAuthorizationToken(context.tenantId);
+          const updatedAccessToken = await getAccessToken();
 
           if (updatedAccessToken !== accessToken) {
             accessToken = updatedAccessToken;

--- a/apps/vs-code-designer/src/app/utils/codeless/connection.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/connection.ts
@@ -475,7 +475,7 @@ async function createAccessPolicyInConnection(
   site: ParsedSite,
   identity: any
 ): Promise<void> {
-  const accessToken = await getAuthorizationToken();
+  const accessToken = await getAuthorizationToken(identityWizardContext.tenantId ?? site.subscription?.tenantId);
   const getUrl = `${connectionId}?api-version=2018-07-01-preview`;
   let connection: any;
 

--- a/apps/vs-code-designer/src/app/utils/codeless/getAuthorizationToken.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/getAuthorizationToken.ts
@@ -1,9 +1,33 @@
 import { getSessionFromVSCode } from '@microsoft/vscode-azext-azureauth/out/src/getSessionFromVSCode';
 import { getConfiguredAzureEnv } from '@microsoft/vscode-azext-azureauth';
+import { localize } from '../../../localize';
+import type { AzExtTreeItem } from '@microsoft/vscode-azext-utils';
 
 export async function getAuthorizationToken(tenantId?: string): Promise<string> {
   const session = await getSessionFromVSCode(undefined, tenantId, { createIfNone: true });
   return `Bearer ${session?.accessToken}`;
+}
+
+/**
+ * Retrieves the authorization token from the provided node.
+ * @param {AzExtTreeItem} node - The tree item node to retrieve the authorization token from.
+ * @returns {Promise<string>} - A promise that resolves to the authorization token.
+ */
+export async function getAuthorizationTokenFromNode(node: AzExtTreeItem): Promise<string> {
+  if (!node) {
+    throw new Error(localize('noNode', 'No node provided to retrieve the authorization token.'));
+  }
+
+  if (!node.subscription) {
+    throw new Error(localize('noSubscription', 'No subscription found for the selected node.'));
+  }
+
+  const subAccessToken = await node.subscription.credentials?.getToken();
+  if (subAccessToken) {
+    return `Bearer ${subAccessToken.token ?? subAccessToken}`;
+  }
+
+  return await getAuthorizationToken(node.subscription.tenantId);
 }
 
 export async function getCloudHost(): Promise<string> {

--- a/apps/vs-code-designer/src/app/utils/subscription.ts
+++ b/apps/vs-code-designer/src/app/utils/subscription.ts
@@ -10,9 +10,9 @@ import { SubscriptionTreeItem } from '../tree/subscriptionTree/SubscriptionTreeI
 
 /**
  * Retrieves the subscription context based on the provided subscription ID or prompts the user to select a subscription node.
- * @param context - The action context.
- * @param subscriptionId - Optional subscription ID to find the specific subscription node.
- * @return A promise that resolves to the found or selected node's subscription context.
+ * @param {IActionContext} context - The action context.
+ * @param {string} subscriptionId - Optional subscription ID to find the specific subscription node.
+ * @returns {Promise<ISubscriptionContext>} - A promise that resolves to the found or selected node's subscription context.
  */
 export async function getSubscriptionContext(context: IActionContext, subscriptionId?: string): Promise<ISubscriptionContext> {
   let node: AzExtParentTreeItem;

--- a/apps/vs-code-designer/src/app/utils/subscription.ts
+++ b/apps/vs-code-designer/src/app/utils/subscription.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import type { AzExtParentTreeItem, IActionContext, ISubscriptionContext } from '@microsoft/vscode-azext-utils';
+import { ext } from '../../extensionVariables';
+import { isString } from '@microsoft/logic-apps-shared';
+import { localize } from '../../localize';
+import { SubscriptionTreeItem } from '../tree/subscriptionTree/SubscriptionTreeItem';
+
+/**
+ * Retrieves the subscription context based on the provided subscription ID or prompts the user to select a subscription node.
+ * @param context - The action context.
+ * @param subscriptionId - Optional subscription ID to find the specific subscription node.
+ * @return A promise that resolves to the found or selected node's subscription context.
+ */
+export async function getSubscriptionContext(context: IActionContext, subscriptionId?: string): Promise<ISubscriptionContext> {
+  let node: AzExtParentTreeItem;
+
+  if (isString(subscriptionId)) {
+    node = await ext.rgApi.appResourceTree.findTreeItem(`/subscriptions/${subscriptionId}`, context);
+    if (!node) {
+      throw new Error(localize('noMatchingSubscription', 'Failed to find a subscription matching id "{0}".', subscriptionId));
+    }
+  } else {
+    node = await ext.rgApi.appResourceTree.showTreeItemPicker<AzExtParentTreeItem>(SubscriptionTreeItem.contextValue, context);
+  }
+
+  return node.subscription;
+}


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Sometimes the default tenant used to get auth token does not have required permissions. Fix by explicitly passing tenant when available.

## Impact of Change
- **Users**: Fix 401 issues related to invalid tenant across multiple commands

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge 
