### PR TITLE
fix(templates): Filtering out agentic workflows from workflow app in custom template

### DIFF
--- a/libs/designer/src/lib/core/configuretemplate/utils/queries.ts
+++ b/libs/designer/src/lib/core/configuretemplate/utils/queries.ts
@@ -142,18 +142,26 @@ export const useWorkflowsInApp = (
   subscriptionId: string,
   resourceGroup: string,
   logicAppName: string,
-  isConsumption: boolean
+  isConsumption: boolean,
+  filter?: (workflow: ArmResource<any>) => boolean
 ): UseQueryResult<WorkflowResource[], unknown> => {
   const queryClient = useQueryClient();
   return useQuery(
-    ['workflowsInApp', subscriptionId?.toLowerCase(), resourceGroup?.toLowerCase(), logicAppName?.toLowerCase(), isConsumption],
+    [
+      'workflowsInApp',
+      subscriptionId?.toLowerCase(),
+      resourceGroup?.toLowerCase(),
+      logicAppName?.toLowerCase(),
+      isConsumption,
+      `hasFilter:${!!filter}`,
+    ],
     async () => {
       if (isConsumption) {
         const workflow = await getConsumptionWorkflow(subscriptionId, resourceGroup, logicAppName, queryClient);
         return [{ id: workflow.id, name: workflow.name, triggerType: getTriggerFromDefinition(workflow.properties.definition.triggers) }];
       }
 
-      return ResourceService().listWorkflowsInApp(subscriptionId, resourceGroup, logicAppName, isConsumption);
+      return ResourceService().listWorkflowsInApp(subscriptionId, resourceGroup, logicAppName, filter);
     },
     {
       cacheTime: 1000 * 60 * 60 * 24,

--- a/libs/designer/src/lib/ui/configuretemplate/workflows/selectWorkflows.tsx
+++ b/libs/designer/src/lib/ui/configuretemplate/workflows/selectWorkflows.tsx
@@ -5,7 +5,7 @@ import { useWorkflowsInApp } from '../../../core/configuretemplate/utils/queries
 import { ResourcePicker } from '../../templates';
 import { useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
-import { equals, type LogicAppResource } from '@microsoft/logic-apps-shared';
+import { type ArmResource, equals, type LogicAppResource } from '@microsoft/logic-apps-shared';
 import {
   TableBody,
   TableCell,
@@ -28,6 +28,7 @@ import { useResourceStrings } from '../resources';
 import type { WorkflowTemplateData } from '../../../core';
 import { useTemplatesStrings } from '../../templates/templatesStrings';
 import { tableHeaderStyle } from '../common';
+import { WorkflowKind } from '../../../core/state/workflow/workflowInterfaces';
 
 export const SelectWorkflows = ({
   selectedWorkflowsList,
@@ -44,7 +45,13 @@ export const SelectWorkflows = ({
     resourceGroup: state.workflow.resourceGroup,
     selectedTabId: state.tab.selectedTabId,
   }));
-  const { data: workflows, isLoading } = useWorkflowsInApp(subscriptionId, resourceGroup, logicAppName ?? '', !!isConsumption);
+  const { data: workflows, isLoading } = useWorkflowsInApp(
+    subscriptionId,
+    resourceGroup,
+    logicAppName ?? '',
+    !!isConsumption,
+    filterWorkflows
+  );
 
   const onLogicAppSelected = useCallback(
     (app: LogicAppResource) => {
@@ -261,4 +268,9 @@ export const SelectWorkflows = ({
       </TemplatesSection>
     </div>
   );
+};
+
+// TODO: This need to be updated when kind if merged with Stateful in backend [ETA July end]
+const filterWorkflows = (workflow: ArmResource<any>) => {
+  return !equals(workflow.kind, WorkflowKind.AGENTIC);
 };

--- a/libs/logic-apps-shared/src/designer-client-services/lib/resource.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/resource.ts
@@ -15,7 +15,7 @@ export interface IResourceService {
     subscriptionId: string,
     resourceGroup: string,
     logicAppName: string,
-    isConsumption: boolean
+    filter?: (workflow: ArmResource<any>) => boolean
   ) => Promise<WorkflowResource[]>;
   getResource: (resourceId: string, queryParameters: Record<string, string>) => Promise<ArmResource<any>>;
 }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
The change includes to filter out Agentic workflows from workflows selection in custom template.
This is needed because the support for Agentic workflows is not added for templates yet, so we need to avoid creating custom templates with agentic workflows.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Reduces the error in workflows generated from custom templates
- **Developers**: Added the function which should be used to filter out workflows if needed
- **System**: NA

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@divyaswarnkar @Elaina-Lee @takyyon 

## Screenshots/Videos
NA
