### PR TITLE
fix(designer): Prevent moving operations after their dependents

### DIFF
--- a/libs/designer/src/lib/core/state/operation/operationSelector.ts
+++ b/libs/designer/src/lib/core/state/operation/operationSelector.ts
@@ -129,12 +129,15 @@ interface TokenDependencies {
 }
 export const useTokenDependencies = (nodeId: string): TokenDependencies => {
   const operationInputParameters = useRawInputParameters(nodeId);
+  const variables = useSelector((state: RootState) => state.tokens.variables);
+
   return useMemo(() => {
     if (!operationInputParameters) {
       return { dependencies: new Set(), loopSources: new Set() };
     }
     const dependencies = new Set<string>();
     const loopSources = new Set<string>();
+
     for (const group of Object.values(operationInputParameters.parameterGroups)) {
       for (const parameter of group.parameters) {
         for (const value of parameter.value) {
@@ -144,15 +147,26 @@ export const useTokenDependencies = (nodeId: string): TokenDependencies => {
           if (value.token?.actionName) {
             dependencies.add(value.token.actionName);
           }
+          // Check for variable tokens
+          if (value.token?.tokenType === 'variable' && value.token?.name) {
+            // Find which node initializes this variable
+            for (const [nodeId, nodeVariables] of Object.entries(variables)) {
+              if (nodeVariables.some((v) => v.name === value.token?.name)) {
+                dependencies.add(nodeId);
+                break;
+              }
+            }
+          }
         }
       }
     }
     return { dependencies, loopSources };
-  }, [operationInputParameters]);
+  }, [operationInputParameters, variables]);
 };
 
 export const useNodesTokenDependencies = (nodes: Set<string>) => {
   const operationsInputsParameters = useOperationsInputParameters();
+  const variables = useSelector((state: RootState) => state.tokens.variables);
   const dependencies: Record<string, Set<string>> = {};
   if (!operationsInputsParameters) {
     return dependencies;
@@ -169,6 +183,16 @@ export const useNodesTokenDependencies = (nodes: Set<string>) => {
             }
             if (value.token?.arrayDetails?.loopSource) {
               innerDependencies.add(value.token.arrayDetails.loopSource);
+            }
+            // Check for variable tokens
+            if (value.token?.tokenType === 'variable' && value.token?.name) {
+              // Find which node initializes this variable
+              for (const [nodeId, nodeVariables] of Object.entries(variables)) {
+                if (nodeVariables.some((v) => v.name === value.token?.name)) {
+                  innerDependencies.add(nodeId);
+                  break;
+                }
+              }
             }
           }
         }

--- a/libs/designer/src/lib/ui/connections/__tests__/helpers.spec.ts
+++ b/libs/designer/src/lib/ui/connections/__tests__/helpers.spec.ts
@@ -1,5 +1,45 @@
 import { describe, expect, it } from 'vitest';
-import { canDropItem } from '../helpers';
+import { canDropItem, getDownstreamDependencies } from '../helpers';
+
+describe('getDownstreamDependencies', () => {
+  it('should return empty set when no nodes depend on the given node', () => {
+    const allNodesDependencies = {
+      node1: new Set(['node2', 'node3']),
+      node2: new Set(['node3']),
+      node3: new Set([]),
+    };
+
+    const result = getDownstreamDependencies('node4', allNodesDependencies);
+    expect(result.size).toBe(0);
+  });
+
+  it('should return nodes that directly depend on the given node', () => {
+    const allNodesDependencies = {
+      node1: new Set(['node2', 'node3']),
+      node2: new Set(['node3']),
+      node3: new Set([]),
+      node4: new Set(['node2']),
+    };
+
+    const result = getDownstreamDependencies('node2', allNodesDependencies);
+    expect(result.size).toBe(2);
+    expect(result.has('node1')).toBe(true);
+    expect(result.has('node4')).toBe(true);
+  });
+
+  it('should handle node IDs with and without tags', () => {
+    const allNodesDependencies = {
+      node1: new Set(['node2-#tag']),
+      node2: new Set(['node3']),
+      node3: new Set(['node2']),
+    };
+
+    const result = getDownstreamDependencies('node2-#tag', allNodesDependencies);
+    expect(result.size).toBe(2);
+    expect(result.has('node1')).toBe(true);
+    expect(result.has('node3')).toBe(true);
+  });
+});
 
 describe('canDropItem', () => {
   const emptySet = new Set<string>();
@@ -44,6 +84,89 @@ describe('canDropItem', () => {
         emptySet,
         'Business_logic',
         'Scope-#scope'
+      )
+    ).toBeFalsy();
+  });
+
+  it('should prevent drop when node would be moved after its dependents', () => {
+    const upstreamNodes = new Set(['trigger', 'useVariable']);
+    const upstreamNodesDependencies = {
+      trigger: emptySet,
+      useVariable: new Set(['initVariable']),
+    };
+    const allNodesDependencies = {
+      trigger: emptySet,
+      initVariable: emptySet,
+      useVariable: new Set(['initVariable']),
+    };
+
+    expect(
+      canDropItem(
+        { id: 'initVariable', dependencies: [] },
+        upstreamNodes,
+        upstreamNodesDependencies,
+        emptySet,
+        undefined,
+        undefined,
+        false,
+        false,
+        allNodesDependencies
+      )
+    ).toBeFalsy();
+  });
+
+  it('should allow drop when node has downstream dependencies that are not upstream', () => {
+    const upstreamNodes = new Set(['trigger']);
+    const upstreamNodesDependencies = {
+      trigger: emptySet,
+    };
+    const allNodesDependencies = {
+      trigger: emptySet,
+      initVariable: emptySet,
+      useVariable: new Set(['initVariable']),
+    };
+
+    expect(
+      canDropItem(
+        { id: 'initVariable', dependencies: [] },
+        upstreamNodes,
+        upstreamNodesDependencies,
+        emptySet,
+        undefined,
+        undefined,
+        false,
+        false,
+        allNodesDependencies
+      )
+    ).toBeTruthy();
+  });
+
+  it('should prevent drop when variable initialization would be moved after usage', () => {
+    const upstreamNodes = new Set(['trigger', 'parseJson', 'action2']);
+    const upstreamNodesDependencies = {
+      trigger: emptySet,
+      parseJson: new Set(['Initialize_ArrayVariable']),
+      action2: new Set(['Initialize_ArrayVariable', 'parseJson']),
+    };
+    const allNodesDependencies = {
+      trigger: emptySet,
+      Initialize_ArrayVariable: emptySet,
+      parseJson: new Set(['Initialize_ArrayVariable']),
+      action2: new Set(['Initialize_ArrayVariable', 'parseJson']),
+      action3: new Set(['action2']),
+    };
+
+    expect(
+      canDropItem(
+        { id: 'Initialize_ArrayVariable', dependencies: [] },
+        upstreamNodes,
+        upstreamNodesDependencies,
+        emptySet,
+        'action3',
+        'action2',
+        false,
+        false,
+        allNodesDependencies
       )
     ).toBeFalsy();
   });

--- a/libs/designer/src/lib/ui/connections/dropzone.tsx
+++ b/libs/designer/src/lib/ui/connections/dropzone.tsx
@@ -26,6 +26,7 @@ import {
   useIsWithinAgenticLoop,
   useNodeDisplayName,
   useNodeMetadata,
+  useNodeIds,
 } from '../../core/state/workflow/workflowSelectors';
 import { AllowDropTarget } from './dynamicsvgs/allowdroptarget';
 import { BlockDropTarget } from './dynamicsvgs/blockdroptarget';
@@ -83,6 +84,10 @@ export const DropZone: React.FC<DropZoneProps> = memo(({ graphId, parentId, chil
   const upstreamNodesDependencies = useNodesTokenDependencies(upstreamNodes);
   const upstreamScopeArr = useAllGraphParents(graphId);
   const upstreamScopes = useMemo(() => new Set(upstreamScopeArr), [upstreamScopeArr]);
+
+  // Get all nodes in the workflow to compute downstream dependencies
+  const allNodeIds = useNodeIds();
+  const allNodesDependencies = useNodesTokenDependencies(new Set(allNodeIds));
 
   const handlePasteClicked = useCallback(async () => {
     const relationshipIds = { graphId, childId, parentId };
@@ -150,13 +155,14 @@ export const DropZone: React.FC<DropZoneProps> = memo(({ graphId, parentId, chil
           childId,
           parentId,
           preventDropItemInA2A,
-          isWithinAgenticLoop
+          isWithinAgenticLoop,
+          allNodesDependencies
         ),
       collect: (monitor) => ({
         canDrop: monitor.canDrop(),
       }),
     }),
-    [graphId, parentId, childId, upstreamNodes, upstreamNodesDependencies, preventDropItemInA2A, isWithinAgenticLoop]
+    [graphId, parentId, childId, upstreamNodes, upstreamNodesDependencies, preventDropItemInA2A, isWithinAgenticLoop, allNodesDependencies]
   );
 
   const parentName = useNodeDisplayName(removeIdTag(parentId ?? ''));

--- a/libs/designer/src/lib/ui/connections/helpers.ts
+++ b/libs/designer/src/lib/ui/connections/helpers.ts
@@ -9,6 +9,26 @@ export interface DropItem {
   isAgent?: boolean;
 }
 
+/**
+ * Computes the set of nodes that depend on the given node (downstream dependencies)
+ * @param nodeId - The node to find dependents for
+ * @param allNodesDependencies - Map of all nodes and their dependencies
+ * @returns Set of node IDs that depend on the given node
+ */
+export const getDownstreamDependencies = (nodeId: string, allNodesDependencies: Record<string, Set<string>>): Set<string> => {
+  const downstreamNodes = new Set<string>();
+  const nodeIdWithoutTag = removeIdTag(nodeId);
+
+  // Check all nodes to see if they depend on this node
+  for (const [node, dependencies] of Object.entries(allNodesDependencies)) {
+    if (dependencies.has(nodeId) || dependencies.has(nodeIdWithoutTag)) {
+      downstreamNodes.add(node);
+    }
+  }
+
+  return downstreamNodes;
+};
+
 export const canDropItem = (
   item: DropItem,
   upstreamNodes: Set<string>,
@@ -17,7 +37,8 @@ export const canDropItem = (
   childId: string | undefined,
   parentId: string | undefined,
   preventDropItemInA2A: boolean,
-  isWithinAgenticLoop: boolean
+  isWithinAgenticLoop: boolean,
+  allNodesDependencies?: Record<string, Set<string>>
 ): boolean => {
   // Prevent dropping agents within agentic loops
   if (item.isAgent && isWithinAgenticLoop) {
@@ -43,6 +64,20 @@ export const canDropItem = (
   }
 
   const nodeId = removeIdTag(item.id);
+
+  // Prevent moving a node after any nodes that depend on it
+  if (allNodesDependencies) {
+    const downstreamDependencies = getDownstreamDependencies(item.id, allNodesDependencies);
+
+    // Check if any downstream dependencies would become upstream after the move
+    for (const downstreamNode of downstreamDependencies) {
+      if (upstreamNodes.has(downstreamNode)) {
+        // This node has outputs that are used by a node that would be upstream after the move
+        return false;
+      }
+    }
+  }
+
   delete upstreamNodesDependencies[nodeId];
   upstreamNodes.delete(nodeId);
 


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Medium - Moderate changes, some user impact

## What & Why
This PR fixes an issue where operations like "Initialize Variable" could be dragged and dropped after actions that depend on them, which would break the workflow. The issue occurred because variable tokens weren't being tracked as dependencies in the drag/drop validation logic.

The fix adds proper dependency tracking for variable tokens and validates that operations cannot be moved after any nodes that depend on them.

Fixes #6490

## Impact of Change
- **Users**: Workflow integrity is preserved - users can no longer accidentally break their workflows by moving operations after their dependents
- **Developers**: Enhanced dependency tracking now includes variable tokens alongside regular action outputs
- **System**: No performance impact - validation happens only during drag operations

## Test Plan
- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer with variable initialization scenarios

### Test Coverage:
- Added tests for `getDownstreamDependencies` function
- Added tests for preventing drops when nodes have downstream dependencies  
- Added specific test case for variable initialization scenarios
- All existing tests continue to pass

## Contributors
Thanks @vgouth for reporting

## Screenshots/Videos

https://github.com/user-attachments/assets/5c03bee9-cb60-49ab-82e5-2ee061c6cfec

