### PR TITLE
feat(Mcp): Add different editor support for parameters in Mcp

### DIFF
--- a/libs/designer-ui/src/lib/arrayeditor/collapsedarray.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/collapsedarray.tsx
@@ -20,7 +20,7 @@ export interface CollapsedArrayProps {
   setItems: ((simpleItems: SimpleArrayItem[]) => void) | ((complexItems: ComplexArrayItems[]) => void);
   setIsValid: (b: boolean) => void;
   onBlur?: () => void;
-  getTokenPicker: GetTokenPickerHandler;
+  getTokenPicker?: GetTokenPickerHandler;
   tokenMapping?: Record<string, ValueSegment>;
   loadParameterValueFromString?: loadParameterValueFromStringHandler;
   basePlugins?: BasePlugins;

--- a/libs/designer-ui/src/lib/arrayeditor/expandedcomplexarray.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/expandedcomplexarray.tsx
@@ -25,7 +25,7 @@ export interface ExpandedComplexArrayProps {
   itemKey?: string;
   isNested?: boolean;
   options?: ComboboxItem[];
-  getTokenPicker: GetTokenPickerHandler;
+  getTokenPicker?: GetTokenPickerHandler;
   tokenMapping?: Record<string, ValueSegment>;
   loadParameterValueFromString?: loadParameterValueFromStringHandler;
   isDynamic?: boolean;

--- a/libs/designer-ui/src/lib/arrayeditor/expandedsimplearray.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/expandedsimplearray.tsx
@@ -37,7 +37,7 @@ export interface ExpandedSimpleArrayProps {
   tokenPickerButtonProps?: TokenPickerButtonEditorProps;
   setItems: (newItems: SimpleArrayItem[]) => void;
   options?: ComboboxItem[];
-  getTokenPicker: GetTokenPickerHandler;
+  getTokenPicker?: GetTokenPickerHandler;
   tokenMapping?: Record<string, ValueSegment>;
   loadParameterValueFromString?: loadParameterValueFromStringHandler;
   isDynamic?: boolean;

--- a/libs/designer-ui/src/lib/arrayeditor/index.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/index.tsx
@@ -71,7 +71,7 @@ export interface ArrayEditorProps extends BaseEditorProps {
   options?: ComboboxItem[];
   // Event Handlers
   castParameter: CastHandler;
-  getTokenPicker: GetTokenPickerHandler;
+  getTokenPicker?: GetTokenPickerHandler;
   onMenuOpen?: CallbackHandler;
   // Error Handling
   errorDetails?: { message: string };

--- a/libs/designer-ui/src/lib/dictionary/index.tsx
+++ b/libs/designer-ui/src/lib/dictionary/index.tsx
@@ -1,7 +1,7 @@
 import constants from '../constants';
 import type { ValueSegment } from '../editor';
 import { EditorCollapseToggle } from '../editor';
-import type { BaseEditorProps, GetTokenPickerHandler } from '../editor/base';
+import type { BaseEditorProps } from '../editor/base';
 import { convertKeyValueItemToSegments } from '../editor/base/utils/keyvalueitem';
 import { CollapsedDictionary } from './collapsedDictionary';
 import { ExpandedDictionary } from './expandeddictionary';
@@ -27,7 +27,6 @@ export interface DictionaryEditorProps extends BaseEditorProps {
   valueTitle?: string;
   keyType?: string;
   dictionaryType?: DictionaryType;
-  getTokenPicker: GetTokenPickerHandler;
 }
 
 export const DictionaryEditor: React.FC<DictionaryEditorProps> = ({

--- a/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
+++ b/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
@@ -23,6 +23,7 @@ import {
   getValueFromPickerSelectedItem,
   loadDynamicTreeItemsForParameter,
   loadDynamicValuesForParameter,
+  parameterValueToStringWithoutCasting,
   updateParameterAndDependencies,
 } from '../../../core/utils/parameters/helper';
 import { useDispatch, useSelector } from 'react-redux';
@@ -37,6 +38,10 @@ interface ParameterEditorProps {
   onParameterVisibilityUpdate: () => void;
   handleParameterValueChange: (parameterId: string, newValue: ValueSegment[]) => void;
 }
+
+const mcpEditorsPlugin = {
+  tokens: false,
+};
 
 export const ParameterEditor = ({
   operationId,
@@ -135,6 +140,10 @@ export const ParameterEditor = ({
     },
   });
 
+  const onCastParameter = (value: ValueSegment[]): string => {
+    return parameterValueToStringWithoutCasting(value);
+  };
+
   const dropdownOptions = getDropdownOptionsFromOptions(parameter.editorOptions);
   const labelForAutomationId = replaceWhiteSpaceWithUnderscore(parameter.label);
 
@@ -148,16 +157,14 @@ export const ParameterEditor = ({
           label={parameter.label}
           placeholder={parameter.placeholder}
           initialValue={parameter.value}
-          // isDynamic={isDynamic}
-          basePlugins={{ tokens: false }}
+          basePlugins={mcpEditorsPlugin}
           itemSchema={parameter.editorViewModel.itemSchema}
           onChange={onValueChange}
           options={dropdownOptions}
           isLoading={parameter.dynamicData?.status === DynamicLoadStatus.LOADING}
           errorDetails={parameter.dynamicData?.error ? { message: parameter.dynamicData.error.message } : undefined}
           onMenuOpen={onComboboxMenuOpen}
-          // loadParameterValueFromString
-          castParameter={(_, _2) => ''} // TODO: Placeholder for castParameter function
+          castParameter={onCastParameter}
           dataAutomationId={`msla-setting-token-editor-combobox-${labelForAutomationId}`}
         />
       );
@@ -171,8 +178,7 @@ export const ParameterEditor = ({
           type={parameter.editorViewModel.type}
           authenticationValue={parameter.editorViewModel.authenticationValue}
           onChange={onValueChange}
-          // loadParameterValueFromString={loadParameterValueFromString}
-          basePlugins={{ tokens: false }}
+          basePlugins={mcpEditorsPlugin}
         />
       );
 
@@ -182,13 +188,12 @@ export const ParameterEditor = ({
           labelId={labelForAutomationId}
           label={parameter.label}
           placeholder={parameter.placeholder}
-          basePlugins={{ tokens: false }}
+          basePlugins={mcpEditorsPlugin}
           readonly={parameter.editorOptions?.readOnly}
           initialValue={parameter.value}
           initialItems={parameter.editorViewModel.items}
           valueType={parameter.editorOptions?.valueType}
           onChange={onValueChange}
-          // loadParameterValueFromString={loadParameterValueFromString}
           dataAutomationId={`msla-setting-token-editor-dictionaryeditor-${labelForAutomationId}`}
         />
       );
@@ -213,10 +218,11 @@ export const ParameterEditor = ({
     case constants.EDITOR.COMBOBOX:
       return (
         <Combobox
+          className="msla-setting-token-editor-container"
           labelId={labelForAutomationId}
           label={parameter.label}
           placeholder={parameter.placeholder}
-          basePlugins={{ tokens: false }}
+          basePlugins={mcpEditorsPlugin}
           initialValue={parameter.value}
           options={dropdownOptions}
           useOption={true}
@@ -236,7 +242,7 @@ export const ParameterEditor = ({
           className="msla-setting-token-editor-container"
           labelId={labelForAutomationId}
           placeholder={parameter.placeholder}
-          basePlugins={{ clearEditor: true, tokens: false }}
+          basePlugins={{ ...mcpEditorsPlugin, clearEditor: true }}
           initialValue={parameter.value}
           displayValue={parameter.editorViewModel.displayValue}
           type={parameter.editorOptions?.pickerType}
@@ -256,8 +262,7 @@ export const ParameterEditor = ({
           labelId={labelForAutomationId}
           initialValue={parameter.value}
           placeholder={parameter.placeholder}
-          basePlugins={{ tokens: false }}
-          // loadParameterValueFromString={loadParameterValueFromString}
+          basePlugins={mcpEditorsPlugin}
           onChange={onValueChange}
           valueType={constants.SWAGGER.TYPE.ANY}
           dataAutomationId={`msla-setting-token-editor-htmleditor-${labelForAutomationId}`}
@@ -287,7 +292,7 @@ export const ParameterEditor = ({
       return (
         <StringEditor
           className={mergeClasses('msla-setting-token-editor-container', styles.parameterEditor)}
-          basePlugins={{ tokens: false }}
+          basePlugins={mcpEditorsPlugin}
           initialValue={parameter.value}
           onChange={onParameterVisibilityUpdate}
           editorBlur={onValueChange}

--- a/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
+++ b/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
@@ -147,7 +147,7 @@ export const ParameterEditor = ({
           ...parameter,
           value,
         } as ParameterInfo,
-        /* isDefinitionValue */ false
+        /* isDefinitionValue */ true
       ) ?? ''
     );
   };

--- a/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
+++ b/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
@@ -23,7 +23,7 @@ import {
   getValueFromPickerSelectedItem,
   loadDynamicTreeItemsForParameter,
   loadDynamicValuesForParameter,
-  parameterValueToStringWithoutCasting,
+  parameterValueToString,
   updateParameterAndDependencies,
 } from '../../../core/utils/parameters/helper';
 import { useDispatch, useSelector } from 'react-redux';
@@ -141,7 +141,15 @@ export const ParameterEditor = ({
   });
 
   const onCastParameter = (value: ValueSegment[]): string => {
-    return parameterValueToStringWithoutCasting(value);
+    return (
+      parameterValueToString(
+        {
+          ...parameter,
+          value,
+        } as ParameterInfo,
+        /* isDefinitionValue */ false
+      ) ?? ''
+    );
   };
 
   const dropdownOptions = getDropdownOptionsFromOptions(parameter.editorOptions);
@@ -161,8 +169,6 @@ export const ParameterEditor = ({
           itemSchema={parameter.editorViewModel.itemSchema}
           onChange={onValueChange}
           options={dropdownOptions}
-          isLoading={parameter.dynamicData?.status === DynamicLoadStatus.LOADING}
-          errorDetails={parameter.dynamicData?.error ? { message: parameter.dynamicData.error.message } : undefined}
           onMenuOpen={onComboboxMenuOpen}
           castParameter={onCastParameter}
           dataAutomationId={`msla-setting-token-editor-combobox-${labelForAutomationId}`}

--- a/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
+++ b/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
@@ -1,11 +1,19 @@
 import {
+  ArrayEditor,
+  AuthenticationEditor,
+  type AuthenticationEditorOptions,
   type ChangeState,
   Combobox,
+  DictionaryEditor,
+  DropdownEditor,
   DynamicLoadStatus,
   FilePickerEditor,
   getDropdownOptionsFromOptions,
+  HTMLEditor,
   mergeClasses,
+  SchemaEditor,
   StringEditor,
+  TableEditor,
 } from '@microsoft/designer-ui';
 import { getPropertyValue, replaceWhiteSpaceWithUnderscore, type ParameterInfo, type ValueSegment } from '@microsoft/logic-apps-shared';
 import { useEditOperationStyles } from './styles';
@@ -131,10 +139,82 @@ export const ParameterEditor = ({
   const labelForAutomationId = replaceWhiteSpaceWithUnderscore(parameter.label);
 
   switch (parameter.editor?.toLowerCase()) {
+    case constants.EDITOR.ARRAY:
+      return (
+        <ArrayEditor
+          labelId={labelForAutomationId}
+          arrayType={parameter.editorViewModel.arrayType}
+          initialMode={parameter.editorOptions?.initialMode}
+          label={parameter.label}
+          placeholder={parameter.placeholder}
+          initialValue={parameter.value}
+          // isDynamic={isDynamic}
+          basePlugins={{ tokens: false }}
+          itemSchema={parameter.editorViewModel.itemSchema}
+          onChange={onValueChange}
+          options={dropdownOptions}
+          isLoading={parameter.dynamicData?.status === DynamicLoadStatus.LOADING}
+          errorDetails={parameter.dynamicData?.error ? { message: parameter.dynamicData.error.message } : undefined}
+          onMenuOpen={onComboboxMenuOpen}
+          // loadParameterValueFromString
+          castParameter={(_, _2) => ''} // TODO: Placeholder for castParameter function
+          dataAutomationId={`msla-setting-token-editor-combobox-${labelForAutomationId}`}
+        />
+      );
+
+    case constants.EDITOR.AUTHENTICATION:
+      return (
+        <AuthenticationEditor
+          labelId={labelForAutomationId}
+          initialValue={parameter.value}
+          options={parameter.editorOptions as AuthenticationEditorOptions}
+          type={parameter.editorViewModel.type}
+          authenticationValue={parameter.editorViewModel.authenticationValue}
+          onChange={onValueChange}
+          // loadParameterValueFromString={loadParameterValueFromString}
+          basePlugins={{ tokens: false }}
+        />
+      );
+
+    case constants.EDITOR.DICTIONARY:
+      return (
+        <DictionaryEditor
+          labelId={labelForAutomationId}
+          label={parameter.label}
+          placeholder={parameter.placeholder}
+          basePlugins={{ tokens: false }}
+          readonly={parameter.editorOptions?.readOnly}
+          initialValue={parameter.value}
+          initialItems={parameter.editorViewModel.items}
+          valueType={parameter.editorOptions?.valueType}
+          onChange={onValueChange}
+          // loadParameterValueFromString={loadParameterValueFromString}
+          dataAutomationId={`msla-setting-token-editor-dictionaryeditor-${labelForAutomationId}`}
+        />
+      );
+
+    case constants.EDITOR.DROPDOWN:
+      return (
+        <DropdownEditor
+          label={parameter.label}
+          initialValue={parameter.value}
+          options={dropdownOptions.map((option: any, index: number) => ({
+            key: index.toString(),
+            ...option,
+          }))}
+          placeholder={parameter.placeholder}
+          multiSelect={!!getPropertyValue(parameter.editorOptions, 'multiSelect')}
+          serialization={parameter.editorOptions?.serialization}
+          onChange={onValueChange}
+          dataAutomationId={`msla-setting-token-editor-dropdowneditor-${labelForAutomationId}`}
+        />
+      );
+
     case constants.EDITOR.COMBOBOX:
       return (
         <Combobox
           labelId={labelForAutomationId}
+          label={parameter.label}
           placeholder={parameter.placeholder}
           basePlugins={{ tokens: false }}
           initialValue={parameter.value}
@@ -167,6 +247,39 @@ export const ParameterEditor = ({
           errorDetails={parameter.dynamicData?.error ? { message: parameter.dynamicData.error.message } : undefined}
           editorBlur={onValueChange}
           dataAutomationId={`msla-setting-token-editor-filepickereditor-${labelForAutomationId}`}
+        />
+      );
+
+    case constants.EDITOR.HTML:
+      return (
+        <HTMLEditor
+          labelId={labelForAutomationId}
+          initialValue={parameter.value}
+          placeholder={parameter.placeholder}
+          basePlugins={{ tokens: false }}
+          // loadParameterValueFromString={loadParameterValueFromString}
+          onChange={onValueChange}
+          valueType={constants.SWAGGER.TYPE.ANY}
+          dataAutomationId={`msla-setting-token-editor-htmleditor-${labelForAutomationId}`}
+        />
+      );
+
+    case constants.EDITOR.SCHEMA:
+      return <SchemaEditor label={parameter.label} initialValue={parameter.value} onChange={onValueChange} />;
+
+    case constants.EDITOR.TABLE:
+      return (
+        <TableEditor
+          labelId={labelForAutomationId}
+          initialValue={parameter.value}
+          initialItems={parameter.editorViewModel.items}
+          columnMode={parameter.editorViewModel.columnMode}
+          columns={parameter.editorOptions?.columns?.count}
+          titles={parameter.editorOptions?.columns?.titles}
+          keys={parameter.editorOptions?.columns?.keys}
+          types={parameter.editorOptions?.columns?.types}
+          onChange={onValueChange}
+          dataAutomationId={`msla-setting-token-editor-tableditor-${labelForAutomationId}`}
         />
       );
 


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [X] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [X] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Adding capability for different editors other than string editor to help user type various inputs
- css is still broken, will be coming in a separate PR

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users can access different editors
- **Developers**: ParameterEditor uses different editors
- **System**: n/a

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@preetriti1 

## Screenshots/Videos
<img width="3629" height="1886" alt="image" src="https://github.com/user-attachments/assets/a30757a4-bd18-4811-9a35-073fd8c7c830" />