### PR TITLE
fix(designer): Send original response if dynamic data pagination fails

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/connector.ts
@@ -1,6 +1,6 @@
 import { getIntl } from '../../../intl/src';
 import type { OpenAPIV2, OperationInfo } from '../../../utils/src';
-import { ArgumentException, equals, ConnectorServiceException, ConnectorServiceErrorCode } from '../../../utils/src';
+import { ArgumentException, equals, ConnectorServiceException, ConnectorServiceErrorCode, parseErrorMessage } from '../../../utils/src';
 import type {
   IConnectorService,
   ListDynamicValue,
@@ -192,8 +192,14 @@ export abstract class BaseConnectorService implements IConnectorService {
       const isArrayPagination = Array.isArray(initialResponse.value) && nextLink;
 
       if (isArrayPagination) {
-        const allValues = await this._getAllPagedValues(initialResponse, request.headers);
-        return { ...initialResponse, value: allValues, __usedNextPage: true };
+        const paginationResult = await this._getAllPagedValues(initialResponse, request.headers);
+        return {
+          ...initialResponse,
+          value: paginationResult.values,
+          __usedNextPage: true,
+          __paginationIncomplete: paginationResult.incomplete,
+          __paginationError: paginationResult.error,
+        };
       }
 
       return initialResponse;
@@ -212,29 +218,44 @@ export abstract class BaseConnectorService implements IConnectorService {
     return this._getResponseFromDynamicApi(initialResponse, baseUri);
   }
 
-  private async _getAllPagedValues(initialResponse: any, headers: Record<string, any>): Promise<any[]> {
+  private async _getAllPagedValues(
+    initialResponse: any,
+    headers: Record<string, any>
+  ): Promise<{ values: any[]; incomplete: boolean; error?: string }> {
     let pageData = initialResponse;
     const allValues: any[] = Array.isArray(pageData.value) ? [...pageData.value] : [];
 
     let nextLink: string | undefined = pageData.nextLink || pageData['@odata.nextLink'];
+    let incomplete = false;
+    let lastError: string | undefined;
 
     while (nextLink) {
-      const pagedResponse = await this.options.httpClient.get({
-        uri: nextLink,
-        headers,
-      });
+      try {
+        const pagedResponse = await this.options.httpClient.get({
+          uri: nextLink,
+          headers,
+        });
 
-      pageData = this._getResponseFromDynamicApi({ response: { statusCode: 'OK', body: pagedResponse, headers } }, nextLink);
+        pageData = this._getResponseFromDynamicApi({ response: { statusCode: 'OK', body: pagedResponse, headers } }, nextLink);
 
-      if (!pageData || !Array.isArray(pageData.value)) {
-        throw new Error(`Invalid response at nextLink: ${nextLink}`);
+        if (!pageData || !Array.isArray(pageData.value)) {
+          throw new Error(`Invalid response at nextLink: ${nextLink}`);
+        }
+
+        allValues.push(...pageData.value);
+        nextLink = pageData.nextLink || pageData['@odata.nextLink'];
+      } catch (error: any) {
+        incomplete = true;
+        lastError = parseErrorMessage(error);
+        break;
       }
-
-      allValues.push(...pageData.value);
-      nextLink = pageData.nextLink || pageData['@odata.nextLink'];
     }
 
-    return allValues;
+    return {
+      values: allValues,
+      incomplete,
+      error: lastError,
+    };
   }
 
   private _handleError(ex: any, intl: IntlShape, method: string, baseUri: string, path: string) {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/connector.ts
@@ -4,6 +4,8 @@ import type { BaseConnectorServiceOptions } from '../base';
 import { BaseConnectorService } from '../base';
 import type { ListDynamicValue, ManagedIdentityRequestProperties, TreeDynamicExtension, TreeDynamicValue } from '../connector';
 import { pathCombine, unwrapPaginatedResponse } from '../helpers';
+import { LoggerService } from '../logger';
+import { LogEntryLevel } from '../logging/logEntry';
 
 interface ConsumptionConnectorServiceOptions extends BaseConnectorServiceOptions {
   workflowReferenceId: string;
@@ -32,6 +34,14 @@ export class ConsumptionConnectorService extends BaseConnectorService {
       parameters,
       managedIdentityProperties ? { workflowReference: { id: workflowReferenceId } } : undefined
     );
+
+    if (result?.__paginationIncomplete) {
+      LoggerService().log({
+        message: `Pagination request unsuccessful, some values may be missing. ${result.__paginationError || ''} on ${connectorId}`,
+        level: LogEntryLevel.Error,
+        area: 'unwrapPaginatedResponse',
+      });
+    }
 
     return unwrapPaginatedResponse(result);
   }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixes an issue where on fetching nextPage on dynamic data that if the nextPage fails that we no longer send the original response. This is an issue because non-ARM connectors will fail due to not having the correct auth token (this will need to be revisited). For now this PR will handle it so that we at least send the original payload.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes regression for dynamic data pagination failures.
- **Developers**: Ensures original payload is sent despite paging errors.
- **System**: None

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@preetriti1, @DanielleCogs 

## Screenshots/Videos
<!-- Visual changes only -->
