### PR TITLE
fix(designer): update agent ID format from hyphen to underscore

### DIFF
--- a/libs/designer/src/lib/ui/common/EdgeContextualMenu/EdgeContextualMenu.tsx
+++ b/libs/designer/src/lib/ui/common/EdgeContextualMenu/EdgeContextualMenu.tsx
@@ -106,7 +106,7 @@ export const EdgeContextualMenu = () => {
       return;
     }
 
-    const newAgentId = `Agent-${customLengthGuid(4)}`;
+    const newAgentId = `Agent_${customLengthGuid(4)}`;
 
     if (isA2AWorkflow && hasUpstreamAgenticLoop && parentId) {
       // If this is an A2A flow and the parent is an agent, don't add any relationships, instead add a handoff tool + operation


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Updates the agent ID format in EdgeContextualMenu from using hyphens (`Agent-{guid}`) to underscores (`Agent_{guid}`). This change ensures consistency with expected agent naming conventions.

## Impact of Change
- **Users**: Agent IDs will now use underscore format instead of hyphen format
- **Developers**: No API changes, minimal code change
- **System**: No performance or architectural impact

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Edge contextual menu agent creation flow

## Contributors
<\!-- Tag team members who contributed ideas, reviews, or implementation -->
@AbodeSaafan 

## Screenshots/Videos
#### Before

<img width="832" height="844" alt="CleanShot 2025-07-23 at 10 18 14@2x" src="https://github.com/user-attachments/assets/73d27bca-1a65-41ae-8ba7-d5f6b44929ea" />


#### After
<img width="854" height="1314" alt="CleanShot 2025-07-23 at 10 17 47@2x" src="https://github.com/user-attachments/assets/2c93b4c2-b7b3-4c21-ba47-2be0630cdba3" />
<img width="1106" height="786" alt="CleanShot 2025-07-23 at 10 17 57@2x" src="https://github.com/user-attachments/assets/57f39e6e-6b9b-4e48-ac7a-de4be058cc2e" />

