### PR TITLE
fix(designer): Fixed issues with A2A run-after-trigger functionality

### DIFF
--- a/apps/Standalone/src/designer/app/LocalDesigner/localDesigner.tsx
+++ b/apps/Standalone/src/designer/app/LocalDesigner/localDesigner.tsx
@@ -36,6 +36,7 @@ const connectionServiceStandard = new StandardConnectionService({
   baseUrl: '/url',
   apiVersion: '2018-11-01',
   httpClient,
+  writeConnection: () => Promise.resolve(),
   apiHubServiceDetails: {
     apiVersion: '2018-07-01-preview',
     baseUrl: '/baseUrl',

--- a/libs/designer/src/lib/core/actions/bjsworkflow/runafter.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/runafter.ts
@@ -1,4 +1,4 @@
-import { addEdgeFromRunAfter, removeEdgeFromRunAfter } from '../../state/workflow/workflowSlice';
+import { addRunAfter, removeRunAfter } from '../../state/workflow/workflowSlice';
 import type { RootState } from '../../store';
 import { updateAllUpstreamNodes } from './initialize';
 import { createAsyncThunk } from '@reduxjs/toolkit';
@@ -8,34 +8,32 @@ export interface EdgeRunAfterPayload {
   childOperationId: string;
 }
 
-export const addEdgeFromRunAfterOperation = createAsyncThunk(
-  'addEdgeFromRunAfter',
+export const addOperationRunAfter = createAsyncThunk(
+  'addOperationRunAfter',
   async (edgePayload: EdgeRunAfterPayload, { dispatch, getState }) => {
     const { parentOperationId, childOperationId } = edgePayload;
     dispatch(
-      addEdgeFromRunAfter({
+      addRunAfter({
         parentOperationId,
         childOperationId,
       })
     );
     updateAllUpstreamNodes(getState() as RootState, dispatch);
-
     return;
   }
 );
 
-export const removeEdgeFromRunAfterOperation = createAsyncThunk(
-  'removeEdgeFromRunAfter',
+export const removeOperationRunAfter = createAsyncThunk(
+  'removeOperationRunAfter',
   async (edgePayload: EdgeRunAfterPayload, { dispatch, getState }) => {
     const { parentOperationId, childOperationId } = edgePayload;
     dispatch(
-      removeEdgeFromRunAfter({
+      removeRunAfter({
         parentOperationId,
         childOperationId,
       })
     );
     updateAllUpstreamNodes(getState() as RootState, dispatch);
-
     return;
   }
 );

--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -13,6 +13,7 @@ import {
   isScopeOperation,
   WORKFLOW_NODE_TYPES,
   getRecordEntry,
+  equals,
 } from '@microsoft/logic-apps-shared';
 
 export interface AddNodePayload {
@@ -55,7 +56,8 @@ export const addNodeToWorkflow = (
   state.isDirty = true;
 
   const isAfterTrigger = getRecordEntry(nodesMetadata, parentId ?? '')?.isRoot && graphId === 'root';
-  const shouldAddRunAfters = !isRoot && !isAfterTrigger;
+  const allowRunAfterTrigger = equals(state.workflowKind, 'agent');
+  const shouldAddRunAfters = allowRunAfterTrigger || (!isRoot && !isAfterTrigger);
   nodesMetadata[newNodeId] = { graphId: subgraphId ?? graphId, parentNodeId, isRoot };
   state.operations[newNodeId] = { ...state.operations[newNodeId], type: operation.type };
   state.newlyAddedOperations[newNodeId] = newNodeId;

--- a/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/deleteNodeFromWorkflow.ts
@@ -81,7 +81,8 @@ export const deleteNodeFromWorkflow = (
     const graphId = workflowGraph.id;
     const parentMetadata = getRecordEntry(nodesMetadata, parentId);
     const isAfterTrigger = parentMetadata?.isRoot && graphId === 'root';
-    const shouldAddRunAfters = !isRoot && !isAfterTrigger;
+    const allowRunAfterTrigger = equals(state.workflowKind, 'agent');
+    const shouldAddRunAfters = allowRunAfterTrigger || (!isRoot && !isAfterTrigger);
     reassignEdgeSources(state, nodeId, parentId, workflowGraph, shouldAddRunAfters);
     removeEdge(state, parentId, nodeId, workflowGraph);
   }

--- a/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/moveNodeInWorkflow.ts
@@ -4,7 +4,7 @@ import type { NodesMetadata, WorkflowState } from '../state/workflow/workflowInt
 import type { WorkflowNode } from './models/workflowNode';
 import { addNewEdge, reassignEdgeSources, reassignEdgeTargets, removeEdge, applyIsRootNode } from './restructuringHelpers';
 import type { LogicAppsV2 } from '@microsoft/logic-apps-shared';
-import { containsIdTag, getRecordEntry } from '@microsoft/logic-apps-shared';
+import { containsIdTag, equals, getRecordEntry } from '@microsoft/logic-apps-shared';
 
 export interface MoveNodePayload {
   nodeId: string;
@@ -74,7 +74,8 @@ export const moveNodeInWorkflow = (
     const graphId = oldWorkflowGraph.id;
     const parentMetadata = getRecordEntry(nodesMetadata, parentId);
     const isAfterTrigger = parentMetadata?.isRoot && graphId === 'root';
-    const shouldAddRunAfters = !isOldRoot && !isAfterTrigger;
+    const allowRunAfterTrigger = equals(state.workflowKind, 'agent');
+    const shouldAddRunAfters = allowRunAfterTrigger || (!isOldRoot && !isAfterTrigger);
     reassignEdgeSources(state, nodeId, parentId, oldWorkflowGraph, shouldAddRunAfters);
     removeEdge(state, parentId, nodeId, oldWorkflowGraph);
   }
@@ -105,7 +106,8 @@ export const moveNodeInWorkflow = (
 
   const parentMetadata = getRecordEntry(nodesMetadata, parentId);
   const isAfterTrigger = (parentMetadata?.isRoot && newGraphId === 'root') ?? false;
-  const shouldAddRunAfters = !isNewRoot && !isAfterTrigger;
+  const allowRunAfterTrigger = equals(state.workflowKind, 'agent');
+  const shouldAddRunAfters = allowRunAfterTrigger || (!isNewRoot && !isAfterTrigger);
 
   // 1 parent, 1 child
   if (parentId && childId) {

--- a/libs/designer/src/lib/core/parsers/pasteScopeInWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/pasteScopeInWorkflow.ts
@@ -2,7 +2,7 @@ import type { RelationshipIds } from '../state/panel/panelTypes';
 import type { NodesMetadata, Operations, WorkflowState } from '../state/workflow/workflowInterfaces';
 import type { WorkflowNode } from './models/workflowNode';
 import { addNewEdge, reassignEdgeSources, reassignEdgeTargets, removeEdge, applyIsRootNode } from './restructuringHelpers';
-import { containsIdTag, getRecordEntry } from '@microsoft/logic-apps-shared';
+import { containsIdTag, equals, getRecordEntry } from '@microsoft/logic-apps-shared';
 
 export interface PasteScopeNodePayload {
   relationshipIds: RelationshipIds;
@@ -56,7 +56,8 @@ export const pasteScopeInWorkflow = (
 
   const parentMetadata = getRecordEntry(state.nodesMetadata, parentId);
   const isAfterTrigger = (parentMetadata?.isRoot && newGraphId === 'root') ?? false;
-  const shouldAddRunAfters = !isNewRoot && !isAfterTrigger;
+  const allowRunAfterTrigger = equals(state.workflowKind, 'agent');
+  const shouldAddRunAfters = allowRunAfterTrigger || (!isNewRoot && !isAfterTrigger);
 
   // clear the existing runAfter
   (getRecordEntry(state.operations, nodeId) as any).runAfter = {};

--- a/libs/designer/src/lib/core/state/undoRedo/undoRedoTypes.ts
+++ b/libs/designer/src/lib/core/state/undoRedo/undoRedoTypes.ts
@@ -4,13 +4,13 @@ import { updateParameterAndDependencies } from '../../utils/parameters/helper';
 import { updateStaticResults } from '../operation/operationMetadataSlice';
 import {
   addAgentTool,
-  addEdgeFromRunAfter,
+  addRunAfter,
   addNode,
   addSwitchCase,
   moveNode,
   pasteNode,
   pasteScopeNode,
-  removeEdgeFromRunAfter,
+  removeRunAfter,
   replaceId,
   updateRunAfter,
 } from '../workflow/workflowSlice';
@@ -47,8 +47,8 @@ export const undoableWorkflowActionTypes = [
   pasteNode,
   pasteScopeNode,
   updateRunAfter,
-  removeEdgeFromRunAfter,
-  addEdgeFromRunAfter,
+  removeRunAfter,
+  addRunAfter,
   /**
    * Following operations trigger state save outside of middleware:
    * 1. Delete node operations are tracked through DeleteModal since there are different delete actions for different node types

--- a/libs/designer/src/lib/core/state/workflow/helper.ts
+++ b/libs/designer/src/lib/core/state/workflow/helper.ts
@@ -1,4 +1,6 @@
+import { equals } from '@microsoft/logic-apps-shared';
 import type { WorkflowNode } from '../../../core/parsers/models/workflowNode';
+import type { WorkflowState } from './workflowInterfaces';
 
 /**
  * Recursively clones a node while pruning (removing) any nodes that are in the nodesToRemove set.
@@ -125,4 +127,8 @@ export const collapseFlowTree = (
   });
 
   return { graph: prunedTree, collapsedMapping: collapsedMappingArrays };
+};
+
+export const isA2AWorkflow = (state: WorkflowState): boolean => {
+  return equals(state.workflowKind, 'agent');
 };

--- a/libs/designer/src/lib/ui/connections/edge.tsx
+++ b/libs/designer/src/lib/ui/connections/edge.tsx
@@ -13,7 +13,7 @@ import { DropZone } from './dropzone';
 import { ArrowCap } from './dynamicsvgs/arrowCap';
 import { CollapsedRunAfterIndicator, RunAfterIndicator } from './runAfterIndicator';
 import { useIsNodeSelectedInOperationPanel } from '../../core/state/panel/panelSelectors';
-import { removeEdgeFromRunAfterOperation } from '../../core/actions/bjsworkflow/runafter';
+import { removeOperationRunAfter } from '../../core/actions/bjsworkflow/runafter';
 import { EdgePathContextMenu, useContextMenu } from './edgePathContextMenu';
 import type { AppDispatch } from '../../core';
 
@@ -152,7 +152,7 @@ const ButtonEdge: React.FC<EdgeProps<LogicAppsEdgeProps>> = ({
 
   const deleteEdge = useCallback(() => {
     dispatch(
-      removeEdgeFromRunAfterOperation({
+      removeOperationRunAfter({
         parentOperationId: sourceId,
         childOperationId: targetId,
       })

--- a/libs/designer/src/lib/ui/connections/handoffEdge.tsx
+++ b/libs/designer/src/lib/ui/connections/handoffEdge.tsx
@@ -19,7 +19,7 @@ import { useReadOnly } from '../../core/state/designerOptions/designerOptionsSel
 import { useNodeMetadata } from '../../core/state/workflow/workflowSelectors';
 import { ArrowCap } from './dynamicsvgs/arrowCap';
 import { useIsNodeSelectedInOperationPanel } from '../../core/state/panel/panelSelectors';
-import { removeEdgeFromRunAfterOperation } from '../../core/actions/bjsworkflow/runafter';
+import { removeOperationRunAfter } from '../../core/actions/bjsworkflow/runafter';
 import { EdgePathContextMenu, useContextMenu } from './edgePathContextMenu';
 import { changePanelNode, type AppDispatch } from '../../core';
 import { HandoffIcon } from './dynamicsvgs/handoffIcon';
@@ -130,7 +130,7 @@ const HandoffEdge: React.FC<EdgeProps<LogicAppsEdgeProps>> = ({ id, source, targ
 
   const deleteEdge = useCallback(() => {
     dispatch(
-      removeEdgeFromRunAfterOperation({
+      removeOperationRunAfter({
         parentOperationId: sourceId,
         childOperationId: targetId,
       })

--- a/libs/designer/src/lib/ui/settings/sections/runafter.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/runafter.tsx
@@ -1,7 +1,7 @@
 import type { SectionProps } from '../';
 import { SettingSectionName } from '../';
 import type { AppDispatch, RootState } from '../../../core';
-import { addEdgeFromRunAfterOperation, removeEdgeFromRunAfterOperation } from '../../../core/actions/bjsworkflow/runafter';
+import { addOperationRunAfter, removeOperationRunAfter } from '../../../core/actions/bjsworkflow/runafter';
 import { useActionMetadata, useRootTriggerId } from '../../../core/state/workflow/workflowSelectors';
 import { updateRunAfter } from '../../../core/state/workflow/workflowSlice';
 import { useIsA2AWorkflow } from '../../../core/state/designerView/designerViewSelectors';
@@ -93,7 +93,7 @@ export const RunAfter = ({ nodeId, readOnly = false, expanded, validationErrors,
         },
         onDelete: () => {
           dispatch(
-            removeEdgeFromRunAfterOperation({
+            removeOperationRunAfter({
               parentOperationId: id,
               childOperationId: nodeId,
             })
@@ -120,7 +120,7 @@ export const RunAfter = ({ nodeId, readOnly = false, expanded, validationErrors,
           readOnly,
           onEdgeAddition: (parentNode: string) => {
             dispatch(
-              addEdgeFromRunAfterOperation({
+              addOperationRunAfter({
                 parentOperationId: parentNode,
                 childOperationId: nodeId,
               })

--- a/libs/designer/src/lib/ui/settings/sections/runafterconfiguration/runafterActionSelector.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/runafterconfiguration/runafterActionSelector.tsx
@@ -1,5 +1,5 @@
 import type { AppDispatch, RootState } from '../../../../core';
-import { addEdgeFromRunAfterOperation, removeEdgeFromRunAfterOperation } from '../../../../core/actions/bjsworkflow/runafter';
+import { addOperationRunAfter, removeOperationRunAfter } from '../../../../core/actions/bjsworkflow/runafter';
 import { useOperationVisuals } from '../../../../core/state/operation/operationSelector';
 import { useOperationPanelSelectedNodeId } from '../../../../core/state/panel/panelSelectors';
 import { useNodeDisplayName, useRootTriggerId } from '../../../../core/state/workflow/workflowSelectors';
@@ -130,7 +130,7 @@ export const RunAfterActionSelector = ({ readOnly }: { readOnly: boolean }) => {
         const removedItems = selectedValues.actions.filter((x) => !data.checkedItems.includes(x));
         removedItems.forEach((item) => {
           dispatch(
-            removeEdgeFromRunAfterOperation({
+            removeOperationRunAfter({
               parentOperationId: item,
               childOperationId: currentNodeId,
             })
@@ -138,7 +138,7 @@ export const RunAfterActionSelector = ({ readOnly }: { readOnly: boolean }) => {
         });
         newItems.forEach((item) => {
           dispatch(
-            addEdgeFromRunAfterOperation({
+            addOperationRunAfter({
               parentOperationId: item,
               childOperationId: currentNodeId,
             })


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
For A2A workflows, operations running after the trigger do need run-after data pointing to the trigger.
This is different than other workflow types and has been adjusted in all necessary places.
Any operation that puts a node after the trigger should populate with run-after-trigger data (ie. add, paste, move)

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: A2A workflows will now serialize properly
- **Developers**: No changes
- **System**: No changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
<img width="1024" height="513" alt="image" src="https://github.com/user-attachments/assets/9e6ef4d8-b9d1-45c0-889b-0800d9b4c7d5" />
<img width="1012" height="423" alt="image" src="https://github.com/user-attachments/assets/bd17372c-551f-47a9-b9d0-272621dee0e9" />
