### PR TITLE
fix(designer): Properly handling converting view model back into parameter value

### DIFF
--- a/libs/designer-ui/src/lib/editor/initializevariable/__test__/util.spec.tsx
+++ b/libs/designer-ui/src/lib/editor/initializevariable/__test__/util.spec.tsx
@@ -68,7 +68,7 @@ describe('getParameterValue', () => {
 
     const result = getParameterValue('ignored', VARIABLE_TYPE.STRING, nodeMap, () => [mockSegment]);
 
-    expect(result[0].value).toBe('TEST_TOKEN');
+    expect(result[0].value).toBe('triggerBody()');
   });
 });
 

--- a/libs/designer-ui/src/lib/editor/shared/testtokensegment.ts
+++ b/libs/designer-ui/src/lib/editor/shared/testtokensegment.ts
@@ -15,7 +15,7 @@ export const testTokenSegment: ValueSegment = {
     title: 'TEST_TOKEN',
     value: 'triggerBody()',
   },
-  value: 'TEST_TOKEN',
+  value: 'triggerBody()',
 };
 
 export const outputToken: OutputToken = {

--- a/libs/designer-ui/src/lib/flyout/__test__/__snapshots__/flyout.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/flyout/__test__/__snapshots__/flyout.spec.tsx.snap
@@ -44,6 +44,50 @@ exports[`ui/flyout > should render 1`] = `
 </div>
 `;
 
+exports[`ui/flyout > should render 2`] = `
+<div
+  className="ms-TooltipHost root-116"
+  onBlurCapture={[Function]}
+  onFocusCapture={[Function]}
+  onKeyDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  role="none"
+>
+  <button
+    aria-label="text"
+    className="msla-button msla-flyout ___frx9oy0_1ljmivh f14t3ns0"
+    data-testid="callout-btn"
+    onClick={[Function]}
+    tabIndex={0}
+  >
+    <img
+      alt=""
+      className="msla-flyout-icon lg ___12p8g0n_rgjm4a0 f14t3ns0 f1w9dchk fxldao9 f2zxqi f1phki43 febqm8h ff9s3yw"
+      draggable={false}
+      role="presentation"
+      src="/src/lib/card/images/information_tiny.svg"
+    />
+  </button>
+  <div
+    hidden={true}
+    id="tooltip1"
+    style={
+      {
+        "border": 0,
+        "height": 1,
+        "margin": -1,
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "absolute",
+        "whiteSpace": "nowrap",
+        "width": 1,
+      }
+    }
+  />
+</div>
+`;
+
 exports[`ui/flyout > should render with a non-zero tab index 1`] = `
 <div
   className="ms-TooltipHost root-116"
@@ -72,6 +116,50 @@ exports[`ui/flyout > should render with a non-zero tab index 1`] = `
   <div
     hidden={true}
     id="tooltip2"
+    style={
+      {
+        "border": 0,
+        "height": 1,
+        "margin": -1,
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "absolute",
+        "whiteSpace": "nowrap",
+        "width": 1,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`ui/flyout > should render with a non-zero tab index 2`] = `
+<div
+  className="ms-TooltipHost root-116"
+  onBlurCapture={[Function]}
+  onFocusCapture={[Function]}
+  onKeyDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  role="none"
+>
+  <button
+    aria-label="text"
+    className="msla-button msla-flyout ___frx9oy0_1ljmivh f14t3ns0"
+    data-testid="callout-btn"
+    onClick={[Function]}
+    tabIndex={-1}
+  >
+    <img
+      alt=""
+      className="msla-flyout-icon lg ___12p8g0n_rgjm4a0 f14t3ns0 f1w9dchk fxldao9 f2zxqi f1phki43 febqm8h ff9s3yw"
+      draggable={false}
+      role="presentation"
+      src="/src/lib/card/images/information_tiny.svg"
+    />
+  </button>
+  <div
+    hidden={true}
+    id="tooltip5"
     style={
       {
         "border": 0,
@@ -132,6 +220,50 @@ exports[`ui/flyout > should render with a title 1`] = `
 </div>
 `;
 
+exports[`ui/flyout > should render with a title 2`] = `
+<div
+  className="ms-TooltipHost root-116"
+  onBlurCapture={[Function]}
+  onFocusCapture={[Function]}
+  onKeyDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  role="none"
+>
+  <button
+    aria-label="title"
+    className="msla-button msla-flyout ___frx9oy0_1ljmivh f14t3ns0"
+    data-testid="callout-btn"
+    onClick={[Function]}
+    tabIndex={0}
+  >
+    <img
+      alt=""
+      className="msla-flyout-icon lg ___12p8g0n_rgjm4a0 f14t3ns0 f1w9dchk fxldao9 f2zxqi f1phki43 febqm8h ff9s3yw"
+      draggable={false}
+      role="presentation"
+      src="/src/lib/card/images/information_tiny.svg"
+    />
+  </button>
+  <div
+    hidden={true}
+    id="tooltip7"
+    style={
+      {
+        "border": 0,
+        "height": 1,
+        "margin": -1,
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "absolute",
+        "whiteSpace": "nowrap",
+        "width": 1,
+      }
+    }
+  />
+</div>
+`;
+
 exports[`ui/flyout > should render with an ARIA label 1`] = `
 <div
   className="ms-TooltipHost root-116"
@@ -160,6 +292,52 @@ exports[`ui/flyout > should render with an ARIA label 1`] = `
   <div
     hidden={true}
     id="tooltip1"
+    style={
+      {
+        "border": 0,
+        "height": 1,
+        "margin": -1,
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "absolute",
+        "whiteSpace": "nowrap",
+        "width": 1,
+      }
+    }
+  >
+    aria-label
+  </div>
+</div>
+`;
+
+exports[`ui/flyout > should render with an ARIA label 2`] = `
+<div
+  className="ms-TooltipHost root-116"
+  onBlurCapture={[Function]}
+  onFocusCapture={[Function]}
+  onKeyDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  role="none"
+>
+  <button
+    aria-label="aria-label"
+    className="msla-button msla-flyout ___frx9oy0_1ljmivh f14t3ns0"
+    data-testid="callout-btn"
+    onClick={[Function]}
+    tabIndex={0}
+  >
+    <img
+      alt=""
+      className="msla-flyout-icon lg ___12p8g0n_rgjm4a0 f14t3ns0 f1w9dchk fxldao9 f2zxqi f1phki43 febqm8h ff9s3yw"
+      draggable={false}
+      role="presentation"
+      src="/src/lib/card/images/information_tiny.svg"
+    />
+  </button>
+  <div
+    hidden={true}
+    id="tooltip3"
     style={
       {
         "border": 0,

--- a/libs/designer-ui/src/lib/flyout2/__test__/__snapshots__/flyout2.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/flyout2/__test__/__snapshots__/flyout2.spec.tsx.snap
@@ -18,6 +18,24 @@ exports[`lib/flyout2 > should render 1`] = `
 </button>
 `;
 
+exports[`lib/flyout2 > should render 2`] = `
+<button
+  aria-label="text"
+  className="msla-button msla-flyout"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+>
+  <img
+    alt=""
+    className="msla-flyout-icon"
+    draggable={false}
+    role="presentation"
+    src="/src/lib/card/images/information_tiny.svg"
+  />
+</button>
+`;
+
 exports[`lib/flyout2 > should render with a documentation link 1`] = `
 <button
   aria-label="text"
@@ -36,6 +54,24 @@ exports[`lib/flyout2 > should render with a documentation link 1`] = `
 </button>
 `;
 
+exports[`lib/flyout2 > should render with a documentation link 2`] = `
+<button
+  aria-label="text"
+  className="msla-button msla-flyout"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+>
+  <img
+    alt=""
+    className="msla-flyout-icon"
+    draggable={false}
+    role="presentation"
+    src="/src/lib/card/images/information_tiny.svg"
+  />
+</button>
+`;
+
 exports[`lib/flyout2 > should render with a non-zero tab index 1`] = `
 <button
   aria-label="text"
@@ -50,6 +86,24 @@ exports[`lib/flyout2 > should render with a non-zero tab index 1`] = `
     draggable={false}
     role="presentation"
     src="data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2011%2011'%3e%3cdefs%3e%3cstyle%3e%20.a%20{%20fill:%20%23919191;%20}%20%3c/style%3e%3c/defs%3e%3ctitle%3eInfoTiny%3c/title%3e%3cpath%20class='a'%20d='M12105.5,5893a5.45,5.45,0,0,1-1.46-.19,5.49,5.49,0,0,1-3.84-3.84,5.6,5.6,0,0,1,0-2.93,5.49,5.49,0,0,1,3.84-3.84,5.6,5.6,0,0,1,2.93,0,5.49,5.49,0,0,1,3.84,3.84,5.6,5.6,0,0,1,0,2.93,5.49,5.49,0,0,1-3.84,3.84A5.45,5.45,0,0,1,12105.5,5893Zm0-10.27a4.63,4.63,0,0,0-1.27.17,4.88,4.88,0,0,0-1.14.48,4.77,4.77,0,0,0-1.71,1.71,4.87,4.87,0,0,0-.48,1.14,4.73,4.73,0,0,0,0,2.53,4.87,4.87,0,0,0,.48,1.14,4.77,4.77,0,0,0,1.71,1.71,4.88,4.88,0,0,0,1.14.48,4.74,4.74,0,0,0,2.53,0,4.87,4.87,0,0,0,1.14-.48,4.77,4.77,0,0,0,1.71-1.71,4.88,4.88,0,0,0,.48-1.14,4.74,4.74,0,0,0,0-2.53,4.87,4.87,0,0,0-.48-1.14,4.77,4.77,0,0,0-1.71-1.71,4.87,4.87,0,0,0-1.14-.48A4.64,4.64,0,0,0,12105.5,5882.73Zm-0.5,2.27h1v0.8h-1V5885Zm0,2h1v3h-1v-3Z'%20transform='translate(-12100%20-5882)'%20/%3e%3c/svg%3e"
+  />
+</button>
+`;
+
+exports[`lib/flyout2 > should render with a non-zero tab index 2`] = `
+<button
+  aria-label="text"
+  className="msla-button msla-flyout"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={-1}
+>
+  <img
+    alt=""
+    className="msla-flyout-icon"
+    draggable={false}
+    role="presentation"
+    src="/src/lib/card/images/information_tiny.svg"
   />
 </button>
 `;
@@ -73,6 +127,25 @@ exports[`lib/flyout2 > should render with a title 1`] = `
 </button>
 `;
 
+exports[`lib/flyout2 > should render with a title 2`] = `
+<button
+  aria-label="title"
+  className="msla-button msla-flyout"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+  title="title"
+>
+  <img
+    alt=""
+    className="msla-flyout-icon"
+    draggable={false}
+    role="presentation"
+    src="/src/lib/card/images/information_tiny.svg"
+  />
+</button>
+`;
+
 exports[`lib/flyout2 > should render with an ARIA label 1`] = `
 <button
   aria-label="aria-label"
@@ -87,6 +160,24 @@ exports[`lib/flyout2 > should render with an ARIA label 1`] = `
     draggable={false}
     role="presentation"
     src="data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2011%2011'%3e%3cdefs%3e%3cstyle%3e%20.a%20{%20fill:%20%23919191;%20}%20%3c/style%3e%3c/defs%3e%3ctitle%3eInfoTiny%3c/title%3e%3cpath%20class='a'%20d='M12105.5,5893a5.45,5.45,0,0,1-1.46-.19,5.49,5.49,0,0,1-3.84-3.84,5.6,5.6,0,0,1,0-2.93,5.49,5.49,0,0,1,3.84-3.84,5.6,5.6,0,0,1,2.93,0,5.49,5.49,0,0,1,3.84,3.84,5.6,5.6,0,0,1,0,2.93,5.49,5.49,0,0,1-3.84,3.84A5.45,5.45,0,0,1,12105.5,5893Zm0-10.27a4.63,4.63,0,0,0-1.27.17,4.88,4.88,0,0,0-1.14.48,4.77,4.77,0,0,0-1.71,1.71,4.87,4.87,0,0,0-.48,1.14,4.73,4.73,0,0,0,0,2.53,4.87,4.87,0,0,0,.48,1.14,4.77,4.77,0,0,0,1.71,1.71,4.88,4.88,0,0,0,1.14.48,4.74,4.74,0,0,0,2.53,0,4.87,4.87,0,0,0,1.14-.48,4.77,4.77,0,0,0,1.71-1.71,4.88,4.88,0,0,0,.48-1.14,4.74,4.74,0,0,0,0-2.53,4.87,4.87,0,0,0-.48-1.14,4.77,4.77,0,0,0-1.71-1.71,4.87,4.87,0,0,0-1.14-.48A4.64,4.64,0,0,0,12105.5,5882.73Zm-0.5,2.27h1v0.8h-1V5885Zm0,2h1v3h-1v-3Z'%20transform='translate(-12100%20-5882)'%20/%3e%3c/svg%3e"
+  />
+</button>
+`;
+
+exports[`lib/flyout2 > should render with an ARIA label 2`] = `
+<button
+  aria-label="aria-label"
+  className="msla-button msla-flyout"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+>
+  <img
+    alt=""
+    className="msla-flyout-icon"
+    draggable={false}
+    role="presentation"
+    src="/src/lib/card/images/information_tiny.svg"
   />
 </button>
 `;

--- a/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheadercomment.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheadercomment.spec.tsx.snap
@@ -60,3 +60,64 @@ exports[`ui/panel/panelheadercomment > should construct. 1`] = `
   />
 </div>
 `;
+
+exports[`ui/panel/panelheadercomment > should construct. 2`] = `
+<div
+  className="msla-panel-comment-container"
+>
+  <CustomizedIconButton
+    aria-expanded={true}
+    ariaLabel="Hide description"
+    className="msla-panel-comment-toggle-inline"
+    iconProps={
+      {
+        "iconName": "ChevronDown",
+      }
+    }
+    onClick={[Function]}
+    title="Hide description"
+  />
+  <StyledTextFieldBase
+    ariaLabel="Description"
+    autoAdjustHeight={true}
+    borderless={true}
+    className="msla-card-comment"
+    componentRef={
+      {
+        "current": null,
+      }
+    }
+    maxLength={256}
+    multiline={true}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    placeholder="Add a description"
+    resizable={false}
+    styles={
+      {
+        "field": {
+          "backgroundColor": "#faf9f8",
+          "fontSize": undefined,
+          "lineHeight": undefined,
+          "maxHeight": "25vh",
+          "overflowY": "auto",
+          "paddingLeft": "28px",
+          "paddingRight": "8px",
+        },
+        "fieldGroup": {
+          "maxHeight": "25vh",
+          "position": "relative",
+        },
+        "root": {
+          "display": "block",
+          "marginTop": 0,
+        },
+      }
+    }
+    value=""
+  />
+</div>
+`;

--- a/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheadertitle.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheadertitle.spec.tsx.snap
@@ -30,3 +30,34 @@ exports[`ui/panel/panelheadertitle > should construct. 1`] = `
   }
 />
 `;
+
+exports[`ui/panel/panelheadertitle > should construct. 2`] = `
+<StyledTextFieldBase
+  ariaLabel="Card title"
+  borderless={true}
+  className="msla-card-title"
+  componentRef={
+    {
+      "current": null,
+    }
+  }
+  errorMessage=""
+  maxLength={80}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onKeyDown={[Function]}
+  styles={
+    {
+      "errorMessage": {
+        "paddingLeft": "8px",
+      },
+      "fieldGroup": {
+        "background": "inherit",
+      },
+      "root": {
+        "marginTop": "5px",
+      },
+    }
+  }
+/>
+`;


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
There was an edge case where if you modify the parameter outside of the editor (ex. updating a token from the output parameter) it makes it so that we don't update the parameter value. This then causes an issue because before serialization of the editor, the parameter value is actually a single token (e.g. @greater(...)) rather than an array of literals and tokens. I've moved this logic to always serialize from the editor view model so that we aren't trying to serialize from something that isn't "prepped" yet.

Fixed support for negated operators (e.g., notcontains → @not(contains(...))).

This ensures consistency with expected expression format in Logic App query serialization. Also added unit tests using Vitest to validate the logic.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes known bugs on the simple query builder
- **Developers**: Correct serialization output when working with the query builder; better test coverage for RowItemProps → expression conversion. Fixes cases missed from https://github.com/Azure/LogicAppsUX/pull/7673
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@ccastrotrejo tagging castro who has a customer issue which this fixes

## Screenshots/Videos
<!-- Visual changes only -->
