### PR TITLE
fix(designer): Agent Instruction Value Type set incorrectly 

### DIFF
--- a/libs/designer-ui/src/lib/agentinstruction/index.tsx
+++ b/libs/designer-ui/src/lib/agentinstruction/index.tsx
@@ -9,7 +9,7 @@ import { css } from '@fluentui/utilities';
 import { ArrayEditor, ArrayType } from '../arrayeditor';
 import { Label } from '../label';
 import { useAgentInstructionStyles } from './agentinstruction.styles';
-import constants from './../constants';
+import constants from '../constants';
 
 export const NavigateIcon = bundleIcon(Open12Regular, Open12Filled);
 

--- a/libs/designer-ui/src/lib/agentinstruction/index.tsx
+++ b/libs/designer-ui/src/lib/agentinstruction/index.tsx
@@ -9,6 +9,7 @@ import { css } from '@fluentui/utilities';
 import { ArrayEditor, ArrayType } from '../arrayeditor';
 import { Label } from '../label';
 import { useAgentInstructionStyles } from './agentinstruction.styles';
+import constants from './../constants';
 
 export const NavigateIcon = bundleIcon(Open12Regular, Open12Filled);
 
@@ -89,6 +90,7 @@ export const AgentInstructionEditor = ({
           placeholder={systemPlaceholder}
           initialValue={systemMessage}
           editorBlur={(newState: ChangeState) => handleValueChange(newState, AGENT_INSTRUCTION_TYPES.SYSTEM)}
+          valueType={constants.SWAGGER.TYPE.STRING}
         />
         <Label text={userItemLabel} />
         <ArrayEditor


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Changes the agent instruction to use the correct value Type (string). It was inheriting the valueType from the manifest (array) as it should be serialized as so, but because the Agent instruction is combined with user instruction during serialization; however as an editor it should be of string type.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Can use string-accepted tokens instead of array-accepted
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@kewear for raising the issue

## Screenshots/Videos
<!-- Visual changes only -->
