### PR TITLE
fix(designer/mcp): Fixing Browse not picking up all connectors

### DIFF
--- a/libs/designer/src/lib/ui/mcp/connectors/ConnectorBrowseView.tsx
+++ b/libs/designer/src/lib/ui/mcp/connectors/ConnectorBrowseView.tsx
@@ -11,9 +11,15 @@ const sortConnectors = (connectors: Connector[]): Connector[] => {
 const supportsActions = (connector: Connector): boolean => {
   const capabilities = connector.properties?.capabilities ?? [];
 
-  // If no capabilities are defined, assume it doesn't support actions
+  // If no capabilities are defined, assume it supports actions
   if (capabilities.length === 0) {
-    return false;
+    return true;
+  }
+
+  // If connector has neither actions nor triggers capabilities, assume it supports actions
+  const hasActionCapabilities = capabilities.includes('actions') || capabilities.includes('triggers');
+  if (!hasActionCapabilities) {
+    return true;
   }
 
   // Check if it explicitly supports actions

--- a/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
@@ -30,6 +30,7 @@ const priorityConnectors = [
   '/managedApis/sql',
   '/connectionProviders/azureFunctionOperation',
   'managedApis/office365',
+  'managedApis/sharepointonline',
 ];
 const getRunTimeValue = (connector: Connector): number => {
   if (isBuiltInConnector(connector)) {
@@ -113,7 +114,13 @@ export const BrowseView = (props: BrowseViewProps) => {
         return true;
       }
 
-      // Filter based on specific action type
+      // If connector has neither actions nor triggers capabilities, show it (assume it supports both)
+      const hasActionCapabilities = capabilities.includes('actions') || capabilities.includes('triggers');
+      if (!hasActionCapabilities) {
+        return true;
+      }
+
+      // Filter based on specific action type for connectors that do have explicit capabilities
       if (actionType === 'triggers') {
         return capabilities.includes('triggers');
       }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
In Designer and MCP we moved instead of loading all the operations in browse to just loading all the connectors. In doing so we also filter based on connector capabilities. Some connectors (26 connectors) seem to not have 'actions'  or 'triggers' capabilities and they end up being filtered out from our browse experience.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: In browse, users should be able to see the previously filtered out connectors
- **Developers**: Changing some of the processing of the api results so that if a connector doesn't have either `actions` or `triggers` to show by default
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@eric-b-wu

## Screenshots/Videos
<!-- Visual changes only -->
