### PR TITLE
fix(designer): prevent agent operations from displaying trigger info

### DIFF
--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -23,6 +23,7 @@ import { PanelContainer, PanelScope } from '@microsoft/designer-ui';
 import {
   equals,
   getObjectPropertyValue,
+  getRecordEntry,
   HostService,
   isNullOrEmpty,
   isNullOrUndefined,
@@ -50,7 +51,8 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
 
   const runData = useRunData(selectedNode);
   const { isTriggerNode, nodesMetadata, idReplacements, operationInfo, showTriggerInfo } = useSelector((state: RootState) => {
-    const isTrigger = isRootNodeInGraph(selectedNode, 'root', state.workflow.nodesMetadata);
+    const isAgent = equals(getRecordEntry(state.workflow.operations, selectedNode)?.type, 'agent');
+    const isTrigger = isRootNodeInGraph(selectedNode, 'root', state.workflow.nodesMetadata) && !isAgent;
     const operationInfo = state.operations.operationInfo[selectedNode];
     return {
       isTriggerNode: isTrigger,


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
This change prevents agent operations from being incorrectly treated as triggers in the node details panel. Previously, agent operations would display trigger-related information because they are root nodes, but agents should not be considered triggers for UI purposes.

## Impact of Change
- **Users**: Agent operations will no longer incorrectly display trigger information in the node details panel
- **Developers**: Added logic to distinguish between triggers and agent operations using operation type checking
- **System**: Minor performance impact from additional type checking

## Test Plan
- [x] Manual testing completed
- [x] Tested in: Standalone designer environment

## Contributors
@ccastrotrejo @rllyy97 