### PR TITLE
fix(Designer): Update control buttons style to use content-box sizing

### DIFF
--- a/libs/designer/src/lib/ui/styles.less
+++ b/libs/designer/src/lib/ui/styles.less
@@ -128,6 +128,7 @@
   border-bottom: 1px solid var(--colorNeutralStroke1);
   padding: 12px !important;
 	fill: var(--colorNeutralForeground1);
+  box-sizing: content-box;
 
   svg {
     height: 100%;


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
This change adds `box-sizing: content-box` to the control buttons style in the designer UI to fix layout issues where buttons were not displaying correctly with their intended dimensions.

## Impact of Change
- **Users**: Improved visual consistency of control buttons in the designer interface
- **Developers**: No API changes or breaking changes
- **System**: Minimal performance impact, purely cosmetic CSS fix

## Test Plan
- [x] Manual testing completed
- [x] Tested in: Designer UI with control buttons

## Contributors
 @rllyy97 

## Screenshots/Videos
### Before
![CleanShot 2025-07-03 at 08 13 49@2x](https://github.com/user-attachments/assets/9ad24711-aaca-44c9-a3d3-99854aacaa6a)

### After

![CleanShot 2025-07-03 at 08 13 39@2x](https://github.com/user-attachments/assets/5f59d874-b54b-42f9-b377-b4027ab98814)
