### PR TITLE
feat(Mcp): Add Close Blade Support + Revised Register Mcp Server Call

### DIFF
--- a/apps/Standalone/src/mcp/app/McpStandard.tsx
+++ b/apps/Standalone/src/mcp/app/McpStandard.tsx
@@ -92,9 +92,10 @@ export const McpStandard = () => {
     async ({ logicAppId, workflows, connectionsData }: McpWorkflowsData, onCompleted?: () => void) => {
       const workflowsToCreate = Object.keys(workflows).map((key) => ({
         name: key,
-        workflow: workflows[key].definition,
-        kind: workflows[key].kind,
+        workflow: workflows[key],
       }));
+
+      console.log('Registering MCP server with workflows:', workflowsToCreate);
 
       await saveWorkflowStandard(
         logicAppId,

--- a/apps/Standalone/src/mcp/app/McpStandard.tsx
+++ b/apps/Standalone/src/mcp/app/McpStandard.tsx
@@ -88,29 +88,31 @@ export const McpStandard = () => {
     }
   }, [objectId, tenantId]);
 
-  const onRegisterMcpServer = useCallback(
-    async ({ logicAppId, workflows, connectionsData }: McpWorkflowsData, onCompleted?: () => void) => {
-      const workflowsToCreate = Object.keys(workflows).map((key) => ({
-        name: key,
-        workflow: workflows[key],
-      }));
+  const onRegisterMcpServer = useCallback(async (workflowsData: McpWorkflowsData, onCompleted?: () => void) => {
+    const { logicAppId, workflows, connectionsData } = workflowsData;
+    const workflowsToCreate = Object.keys(workflows).map((key) => ({
+      name: key,
+      workflow: workflows[key],
+    }));
 
-      console.log('Registering MCP server with workflows:', workflowsToCreate);
+    console.log('Generated workflows:', workflowsData);
 
-      await saveWorkflowStandard(
-        logicAppId,
-        workflowsToCreate,
-        connectionsData,
-        /* parametersData */ undefined,
-        /* settingsProperties */ undefined,
-        /* customCodeData */ undefined,
-        /* clearDirtyState */ () => {},
-        { skipValidation: true, throwError: true }
-      );
-      onCompleted?.();
-    },
-    []
-  );
+    await saveWorkflowStandard(
+      logicAppId,
+      workflowsToCreate,
+      connectionsData,
+      /* parametersData */ undefined,
+      /* settingsProperties */ undefined,
+      /* customCodeData */ undefined,
+      /* clearDirtyState */ () => {},
+      { skipValidation: true, throwError: true }
+    );
+    onCompleted?.();
+  }, []);
+
+  const onClose = useCallback(() => {
+    console.log('Close button clicked');
+  }, []);
 
   return (
     <McpWizardProvider locale="en-US" theme={theme}>
@@ -119,7 +121,7 @@ export const McpStandard = () => {
           <div className={styles.wizardContent}>
             <div className={styles.wizardWrapper}>
               <McpDataProvider resourceDetails={resourceDetails} onResourceChange={onResourceChange} services={services}>
-                <McpWizard registerMcpServer={onRegisterMcpServer} />
+                <McpWizard registerMcpServer={onRegisterMcpServer} onClose={onClose} />
                 <div id="mcp-layer-host" className={styles.layerHost} />
               </McpDataProvider>
             </div>

--- a/libs/designer/src/lib/ui/mcp/wizard/McpWizard.tsx
+++ b/libs/designer/src/lib/ui/mcp/wizard/McpWizard.tsx
@@ -24,7 +24,7 @@ import { getResourceNameFromId } from '@microsoft/logic-apps-shared';
 
 export type RegisterMcpServerHandler = (workflowsData: McpWorkflowsData, onCompleted?: () => void) => Promise<void>;
 
-export const McpWizard = ({ registerMcpServer }: { registerMcpServer: RegisterMcpServerHandler }) => {
+export const McpWizard = ({ registerMcpServer, onClose }: { registerMcpServer: RegisterMcpServerHandler; onClose: () => void }) => {
   const dispatch = useDispatch<AppDispatch>();
   const intl = useIntl();
   const styles = useMcpWizardStyles();
@@ -169,14 +169,8 @@ export const McpWizard = ({ registerMcpServer }: { registerMcpServer: RegisterMc
       connection,
       operation
     );
-    console.log('Generated workflows:', workflowsData);
     await registerMcpServer(workflowsData, onRegisterCompleted);
   }, [connection, logicAppName, operation, registerMcpServer, resourceGroup, subscriptionId, onRegisterCompleted]);
-
-  const handleCancel = useCallback(() => {
-    // TODO: Implement cancel logic
-    console.log('Cancel clicked');
-  }, []);
 
   const INTL_TEXT = {
     connectorsTitle: intl.formatMessage({
@@ -264,11 +258,11 @@ export const McpWizard = ({ registerMcpServer }: { registerMcpServer: RegisterMc
             id: 'OA8qkc',
             description: 'Button text for closing the wizard without saving',
           }),
-          onClick: handleCancel,
+          onClick: onClose,
         },
       ],
     };
-  }, [intl, logicAppName, subscriptionId, resourceGroup, connection, operation, handleCancel, handleRegisterMcpServer]);
+  }, [intl, logicAppName, subscriptionId, resourceGroup, connection, operation, onClose, handleRegisterMcpServer]);
 
   return (
     <div className={styles.wizardContainer}>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [X] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [X] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Adds Close Blade support to the MCP Wizard and revises the Register MCP Server handler to correctly handle workflow creation process

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users can now close the MCP wizard via a new button, improving usability.
- **Developers**: Refactored registration logic may affect API consumers or extension contributors.
- **System**: Minor adjustment to handler parameters; generally low architectural risk but pay attention to regression possibilities.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@preetriti1, @Eric-B-Wu

## Screenshots/Videos
<!-- Visual changes only -->
