### PR TITLE
feat(Designer): Added `x-ms-is-node-id` input parameter property

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -3807,9 +3807,12 @@ export function parameterValueToString(
   idReplacements?: Record<string, string>,
   shouldEncodeBasedOnMetadata = true
 ): string | undefined {
-  const remappedId = idReplacements?.[parameterInfo.preservedValue ?? ''];
-  if (remappedId && parameterInfo.schema?.['x-ms-is-node-id']) {
-    return remappedId;
+  if (parameterInfo.schema?.['x-ms-is-node-id']) {
+    const oldValue = parameterInfo.value?.[0]?.value ?? '';
+    const remappedValue = idReplacements?.[oldValue] ?? oldValue;
+    if (remappedValue) {
+      return remappedValue;
+    }
   }
 
   const { value: remappedValue, didRemap } = isRecordNotEmpty(idReplacements)

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -3807,6 +3807,11 @@ export function parameterValueToString(
   idReplacements?: Record<string, string>,
   shouldEncodeBasedOnMetadata = true
 ): string | undefined {
+  const remappedId = idReplacements?.[parameterInfo.preservedValue ?? ''];
+  if (remappedId && parameterInfo.schema?.['x-ms-is-node-id']) {
+    return remappedId;
+  }
+
   const { value: remappedValue, didRemap } = isRecordNotEmpty(idReplacements)
     ? remapValueSegmentsWithNewIds(parameterInfo.value, idReplacements ?? {})
     : { value: parameterInfo.value, didRemap: false };

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/handoff.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/handoff.ts
@@ -22,6 +22,7 @@ export default {
           description: 'Agent Name',
           required: true,
           'x-ms-visibility': 'hideInUI',
+          'x-ms-is-node-id': true,
         },
         message: {
           type: 'string',


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Added a new `x-ms-is-node-id` input parameter property.
Currently all this does is remap the parameter value with our node id replacement object.
For example on handoff nodes, the input is the id of another agent node, so if that targetted node changes it's ID, we need to update the parameter value as well. 

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No change
- **Developers**: Added a new `x-ms-is-node-id` input parameter property
- **System**: No change

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97, @Eric-B-Wu 

## Screenshots/Videos
<!-- Visual changes only -->
<img width="914" height="581" alt="image" src="https://github.com/user-attachments/assets/1849470f-c36e-4384-b3a0-e0cc9b7db9b0" />

