### PR TITLE
fix(ci): Add label change triggers to AI PR validation workflow

### DIFF
--- a/.github/workflows/pr-ai-validation.yml
+++ b/.github/workflows/pr-ai-validation.yml
@@ -2,7 +2,7 @@ name: PR AI Validation
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize]
+    types: [opened, edited, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
This PR adds `labeled` and `unlabeled` event types to the AI PR validation workflow triggers. Currently, the workflow only runs on PR open, edit, and synchronize events. Adding label change triggers ensures the AI validation runs when labels are modified on PRs.

## Impact of Change
- **Users**: No user-facing impact
- **Developers**: AI PR validation will now automatically run when labels are added or removed from PRs
- **System**: Minimal impact - just adds two additional trigger events to existing workflow

## Test Plan
- [x] Manual testing completed
- [x] Tested in: Will be tested when PR is created and labels are added/removed

## Contributors
N/A

## Screenshots/Videos
N/A - Infrastructure change only