### PR TITLE
fix(standalone): Race condition causing fetching childworkflows in parallel to miss flows

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/ChildWorkflow.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/ChildWorkflow.ts
@@ -3,7 +3,6 @@ import type { Workflow } from '../Models/Workflow';
 import { hybridApiVersion, HybridAppUtility } from '../Utilities/HybridAppUtilities';
 import type { HttpClient } from './HttpClient';
 import type { ListDynamicValue } from '@microsoft/logic-apps-shared';
-import { hasProperty, getPropertyValue } from '@microsoft/logic-apps-shared';
 
 export interface DynamicCallServiceOptions {
   apiVersion: string;
@@ -18,7 +17,8 @@ interface ChildWorkflowServiceOptions extends DynamicCallServiceOptions {
 }
 
 export class ChildWorkflowService {
-  private _workflowsRequestSchema: Record<string, any> | undefined;
+  private _workflowsWithRequestTrigger: Record<string, any> | undefined;
+  private _schemaCache: Record<string, any> = {};
 
   constructor(private readonly options: ChildWorkflowServiceOptions) {
     const { apiVersion, baseUrl, httpClient, siteResourceId, workflowName } = this.options;
@@ -43,11 +43,11 @@ export class ChildWorkflowService {
   public async getWorkflowsWithRequestTrigger(): Promise<ListDynamicValue[]> {
     const { workflowName } = this.options;
 
-    if (this._workflowsRequestSchema === undefined) {
-      this._workflowsRequestSchema = await this._getWorkflowsWithSingleRequestTrigger();
+    if (this._workflowsWithRequestTrigger === undefined) {
+      this._workflowsWithRequestTrigger = await this._getWorkflowsWithSingleRequestTrigger();
     }
 
-    const workflows = Object.keys(this._workflowsRequestSchema);
+    const workflows = Object.keys(this._workflowsWithRequestTrigger);
     return workflows
       .filter((workflow) => workflow.toLowerCase() !== workflowName.toLowerCase())
       .map((workflow) => ({ value: workflow, displayName: workflow }));
@@ -55,50 +55,42 @@ export class ChildWorkflowService {
 
   public async getWorkflowTriggerSchema(workflowName: string): Promise<Record<string, any>> {
     const normalizedName = workflowName.toLowerCase();
-    if (this._workflowsRequestSchema?.[normalizedName]) {
-      return this._workflowsRequestSchema[normalizedName];
-    }
 
-    try {
+    return this._getCachedSchema(normalizedName, async () => {
       const workflowUrl = `${this.options.siteResourceId}/workflows/${workflowName}`;
       const workflowContent = await this._getWorkflowContent(workflowUrl);
       const {
         definition: { triggers },
       } = workflowContent;
-      const schema = getTriggerSchema(triggers);
-
-      if (this._workflowsRequestSchema === undefined) {
-        this._workflowsRequestSchema = {};
-      }
-
-      this._workflowsRequestSchema[normalizedName] = schema;
-
-      return schema;
-    } catch {
-      // TODO(psamband): Log error but do not throw.
-      return {};
-    }
+      return getTriggerSchema(triggers);
+    });
   }
 
   public async getLogicAppSwagger(workflowId: string): Promise<Record<string, any>> {
-    if (hasProperty(this._workflowsRequestSchema ?? {}, workflowId)) {
-      return getPropertyValue(this._workflowsRequestSchema, workflowId);
-    }
-
-    try {
+    return this._getCachedSchema(workflowId, async () => {
       const { baseUrl, httpClient } = this.options;
       const workflowContent = await httpClient.get<any>({
         uri: `${baseUrl}${workflowId}`,
         queryParameters: { 'api-version': '2019-05-01' },
       });
-      const schema = getTriggerSchema(workflowContent.properties?.definition?.triggers ?? {});
+      return getTriggerSchema(workflowContent.properties?.definition?.triggers ?? {});
+    });
+  }
 
-      if (this._workflowsRequestSchema === undefined) {
-        this._workflowsRequestSchema = {};
-      }
+  private async _getCachedSchema(key: string, fetcher: () => Promise<any>): Promise<Record<string, any>> {
+    // Check general schema cache first
+    if (this._schemaCache[key]) {
+      return this._schemaCache[key];
+    }
 
-      this._workflowsRequestSchema[workflowId] = schema;
+    // Check workflows with request trigger cache
+    if (this._workflowsWithRequestTrigger?.[key]) {
+      return this._workflowsWithRequestTrigger[key];
+    }
 
+    try {
+      const schema = await fetcher();
+      this._schemaCache[key] = schema;
       return schema;
     } catch {
       // TODO(psamband): Log error but do not throw.

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/ChildWorkflow.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/ChildWorkflow.ts
@@ -17,7 +17,7 @@ interface ChildWorkflowServiceOptions extends DynamicCallServiceOptions {
 }
 
 export class ChildWorkflowService {
-  private _workflowsWithRequestTrigger: Record<string, any> | undefined;
+  private _workflowsWithRequestTrigger: string[] | undefined;
   private _schemaCache: Record<string, any> = {};
 
   constructor(private readonly options: ChildWorkflowServiceOptions) {
@@ -47,8 +47,7 @@ export class ChildWorkflowService {
       this._workflowsWithRequestTrigger = await this._getWorkflowsWithSingleRequestTrigger();
     }
 
-    const workflows = Object.keys(this._workflowsWithRequestTrigger);
-    return workflows
+    return this._workflowsWithRequestTrigger
       .filter((workflow) => workflow.toLowerCase() !== workflowName.toLowerCase())
       .map((workflow) => ({ value: workflow, displayName: workflow }));
   }
@@ -78,14 +77,9 @@ export class ChildWorkflowService {
   }
 
   private async _getCachedSchema(key: string, fetcher: () => Promise<any>): Promise<Record<string, any>> {
-    // Check general schema cache first
+    // Check schema cache
     if (this._schemaCache[key]) {
       return this._schemaCache[key];
-    }
-
-    // Check workflows with request trigger cache
-    if (this._workflowsWithRequestTrigger?.[key]) {
-      return this._workflowsWithRequestTrigger[key];
     }
 
     try {
@@ -98,9 +92,9 @@ export class ChildWorkflowService {
     }
   }
 
-  private async _getWorkflowsWithSingleRequestTrigger(): Promise<Record<string, any>> {
+  private async _getWorkflowsWithSingleRequestTrigger(): Promise<string[]> {
     const workflowsInApp = await this._listWorkflows();
-    const workflowsWithSingleRequestTrigger: Record<string, any> = {};
+    const workflowNames: string[] = [];
 
     // Create an array of promises for all workflow content fetches
     const workflowPromises = workflowsInApp.map(async (workflow) => {
@@ -109,10 +103,9 @@ export class ChildWorkflowService {
 
       if (workflowContent !== undefined && hasSingleRequestTrigger(workflowContent?.definition?.triggers)) {
         const workflowName = id.split('/').slice(-1)[0];
-        return {
-          name: workflowName.toLowerCase(),
-          triggerSchema: getTriggerSchema(workflowContent.definition.triggers),
-        };
+        // Cache the schema while we have it
+        this._schemaCache[workflowName.toLowerCase()] = getTriggerSchema(workflowContent.definition.triggers);
+        return workflowName.toLowerCase();
       }
       return null;
     });
@@ -122,11 +115,11 @@ export class ChildWorkflowService {
 
     for (const result of results) {
       if (result.status === 'fulfilled' && result.value) {
-        workflowsWithSingleRequestTrigger[result.value.name] = result.value.triggerSchema;
+        workflowNames.push(result.value);
       }
     }
 
-    return workflowsWithSingleRequestTrigger;
+    return workflowNames;
   }
 
   private async _listWorkflows(): Promise<Workflow[]> {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
  The _workflowsRequestSchema cache was being shared between two different purposes: storing "workflows with request triggers" and caching individual workflow schemas. When getWorkflowTriggerSchema() or getLogicAppSwagger() added schemas for any workflow to this cache, it contaminated the "workflows with request triggers" list, causing the combobox to not show the actual returned response.

Separated into two distinct caches:
  - _workflowsWithRequestTrigger: string[] - immutable list of workflow names with request triggers
  - _schemaCache: Record<string, any> - general cache for all individual schema fetches

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No longer see inconsistent workflow dropdown lists
- **Developers**: Cache architecture with separated concerns
- **System**: Eliminates race conditions in cache mutations; schemas are now cached more efficiently during initial workflow scan

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@Eric-B-Wu 

## Screenshots/Videos
<!-- Visual changes only -->
