### PR TITLE
fix(vscode): Update getWorkspaceFolder to always return WorkspaceFolder

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createCodeful/CodefulWorkflowCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createCodeful/CodefulWorkflowCreateStep.ts
@@ -37,7 +37,6 @@ import { createConnectionsJson } from '../../utils/codeless/connection';
 import { createEmptyParametersJson } from '../../utils/codeless/parameter';
 import { getDebugConfigs, updateDebugConfigs } from '../../utils/vsCodeConfig/launch';
 import { getWorkspaceFolder, isMultiRootWorkspace } from '../../utils/workspace';
-import { isNullOrUndefined, isString } from '@microsoft/logic-apps-shared';
 import { localize } from '../../../localize';
 
 export class CodefulWorkflowCreateStep extends WorkflowCreateStepBase<IFunctionWizardContext> {
@@ -68,7 +67,7 @@ export class CodefulWorkflowCreateStep extends WorkflowCreateStepBase<IFunctionW
     await this.createSystemArtifacts(context);
 
     if (context.workspaceFolder === undefined) {
-      context.workspaceFolder = await this.getWorkspaceFolder(context);
+      context.workspaceFolder = await getWorkspaceFolder(context);
     }
 
     await this.updateLogicAppLaunchJson(
@@ -80,32 +79,6 @@ export class CodefulWorkflowCreateStep extends WorkflowCreateStepBase<IFunctionW
     );
 
     return workflowCsFullPath;
-  }
-
-  private createWorkspaceFolderFromPath(path: string): vscode.WorkspaceFolder {
-    const uri = vscode.Uri.file(path);
-    return {
-      uri,
-      name: uri.fsPath.split(/[\\/]/).pop() || uri.fsPath,
-      index: 0, // Set appropriately if you have multiple folders
-    };
-  }
-
-  private async getWorkspaceFolder(context: IFunctionWizardContext): Promise<vscode.WorkspaceFolder | undefined> {
-    let workspaceFolder: string | vscode.WorkspaceFolder | undefined;
-    let workspacePath = context.workspacePath;
-    workspacePath = isString(workspacePath) ? workspacePath : undefined;
-    if (workspacePath === undefined) {
-      workspaceFolder = await getWorkspaceFolder(context);
-      workspacePath = isNullOrUndefined(workspaceFolder)
-        ? undefined
-        : isString(workspaceFolder)
-          ? workspaceFolder
-          : workspaceFolder.uri.fsPath;
-    } else {
-      workspaceFolder = this.createWorkspaceFolderFromPath(workspacePath);
-    }
-    return workspaceFolder as vscode.WorkspaceFolder;
   }
 
   /**

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/ConvertToWorkspace.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/ConvertToWorkspace.test.ts
@@ -151,7 +151,7 @@ describe('convertToWorkspace', () => {
 
     const result = await convertToWorkspace(context);
 
-    expect(isLogicAppProjectInRootSpy).toHaveBeenCalledWith(testLogicAppChildFolder);
+    expect(isLogicAppProjectInRootSpy).toHaveBeenCalledWith(testWorkspaceFolder);
     expect(showInfoSpy).toHaveBeenCalledWith(
       localize(
         'openContainingWorkspace',

--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/FolderListStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/FolderListStep.ts
@@ -21,7 +21,7 @@ export class FolderListStep extends AzureWizardPromptStep<IProjectWizardContext>
   }
 
   public async prompt(context: IProjectWizardContext): Promise<void> {
-    const placeHolder: string = localize('selectNewProjectFolder', 'Select the folder that will contain your workflow project');
+    const placeHolder: string = localize('selectNewProjectFolder', 'Select the folder that will contain your logic app workspace');
     FolderListStep.setProjectPath(context, await selectWorkspaceFolder(context, placeHolder));
   }
 

--- a/apps/vs-code-designer/src/app/utils/__test__/workspace.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/workspace.test.ts
@@ -22,7 +22,7 @@ describe('workspaceUtils.getWorkspaceFolder', () => {
     },
   };
 
-  const mockFolder = (fsPath: string): vscode.WorkspaceFolder => ({ uri: { fsPath } }) as vscode.WorkspaceFolder;
+  const mockWorkspaceFolder = (fsPath: string): vscode.WorkspaceFolder => ({ uri: { fsPath } }) as vscode.WorkspaceFolder;
 
   beforeEach(() => {
     // Reset workspace state and mocks before each test
@@ -37,11 +37,11 @@ describe('workspaceUtils.getWorkspaceFolder', () => {
   });
 
   it('should prompt to open project if no workspace folders are open', async () => {
-    const folder1 = mockFolder('/path/one');
+    const workspaceFolder = mockWorkspaceFolder(path.join('path', 'one'));
     (vscode.workspace as any).workspaceFolders = [];
 
     const promptOpenProjectOrWorkspaceSpy = vi.fn(() => {
-      (vscode.workspace as any).workspaceFolders = [folder1];
+      (vscode.workspace as any).workspaceFolders = [workspaceFolder];
     });
 
     (fse.readdir as unknown as Mock).mockReturnValue([
@@ -52,15 +52,16 @@ describe('workspaceUtils.getWorkspaceFolder', () => {
     (promptOpenProjectOrWorkspace as Mock).mockImplementation(promptOpenProjectOrWorkspaceSpy);
 
     await workspaceUtils.getWorkspaceFolder(mockContext);
+
     expect(promptOpenProjectOrWorkspaceSpy).toHaveBeenCalled();
   });
 
   it('should prompt to open project if workspace folders are undefined', async () => {
-    const folder1 = mockFolder('/path/one');
+    const workspaceFolder = mockWorkspaceFolder(path.join('path', 'one'));
     (vscode.workspace as any).workspaceFolders = undefined;
 
     const promptOpenProjectOrWorkspaceSpy = vi.fn(() => {
-      (vscode.workspace as any).workspaceFolders = [folder1];
+      (vscode.workspace as any).workspaceFolders = [workspaceFolder];
     });
 
     (fse.readdir as unknown as Mock).mockReturnValue([
@@ -71,194 +72,185 @@ describe('workspaceUtils.getWorkspaceFolder', () => {
     (promptOpenProjectOrWorkspace as Mock).mockImplementation(promptOpenProjectOrWorkspaceSpy);
 
     await workspaceUtils.getWorkspaceFolder(mockContext);
+
     expect(promptOpenProjectOrWorkspaceSpy).toHaveBeenCalled();
   });
 
-  it('should return the only workspace folder if there is only one', async () => {
-    const folder1 = mockFolder('/path/one');
-    const subfolder1 = '/path/one/dir1';
-    (vscode.workspace as any).workspaceFolders = [folder1];
+  it('should return the only workspace folder if there is only one (nested project folder)', async () => {
+    const workspaceFolder = mockWorkspaceFolder(path.join('path', 'one'));
+    const childLogicAppFolder = path.join(workspaceFolder.uri.fsPath, 'LogicApp1');
 
-    const promptOpenProjectOrWorkspaceSpy = vi.fn(() => {
-      (vscode.workspace as any).workspaceFolders = [folder1];
-    });
-
-    (fse.readdir as unknown as Mock).mockReturnValue([{ name: 'dir1', isDirectory: () => true }]);
-
-    const tryGetLogicAppProjectRootSpy = vi.fn(() => {
-      return '/path/one/dir1';
-    });
-    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
+    (vscode.workspace as any).workspaceFolders = [workspaceFolder];
+    const promptOpenProjectOrWorkspaceSpy = vi.fn(() => {});
+    const tryGetLogicAppProjectRootSpy = vi.fn(() => childLogicAppFolder);
 
     (promptOpenProjectOrWorkspace as Mock).mockImplementation(promptOpenProjectOrWorkspaceSpy);
+    (fse.readdir as unknown as Mock).mockReturnValue([{ name: 'LogicApp1', isDirectory: () => true }]);
+    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
 
     const result = await workspaceUtils.getWorkspaceFolder(mockContext);
+
     expect(promptOpenProjectOrWorkspaceSpy).not.toHaveBeenCalled();
-    expect(result).toEqual(subfolder1);
+    expect(result).toEqual(workspaceFolder);
   });
 
-  it('should return the only workspace folder if there is only one after prompting', async () => {
-    const folder1 = mockFolder('/path/one');
-    const subfolder1 = '/path/one/dir1';
+  it('should return the only workspace folder if there is only one after prompting (nested project folder)', async () => {
+    const workspaceFolder = mockWorkspaceFolder(path.join('path', 'one'));
+    const childLogicAppFolder = path.join(workspaceFolder.uri.fsPath, 'LogicApp1');
+
     (vscode.workspace as any).workspaceFolders = undefined;
-
     const promptOpenProjectOrWorkspaceSpy = vi.fn(() => {
-      (vscode.workspace as any).workspaceFolders = [folder1];
+      (vscode.workspace as any).workspaceFolders = [workspaceFolder];
     });
-
-    (fse.readdir as unknown as Mock).mockResolvedValue([{ name: 'dir1', isDirectory: () => true }]);
-
-    const tryGetLogicAppProjectRootSpy = vi.fn(() => {
-      return '/path/one/dir1';
-    });
-    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
+    const tryGetLogicAppProjectRootSpy = vi.fn(() => childLogicAppFolder);
 
     (promptOpenProjectOrWorkspace as Mock).mockImplementation(promptOpenProjectOrWorkspaceSpy);
+    (fse.readdir as unknown as Mock).mockResolvedValue([{ name: 'LogicApp1', isDirectory: () => true }]);
+    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
 
     const result = await workspaceUtils.getWorkspaceFolder(mockContext);
-    expect(result).toEqual(subfolder1);
+
+    expect(promptOpenProjectOrWorkspaceSpy).toHaveBeenCalled();
+    expect(result).toEqual(workspaceFolder);
   });
 
   it('should return undefined if no logic app project is found among multiple folders', async () => {
-    const folder1 = mockFolder('/path/one');
-    const folder2 = mockFolder('/path/two');
-    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+    const workspaceFolderNonlogic1 = mockWorkspaceFolder(path.join('path', 'one'));
+    const workspaceFolderNonlogic2 = mockWorkspaceFolder(path.join('path', 'two'));
 
-    const tryGetLogicAppProjectRootSpy = vi.fn(() => {
-      return undefined;
-    });
+    (vscode.workspace as any).workspaceFolders = [workspaceFolderNonlogic1, workspaceFolderNonlogic2];
+    const tryGetLogicAppProjectRootSpy = vi.fn(() => undefined);
     (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
 
     const result = await workspaceUtils.getWorkspaceFolder(mockContext);
+
     expect(tryGetLogicAppProjectRootSpy).toHaveBeenCalledTimes(2);
     expect(result).toBeUndefined();
   });
 
   it('should return the only logic app project if there is only one', async () => {
-    const folder1 = mockFolder('/logic/path');
-    const folder2 = mockFolder('/nonlogic/path');
-    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+    const workspaceFolderLogicPath = path.join('logic', 'path');
+    const workspaceFolderNonlogicPath = path.join('nonlogic', 'path');
+    const workspaceFolderLogic = mockWorkspaceFolder(workspaceFolderLogicPath);
+    const workspaceFolderNonlogic = mockWorkspaceFolder(workspaceFolderNonlogicPath);
 
-    // For folder1 return a valid project root, for folder2 return undefined.
+    (vscode.workspace as any).workspaceFolders = [workspaceFolderLogic, workspaceFolderNonlogic];
     const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => {
-      return folder.uri.fsPath === '/logic/path' ? folder.uri.fsPath : undefined;
+      return folder.uri.fsPath === workspaceFolderLogicPath ? folder.uri.fsPath : undefined;
     });
     (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
 
     const result = await workspaceUtils.getWorkspaceFolder(mockContext);
 
-    expect(result).toBe('/logic/path');
+    expect(result).toBe(workspaceFolderLogic);
     expect(tryGetLogicAppProjectRootSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should return the first logic app project if skipPromptOnMultipleFolders is true', async () => {
-    const folder1 = mockFolder('/logic/path1');
-    const folder2 = mockFolder('/logic/path2');
-    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+    const workspaceFolderLogicPath1 = path.join('logic', 'path1');
+    const workspaceFolderLogicPath2 = path.join('logic', 'path2');
+    const workspaceFolderLogic1 = mockWorkspaceFolder(workspaceFolderLogicPath1);
+    const workspaceFolderLogic2 = mockWorkspaceFolder(workspaceFolderLogicPath2);
 
-    // Both folders return a valid project root.
-    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => {
-      return folder.uri.fsPath;
-    });
+    (vscode.workspace as any).workspaceFolders = [workspaceFolderLogic1, workspaceFolderLogic2];
+    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => folder.uri.fsPath);
     (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
 
     const result = await workspaceUtils.getWorkspaceFolder(mockContext, undefined, true);
-    // Expect the first folder (or its project root) to be returned.
-    expect(result).toBe('/logic/path1');
+
+    expect(result).toBe(workspaceFolderLogic1);
     expect(tryGetLogicAppProjectRootSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should prompt the user to select a logic app project if there are multiple', async () => {
-    const folder1 = mockFolder('/logic/path1');
-    const folder2 = mockFolder('/logic/path2');
-    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
-    // Both folders are logic app projects.
-    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => {
-      return folder.uri.fsPath;
-    });
-    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
+    const workspaceFolderLogicPath1 = path.join('logic', 'path1');
+    const workspaceFolderLogicPath2 = path.join('logic', 'path2');
+    const workspaceFolderLogic1 = mockWorkspaceFolder(workspaceFolderLogicPath1);
+    const workspaceFolderLogic2 = mockWorkspaceFolder(workspaceFolderLogicPath2);
 
-    const quickPickSpy = vi.spyOn(mockContext.ui, 'showQuickPick').mockResolvedValue({ data: folder2 });
+    (vscode.workspace as any).workspaceFolders = [workspaceFolderLogic1, workspaceFolderLogic2];
+    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => folder.uri.fsPath);
+    (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
+    const quickPickSpy = vi.spyOn(mockContext.ui, 'showQuickPick').mockResolvedValue({ data: workspaceFolderLogic2 });
 
     const result = await workspaceUtils.getWorkspaceFolder(mockContext);
+
     expect(quickPickSpy).toHaveBeenCalled();
-    expect(result).toBe(folder2);
+    expect(result).toBe(workspaceFolderLogic2);
   });
 
   it('should throw UserCancelledError if user cancels the prompt', async () => {
-    const folder1 = mockFolder('/logic/path1');
-    const folder2 = mockFolder('/logic/path2');
-    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+    const folder1 = mockWorkspaceFolder(path.join('logic', 'path1'));
+    const folder2 = mockWorkspaceFolder(path.join('logic', 'path2'));
 
-    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => {
-      return folder.uri.fsPath;
-    });
+    (vscode.workspace as any).workspaceFolders = [folder1, folder2];
+    const tryGetLogicAppProjectRootSpy = vi.fn(async (_context, folder) => folder.uri.fsPath);
     (tryGetLogicAppProjectRoot as Mock).mockImplementation(tryGetLogicAppProjectRootSpy);
     vi.spyOn(mockContext.ui, 'showQuickPick').mockResolvedValue(undefined);
 
     await expect(workspaceUtils.getWorkspaceFolder(mockContext)).rejects.toThrowError();
   });
+});
 
-  describe('workspaceUtils.getWorkspaceLogicAppFolders', () => {
-    const testLogicAppProjectPath1 = path.join('test', 'project', 'LogicApp1');
-    const testLogicAppProjectPath2 = path.join('test', 'project', 'LogicApp2');
-    const testWorkspaceFolders = [
-      { name: 'LogicApp1', uri: { fsPath: testLogicAppProjectPath1 }, index: 0 },
-      { name: 'LogicApp2', uri: { fsPath: testLogicAppProjectPath2 }, index: 1 },
-    ];
+describe('workspaceUtils.getWorkspaceLogicAppFolders', () => {
+  const testLogicAppProjectPath1 = path.join('test', 'project', 'LogicApp1');
+  const testLogicAppProjectPath2 = path.join('test', 'project', 'LogicApp2');
+  const testWorkspaceFolders = [
+    { name: 'LogicApp1', uri: { fsPath: testLogicAppProjectPath1 }, index: 0 },
+    { name: 'LogicApp2', uri: { fsPath: testLogicAppProjectPath2 }, index: 1 },
+  ];
 
-    beforeEach(() => {
-      (vscode.workspace as any).workspaceFolders = testWorkspaceFolders;
+  beforeEach(() => {
+    (vscode.workspace as any).workspaceFolders = testWorkspaceFolders;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return an empty array if no workspace folders are open', async () => {
+    (vscode.workspace as any).workspaceFolders = [];
+    const tryGetAllLogicAppProjectRootsSpy = vi.fn(async (folder: vscode.WorkspaceFolder) => {
+      if (folder.uri.fsPath === testLogicAppProjectPath1) {
+        return [folder];
+      } else if (folder.uri.fsPath === testLogicAppProjectPath2) {
+        return ['root2a', 'root2b'];
+      }
+      return [];
     });
 
-    afterEach(() => {
-      vi.restoreAllMocks();
+    const result = await workspaceUtils.getWorkspaceLogicAppFolders();
+
+    expect(tryGetAllLogicAppProjectRootsSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('should collect logic app roots from each workspace folder', async () => {
+    const tryGetAllLogicAppProjectRootsSpy = vi.fn(async (folder: vscode.WorkspaceFolder) => {
+      if (folder.uri.fsPath === testLogicAppProjectPath1) {
+        return [folder];
+      } else if (folder.uri.fsPath === testLogicAppProjectPath2) {
+        return ['root2a', 'root2b'];
+      }
+      return [];
     });
+    (tryGetAllLogicAppProjectRoots as Mock).mockImplementation(tryGetAllLogicAppProjectRootsSpy);
 
-    it('should return an empty array if no workspace folders are open', async () => {
-      (vscode.workspace as any).workspaceFolders = [];
-      const tryGetAllLogicAppProjectRootsSpy = vi.fn(async (folder: vscode.WorkspaceFolder) => {
-        if (folder.uri.fsPath === testLogicAppProjectPath1) {
-          return [folder];
-        } else if (folder.uri.fsPath === testLogicAppProjectPath2) {
-          return ['root2a', 'root2b'];
-        }
-        return [];
-      });
+    const result = await workspaceUtils.getWorkspaceLogicAppFolders();
 
-      const result = await workspaceUtils.getWorkspaceLogicAppFolders();
+    expect(tryGetAllLogicAppProjectRootsSpy).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([testLogicAppProjectPath1, 'root2a', 'root2b']);
+  });
 
-      expect(tryGetAllLogicAppProjectRootsSpy).not.toHaveBeenCalled();
-      expect(result).toEqual([]);
+  it('should return an empty array if none of the workspace folders contain a logic app project', async () => {
+    const tryGetAllLogicAppProjectRootsSpy = vi.fn(async () => {
+      return [];
     });
+    (tryGetAllLogicAppProjectRoots as Mock).mockImplementation(tryGetAllLogicAppProjectRootsSpy);
 
-    it('should collect logic app roots from each workspace folder', async () => {
-      const tryGetAllLogicAppProjectRootsSpy = vi.fn(async (folder: vscode.WorkspaceFolder) => {
-        if (folder.uri.fsPath === testLogicAppProjectPath1) {
-          return [folder];
-        } else if (folder.uri.fsPath === testLogicAppProjectPath2) {
-          return ['root2a', 'root2b'];
-        }
-        return [];
-      });
-      (tryGetAllLogicAppProjectRoots as Mock).mockImplementation(tryGetAllLogicAppProjectRootsSpy);
+    const result = await workspaceUtils.getWorkspaceLogicAppFolders();
 
-      const result = await workspaceUtils.getWorkspaceLogicAppFolders();
-
-      expect(tryGetAllLogicAppProjectRootsSpy).toHaveBeenCalledTimes(2);
-      expect(result).toEqual([testLogicAppProjectPath1, 'root2a', 'root2b']);
-    });
-
-    it('should return an empty array if none of the workspace folders contain a logic app project', async () => {
-      const tryGetAllLogicAppProjectRootsSpy = vi.fn(async () => {
-        return [];
-      });
-      (tryGetAllLogicAppProjectRoots as Mock).mockImplementation(tryGetAllLogicAppProjectRootsSpy);
-
-      const result = await workspaceUtils.getWorkspaceLogicAppFolders();
-
-      expect(tryGetAllLogicAppProjectRootsSpy).toHaveBeenCalledTimes(2);
-      expect(result).toEqual([]);
-    });
+    expect(tryGetAllLogicAppProjectRootsSpy).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([]);
   });
 });


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Update getWorkspaceFolder to always find and return the workspace folder corresponding to the project root. If the project root is not a workspace folder, returns the parent workspace folder

## Impact of Change
- **Users**: Avoids possible edge case errors where context.workspaceFolder.Name is undefined
- **Developers**: Addresses type errors

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge 
