### PR TITLE
feat(vscode): Add multi-initialize support based on extension bundle ID

### DIFF
--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -50,7 +50,6 @@ import { viewProperties } from './viewProperties';
 import { configureWebhookRedirectEndpoint } from './workflows/configureWebhookRedirectEndpoint/configureWebhookRedirectEndpoint';
 import { enableAzureConnectors } from './workflows/enableAzureConnectors';
 import { exportLogicApp } from './workflows/exportLogicApp';
-import { getDebugSymbolDll } from './workflows/getDebugSymbolDll';
 import { openDesigner } from './workflows/openDesigner/openDesigner';
 import { openOverview } from './workflows/openOverview';
 import { reviewValidation } from './workflows/reviewValidation';
@@ -66,6 +65,7 @@ import type { Uri } from 'vscode';
 import { pickCustomCodeNetHostProcess } from './pickCustomCodeNetHostProcess';
 import { debugLogicApp } from './debugLogicApp';
 import { syncCloudSettings } from './syncCloudSettings';
+import { getDebugSymbolDll } from '../utils/getDebugSymbolDll';
 
 export function registerCommands(): void {
   registerCommandWithTreeNodeUnwrapping(extensionCommand.openDesigner, openDesigner);

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -44,6 +44,7 @@ import { env, ProgressLocation, Uri, ViewColumn, window, workspace } from 'vscod
 import type { WebviewPanel, ProgressOptions } from 'vscode';
 import type { IAzureConnectorsContext } from '../azureConnectorWizard';
 import { saveBlankUnitTest } from '../unitTest/saveBlankUnitTest';
+import { getBundleVersionNumber } from '../../../utils/getDebugSymbolDll';
 
 export default class OpenDesignerForLocalProject extends OpenDesignerBase {
   private readonly workflowFilePath: string;
@@ -131,6 +132,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
     const callbackUri: Uri = await (env as any).asExternalUri(
       Uri.parse(`${env.uriScheme}://ms-azuretools.vscode-azurelogicapps/authcomplete`)
     );
+    this.context.telemetry.properties.extensionBundleVersion = this.panelMetadata.extensionBundleVersion;
     this.oauthRedirectUrl = callbackUri.toString(true);
 
     this.panel.webview.html = await this.getWebviewContent({
@@ -474,6 +476,8 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
     const customCodeData: Record<string, string> = await getCustomCodeFromFiles(this.workflowFilePath);
     const workflowDetails = await getManualWorkflowsInLocalProject(projectPath, this.workflowName);
     const artifacts = await getArtifactsInLocalProject(projectPath);
+    const bundleVersionNumber = await getBundleVersionNumber();
+
     let localSettings: Record<string, string>;
     let azureDetails: AzureConnectorDetails;
 
@@ -500,6 +504,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
       artifacts,
       schemaArtifacts: this.schemaArtifacts,
       mapArtifacts: this.mapArtifacts,
+      extensionBundleVersion: bundleVersionNumber,
     };
   }
 

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
@@ -32,6 +32,7 @@ import type { WebviewPanel } from 'vscode';
 import { Uri, ViewColumn } from 'vscode';
 import { getArtifactsInLocalProject } from '../../../utils/codeless/artifacts';
 import { saveBlankUnitTest } from '../unitTest/saveBlankUnitTest';
+import { getBundleVersionNumber } from '../../../utils/getDebugSymbolDll';
 
 export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
   private projectPath: string | undefined;
@@ -92,7 +93,7 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
     });
     this.panelMetadata.mapArtifacts = this.mapArtifacts;
     this.panelMetadata.schemaArtifacts = this.schemaArtifacts;
-
+    this.context.telemetry.properties.extensionBundleVersion = this.panelMetadata.extensionBundleVersion;
     this.panel.webview.onDidReceiveMessage(
       async (message) => await this._handleWebviewMsg(message),
       /* thisArgs */ undefined,
@@ -191,6 +192,8 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
     const workflowContent: any = JSON.parse(readFileSync(this.workflowFilePath, 'utf8'));
     const parametersData: Record<string, Parameter> = await getParametersFromFile(this.context, this.workflowFilePath);
     const customCodeData: Record<string, string> = await getCustomCodeFromFiles(this.workflowFilePath);
+    const bundleVersionNumber = await getBundleVersionNumber();
+
     let localSettings: Record<string, string>;
     let azureDetails: AzureConnectorDetails;
 
@@ -216,6 +219,7 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
       standardApp: getStandardAppData(this.workflowName, { ...workflowContent, definition: {} }),
       schemaArtifacts: this.schemaArtifacts,
       mapArtifacts: this.mapArtifacts,
+      extensionBundleVersion: bundleVersionNumber,
     };
   }
 }

--- a/apps/vs-code-designer/src/app/utils/__test__/getDebugSymbolDll.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/getDebugSymbolDll.test.ts
@@ -1,0 +1,149 @@
+import { getBundleVersionNumber } from '../getDebugSymbolDll';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import * as cp from 'child_process';
+import { extensionBundleId } from '../../../constants';
+
+// Mock VS Code
+vi.mock('vscode', () => ({
+  workspace: {
+    getConfiguration: vi.fn(),
+    workspaceFolders: [],
+  },
+}));
+
+// Mock fs-extra
+vi.mock('fs-extra', () => ({
+  readdir: vi.fn(),
+  stat: vi.fn(),
+}));
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+// Mock localize
+vi.mock('../../localize', () => ({
+  localize: vi.fn((key: string, defaultValue: string) => defaultValue),
+}));
+
+// Mock extension variables
+vi.mock('../../extensionVariables', () => ({
+  ext: {
+    outputChannel: {
+      appendLog: vi.fn(),
+    },
+  },
+}));
+
+// Mock funcVersion
+vi.mock('../funcCoreTools/funcVersion', () => ({
+  getFunctionsCommand: vi.fn(() => 'func'),
+}));
+
+const mockedFse = vi.mocked(fse);
+const mockedExecSync = vi.mocked(cp.execSync);
+
+describe('getBundleVersionNumber', () => {
+  const mockBundleFolderRoot = '/mock/bundle/root';
+  const mockBundleFolder = path.join(mockBundleFolderRoot, extensionBundleId);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExecSync.mockReturnValue(`${mockBundleFolderRoot}Microsoft.Azure.Functions.ExtensionBundle\n`);
+  });
+
+  it('should return the highest version number from available bundle folders', async () => {
+    const mockFolders = ['1.0.0', '2.1.0', '1.5.0', 'some-file.txt'];
+    mockedFse.readdir.mockResolvedValue(mockFolders as any);
+    mockedFse.stat.mockImplementation((filePath: any) => {
+      const fileName = path.basename(filePath.toString());
+      return Promise.resolve({
+        isDirectory: () => fileName !== 'some-file.txt',
+      } as any);
+    });
+
+    const result = await getBundleVersionNumber();
+
+    expect(result).toBe('2.1.0');
+    expect(mockedFse.readdir).toHaveBeenCalledWith(mockBundleFolder);
+  });
+
+  it('should handle version numbers with different digit counts', async () => {
+    const mockFolders = ['1.0.0', '10.2.1', '2.15.3'];
+    mockedFse.readdir.mockResolvedValue(mockFolders as any);
+    mockedFse.stat.mockImplementation(() => {
+      return Promise.resolve({
+        isDirectory: () => true,
+      } as any);
+    });
+
+    const result = await getBundleVersionNumber();
+
+    expect(result).toBe('10.2.1');
+  });
+
+  it('should return default version when only non-directory files exist', async () => {
+    const mockFolders = ['file1.txt', 'file2.log'];
+    mockedFse.readdir.mockResolvedValue(mockFolders as any);
+    mockedFse.stat.mockImplementation(() => {
+      return Promise.resolve({
+        isDirectory: () => false,
+      } as any);
+    });
+
+    const result = await getBundleVersionNumber();
+
+    expect(result).toBe('0.0.0');
+  });
+
+  it('should handle single version folder', async () => {
+    const mockFolders = ['1.2.3'];
+    mockedFse.readdir.mockResolvedValue(mockFolders as any);
+    mockedFse.stat.mockImplementation(() => {
+      return Promise.resolve({
+        isDirectory: () => true,
+      } as any);
+    });
+
+    const result = await getBundleVersionNumber();
+
+    expect(result).toBe('1.2.3');
+  });
+
+  it('should throw error when no bundle folders found', async () => {
+    mockedFse.readdir.mockResolvedValue([] as any);
+
+    await expect(getBundleVersionNumber()).rejects.toThrow('Extension bundle could not be found.');
+  });
+
+  it('should handle mixed version formats correctly', async () => {
+    const mockFolders = ['1.0', '1.0.0', '1.0.0.1'];
+    mockedFse.readdir.mockResolvedValue(mockFolders as any);
+    mockedFse.stat.mockImplementation(() => {
+      return Promise.resolve({
+        isDirectory: () => true,
+      } as any);
+    });
+
+    const result = await getBundleVersionNumber();
+
+    expect(result).toBe('1.0.0.1');
+  });
+
+  it('should call execSync to get the bundle root path', async () => {
+    const mockFolders = ['1.0.0'];
+    mockedFse.readdir.mockResolvedValue(mockFolders as any);
+    mockedFse.stat.mockImplementation(() => {
+      return Promise.resolve({
+        isDirectory: () => true,
+      } as any);
+    });
+
+    await getBundleVersionNumber();
+
+    expect(mockedExecSync).toHaveBeenCalledWith('func GetExtensionBundlePath', { encoding: 'utf8' });
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/getDebugSymbolDll.ts
+++ b/apps/vs-code-designer/src/app/utils/getDebugSymbolDll.ts
@@ -2,15 +2,33 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { debugSymbolDll, extensionBundleId } from '../../../constants';
-import { ext } from '../../../extensionVariables';
-import { localize } from '../../../localize';
-import { getFunctionsCommand } from '../../utils/funcCoreTools/funcVersion';
+import { debugSymbolDll, extensionBundleId } from '../../constants';
+import { ext } from '../../extensionVariables';
+import { localize } from '../../localize';
+import { getFunctionsCommand } from './funcCoreTools/funcVersion';
 import * as cp from 'child_process';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 
 export async function getDebugSymbolDll(): Promise<string> {
+  const bundleFolderRoot = await getExtensionBundleFolder();
+  const bundleFolder = path.join(bundleFolderRoot, extensionBundleId);
+  const bundleVersionNumber = await getBundleVersionNumber();
+
+  return path.join(bundleFolder, bundleVersionNumber, 'bin', debugSymbolDll);
+}
+
+/**
+ * Retrieves the highest version number of the extension bundle available in the bundle folder.
+ *
+ * This function locates the extension bundle folder, enumerates its subdirectories,
+ * and determines the maximum version number present among them. If no bundle is found,
+ * it throws an error.
+ *
+ * @returns {Promise<string>} A promise that resolves to the highest bundle version number as a string (e.g., "1.2.3").
+ * @throws {Error} If the extension bundle folder is missing or contains no subdirectories.
+ */
+export async function getBundleVersionNumber(): Promise<string> {
   const bundleFolderRoot = await getExtensionBundleFolder();
   const bundleFolder = path.join(bundleFolderRoot, extensionBundleId);
   let bundleVersionNumber = '0.0.0';
@@ -27,7 +45,7 @@ export async function getDebugSymbolDll(): Promise<string> {
     }
   }
 
-  return path.join(bundleFolder, bundleVersionNumber, 'bin', debugSymbolDll);
+  return bundleVersionNumber;
 }
 
 /**

--- a/apps/vs-code-react/src/app/designer/app.tsx
+++ b/apps/vs-code-react/src/app/designer/app.tsx
@@ -3,7 +3,7 @@ import type { AppDispatch, RootState } from '../../state/store';
 import { VSCodeContext } from '../../webviewCommunication';
 import { DesignerCommandBar } from './DesignerCommandBar';
 import './app.less';
-import { getDesignerServices } from './servicesHelper';
+import { getDesignerServices, isMultiVariableSupport } from './servicesHelper';
 import { getRunInstanceMocks } from './utilities/runInstance';
 import { convertConnectionsDataToReferences } from './utilities/workflow';
 import { Spinner, SpinnerSize } from '@fluentui/react';
@@ -128,6 +128,11 @@ export const DesignerApp = () => {
     return convertConnectionsDataToReferences(connectionData);
   }, [connectionData]);
 
+  const isMultiVariableSupportEnabled = useMemo(
+    () => isMultiVariableSupport(panelMetaData?.extensionBundleVersion),
+    [panelMetaData?.extensionBundleVersion]
+  );
+
   const getRunInstance = () => {
     return services.runService.getRun(runId);
   };
@@ -245,6 +250,7 @@ export const DesignerApp = () => {
           services: services,
           hostOptions: {
             displayRuntimeInfo: true,
+            enableMultiVariable: isMultiVariableSupportEnabled,
           },
         }}
       >

--- a/apps/vs-code-react/src/app/designer/servicesHelper.ts
+++ b/apps/vs-code-react/src/app/designer/servicesHelper.ts
@@ -402,3 +402,27 @@ const addOrUpdateAppSettings = (settings: Record<string, string>, originalSettin
 
   return updatedSettings;
 };
+
+export const isMultiVariableSupport = (version?: string): boolean => {
+  if (!version) {
+    return false;
+  }
+
+  const [major, minor, patch] = version.split('.').map(Number);
+  if ([major, minor, patch].some(Number.isNaN)) {
+    return false;
+  }
+
+  // Compare with 1.114.22
+  if (major > 1) {
+    return true;
+  }
+  if (major === 1 && minor > 114) {
+    return true;
+  }
+  if (major === 1 && minor === 114 && patch > 22) {
+    return true;
+  }
+
+  return false;
+};

--- a/libs/vscode-extension/src/lib/models/workflow.ts
+++ b/libs/vscode-extension/src/lib/models/workflow.ts
@@ -26,6 +26,7 @@ export interface IDesignerPanelMetadata {
   accessToken?: string;
   schemaArtifacts: FileDetails[];
   mapArtifacts: Record<string, FileDetails[]>;
+  extensionBundleVersion?: string;
 }
 
 export interface StandardApp {


### PR DESCRIPTION
Cherry-pick of the following PR: #7692 

## Commit Type
- [x] feature - New functionality

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Added functionality to support multiple initialization based on extension bundle ID for VS Code extensions. This enhancement allows different VS Code extensions to initialize with their own configuration while maintaining compatibility with existing single-extension workflows.

## Impact of Change
- **Users**: No user-facing changes - internal functionality enhancement
- **Developers**: New multi-initialize capability available for VS Code extension development
- **System**: Enhanced extension initialization system with bundle ID support

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: VS Code extension development environment

## Contributors
@ccastrotrejo

## Screenshots
![CleanShot 2025-07-02 at 12 49 50@2x](https://github.com/user-attachments/assets/6c6c6912-d5b7-4065-a81f-be99d15848c7)

