### PR TITLE
perf(Designer): Moved `canDrop` calculations to a conditional component

### DIFF
--- a/libs/designer/src/lib/core/state/operation/operationSelector.ts
+++ b/libs/designer/src/lib/core/state/operation/operationSelector.ts
@@ -166,13 +166,17 @@ export const useTokenDependencies = (nodeId: string): TokenDependencies => {
 export const useNodesTokenDependencies = (nodes: Set<string>) => {
   const operationsInputsParameters = useOperationsInputParameters();
   const variables = useSelector((state: RootState) => state.tokens.variables);
-  const dependencies: Record<string, Set<string>> = {};
-  if (!operationsInputsParameters) {
-    return dependencies;
-  }
-  for (const node of nodes) {
-    const operationInputParameters = getRecordEntry(operationsInputsParameters, node);
-    if (operationInputParameters) {
+  return useMemo(() => {
+    const dependencies: Record<string, Set<string>> = {};
+    if (!operationsInputsParameters) {
+      return dependencies;
+    }
+    for (const node of nodes) {
+      const operationInputParameters = getRecordEntry(operationsInputsParameters, node);
+      if (!operationInputParameters) {
+        dependencies[node] = new Set();
+        continue;
+      }
       const innerDependencies = new Set<string>();
       for (const group of Object.values(operationInputParameters.parameterGroups)) {
         for (const parameter of group.parameters) {
@@ -197,11 +201,9 @@ export const useNodesTokenDependencies = (nodes: Set<string>) => {
         }
       }
       dependencies[node] = innerDependencies;
-    } else {
-      dependencies[node] = new Set();
     }
-  }
-  return dependencies;
+    return dependencies;
+  }, [nodes, operationsInputsParameters, variables]);
 };
 
 export const useAllOperationErrors = () => useSelector(createSelector(getOperationState, (state) => state.errors));

--- a/libs/designer/src/lib/ui/connections/dropTarget.tsx
+++ b/libs/designer/src/lib/ui/connections/dropTarget.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable react/display-name */
+import { useMemo } from 'react';
+import { useDrop } from 'react-dnd';
+import { css } from '@fluentui/utilities';
+import { containsIdTag } from '@microsoft/logic-apps-shared';
+
+import { useNodesTokenDependencies } from '../../core/state/operation/operationSelector';
+import { useAllGraphParents, useGetAllOperationNodesWithin, useNodeIds } from '../../core/state/workflow/workflowSelectors';
+import { AllowDropTarget } from './dynamicsvgs/allowdroptarget';
+import { BlockDropTarget } from './dynamicsvgs/blockdroptarget';
+import type { DropItem } from './helpers';
+import { canDropItem } from './helpers';
+import { useIsDarkMode } from '../../core/state/designerOptions/designerOptionsSelectors';
+
+interface DropTargetProps {
+  graphId: string;
+  parentId?: string;
+  childId?: string;
+  upstreamNodesOfChild: string[];
+  preventDropItemInA2A: boolean;
+  isWithinAgenticLoop: boolean;
+}
+
+export const DropTarget: React.FC<DropTargetProps> = ({
+  graphId,
+  parentId,
+  childId,
+  upstreamNodesOfChild,
+  preventDropItemInA2A,
+  isWithinAgenticLoop,
+}) => {
+  const isDarkMode = useIsDarkMode();
+
+  const immediateAncestor = useGetAllOperationNodesWithin(parentId && !containsIdTag(parentId) ? parentId : '');
+  const upstreamNodes = useMemo(() => new Set([...upstreamNodesOfChild, ...immediateAncestor]), [immediateAncestor, upstreamNodesOfChild]);
+  const upstreamNodesDependencies = useNodesTokenDependencies(upstreamNodes);
+  const upstreamScopeArr = useAllGraphParents(graphId);
+  const upstreamScopes = useMemo(() => new Set(upstreamScopeArr), [upstreamScopeArr]);
+
+  // Get all nodes in the workflow to compute downstream dependencies
+  const allNodeIds = useNodeIds();
+  const allNodesDependencies = useNodesTokenDependencies(new Set(allNodeIds));
+
+  const [{ canDrop }, drop] = useDrop(
+    () => ({
+      accept: 'BOX',
+      drop: () => ({ graphId, parentId, childId }),
+      canDrop: (item: DropItem) =>
+        canDropItem(
+          item,
+          upstreamNodes,
+          upstreamNodesDependencies,
+          upstreamScopes,
+          childId,
+          parentId,
+          preventDropItemInA2A,
+          isWithinAgenticLoop,
+          allNodesDependencies
+        ),
+      collect: (monitor) => ({
+        canDrop: monitor.canDrop(),
+      }),
+    }),
+    [graphId, parentId, childId, upstreamNodes, upstreamNodesDependencies, preventDropItemInA2A, isWithinAgenticLoop, allNodesDependencies]
+  );
+
+  return (
+    <div
+      ref={drop}
+      className={css('msla-drop-zone-viewmanager', canDrop ? 'canDrop' : 'cannotDrop')}
+      style={{ display: 'grid', placeItems: 'center' }}
+    >
+      {canDrop ? <AllowDropTarget fill="#0078D4" /> : <BlockDropTarget fill={isDarkMode ? '#252423' : '#edebe9'} />}
+    </div>
+  );
+};

--- a/libs/designer/src/lib/ui/connections/dropzone.tsx
+++ b/libs/designer/src/lib/ui/connections/dropzone.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable react/display-name */
 import { memo, useCallback, useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
-import { useDrop } from 'react-dnd';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useIntl } from 'react-intl';
-import { css } from '@fluentui/utilities';
 import { ActionButtonV2 } from '@microsoft/designer-ui';
 import {
   containsIdTag,
@@ -15,28 +13,20 @@ import {
   LoggerService,
 } from '@microsoft/logic-apps-shared';
 
-import { useNodesTokenDependencies } from '../../core/state/operation/operationSelector';
 import type { AppDispatch } from '../../core';
 import { pasteOperation, pasteScopeOperation } from '../../core/actions/bjsworkflow/copypaste';
 import { useUpstreamNodes } from '../../core/state/tokens/tokenSelectors';
 import {
-  useAllGraphParents,
-  useGetAllOperationNodesWithin,
   useHasUpstreamAgenticLoop,
   useIsWithinAgenticLoop,
   useNodeDisplayName,
   useNodeMetadata,
-  useNodeIds,
 } from '../../core/state/workflow/workflowSelectors';
-import { AllowDropTarget } from './dynamicsvgs/allowdroptarget';
-import { BlockDropTarget } from './dynamicsvgs/blockdroptarget';
 import { retrieveClipboardData } from '../../core/utils/clipboard';
 import { setEdgeContextMenuData } from '../../core/state/designerView/designerViewSlice';
 import { useIsA2AWorkflow } from '../../core/state/designerView/designerViewSelectors';
-import type { DropItem } from './helpers';
-import { canDropItem } from './helpers';
 import { useIsDraggingNode } from '../../core/hooks/useIsDraggingNode';
-import { useIsDarkMode } from '../../core/state/designerOptions/designerOptionsSelectors';
+import { DropTarget } from './dropTarget';
 
 export interface DropZoneProps {
   graphId: string;
@@ -49,7 +39,6 @@ export interface DropZoneProps {
 export const DropZone: React.FC<DropZoneProps> = memo(({ graphId, parentId, childId, isLeaf = false, tabIndex = 0 }) => {
   const intl = useIntl();
   const dispatch = useDispatch<AppDispatch>();
-  const isDarkMode = useIsDarkMode();
   const isA2AWorkflow = useIsA2AWorkflow();
 
   const nodeMetadata = useNodeMetadata(removeIdTag(parentId ?? ''));
@@ -78,16 +67,6 @@ export const DropZone: React.FC<DropZoneProps> = memo(({ graphId, parentId, chil
     // No upstream agentic loop, allow drop
     return false;
   }, [hasUpstreamAgenticLoop, isA2AWorkflow, isWithinAgenticLoop]);
-
-  const immediateAncestor = useGetAllOperationNodesWithin(parentId && !containsIdTag(parentId) ? parentId : '');
-  const upstreamNodes = useMemo(() => new Set([...upstreamNodesOfChild, ...immediateAncestor]), [immediateAncestor, upstreamNodesOfChild]);
-  const upstreamNodesDependencies = useNodesTokenDependencies(upstreamNodes);
-  const upstreamScopeArr = useAllGraphParents(graphId);
-  const upstreamScopes = useMemo(() => new Set(upstreamScopeArr), [upstreamScopeArr]);
-
-  // Get all nodes in the workflow to compute downstream dependencies
-  const allNodeIds = useNodeIds();
-  const allNodesDependencies = useNodesTokenDependencies(new Set(allNodeIds));
 
   const handlePasteClicked = useCallback(async () => {
     const relationshipIds = { graphId, childId, parentId };
@@ -141,29 +120,6 @@ export const DropZone: React.FC<DropZoneProps> = memo(({ graphId, parentId, chil
   );
 
   const isDragging = useIsDraggingNode();
-
-  const [{ canDrop }, drop] = useDrop(
-    () => ({
-      accept: 'BOX',
-      drop: () => ({ graphId, parentId, childId }),
-      canDrop: (item: DropItem) =>
-        canDropItem(
-          item,
-          upstreamNodes,
-          upstreamNodesDependencies,
-          upstreamScopes,
-          childId,
-          parentId,
-          preventDropItemInA2A,
-          isWithinAgenticLoop,
-          allNodesDependencies
-        ),
-      collect: (monitor) => ({
-        canDrop: monitor.canDrop(),
-      }),
-    }),
-    [graphId, parentId, childId, upstreamNodes, upstreamNodesDependencies, preventDropItemInA2A, isWithinAgenticLoop, allNodesDependencies]
-  );
 
   const parentName = useNodeDisplayName(removeIdTag(parentId ?? ''));
   const childName = useNodeDisplayName(childId);
@@ -240,27 +196,27 @@ export const DropZone: React.FC<DropZoneProps> = memo(({ graphId, parentId, chil
   const buttonRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div
-      ref={(node) => {
-        drop(node);
-        hotkeyRef.current = node;
-      }}
-      className={css('msla-drop-zone-viewmanager', isDragging && (canDrop ? 'canDrop' : 'cannotDrop'))}
-    >
-      {isDragging && (
-        <div style={{ display: 'grid', placeItems: 'center' }}>
-          {canDrop ? <AllowDropTarget fill="#0078D4" /> : <BlockDropTarget fill={isDarkMode ? '#252423' : '#edebe9'} />}
-        </div>
-      )}
-      {!isDragging && (
-        <div ref={buttonRef}>
-          <ActionButtonV2
-            id={buttonId}
-            dataAutomationId={automationId('plus')}
-            tabIndex={tabIndex}
-            title={tooltipText}
-            onClick={actionButtonClick}
-          />
+    <div ref={(node) => (hotkeyRef.current = node)}>
+      {isDragging ? (
+        <DropTarget
+          graphId={graphId}
+          parentId={parentId}
+          childId={childId}
+          upstreamNodesOfChild={upstreamNodesOfChild}
+          preventDropItemInA2A={preventDropItemInA2A}
+          isWithinAgenticLoop={isWithinAgenticLoop}
+        />
+      ) : (
+        <div className={'msla-drop-zone-viewmanager'}>
+          <div ref={buttonRef}>
+            <ActionButtonV2
+              id={buttonId}
+              dataAutomationId={automationId('plus')}
+              tabIndex={tabIndex}
+              title={tooltipText}
+              onClick={actionButtonClick}
+            />
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] perf - Performance improvement

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Moved logic determining the `canDrop` flag on edge drop targets to a conditional component.
Logic now only runs when we need to determine the flag instead of on-render, greatly reducing rending time.
Starting a drag is now slightly slower, but when testing a very zoomed out flow with ~300 nodes on screen it was a barely noticeable difference.
Due to the infrequency of this interaction compared to every time an edge is rendered, I think this is an acceptable tradeoff.

The following tests were run on a 500 node test flow to highlight performance differences.

| [3 test averages]   | Before | After | % Change |
|---------------------|--------|-------|----------|
| Expanding 500 nodes | 8.3s   | 6.3s  | 34% faster   |
| Single edge rendering time | 12.9ms   | 6.6s  | 95% faster   |

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Navigating workflows will feel faster, initial loads will be faster as well
- **Developers**: No change
- **System**: Improved perf when rendering edges

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
