### PR TITLE
fix(localization): update placeholder syntax for milliseconds in Polish strings

### DIFF
--- a/Localize/lang/strings.pl.json
+++ b/Localize/lang/strings.pl.json
@@ -1561,7 +1561,7 @@
   "haeWoU": "Nie można obliczyć danych wyjściowych, ponieważ nie można obliczyć wartości splitOn {splitOn}. W rezultacie dane wyjściowe tej operacji mogą nie być poprawnie widoczne w kolejnych akcjach",
   "hbOvB4": "Tego nie szukam",
   "hdN+aw": "Określa, który kod SKU aplikacji logiki obsługuje szablon (np. standardowe, zużycie).",
-  "hesDPs": "{{count}} ms",
+  "hesDPs": "{count} ms",
   "hhW/w8": "Jeśli w cyklu nie określono konkretnej daty i godziny rozpoczęcia, pierwszy cykl zostanie uruchomiony natychmiast po zapisaniu lub wdrożeniu aplikacji logiki",
   "hlrKDC": "Połączenie",
   "ho2D6F": "Zamknij panel",

--- a/Localize/loc/pl/strings.json.lcl
+++ b/Localize/loc/pl/strings.json.lcl
@@ -14278,7 +14278,7 @@
         <Str Cat="Text">
           <Val><![CDATA[{count} Milliseconds]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[{{count}} ms]]></Val>
+            <Val><![CDATA[{count} ms]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />


### PR DESCRIPTION

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [X] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [X] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
The extra braces in the polish translation were breaking the localization compilation

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No Change
- **Developers**: No Change
- **System**: Language Compilation won't break

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed

## Contributors
N/A

## Screenshots/Videos
N/A
