### PR TITLE
feat(Designer): A2A workflows now have their own bezier pathing for loops

### DIFF
--- a/__mocks__/workflows/LoopTest.json
+++ b/__mocks__/workflows/LoopTest.json
@@ -1,0 +1,124 @@
+{
+	"definition": {
+		"$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+		"actions": {
+			"Initialize_ArrayVariable": {
+				"type": "InitializeVariable",
+				"inputs": {
+					"variables": [
+						{
+							"name": "ArrayVariable",
+							"type": "array",
+							"value": [
+								{
+									"document": "A",
+									"min": 7500001,
+									"policy": "X"
+								},
+								{
+									"document": "B",
+									"min": 7500001,
+									"policy": "Y"
+								},
+								{
+									"document": "C",
+									"min": 7500001,
+									"policy": "Z"
+								}
+							]
+						}
+					]
+				},
+				"runAfter": {}
+			},
+			"Filter_array": {
+				"type": "Query",
+				"inputs": {
+					"from": "test",
+					"where": "@not(contains(length(split(item(), '|')?[0]),length(split(item(), '|')?[0])))"
+				},
+				"runAfter": {
+					"HTTP": [
+						"SUCCEEDED"
+					],
+					"Initialize_ArrayVariable": [
+						"SUCCEEDED"
+					]
+				}
+			},
+			"HTTP": {
+				"type": "Http",
+				"inputs": {
+					"uri": "http://test.com",
+					"method": "GET",
+					"body": "@variables('ArrayVariable')"
+				},
+				"runAfter": {
+					"Filter_array": [
+						"SUCCEEDED"
+					]
+				},
+				"runtimeConfiguration": {
+					"contentTransfer": {
+						"transferMode": "Chunked"
+					}
+				}
+			},
+			"Response": {
+				"type": "Response",
+				"kind": "Http",
+				"inputs": {
+					"statusCode": 200
+				},
+				"runAfter": {
+					"HTTP": [
+						"SUCCEEDED"
+					]
+				}
+			}
+		},
+		"contentVersion": "1.0.0.0",
+		"outputs": {},
+		"triggers": {
+			"manual": {
+				"type": "Request",
+				"kind": "Http",
+				"inputs": {
+					"schema": {
+						"type": "object",
+						"properties": {
+							"array": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"item1": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"item1"
+									]
+								}
+							},
+							"string": {
+								"type": "string"
+							},
+							"number": {
+								"type": "integer"
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"connectionReferences": {},
+	"parameters": {
+		"EILCO Admin Nominations-OCSA List (cr773_EILCOAdminNominations_OCSA_L2)": {
+			"type": "String",
+			"value": "test"
+		}
+	},
+	"kind": "agent"
+}

--- a/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
@@ -24,6 +24,11 @@ const fileOptions = [
   { key: 'Agent.json', text: 'Starter Agent' },
   { key: 'AgentWithChannels.json', text: 'Agent with Channels' },
 
+  // A2A
+  { key: 'divider_A2A', text: '-', itemType: DropdownMenuItemType.Divider },
+  { key: 'A2AHeader', text: 'A2A Workflows', itemType: DropdownMenuItemType.Header },
+  { key: 'LoopTest.json', text: 'Loop Test' },
+
   // Scope Nodes
   { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
   { key: 'ScopeNodesHeader', text: 'Scope Node Testing Workflows', itemType: DropdownMenuItemType.Header },

--- a/apps/Standalone/src/designer/app/SettingsSections/sourceSettings.tsx
+++ b/apps/Standalone/src/designer/app/SettingsSections/sourceSettings.tsx
@@ -6,6 +6,9 @@ import { type HostingPlanTypes, loadLastWorkflow, setHostingPlan, setIsLocalSele
 import { ChoiceGroup, IconButton } from '@fluentui/react';
 import { useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
+import { LocalLogicAppSelector } from '../LocalDesigner/LogicAppSelector/LogicAppSelector';
+import { AzureConsumptionLogicAppSelector } from '../AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureConsumptionLogicAppSelector';
+import { AzureStandardLogicAppSelector } from '../AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector';
 
 const SourceSettings = ({
   showEnvironment = true,
@@ -14,6 +17,7 @@ const SourceSettings = ({
 }: { showEnvironment?: boolean; showHistoryButton?: boolean; showHybridPlan?: boolean }) => {
   const isLocal = useIsLocal();
   const hostingPlan = useHostingPlan();
+
   const dispatch = useDispatch<AppDispatch>();
 
   const resourcePath = useResourcePath();
@@ -56,6 +60,16 @@ const SourceSettings = ({
       {showHistoryButton && !resourcePath && stateHistory ? (
         <IconButton iconProps={{ iconName: 'History' }} title="History" ariaLabel="History" onClick={() => dispatch(loadLastWorkflow())} />
       ) : null}
+      {/* Logic App Selector */}
+      <div style={{ flexGrow: 1 }}>
+        {isLocal ? (
+          <LocalLogicAppSelector />
+        ) : hostingPlan === 'consumption' ? (
+          <AzureConsumptionLogicAppSelector />
+        ) : (
+          <AzureStandardLogicAppSelector />
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/Standalone/src/designer/components/settings_box.tsx
+++ b/apps/Standalone/src/designer/components/settings_box.tsx
@@ -1,9 +1,6 @@
-import { AzureConsumptionLogicAppSelector } from '../app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureConsumptionLogicAppSelector';
-import { AzureStandardLogicAppSelector } from '../app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector';
-import { LocalLogicAppSelector } from '../app/LocalDesigner/LogicAppSelector/LogicAppSelector';
 import ContextSettings from '../app/SettingsSections/contextSettings';
 import SourceSettings from '../app/SettingsSections/sourceSettings';
-import { useHostingPlan, useIsDarkMode, useIsLocal } from '../state/workflowLoadingSelectors';
+import { useIsDarkMode } from '../state/workflowLoadingSelectors';
 import { LocalizationSettings } from './LocalizationSettings';
 import styles from './settings_box.module.less';
 import { darkTheme } from './themes';
@@ -14,8 +11,6 @@ import { css } from '@fluentui/utilities';
 export const SettingsBox = () => {
   const [active, toggleActive] = useBoolean(true);
   const isDark = useIsDarkMode();
-  const isLocal = useIsLocal();
-  const isConsumption = useHostingPlan() === 'consumption';
   const cs = css(styles.toybox, active && styles.active, isDark && styles.dark);
 
   const SettingsSection = (props: any) => {
@@ -42,9 +37,6 @@ export const SettingsBox = () => {
         <div className={styles.contentWrapper}>
           <SettingsSection title="Logic App Source">
             <SourceSettings />
-          </SettingsSection>
-          <SettingsSection title="Workflow Load Settings">
-            {isLocal ? <LocalLogicAppSelector /> : isConsumption ? <AzureConsumptionLogicAppSelector /> : <AzureStandardLogicAppSelector />}
           </SettingsSection>
           <SettingsSection title="Context Settings" startExpanded={false}>
             <ContextSettings />

--- a/libs/designer-ui/src/lib/card/card.less
+++ b/libs/designer-ui/src/lib/card/card.less
@@ -432,8 +432,9 @@
   }
 }
 
-.react-flow__edges {
-  z-index: 100 !important;
+.react-flow__node-GRAPH_NODE,
+.react-flow__node-SUBGRAPH_NODE {
+	z-index: -1 !important;
 }
 
 .msla-content-fit {

--- a/libs/designer/src/lib/core/graphlayout/elklayout.tsx
+++ b/libs/designer/src/lib/core/graphlayout/elklayout.tsx
@@ -9,7 +9,7 @@ import { createContext, useState, useContext } from 'react';
 import { useSelector } from 'react-redux';
 import type { Edge, Node } from '@xyflow/react';
 
-export const layerSpacing = {
+export const spacing = {
   default: '64',
   readOnly: '48',
   onlyEdge: '16',
@@ -26,19 +26,26 @@ const defaultLayoutOptions: Record<string, string> = {
   'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
   'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
   // Spacing values
-  'elk.spacing.edgeNode': '180',
-  'elk.layered.spacing.edgeNodeBetweenLayers': layerSpacing.default,
-  'elk.layered.spacing.nodeNodeBetweenLayers': layerSpacing.default,
+  'elk.spacing.edgeNode': '40',
+  'elk.spacing.edgeEdge': '40',
+  'elk.layered.spacing.edgeNodeBetweenLayers': spacing.default,
+  'elk.layered.spacing.nodeNodeBetweenLayers': spacing.default,
   'elk.padding': '[top=0,left=16,bottom=16,right=16]',
   // This option allows the first layer children of a graph to be laid out in order of appearance in manifest. This is useful for subgraph ordering, like in Switch nodes.
   // 'elk.layered.crossingMinimization.semiInteractive': 'true',
   'elk.layered.crossingMinimization.forceNodeModelOrder': 'false',
   'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
+  // Options for Bezier edges (These do not have any effect on our default edges)
+  'elk.layered.cycleBreaking.strategy': 'DEPTH_FIRST',
+  'elk.edgeRouting': 'SPLINES', // POLYLINE / ORTHOGONAL / SPLINES
+  'elk.layered.edgeRouting.splines.mode': 'CONSERVATIVE_SOFT', // SLOPPY / CONSERVATIVE_SOFT / CONSERVATIVE
+  'elk.portAlignment.default': 'DISTRIBUTED', // DISTRIBUTED / CENTER
+  // 'elk.spacing.portPort': '64',
 };
 
 const readOnlyOptions: Record<string, string> = {
-  'elk.layered.spacing.edgeNodeBetweenLayers': layerSpacing.readOnly,
-  'elk.layered.spacing.nodeNodeBetweenLayers': layerSpacing.readOnly,
+  'elk.layered.spacing.edgeNodeBetweenLayers': spacing.readOnly,
+  'elk.layered.spacing.nodeNodeBetweenLayers': spacing.readOnly,
 };
 
 const elk = new ELK();
@@ -178,8 +185,8 @@ const convertWorkflowGraphToElkGraph = (node: WorkflowNode): ElkNode => {
       nodeType: node?.type ?? WORKFLOW_NODE_TYPES.GRAPH_NODE,
       ...(node.edges?.some((edge) => edge.type === WORKFLOW_EDGE_TYPES.ONLY_EDGE) && {
         'elk.layered.nodePlacement.strategy': 'SIMPLE',
-        'elk.layered.spacing.edgeNodeBetweenLayers': layerSpacing.onlyEdge,
-        'elk.layered.spacing.nodeNodeBetweenLayers': layerSpacing.onlyEdge,
+        'elk.layered.spacing.edgeNodeBetweenLayers': spacing.onlyEdge,
+        'elk.layered.spacing.nodeNodeBetweenLayers': spacing.onlyEdge,
         'elk.layered.crossingMinimization.forceNodeModelOrder': 'true',
       }),
       ...(node.children?.findIndex((child) => child.id.endsWith('#footer')) !== -1 && {

--- a/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -25,3 +25,7 @@ export const useEdgeContextMenuData = () => {
 export const useAgenticWorkflow = () => {
   return useSelector((state: RootState) => equals(state.workflow.workflowKind, 'agentic', false));
 };
+
+export const useIsA2AWorkflow = () => {
+  return useSelector((state: RootState) => equals(state.workflow.workflowKind, 'agent', false));
+};

--- a/libs/designer/src/lib/core/state/workflow/workflowInterfaces.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowInterfaces.ts
@@ -24,6 +24,7 @@ export const WorkflowKind = {
   STATEFUL: 'stateful',
   STATELESS: 'stateless',
   AGENTIC: 'agentic',
+  AGENT: 'agent',
 } as const;
 export type WorkflowKind = (typeof WorkflowKind)[keyof typeof WorkflowKind] | undefined;
 

--- a/libs/designer/src/lib/core/utils/workflow.ts
+++ b/libs/designer/src/lib/core/utils/workflow.ts
@@ -11,5 +11,8 @@ export const parseWorkflowKind = (kind?: string): WorkflowKind => {
   if (equals(kind, 'agentic')) {
     return WorkflowKind.AGENTIC;
   }
+  if (equals(kind, 'agent')) {
+    return WorkflowKind.AGENT;
+  }
   return undefined;
 };

--- a/libs/designer/src/lib/ui/CanvasFinder.tsx
+++ b/libs/designer/src/lib/ui/CanvasFinder.tsx
@@ -54,7 +54,8 @@ export const CanvasFinder = () => {
     const yRawPos = focusNode?.internals.positionAbsolute?.y ?? 0;
 
     const xTarget = xRawPos + (focusNode?.measured?.width ?? DEFAULT_NODE_SIZE.width) / 2; // Center X on node midpoint
-    const yTarget = yRawPos + (focusNode?.measured?.height ?? DEFAULT_NODE_SIZE.height); // Center Y on bottom edge
+    const clampedHeight = Math.min(windowDimensions.height * 0.4, focusNode?.measured?.height ?? DEFAULT_NODE_SIZE.height);
+    const yTarget = yRawPos + clampedHeight / 2; // Center Y on node midpoint
 
     setCenter(xTarget, yTarget, {
       zoom: getZoom(),
@@ -63,7 +64,7 @@ export const CanvasFinder = () => {
 
     dispatch(clearFocusNode());
     dispatch(clearFocusCollapsedNode());
-  }, [focusNode, setCenter, getZoom, dispatch]);
+  }, [focusNode, windowDimensions.height, setCenter, getZoom, dispatch]);
 
   useEffect(() => {
     setCanvasCenterToFocus();

--- a/libs/designer/src/lib/ui/CustomNodes/GraphContainerNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/GraphContainerNode.tsx
@@ -44,7 +44,7 @@ const GraphContainerNode = ({ id }: NodeProps) => {
       >
         <DefaultHandle type="target" />
         <GraphContainer id={id} active={isMonitoringView ? !isNullOrUndefined(runData?.status) : true} selected={selected} />
-        <EdgeDrawSourceHandle />
+        {isSubgraphContainer ? null : <EdgeDrawSourceHandle />}
       </div>
       {showLeafComponents && (
         <div className="edge-drop-zone-container">

--- a/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
@@ -28,9 +28,10 @@ import { SUBGRAPH_TYPES, guid, isNullOrUndefined, removeIdTag, useNodeIndex } fr
 import { memo, useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import type { NodeProps } from '@xyflow/react';
+import { DefaultHandle } from './handles/DefaultHandle';
 
-const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Position.Bottom, id }: NodeProps) => {
+const SubgraphCardNode = ({ id }: NodeProps) => {
   const subgraphId = removeIdTag(id);
   const node = useActionMetadata(subgraphId);
 
@@ -179,7 +180,7 @@ const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Posi
     <div>
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <div style={{ position: 'relative' }}>
-          <Handle className="node-handle top" type="target" position={targetPosition} isConnectable={false} />
+          <DefaultHandle type="target" />
           {metadata?.subgraphType ? (
             <>
               <SubgraphCard
@@ -202,7 +203,7 @@ const SubgraphCardNode = ({ targetPosition = Position.Top, sourcePosition = Posi
               {shouldShowPager ? <LoopsPager metadata={metadata} scopeId={subgraphId} collapsed={graphCollapsed} /> : null}
             </>
           ) : null}
-          <Handle className="node-handle bottom" type="source" position={sourcePosition} isConnectable={false} />
+          <DefaultHandle type="source" />
         </div>
       </div>
       {graphCollapsed ? (

--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -1,7 +1,7 @@
 import { openPanel, useNodesInitialized } from '../core';
 import { usePreloadOperationsQuery, usePreloadConnectorsQuery } from '../core/queries/browse';
 import { useMonitoringView, useReadOnly, useHostOptions, useIsVSCode } from '../core/state/designerOptions/designerOptionsSelectors';
-import { useAgenticWorkflow } from '../core/state/designerView/designerViewSelectors';
+import { useAgenticWorkflow, useIsA2AWorkflow } from '../core/state/designerView/designerViewSelectors';
 import { buildEdgeIdsBySource } from '../core/state/workflow/workflowSlice';
 import type { AppDispatch, RootState } from '../core/store';
 import Controls from './Controls';
@@ -86,6 +86,7 @@ export const Designer = (props: DesignerProps) => {
 
   const isMonitoringView = useMonitoringView();
   const isAgenticWorkflow = useAgenticWorkflow();
+  const isA2AWorkflow = useIsA2AWorkflow(); // Specifically A2A + Handoffs
 
   const DND_OPTIONS: any = {
     backends: [
@@ -128,7 +129,7 @@ export const Designer = (props: DesignerProps) => {
       <div className="msla-designer-canvas msla-panel-mode" ref={designerContainerRef}>
         <ReactFlowProvider>
           <div style={{ flexGrow: 1 }}>
-            <DesignerReactFlow canvasRef={canvasRef}>
+            <DesignerReactFlow canvasRef={canvasRef} isLooping={isA2AWorkflow}>
               {backgroundProps ? <Background {...backgroundProps} /> : null}
               <DeleteModal />
               <DesignerContextualMenu />

--- a/libs/designer/src/lib/ui/DesignerReactFlow.tsx
+++ b/libs/designer/src/lib/ui/DesignerReactFlow.tsx
@@ -1,5 +1,5 @@
 import type { Connection, Edge, EdgeTypes, NodeChange, ReactFlowInstance } from '@xyflow/react';
-import { BezierEdge, ReactFlow } from '@xyflow/react';
+import { BezierEdge as ReactFlowBezierEdge, ReactFlow } from '@xyflow/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { containsIdTag, guid, removeIdTag, WORKFLOW_NODE_TYPES, type WorkflowNodeType } from '@microsoft/logic-apps-shared';
 import { useDispatch } from 'react-redux';
@@ -26,6 +26,7 @@ import CollapsedNode from './CustomNodes/CollapsedCardNode';
 import ScopeCardNode from './CustomNodes/ScopeCardNode';
 import SubgraphCardNode from './CustomNodes/SubgraphCardNode';
 import ButtonEdge from './connections/edge';
+import BezierEdge from './connections/bezierEdge';
 import HiddenEdge from './connections/hiddenEdge';
 
 const DesignerReactFlow = (props: any) => {
@@ -47,9 +48,9 @@ const DesignerReactFlow = (props: any) => {
   };
 
   const edgeTypes = {
-    BUTTON_EDGE: ButtonEdge,
-    HEADING_EDGE: ButtonEdge, // This is functionally the same as a button edge
-    ONLY_EDGE: BezierEdge, // Setting it as default React Flow Edge, can be changed as needed
+    BUTTON_EDGE: props?.isLooping ? BezierEdge : ButtonEdge,
+    HEADING_EDGE: props?.isLooping ? BezierEdge : ButtonEdge,
+    ONLY_EDGE: ReactFlowBezierEdge, // Setting it as default React Flow Edge, can be changed as needed
     HIDDEN_EDGE: HiddenEdge,
   } as EdgeTypes;
 

--- a/libs/designer/src/lib/ui/connections/bezierEdge.tsx
+++ b/libs/designer/src/lib/ui/connections/bezierEdge.tsx
@@ -1,0 +1,297 @@
+import type React from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import type { ElkExtendedEdge } from 'elkjs/lib/elk-api';
+import { EdgeLabelRenderer, type EdgeProps, type XYPosition } from '@xyflow/react';
+import { css } from '@fluentui/utilities';
+import type { LogicAppsV2 } from '@microsoft/logic-apps-shared';
+import {
+  containsIdTag,
+  removeIdTag,
+  RUN_AFTER_STATUS,
+  useEdgeIndex,
+  guid,
+  useNodeGlobalPosition,
+  buildSvgSpline,
+  useEdgesData,
+} from '@microsoft/logic-apps-shared';
+
+import { useReadOnly } from '../../core/state/designerOptions/designerOptionsSelectors';
+import { useActionMetadata, useNodeMetadata } from '../../core/state/workflow/workflowSelectors';
+import { DropZone } from './dropzone';
+import { ArrowCap } from './dynamicsvgs/arrowCap';
+import { RunAfterIndicator } from './runAfterIndicator';
+import { useIsNodeSelectedInOperationPanel } from '../../core/state/panel/panelSelectors';
+import { removeEdgeFromRunAfterOperation } from '../../core/actions/bjsworkflow/runafter';
+import { EdgePathContextMenu, useContextMenu } from './edgePathContextMenu';
+import type { AppDispatch } from '../../core';
+
+interface EdgeContentProps {
+  x: number;
+  y: number;
+  graphId: string;
+  parentId?: string;
+  childId?: string;
+  isLeaf?: boolean;
+  tabIndex?: number;
+}
+
+const EdgeContent = (props: EdgeContentProps) => (
+  <EdgeLabelRenderer>
+    <div
+      style={{
+        width: edgeContentWidth,
+        height: edgeContentHeight,
+        position: 'absolute',
+        left: props.x,
+        top: props.y,
+        pointerEvents: 'all',
+        zIndex: 100,
+      }}
+    >
+      <DropZone graphId={props.graphId} parentId={props.parentId} childId={props.childId} isLeaf={props.isLeaf} tabIndex={props.tabIndex} />
+    </div>
+  </EdgeLabelRenderer>
+);
+
+export interface LogicAppsEdgeProps {
+  id: string;
+  source: string;
+  target: string;
+  elkEdge?: ElkExtendedEdge;
+  style?: React.CSSProperties;
+}
+
+const edgeContentHeight = 24;
+const edgeContentWidth = 24;
+
+const runAfterWidth = 48;
+const runAfterHeight = 12;
+
+const BezierEdge: React.FC<EdgeProps<LogicAppsEdgeProps>> = ({ id, source, target, style = {} }) => {
+  const dispatch = useDispatch<AppDispatch>();
+  const readOnly = useReadOnly();
+  const operationData = useActionMetadata(target) as LogicAppsV2.ActionDefinition;
+
+  const nodeMetadata = useNodeMetadata(source);
+  const sourceId = containsIdTag(source) ? removeIdTag(source) : source;
+  const targetId = containsIdTag(target) ? removeIdTag(target) : target;
+  const graphId = (containsIdTag(source) ? removeIdTag(source) : undefined) ?? nodeMetadata?.graphId ?? '';
+
+  const filteredRunAfters: Record<string, string[]> = useMemo(
+    () =>
+      Object.entries(operationData?.runAfter ?? {}).reduce((pv: Record<string, string[]>, [id, cv]) => {
+        if ((cv ?? []).some((status) => status.toUpperCase() !== RUN_AFTER_STATUS.SUCCEEDED)) {
+          pv[id] = cv;
+        }
+
+        return pv;
+      }, {}),
+    [operationData?.runAfter]
+  );
+
+  const runAfterStatuses = useMemo(() => filteredRunAfters?.[source] ?? [], [filteredRunAfters, source]);
+  const runAfterCount = Object.keys(filteredRunAfters).length;
+  const showRunAfter = runAfterStatuses.length && runAfterCount < 6;
+
+  const edgeData = useEdgesData(id);
+
+  const containerId = useMemo(() => (edgeData?.data?.elkEdge as any)?.container, [edgeData?.data?.elkEdge]);
+  const rootOffset = useNodeGlobalPosition(containerId);
+
+  // Combine all points into a single array
+  const splinePoints: { x: number; y: number }[] = useMemo(() => {
+    const section = (edgeData?.data?.elkEdge as any)?.sections?.[0];
+    return [section?.startPoint, ...(section?.bendPoints ?? []), section?.endPoint].map((point: XYPosition) => ({
+      x: point.x + rootOffset.x,
+      y: point.y + rootOffset.y,
+    }));
+  }, [edgeData?.data?.elkEdge, rootOffset.x, rootOffset.y]);
+
+  const firstPoint = useMemo(() => splinePoints[0] || { x: 0, y: 0 }, [splinePoints]);
+  const lastPoint = useMemo(() => splinePoints[splinePoints.length - 1] || { x: 0, y: 0 }, [splinePoints]);
+  const isInverted = useMemo(() => {
+    // If first point is below last point
+    return firstPoint.y > lastPoint.y;
+  }, [firstPoint, lastPoint]);
+
+  const statusPosition = useMemo(() => {
+    const statusX = firstPoint.x - runAfterWidth / 2;
+    let statusY = firstPoint.y - runAfterHeight;
+    if (!isInverted) {
+      statusY += runAfterHeight;
+    }
+    return { x: statusX, y: statusY };
+  }, [firstPoint.x, firstPoint.y, isInverted]);
+
+  // Create an SVG path string
+  const splinePath = useMemo(() => buildSvgSpline(splinePoints), [splinePoints]);
+
+  const tabIndex = useEdgeIndex(id);
+
+  const isSourceSelected = useIsNodeSelectedInOperationPanel(sourceId);
+  const isTargetSelected = useIsNodeSelectedInOperationPanel(targetId);
+
+  const contextMenu = useContextMenu();
+  const contextSelected = useMemo(() => contextMenu.isShowing, [contextMenu.isShowing]);
+
+  const selected = useMemo(
+    () => isSourceSelected || isTargetSelected || contextSelected,
+    [isSourceSelected, isTargetSelected, contextSelected]
+  );
+
+  const deleteEdge = useCallback(() => {
+    dispatch(
+      removeEdgeFromRunAfterOperation({
+        parentOperationId: sourceId,
+        childOperationId: targetId,
+      })
+    );
+  }, [dispatch, sourceId, targetId]);
+
+  const colorClass = useMemo(() => {
+    if (selected) {
+      return 'highlighted';
+    }
+    return '';
+  }, [selected]);
+
+  const markerId = useMemo(() => `arrow-end-${guid()}`, []);
+
+  const pathRef = useRef<SVGPathElement>(null);
+
+  const [pathReady, setPathReady] = useState(false);
+  useEffect(() => {
+    if (pathRef.current) {
+      setPathReady(true);
+    }
+  }, [pathRef]);
+
+  const getPointOnPath = useCallback(
+    (percent: number) => {
+      if (pathReady && !!pathRef.current) {
+        const totalLength = pathRef.current.getTotalLength();
+        return pathRef.current.getPointAtLength(totalLength * percent);
+      }
+      return { x: 0, y: 0 };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    [pathRef, pathReady]
+  );
+
+  const [midpoint, setMidpoint] = useState<XYPosition>({ x: -999, y: -999 });
+  useEffect(() => {
+    if (!pathReady || !pathRef.current) {
+      console.warn('#> ButtonEdge: Path not ready or ref not set');
+      return;
+    }
+    setMidpoint(getPointOnPath(0.5));
+  }, [getPointOnPath, pathReady, pathRef]);
+
+  const [markerAngle, setMarkerAngle] = useState(0);
+  useEffect(() => {
+    if (!pathReady || !pathRef.current) {
+      return;
+    }
+    const lastPoint = getPointOnPath(0.999);
+    const secondLastPoint = getPointOnPath(0.998);
+    const dx = lastPoint.x - secondLastPoint.x;
+    const dy = lastPoint.y - secondLastPoint.y;
+    const angle = Math.atan2(dy, dx) * (180 / Math.PI);
+    setMarkerAngle(angle - 90);
+  }, [getPointOnPath, pathReady, pathRef]);
+
+  if (!id) {
+    return null;
+  }
+
+  return (
+    <>
+      <defs>
+        <marker
+          id={markerId}
+          className={colorClass}
+          viewBox="0 0 20 20"
+          refX="6"
+          refY="5"
+          markerWidth="10"
+          markerHeight="10"
+          orient={markerAngle}
+        >
+          <ArrowCap />
+        </marker>
+      </defs>
+
+      <path
+        id={id}
+        ref={pathRef}
+        style={style}
+        className={css('react-flow__edge-path', colorClass)}
+        d={splinePath}
+        strokeDasharray={showRunAfter ? '4' : '0'}
+        markerEnd={`url(#${markerId})`}
+        onClick={contextMenu.handle}
+        onContextMenu={contextMenu.handle}
+      />
+
+      {/* KEEP: This is for edge id testing */}
+      {/* <text x={midpoint.x} y={midpoint.y} fontSize="10" fill="black">
+				= {id}
+			</text> */}
+
+      {/* KEEP: This is for spline development testing */}
+      {/* {splinePoints.map((point, index) => (
+				<>
+					<text x={point.x} y={point.y} fontSize="10" fill="black">{index} - {id}</text>
+					<circle
+						key={index}
+						cx={point.x}
+						cy={point.y}
+						r={2}
+						className={css('react-flow__edge-path', 'transition', colorClass)}
+						style={{
+							stroke: 'var(--colorNeutralStroke2)',
+							fill: 'var(--colorNeutralStroke2)',
+						}}
+					/>
+				</>
+			))} */}
+
+      {contextMenu.isShowing && (
+        <EdgePathContextMenu
+          contextMenuLocation={contextMenu.location}
+          open={contextMenu.isShowing}
+          setOpen={contextMenu.setIsShowing}
+          onDelete={deleteEdge}
+        />
+      )}
+
+      {/* ADD ACTION / BRANCH BUTTONS */}
+      {readOnly ? null : (
+        <EdgeContent
+          x={midpoint.x - edgeContentWidth / 2}
+          y={midpoint.y - edgeContentHeight / 2}
+          graphId={graphId}
+          parentId={source}
+          childId={target}
+          tabIndex={tabIndex}
+        />
+      )}
+
+      {/* RUN AFTER INDICATOR */}
+      {showRunAfter ? (
+        <foreignObject
+          id="msla-run-after-traffic-light"
+          width={runAfterWidth}
+          height={runAfterHeight}
+          x={statusPosition.x}
+          y={statusPosition.y}
+        >
+          <RunAfterIndicator statuses={runAfterStatuses} sourceNodeId={source} />
+        </foreignObject>
+      ) : null}
+    </>
+  );
+};
+
+export default memo(BezierEdge);

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/flow-utils.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/flow-utils.ts
@@ -1,3 +1,5 @@
+import type { XYPosition } from '@xyflow/system';
+
 export function getEdgeCenter({
   sourceX,
   sourceY,
@@ -16,4 +18,20 @@ export function getEdgeCenter({
   const centerY = targetY < sourceY ? targetY + yOffset : targetY - yOffset;
 
   return [centerX, centerY, xOffset, yOffset];
+}
+
+export function buildSvgSpline(points: XYPosition[]): string {
+  if (points.length < 4 || (points.length - 1) % 3 !== 0) {
+    console.warn('Invalid point structure for Bézier spline.');
+    return '';
+  }
+
+  let d = `M ${points[0].x},${points[0].y}`;
+  for (let i = 1; i < points.length; i += 3) {
+    const c1 = points[i];
+    const c2 = points[i + 1];
+    const end = points[i + 2];
+    d += ` C ${c1.x},${c1.y} ${c2.x},${c2.y} ${end.x},${end.y}`;
+  }
+  return d;
 }

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/hooks.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/hooks.ts
@@ -1,4 +1,4 @@
-import { useNodesData } from '@xyflow/react';
+import { useNodesData, useInternalNode } from '@xyflow/react';
 import type { MutableRefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEdgesData } from './useEdgesData';
@@ -82,3 +82,7 @@ export const useEdgeIndex = (edgeId?: string) => {
 export const useNodeLeafIndex = (nodeId?: string) => {
   return (useNodesData(nodeId ?? '')?.data?.['nodeLeafIndex'] as number) ?? 0;
 };
+
+export function useNodeGlobalPosition(nodeId: string) {
+  return useInternalNode(nodeId)?.internals?.positionAbsolute ?? { x: 0, y: 0 };
+}

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/index.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/index.ts
@@ -15,3 +15,4 @@ export * from './recurrence';
 export * from './run';
 export * from './stringFunctions';
 export * from './localStorage';
+export * from './useEdgesData';


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
With loops being supported in A2A workflows, our existing edge pathing does not work well.
On A2A workflows specifically we are now using a new Bezier path edge using data from ELK.
For loops this works great, but has some limitations that make it not a great choice for normal workflows.
- Edges are now all separated, there is no overlap for shared parents / children
- This also required the removal of the shared add buttons, so one add button for each edge

Other changes
- Standalone - Moved LA selection boxes inline with the kind selection
- Canvas Finder - Improved the y-positioning for graph nodes
- Edge drawing - Removed draw source on subgraph nodes

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: A2A workflows now have better edge pathing
- **Developers**: Standalone workflow selection moved up to LA source category
- **System**: No change

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@rllyy97

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/8402fc5c-f341-4fbc-9c19-ed86da9feb42)
