### PR TITLE
fix(designer): Remove unneeded useEffect that caused Do Until Loop to revert to run 1

### DIFF
--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -34,7 +34,6 @@ import {
 import {
   setFocusElement,
   setRepetitionRunData,
-  setRunIndex,
   setSubgraphRunData,
   toggleCollapsedGraphId,
   updateAgenticGraph,
@@ -131,14 +130,6 @@ const ScopeCardNode = ({ data, targetPosition = Position.Top, sourcePosition = P
 
   const timelineRepetitionIndex = useTimelineRepetitionIndex();
   const timelineRepetitionCount = useActionTimelineRepetitionCount(scopeId, timelineRepetitionIndex);
-
-  useEffect(() => {
-    if (isTimelineRepetitionSelected) {
-      dispatch(setRunIndex({ page: 0, nodeId: scopeId }));
-    }
-    // We only want this to run when the timeline repetition index changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, timelineRepetitionIndex]);
 
   useEffect(() => {
     if (isMonitoringView && !isTimelineRepetitionSelected) {


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
This change removes an unnecessary useEffect in ScopeCardNode.tsx that was causing Do Until Loop monitoring to always revert to run number 1 when inspecting completed runs. The useEffect was setting the run index to 0 whenever the timeline repetition index changed, which interfered with the user's ability to stay on the current step when navigating through loop iterations.

## Impact of Change
- **Users**: Users can now properly inspect completed runs of Do Until Loops without being forced back to run number 1
- **Developers**: Cleaner code with removal of unnecessary state management
- **System**: Minor performance improvement by removing unnecessary effect

## Test Plan
- [x] Manual testing completed
- [x] Tested in: Portal monitoring view for Do Until Loop workflows

## Contributors
@ccastrotrejo @rllyy97 

Fixes 
#7893
#7895
#7896

## Screenshots

### Before

https://github.com/user-attachments/assets/0fc7e9b0-930a-4576-97a6-b42ab1355a22



### After


https://github.com/user-attachments/assets/c364c23e-cbc3-427c-86bd-0c395c6adf13

