### PR TITLE
fix(Designer): Fixed missed handle instances

### DIFF
--- a/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
@@ -28,9 +28,10 @@ import { SUBGRAPH_TYPES, guid, isNullOrUndefined, removeIdTag, useNodeIndex } fr
 import { memo, useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import type { NodeProps } from '@xyflow/react';
+import { DefaultHandle } from './handles/DefaultHandle';
 
-const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Position.Bottom, id }: NodeProps) => {
+const SubgraphCardNode = ({ id }: NodeProps) => {
   const subgraphId = removeIdTag(id);
   const node = useActionMetadata(subgraphId);
 
@@ -179,7 +180,7 @@ const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Posi
     <div>
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <div style={{ position: 'relative' }}>
-          <Handle className="node-handle top" type="target" position={targetPosition} isConnectable={false} />
+          <DefaultHandle type="target" />
           {metadata?.subgraphType ? (
             <>
               <SubgraphCard
@@ -202,7 +203,7 @@ const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Posi
               {shouldShowPager ? <LoopsPager metadata={metadata} scopeId={subgraphId} collapsed={graphCollapsed} /> : null}
             </>
           ) : null}
-          <Handle className="node-handle bottom" type="source" position={sourcePosition} isConnectable={false} />
+          <DefaultHandle type="source" />
         </div>
       </div>
       {graphCollapsed ? (


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
With a recent refactor of the node handles, two instances were missed on the subgraph nodes.
This led to black dots being shown when the handles should be invisible.
I swapped these out for the new DefaultHandle component.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Removed black dots from subgraph nodes
- **Developers**: No change
- **System**: No change

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@ccastrotrejo @Eric-B-Wu 

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/0926b1a8-9671-4486-8305-01aa9fa71006)
