### PR TITLE
fix(designer): Modify OAuth to accept parameter Name

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/OAuthService.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/OAuthService.ts
@@ -8,7 +8,7 @@ export interface LoginResult {
 export interface IOAuthService {
   openLoginPopup(options: OAuthPopupOptions): IOAuthPopup;
 
-  fetchConsentUrlForConnection: (connectionId: string) => Promise<string>;
+  fetchConsentUrlForConnection: (connectionId: string, oauthKey?: string) => Promise<string>;
   confirmConsentCodeForConnection: (connectionId: string, code: string) => Promise<any>;
 }
 
@@ -173,7 +173,7 @@ export class StandaloneOAuthService implements IOAuthService {
     });
   }
 
-  public async fetchConsentUrlForConnection(connectionName: string) {
+  public async fetchConsentUrlForConnection(connectionName: string, oauthKey?: string) {
     const { baseUrl, httpClient, apiVersion, tenantId, objectId } = this.options;
     const hostName = baseUrl.split('/subscriptions')[0];
     const uri = `${hostName}${this.getConnectionRequestPath(connectionName)}/listConsentLinks`;
@@ -181,7 +181,7 @@ export class StandaloneOAuthService implements IOAuthService {
     const requestBody: ConsentLinkRequest = {
       parameters: [
         {
-          parameterName: 'token',
+          parameterName: oauthKey ?? 'token',
           redirectUrl,
           tenantId,
           objectId,

--- a/apps/vs-code-react/src/app/designer/services/oAuth.ts
+++ b/apps/vs-code-react/src/app/designer/services/oAuth.ts
@@ -160,7 +160,7 @@ export class BaseOAuthService implements IOAuthService {
     });
   }
 
-  public async fetchConsentUrlForConnection(connectionName: string) {
+  public async fetchConsentUrlForConnection(connectionName: string, oauthKey?: string) {
     const { baseUrl, httpClient, apiVersion } = this.options;
     const hostName = baseUrl.split('/subscriptions')[0];
     const uri = `${hostName}${this.getConnectionRequestPath(connectionName)}/listConsentLinks`;
@@ -171,7 +171,7 @@ export class BaseOAuthService implements IOAuthService {
       parameters: [
         {
           objectId: tokenObject[JwtTokenConstants.objectId],
-          parameterName: 'token',
+          parameterName: oauthKey ?? 'token',
           redirectUrl: this._redirectUrl,
           tenantId: tokenObject[JwtTokenConstants.tenantId],
         },

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/connection.ts
@@ -91,8 +91,12 @@ export class ConsumptionConnectionService extends BaseConnectionService {
         /* shouldTestConnection */ false
       );
       const oAuthService = OAuthService();
-      console.log(parametersMetadata);
-      const consentUrl = await oAuthService.fetchConsentUrlForConnection(connectionId);
+      const oauthKey = parametersMetadata?.connectionParameters
+        ? Object.keys(parametersMetadata.connectionParameters).find(
+            (key) => parametersMetadata.connectionParameters?.[key]?.type === 'oauthSetting'
+          )
+        : undefined;
+      const consentUrl = await oAuthService.fetchConsentUrlForConnection(connectionId, oauthKey);
       const oAuthPopupInstance: IOAuthPopup = oAuthService.openLoginPopup({ consentUrl });
 
       const loginResponse = await oAuthPopupInstance.loginPromise;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/connection.ts
@@ -91,6 +91,7 @@ export class ConsumptionConnectionService extends BaseConnectionService {
         /* shouldTestConnection */ false
       );
       const oAuthService = OAuthService();
+      console.log(parametersMetadata);
       const consentUrl = await oAuthService.fetchConsentUrlForConnection(connectionId);
       const oAuthPopupInstance: IOAuthPopup = oAuthService.openLoginPopup({ consentUrl });
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/oAuth.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/oAuth.ts
@@ -11,7 +11,7 @@ export interface LoginResult {
 export interface IOAuthService {
   openLoginPopup(options: OAuthPopupOptions): IOAuthPopup;
 
-  fetchConsentUrlForConnection: (connectionId: string) => Promise<string>;
+  fetchConsentUrlForConnection: (connectionId: string, oauthKey?: string) => Promise<string>;
   confirmConsentCodeForConnection: (connectionId: string, code: string) => Promise<any>;
 }
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
@@ -512,9 +512,13 @@ export class StandardConnectionService extends BaseConnectionService implements 
     );
     const oAuthService = OAuthService();
     let oAuthPopupInstance: IOAuthPopup | undefined;
-
     try {
-      const consentUrl = await oAuthService.fetchConsentUrlForConnection(connectionId);
+      const oauthKey = parametersMetadata?.connectionParameters
+        ? Object.keys(parametersMetadata.connectionParameters).find(
+            (key) => parametersMetadata.connectionParameters?.[key]?.type === 'oauthSetting'
+          )
+        : undefined;
+      const consentUrl = await oAuthService.fetchConsentUrlForConnection(connectionId, oauthKey);
       oAuthPopupInstance = oAuthService.openLoginPopup({ consentUrl });
 
       const loginResponse = await oAuthPopupInstance.loginPromise;


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Previously for oauth we're defaulting to `token` in the parameter which for almost all oauth cases works; however, some connections (example Twitter) it does use a different parameter set name for listing consent links. 

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users will now be able to use twitter connections
- **Developers**: Changes in the oauth service to allow oauthKey to be passed
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Private deployment

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@abatishchev for finding issue

## Screenshots/Videos
<!-- Visual changes only -->
