### PR TITLE
fix(designer): Add opaque backgrounds to React Flow control buttons

### DIFF
--- a/libs/designer/src/lib/ui/styles.less
+++ b/libs/designer/src/lib/ui/styles.less
@@ -95,6 +95,7 @@
   bottom: 0px !important;
   width: 300px;
   height: 225px;
+  background: @ms-color-white;
   border-radius: 4px;
   overflow: hidden;
   box-shadow: 0px 3.2px 7.2px rgba(0, 0, 0, 0.132), 0px 0.6px 1.8px rgba(0, 0, 0, 0.108) !important;
@@ -121,6 +122,7 @@
   position: relative !important;
   left: 0px !important;
   bottom: 0px !important;
+  background: @ms-color-white;
   border-radius: 4px;
   overflow: hidden;
   box-shadow: 0px 3.2px 7.2px rgba(0, 0, 0, 0.132), 0px 0.6px 1.8px rgba(0, 0, 0, 0.108) !important;
@@ -130,6 +132,7 @@
   width: 44px !important;
   height: 44px !important;
   font-size: 30px;
+  background: @ms-color-white;
   border-bottom: 1px solid #eee;
   box-sizing: border-box !important;
   padding: 12px !important;


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
The React Flow control buttons (zoom in/out, fit view, search, minimap toggle) had transparent backgrounds in the light theme, making them difficult to read when the workflow graph extended beneath them. This change adds explicit white backgrounds to ensure the buttons remain visible and usable.

## Impact of Change
- **Users**: Improved visibility of control buttons when workflow graphs extend beneath them. No behavioral changes.
- **Developers**: No API changes or new patterns introduced.
- **System**: No performance impact - only CSS changes.

## Test Plan
- [ ] Unit tests added/updated - N/A (CSS only change)
- [ ] E2E tests added/updated - N/A (visual change only)
- [x] Manual testing completed
- [x] Tested in: Standalone designer with light theme

## Contributors
N/A

## Screenshots/Videos
![CleanShot 2025-06-23 at 22 31 02@2x](https://github.com/user-attachments/assets/1fa65821-b236-4967-be30-c772a5643faf)
![CleanShot 2025-06-23 at 22 37 32@2x](https://github.com/user-attachments/assets/b768fa5e-5758-4c4e-b368-827aa8cb6675)


### Changes Made:
- Added `background: @ms-color-white;` to `.react-flow__controls-button`
- Added `background: @ms-color-white;` to `.react-flow__controls`
- Added `background: @ms-color-white;` to `.react-flow__minimap`