### PR TITLE
feat(mcp): Adding server info in create payload from connector

### DIFF
--- a/apps/Standalone/src/mcp/app/McpStandard.tsx
+++ b/apps/Standalone/src/mcp/app/McpStandard.tsx
@@ -4,7 +4,7 @@ import {
   mcpStore,
   McpWizard,
   McpWizardProvider,
-  type McpWorkflowsData,
+  type McpServerCreateData,
   resetMcpStateOnResourceChange,
 } from '@microsoft/logic-apps-designer';
 import type { RootState } from '../state/Store';
@@ -88,14 +88,14 @@ export const McpStandard = () => {
     }
   }, [objectId, tenantId]);
 
-  const onRegisterMcpServer = useCallback(async (workflowsData: McpWorkflowsData, onCompleted?: () => void) => {
-    const { logicAppId, workflows, connectionsData } = workflowsData;
+  const onRegisterMcpServer = useCallback(async (createData: McpServerCreateData, onCompleted?: () => void) => {
+    const { logicAppId, workflows, connectionsData } = createData;
     const workflowsToCreate = Object.keys(workflows).map((key) => ({
       name: key,
       workflow: workflows[key],
     }));
 
-    console.log('Generated workflows:', workflowsData);
+    console.log('Generated server data:', createData);
 
     await saveWorkflowStandard(
       logicAppId,

--- a/libs/designer/src/lib/core/index.ts
+++ b/libs/designer/src/lib/core/index.ts
@@ -65,7 +65,7 @@ export { ConfigureTemplateDataProvider } from './configuretemplate/ConfigureTemp
 export { McpDataProvider } from './mcp/McpDataProvider';
 export { McpWizardProvider } from './mcp/McpWizardProvider';
 export { resetMcpStateOnResourceChange } from './actions/bjsworkflow/mcp';
-export type { McpWorkflowsData } from './mcp/utils/serializer';
+export type { McpServerCreateData } from './mcp/utils/serializer';
 export {
   validateParameter,
   parameterValueToString,

--- a/libs/designer/src/lib/ui/mcp/wizard/McpWizard.tsx
+++ b/libs/designer/src/lib/ui/mcp/wizard/McpWizard.tsx
@@ -6,7 +6,7 @@ import { McpPanelView, openConnectorPanelView } from '../../../core/state/mcp/pa
 import { useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from '../../../core/state/mcp/store';
 import { McpPanelRoot } from '../panel/mcpPanelRoot';
-import { type McpWorkflowsData, serializeMcpWorkflows } from '../../../core/mcp/utils/serializer';
+import { type McpServerCreateData, serializeMcpWorkflows } from '../../../core/mcp/utils/serializer';
 import { resetQueriesOnRegisterMcpServer } from '../../../core/mcp/utils/queries';
 import { LogicAppSelector } from '../details/logicAppSelector';
 import { useMemo, useCallback } from 'react';
@@ -15,7 +15,7 @@ import { TemplatesPanelFooter } from '@microsoft/designer-ui';
 import { ListOperations } from '../operations/ListOperations';
 import { ListConnectors } from '../connectors/ListConnectors';
 
-export type RegisterMcpServerHandler = (workflowsData: McpWorkflowsData, onCompleted?: () => void) => Promise<void>;
+export type RegisterMcpServerHandler = (workflowsData: McpServerCreateData, onCompleted?: () => void) => Promise<void>;
 
 export const McpWizard = ({ registerMcpServer, onClose }: { registerMcpServer: RegisterMcpServerHandler; onClose: () => void }) => {
   const dispatch = useDispatch<AppDispatch>();


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Adding connector info in server create payload.
This is needed for API center to show mcp server details in their UI

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: User will be able to see connector information in their mcp server
- **Developers**: Added new details in create payload which keeps it extensible
- **System**: NA

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@atuannguyen1101 @Elaina-Lee @Eric-B-Wu 

## Screenshots/Videos
NA
