### PR TITLE
feat(vscode): Update worker runtime to .NET and add func binary permissions

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewProject/createProjectSteps/ScriptProjectCreateStep.ts
@@ -23,7 +23,7 @@ import { ProjectCreateStepBase } from './ProjectCreateStepBase';
 import { nonNullProp } from '@microsoft/vscode-azext-utils';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { IHostJsonV1, IHostJsonV2, ILocalSettingsJson, IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
-import { FuncVersion } from '@microsoft/vscode-extension-logic-apps';
+import { FuncVersion, WorkerRuntime } from '@microsoft/vscode-extension-logic-apps';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
@@ -46,7 +46,7 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
     Values: {
       [azureWebJobsStorageKey]: localEmulatorConnectionString,
       [functionsInprocNet8Enabled]: functionsInprocNet8EnabledTrue,
-      [workerRuntimeKey]: 'node',
+      [workerRuntimeKey]: WorkerRuntime.Dotnet,
       [appKindSetting]: logicAppKind,
     },
   };

--- a/apps/vs-code-designer/src/app/commands/dataMapper/FxWorkflowRuntime.ts
+++ b/apps/vs-code-designer/src/app/commands/dataMapper/FxWorkflowRuntime.ts
@@ -65,7 +65,7 @@ export async function startBackendRuntime(projectPath: string, context: IActionC
           {
             [appKindSetting]: logicAppKind,
             [ProjectDirectoryPathKey]: projectPath,
-            [workerRuntimeKey]: WorkerRuntime.Node,
+            [workerRuntimeKey]: WorkerRuntime.Dotnet,
           },
           true
         );

--- a/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
@@ -179,8 +179,8 @@ export const getLocalSettingsSchema = (isDesignTime: boolean, projectPath?: stri
     IsEncrypted: false,
     Values: {
       [appKindSetting]: logicAppKind,
-      [workerRuntimeKey]: WorkerRuntime.Node,
       ...(projectPath ? { [ProjectDirectoryPathKey]: projectPath } : {}),
+      ...(isDesignTime ? { [workerRuntimeKey]: WorkerRuntime.Node } : { [workerRuntimeKey]: WorkerRuntime.Dotnet }),
       ...(isDesignTime
         ? { [azureWebJobsSecretStorageTypeKey]: azureStorageTypeSetting }
         : { [azureWebJobsStorageKey]: localEmulatorConnectionString }),

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -99,6 +99,13 @@ export async function downloadAndExtractDependency(
         await extractDependency(dependencyFilePath, targetFolder, dependencyName);
         vscode.window.showInformationMessage(localize('successInstall', `Successfully installed ${dependencyName}`));
         if (dependencyName === funcDependencyName) {
+          // Add execute permissions for func and gozip binaries
+          if (process.platform !== Platform.windows) {
+            fs.chmodSync(`${targetFolder}/func`, 0o755);
+            fs.chmodSync(`${targetFolder}/gozip`, 0o755);
+            fs.chmodSync(`${targetFolder}/in-proc8/func`, 0o755);
+            fs.chmodSync(`${targetFolder}/in-proc6/func`, 0o755);
+          }
           await setFunctionsCommand();
           await startAllDesignTimeApis();
         }


### PR DESCRIPTION
Cherry-pick of the following PR - #7785
## Commit Type
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Updates VS Code extension worker runtime configuration from Node.js to .NET for Logic Apps projects and adds execute permissions for Azure Functions Core Tools binaries. This aligns the runtime configuration with Azure Logic Apps standards which primarily use .NET-based workflows, and fixes binary execution issues on Unix systems.

Needed to update permissions due to the following:
- https://github.com/Azure/azure-functions-core-tools/issues/3766
- https://github.com/Azure/azure-functions-core-tools/pull/3797

## Impact of Change
- **Users**: VS Code extension users creating new Logic Apps projects will use .NET runtime by default; improved binary execution on macOS/Linux
- **Developers**: Runtime configuration is now consistent with Azure Logic Apps standards; conditional runtime selection (Node.js for design-time, .NET for runtime)
- **System**: Better alignment with Azure Logic Apps runtime expectations; resolved func binary permission issues on Unix platforms

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: VS Code extension project creation flow and data mapper workflows

## Contributors
@ccastrotrejo, @andrew-eldridge

## Screenshots/Videos

Fixes #7742 
Correlates to - https://github.com/Azure/logicapps/issues/1357#issuecomment-3060482117