### PR TITLE
fix(designer): When creating agent tool to properly set the right active node

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -89,9 +89,9 @@ export const addOperation = createAsyncThunk('addOperation', async (payload: Add
     const newPayload = { ...payload, nodeId };
     const newToolGraphId = (getState() as RootState).panel.discoveryContent.relationshipIds.graphId;
     const agentToolMetadata = (getState() as RootState).panel.discoveryContent.agentToolMetadata;
+    const newToolId = (getState() as RootState).panel.discoveryContent.relationshipIds.subgraphId;
 
     if (isAddingAgentTool) {
-      const newToolId = (getState() as RootState).panel.discoveryContent.relationshipIds.subgraphId;
       if (newToolId && newToolGraphId) {
         if (agentToolMetadata?.newAdditiveSubgraphId && agentToolMetadata?.subGraphManifest) {
           initializeSubgraphFromManifest(agentToolMetadata.newAdditiveSubgraphId, agentToolMetadata?.subGraphManifest, dispatch);
@@ -121,10 +121,10 @@ export const addOperation = createAsyncThunk('addOperation', async (payload: Add
     );
 
     dispatch(setFocusNode(nodeId));
-    if (isAddingAgentTool) {
+    if (isAddingAgentTool && newToolId) {
       dispatch(
         setAlternateSelectedNode({
-          nodeId: newToolGraphId,
+          nodeId: newToolId,
           updatePanelOpenState: true,
           panelPersistence: 'selected',
         })


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
There was a bug we were selecting the agent node id as the active node id rather than the tool id
## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users should see the newly created action and tool parameters in side-by-side panels now
- **Developers**: No dev changes
- **System**: No System Changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@Eric-B-Wu

## Screenshots/Videos
<!-- Visual changes only -->
