### PR TITLE
fix(designer): Remove all references to Mock Python Operation 

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/operationmanifest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/operationmanifest.ts
@@ -42,7 +42,6 @@ import switchManifest from './manifests/switch';
 import agentloopManifest from '../standard/manifest/agentloop';
 import terminateManifest from './manifests/terminate';
 import untilManifest from './manifests/until';
-import { inlinePythonManifest } from './manifests/inlinecode';
 
 const apimanagement = 'apimanagement';
 const apimanagementtrigger = 'apimanagementtrigger';
@@ -56,7 +55,6 @@ const invokefunction = 'invokefunction';
 const javascriptcode = 'javascriptcode';
 const powershellcode = 'powershellcode';
 const csharpcode = 'csharpscriptcode';
-const pythoncode = 'pythoncode';
 const compose = 'compose';
 const csvtable = 'csvtable';
 const htmltable = 'htmltable';
@@ -180,7 +178,6 @@ export const supportedBaseManifestTypes = [
   javascriptcode,
   powershellcode,
   csharpcode,
-  pythoncode,
   join,
   liquid,
   parsejson,
@@ -598,10 +595,6 @@ const builtInOperationsMetadata: Record<string, OperationInfo> = {
     connectorId: inlineCodeConnectorId,
     operationId: csharpcode,
   },
-  [pythoncode]: {
-    connectorId: inlineCodeConnectorId,
-    operationId: pythoncode,
-  },
   [join]: {
     connectorId: dataOperationConnectorId,
     operationId: join,
@@ -802,7 +795,6 @@ export const supportedBaseManifestObjects = new Map<string, OperationManifest>([
   [agentType, agentloopManifest],
   [terminate, terminateManifest],
   [until, untilManifest],
-  [pythoncode, inlinePythonManifest],
 ]);
 
 export const foreachOperationInfo = {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
@@ -406,7 +406,6 @@ export function getClientBuiltInOperations(
     ClientOperationsData.getFutureTimeOperation,
     ClientOperationsData.getPastTimeOperation,
     ClientOperationsData.currentTimeOperation,
-    ClientOperationsData.inlinePythonCodeOperation,
   ];
   return filterOperation ? allOperations.filter(filterOperation) : allOperations;
 }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
it was placed similar to our other inline operations for testing; however, because the python operation is actually under the ACA connector instead on inline, the mock shows up as well.
## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Removal of the mocked inline python operation
- **Developers**: Removal of an operation in search and operation manifest services
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@lambrianmsft catching the issue

## Screenshots/Videos
<!-- Visual changes only -->
