### PR TITLE
feat(Designer): Handoff tools are hidden from the graph

### DIFF
--- a/libs/designer/src/lib/common/constants.ts
+++ b/libs/designer/src/lib/common/constants.ts
@@ -359,6 +359,7 @@ export default {
       FLAT_FILE_ENCODING: 'flatfileencoding',
       FOREACH: 'foreach',
       FUNCTION: 'function',
+      HANDOFF: 'agenthandoff',
       HTTP_WEBHOOK: 'httpwebhook',
       HTTP: 'http',
       IF: 'if',

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -406,12 +406,13 @@ export const buildGraphFromActions = (
       }
     } else if (isAgentAction(action)) {
       for (const [toolKey, toolValue] of Object.entries(action?.tools ?? {})) {
+        const toolActions = Object.values(toolValue.actions ?? {});
         // Add edges for agent handoff actions
-        for (const [_handoffName, handoffAction] of Object.entries(toolValue.actions ?? {})) {
-          if (equals(handoffAction.type, 'AgentHandoff')) {
+        for (const toolAction of toolActions) {
+          if (equals(toolAction.type, constants.NODE.TYPE.HANDOFF)) {
             // Create an edge for the handoff action
             const handoffSource = actionName;
-            const handoffTarget = (handoffAction as any).inputs?.name ?? '';
+            const handoffTarget = (toolAction as any).inputs?.name ?? '';
             if (handoffTarget !== '' && allActionNames.includes(handoffTarget)) {
               edges.push(createWorkflowEdge(handoffSource, handoffTarget, WORKFLOW_EDGE_TYPES.HANDOFF_EDGE));
             }
@@ -422,6 +423,7 @@ export const buildGraphFromActions = (
           allActionNames.push(toolKey);
           continue;
         }
+
         const toolAction: any = action.tools?.[toolKey];
         const newToolId = pasteScopeParams
           ? (pasteScopeParams.renamedNodes[toolKey] ?? toolKey)


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Agent tools with only a handoff action will now be hidden from the UX, instead only being accessible from the handoff edge (for now, keyboard accessible access will come later)
This functions similar to how we hide actions within collapsed graph nodes, they are only hidden from the graph view.
Handoff action data is still accessible and stored in state.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Handoff actions and their containing tools are now hidden from the workflow graph
- **Developers**: No change
- **System**: No change

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
<img width="443" height="790" alt="image" src="https://github.com/user-attachments/assets/3d7eafd3-9135-4fbc-b1d3-1d1aed9b7b9a" />

