### PR TITLE
fix(designer): Remove default action count

### DIFF
--- a/libs/designer/src/lib/ui/settings/sections/general.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/general.tsx
@@ -269,7 +269,7 @@ export const General = ({
         settingType: 'SettingTextField',
         settingProp: {
           id: 'count',
-          value: count?.value ?? 100,
+          value: count?.value,
           customLabel: getSettingLabel(actionCountTitle, actionCountTooltipText),
           readOnly,
           onValueChange: (_, newValue) => onCountValueChange(Number(newValue)),

--- a/libs/designer/src/lib/ui/settings/sections/general.tsx
+++ b/libs/designer/src/lib/ui/settings/sections/general.tsx
@@ -269,7 +269,7 @@ export const General = ({
         settingType: 'SettingTextField',
         settingProp: {
           id: 'count',
-          value: count?.value,
+          value: count?.value ?? '',
           customLabel: getSettingLabel(actionCountTitle, actionCountTooltipText),
           readOnly,
           onValueChange: (_, newValue) => onCountValueChange(Number(newValue)),


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Removing the default action count and letting users define it

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Won't block users anymore and they will need to set the couunt if needed
- **Developers**: NA
- **System**: More than 100 actions can run/added by default now

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
