### PR TITLE
fix(designer): fix issue on monaco caret styling conflicting with panel

### DIFF
--- a/libs/designer-ui/src/lib/editor/monaco/monaco.styles.ts
+++ b/libs/designer-ui/src/lib/editor/monaco/monaco.styles.ts
@@ -9,5 +9,8 @@ export const useMonacoStyles = makeStyles({
   },
   container: {
     // Applied to the container div
+    '& .cursor': {
+      borderLeftStyle: 'solid',
+    },
   },
 });


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Any Monaco editor being loaded in the panel is not showing the caret; think issue is due to makeStyles migration, but this makes it so caret is always shown when editor is focused
https://github.com/Azure/LogicAppsUX/issues/7749

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users should expect to see where their caret is when typing on the monaco editors
- **Developers**: No dev changes
- **System**: No system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
