### PR TITLE
fix(pipeline): Add missing closing quote in stage-artifacts template

### DIFF
--- a/.azure-pipelines/templates/stage-artifacts.yml
+++ b/.azure-pipelines/templates/stage-artifacts.yml
@@ -17,6 +17,6 @@ steps:
         extension.signature.p7s
         **/*.tar.gz
         **/*.tgz
-      TargetFolder: "$(build.artifactstagingdirectory)/build/Root
+      TargetFolder: "$(build.artifactstagingdirectory)/build/Root"
     condition: succeeded()
     


### PR DESCRIPTION
## Commit Type
<\!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<\!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<\!-- Brief context: What does this change and why? -->
Fixed a syntax error in the Azure Pipeline template where a closing quote was missing in the `TargetFolder` parameter of the `stage-artifacts.yml` template. This was causing potential pipeline failures due to malformed YAML.

## Impact of Change
<\!-- Who/what is affected? -->
- **Users**: No user-facing changes
- **Developers**: Ensures Azure Pipeline artifacts are staged correctly without syntax errors
- **System**: Prevents potential pipeline build failures due to malformed YAML syntax

## Test Plan
<\!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: YAML syntax validation

## Contributors
<\!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<\!-- Visual changes only -->