### PR TITLE
ci: Update Azure pipeline artifact paths to use Root directory

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -80,8 +80,8 @@ extends:
                   zipSources: false
               outputs:
                 - output: pipelineArtifact
-                  targetPath: $(build.artifactstagingdirectory)/build/${{ parameters.publishVersion }}
-                  artifactName: Build ${{ parameters.publishVersion }}
+                  targetPath: $(build.artifactstagingdirectory)/build/Root
+                  artifactName: Build Root
             steps:
               - script: git checkout v${{ parameters.publishVersion }} # Replace with your desired version to release
                 displayName: 'Checkout to specific branch'


### PR DESCRIPTION
Changed artifact output paths from dynamic publishVersion parameter to fixed 'Root' directory structure for more consistent artifact handling.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
