### PR TITLE
chore(vscode): Update vscode-azext-azureutils to 0.3.9-beta

### DIFF
--- a/apps/vs-code-designer/package.json
+++ b/apps/vs-code-designer/package.json
@@ -12,7 +12,7 @@
     "@microsoft/logic-apps-shared": "workspace:*",
     "@microsoft/vscode-azext-azureappservice": "0.8.1",
     "@microsoft/vscode-azext-azureauth": "^4.1.0",
-    "@microsoft/vscode-azext-azureutils": "^0.3.9",
+    "@microsoft/vscode-azext-azureutils": "0.3.9-beta",
     "@microsoft/vscode-azext-utils": "0.4.6",
     "@microsoft/vscode-azureresources-api": "^2.0.2",
     "@microsoft/vscode-extension-logic-apps": "workspace:*",

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -36,6 +36,7 @@ import TelemetryReporter from '@vscode/extension-telemetry';
 import { getAllCustomCodeFunctionsProjects } from './app/utils/customCodeUtils';
 import { createVSCodeAzureSubscriptionProvider } from './app/utils/services/VSCodeAzureSubscriptionProvider';
 import { logSubscriptions } from './app/utils/telemetry';
+import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
 
 const perfStats = {
   loadStartTime: Date.now(),
@@ -65,6 +66,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   ext.outputChannel = createAzExtOutputChannel('Azure Logic Apps (Standard)', ext.prefix);
   registerUIExtensionVariables(ext);
+  registerAzureUtilsExtensionVariables(ext);
   registerAppServiceExtensionVariables(ext);
 
   await callWithTelemetryAndErrorHandling(extensionCommand.activate, async (activateContext: IActionContext) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,8 +450,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.1
       '@microsoft/vscode-azext-azureutils':
-        specifier: ^0.3.9
-        version: 0.3.9(@azure/ms-rest-azure-env@2.0.0)(tslib@2.4.0)
+        specifier: 0.3.9-beta
+        version: 0.3.9-beta(@azure/ms-rest-azure-env@2.0.0)(tslib@2.4.0)
       '@microsoft/vscode-azext-utils':
         specifier: 0.4.6
         version: 0.4.6(@azure/ms-rest-azure-env@2.0.0)(tslib@2.4.0)
@@ -4467,6 +4467,9 @@ packages:
 
   '@microsoft/vscode-azext-azureutils@0.3.9':
     resolution: {integrity: sha512-lKhxSROhTBpz45f0hqYDHfdrGlNOgzfMGXbNproqwyc5qnEYBhs/qG65hcwhLzVm44lYPpBP1aka7OyDEocPOQ==}
+
+  '@microsoft/vscode-azext-azureutils@0.3.9-beta':
+    resolution: {integrity: sha512-fm2daKKZpAWR3TTcdVXve7rAIEzDp+aj8lahsFhFPVBgra5QXMDO1nuKVgda/ehMgBeXqtieGkgO4Ua7Hx+KrA==}
 
   '@microsoft/vscode-azext-utils@0.4.6':
     resolution: {integrity: sha512-CPIIvdod95Qdz5vdGg4j7HpryjKEsDVmdir/VduJZHgdVs1iuqa/9UY0+kIg2JnsnpThAdQH36A1GVA8jQeheg==}
@@ -12852,7 +12855,7 @@ snapshots:
       '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.1
       '@azure/core-paging': 1.6.1
-      '@azure/core-rest-pipeline': 1.15.1
+      '@azure/core-rest-pipeline': 1.17.0
       tslib: 2.4.0
     transitivePeerDependencies:
       - supports-color
@@ -12870,11 +12873,11 @@ snapshots:
   '@azure/arm-resources@5.2.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.7.1
-      '@azure/core-client': 1.9.1
+      '@azure/core-auth': 1.9.0
+      '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.1
       '@azure/core-paging': 1.6.1
-      '@azure/core-rest-pipeline': 1.15.1
+      '@azure/core-rest-pipeline': 1.17.0
       tslib: 2.4.0
     transitivePeerDependencies:
       - supports-color
@@ -12886,7 +12889,7 @@ snapshots:
       '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.1
       '@azure/core-paging': 1.6.1
-      '@azure/core-rest-pipeline': 1.15.1
+      '@azure/core-rest-pipeline': 1.17.0
       tslib: 2.4.0
     transitivePeerDependencies:
       - supports-color
@@ -18134,6 +18137,23 @@ snapshots:
       - supports-color
 
   '@microsoft/vscode-azext-azureutils@0.3.9(@azure/ms-rest-azure-env@2.0.0)(tslib@2.4.0)':
+    dependencies:
+      '@azure/arm-resources': 5.2.0
+      '@azure/arm-resources-profile-2020-09-01-hybrid': 2.1.0
+      '@azure/arm-resources-subscriptions': 2.1.0
+      '@azure/arm-storage': 17.2.1
+      '@azure/arm-storage-profile-2020-09-01-hybrid': 2.1.0
+      '@azure/ms-rest-js': 2.7.0
+      '@microsoft/vscode-azext-utils': 0.4.6(@azure/ms-rest-azure-env@2.0.0)(tslib@2.4.0)
+      semver: 7.6.0
+      vscode-nls: 5.2.0
+    transitivePeerDependencies:
+      - '@azure/ms-rest-azure-env'
+      - encoding
+      - supports-color
+      - tslib
+
+  '@microsoft/vscode-azext-azureutils@0.3.9-beta(@azure/ms-rest-azure-env@2.0.0)(tslib@2.4.0)':
     dependencies:
       '@azure/arm-resources': 5.2.0
       '@azure/arm-resources-profile-2020-09-01-hybrid': 2.1.0


### PR DESCRIPTION
## Commit Type
- [x] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Update @microsoft/vscode-azext-azureutils dependency from ^0.3.9 to 0.3.9-beta version for VS Code designer package and register azure utils extension variables.

## Changes Made
- **Package Dependency**: Updated `@microsoft/vscode-azext-azureutils` from `^0.3.9` to `0.3.9-beta` in `apps/vs-code-designer/package.json`
- **Extension Registration**: Added `registerAzureUtilsExtensionVariables(ext)` call in `apps/vs-code-designer/src/main.ts` to properly register azure utils extension variables
- **Import**: Added import for `registerAzureUtilsExtensionVariables` from the azure utils package
- **Lock File**: Updated `pnpm-lock.yaml` to reflect the new beta version dependency

## Impact of Change
- **Users**: Users with Microsoft tenant will now be able to create Storage accounts and Logic apps from vscode extension
- **Developers**: Updated dependency version for development and proper azure utils registration
- **System**: No performance or architecture changes

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed
- [ ] Tested in: Local development environment

## Contributors

## Screenshots/Videos

#### Error
![CleanShot 2025-07-09 at 17 09 51@2x](https://github.com/user-attachments/assets/f7788c6f-d0fe-440a-a0cf-7cb3f1fe1ef8)