### PR TITLE
fix(designer): Center Graph on Mount

### DIFF
--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -88,10 +88,13 @@ export const Designer = (props: DesignerProps) => {
     setReactFlowInstance(instance);
   }, []);
 
+  const hasFitViewRun = useRef(false);
+
   useEffect(() => {
-    if (nodes.length > 0 && reactFlowInstance) {
+    if (!hasFitViewRun.current && nodes.length > 0 && reactFlowInstance) {
       requestAnimationFrame(() => {
         reactFlowInstance.fitView({ padding: 0.6 });
+        hasFitViewRun.current = true;
       });
     }
   }, [nodes, reactFlowInstance]);

--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -34,7 +34,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { Background, ReactFlow, ReactFlowProvider, BezierEdge } from '@xyflow/react';
-import type { BackgroundProps, EdgeTypes, NodeChange } from '@xyflow/react';
+import type { BackgroundProps, EdgeTypes, NodeChange, ReactFlowInstance } from '@xyflow/react';
 import { PerformanceDebugTool } from './common/PerformanceDebug/PerformanceDebug';
 import { CanvasFinder } from './CanvasFinder';
 import { DesignerContextualMenu } from './common/DesignerContextualMenu/DesignerContextualMenu';
@@ -81,6 +81,21 @@ export const Designer = (props: DesignerProps) => {
   const { backgroundProps, panelLocation = PanelLocation.Right, customPanelLocations } = props;
 
   const [nodes, edges, flowSize] = useLayout();
+
+  const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
+
+  const onInit = useCallback((instance: ReactFlowInstance) => {
+    setReactFlowInstance(instance);
+  }, []);
+
+  useEffect(() => {
+    if (nodes.length > 0 && reactFlowInstance) {
+      requestAnimationFrame(() => {
+        reactFlowInstance.fitView({ padding: 0.6 });
+      });
+    }
+  }, [nodes, reactFlowInstance]);
+
   const isEmpty = useIsGraphEmpty();
   const isVSCode = useIsVSCode();
   const isReadOnly = useReadOnly();
@@ -231,6 +246,7 @@ export const Designer = (props: DesignerProps) => {
           <div style={{ flexGrow: 1 }}>
             <ReactFlow
               ref={canvasRef}
+              onInit={onInit}
               nodeTypes={nodeTypes}
               nodes={nodesWithPlaceholder}
               edges={edges}


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
With the layout changes, we were no longer centering the graph on mount
https://github.com/Azure/LogicAppsUX/issues/7570
so when switching to the editable code view and back it was causing the graph to start at 0,0

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Remounting the UI now centers the graph
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@vgouth for finding the issue

## Screenshots/Videos
<!-- Visual changes only -->
