### PR TITLE
feat(designer): improve handoff naming with unique GUIDs

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/handoff.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/handoff.ts
@@ -25,7 +25,7 @@ export const addAgentHandoff = createAsyncThunk('addAgentHandoff', async (payloa
       operationId: agentOperation.id,
     });
 
-    const newHandoffId = `handoff_from_${sourceId}_to_${targetId}`;
+    const newHandoffId = `handoff_${sourceId}_${targetId}`;
     const newToolId = `${newHandoffId}_tool`;
 
     // Initialize subgraph manifest

--- a/libs/designer/src/lib/core/actions/bjsworkflow/handoff.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/handoff.ts
@@ -1,4 +1,4 @@
-import { agentOperation, type OperationManifest, handoffOperation } from '@microsoft/logic-apps-shared';
+import { agentOperation, type OperationManifest, handoffOperation, customLengthGuid } from '@microsoft/logic-apps-shared';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { changePanelNode, type RootState } from '../..';
 import { getOperationManifest } from '../../queries/operation';
@@ -25,7 +25,7 @@ export const addAgentHandoff = createAsyncThunk('addAgentHandoff', async (payloa
       operationId: agentOperation.id,
     });
 
-    const newHandoffId = `handoff_${sourceId}_${targetId}`;
+    const newHandoffId = `handoff_${customLengthGuid(8)}`;
     const newToolId = `${newHandoffId}_tool`;
 
     // Initialize subgraph manifest

--- a/libs/designer/src/lib/ui/connections/handoffEdge.tsx
+++ b/libs/designer/src/lib/ui/connections/handoffEdge.tsx
@@ -118,7 +118,7 @@ const HandoffEdge: React.FC<EdgeProps<LogicAppsEdgeProps>> = ({ id, source, targ
 
   const isSourceSelected = useIsNodeSelectedInOperationPanel(sourceId);
   const isTargetSelected = useIsNodeSelectedInOperationPanel(targetId);
-  const isHandoffSelected = useIsNodeSelectedInOperationPanel(`handoff_from_${sourceId}_to_${targetId}`);
+  const isHandoffSelected = useIsNodeSelectedInOperationPanel(`handoff_${sourceId}_${targetId}`);
 
   const contextMenu = useContextMenu();
   const contextSelected = useMemo(() => contextMenu.isShowing, [contextMenu.isShowing]);

--- a/libs/designer/src/lib/ui/connections/handoffEdge.tsx
+++ b/libs/designer/src/lib/ui/connections/handoffEdge.tsx
@@ -118,14 +118,13 @@ const HandoffEdge: React.FC<EdgeProps<LogicAppsEdgeProps>> = ({ id, source, targ
 
   const isSourceSelected = useIsNodeSelectedInOperationPanel(sourceId);
   const isTargetSelected = useIsNodeSelectedInOperationPanel(targetId);
-  const isHandoffSelected = useIsNodeSelectedInOperationPanel(`handoff_${sourceId}_${targetId}`);
 
   const contextMenu = useContextMenu();
   const contextSelected = useMemo(() => contextMenu.isShowing, [contextMenu.isShowing]);
 
   const selected = useMemo(
-    () => isSourceSelected || isTargetSelected || isHandoffSelected || contextSelected,
-    [isSourceSelected, isTargetSelected, isHandoffSelected, contextSelected]
+    () => isSourceSelected || isTargetSelected || contextSelected,
+    [isSourceSelected, isTargetSelected, contextSelected]
   );
 
   const deleteEdge = useCallback(() => {

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/guid.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/guid.spec.ts
@@ -1,7 +1,115 @@
-import { guid } from '../guid';
-import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
+import { guid, customLengthGuid, isAGuid, guidLength } from '../guid';
+import { describe, it, expect } from 'vitest';
+
 describe('lib/helpers/guid', () => {
-  it('should generate the guid in proper format', () => {
-    expect(guid()).toEqual(expect.stringMatching(/[a-z|\d]{8}-[a-z|\d]{4}-[a-z|\d]{4}-[a-z|\d]{4}-[a-z|\d]{12}/i));
+  describe('guid()', () => {
+    it('should generate the guid in proper format', () => {
+      expect(guid()).toEqual(expect.stringMatching(/[a-z|\d]{8}-[a-z|\d]{4}-[a-z|\d]{4}-[a-z|\d]{4}-[a-z|\d]{12}/i));
+    });
+
+    it('should generate guid with correct length', () => {
+      expect(guid()).toHaveLength(36);
+    });
+
+    it('should generate unique guids on multiple calls', () => {
+      const guid1 = guid();
+      const guid2 = guid();
+      const guid3 = guid();
+
+      expect(guid1).not.toBe(guid2);
+      expect(guid1).not.toBe(guid3);
+      expect(guid2).not.toBe(guid3);
+    });
+
+    it('should use uppercase hex characters', () => {
+      const generatedGuid = guid();
+      expect(generatedGuid).toMatch(/^[0-9A-F-]+$/);
+    });
+  });
+
+  describe('customLengthGuid()', () => {
+    it('should generate guid with specified length', () => {
+      expect(customLengthGuid(10)).toHaveLength(10);
+      expect(customLengthGuid(32)).toHaveLength(32);
+      expect(customLengthGuid(5)).toHaveLength(5);
+    });
+
+    it('should return empty string for zero length', () => {
+      expect(customLengthGuid(0)).toBe('');
+    });
+
+    it('should return empty string for negative length', () => {
+      expect(customLengthGuid(-1)).toBe('');
+      expect(customLengthGuid(-10)).toBe('');
+    });
+
+    it('should generate hexadecimal characters only', () => {
+      const result = customLengthGuid(20);
+      expect(result).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('should generate different results on multiple calls', () => {
+      const result1 = customLengthGuid(16);
+      const result2 = customLengthGuid(16);
+      expect(result1).not.toBe(result2);
+    });
+
+    it('should handle large lengths', () => {
+      const result = customLengthGuid(100);
+      expect(result).toHaveLength(100);
+      expect(result).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('should not contain dashes', () => {
+      const result = customLengthGuid(32);
+      expect(result).not.toContain('-');
+    });
+  });
+
+  describe('isAGuid()', () => {
+    it('should return true for valid GUIDs', () => {
+      expect(isAGuid('12345678-1234-4567-8901-123456789012')).toBe(true);
+      expect(isAGuid('ABCDEF12-ABCD-4567-89AB-123456789ABC')).toBe(true);
+      expect(isAGuid('00000000-0000-4000-8000-000000000000')).toBe(true);
+      expect(isAGuid('ffffffff-ffff-4fff-8fff-ffffffffffff')).toBe(true);
+    });
+
+    it('should return true for GUIDs with curly braces', () => {
+      expect(isAGuid('{12345678-1234-4567-8901-123456789012}')).toBe(true);
+      expect(isAGuid('{ABCDEF12-ABCD-4567-89AB-123456789ABC}')).toBe(true);
+    });
+
+    it('should return true for mixed case GUIDs', () => {
+      expect(isAGuid('AbCdEf12-aBcD-4eFa-8bcD-123456789AbC')).toBe(true);
+    });
+
+    it('should return false for invalid GUID formats', () => {
+      expect(isAGuid('')).toBe(false);
+      expect(isAGuid('not-a-guid')).toBe(false);
+      expect(isAGuid('12345678-1234-4567-8901')).toBe(false);
+      expect(isAGuid('12345678-1234-4567-8901-123456789012-extra')).toBe(false);
+      expect(isAGuid('12345678_1234_4567_8901_123456789012')).toBe(false);
+      expect(isAGuid('123456781234456789011234567890123')).toBe(false);
+    });
+
+    it('should return false for GUIDs with wrong segment lengths', () => {
+      expect(isAGuid('1234567-1234-4567-8901-123456789012')).toBe(false);
+      expect(isAGuid('12345678-123-4567-8901-123456789012')).toBe(false);
+      expect(isAGuid('12345678-1234-456-8901-123456789012')).toBe(false);
+      expect(isAGuid('12345678-1234-4567-890-123456789012')).toBe(false);
+      expect(isAGuid('12345678-1234-4567-8901-12345678901')).toBe(false);
+    });
+
+    it('should return false for GUIDs with invalid characters', () => {
+      expect(isAGuid('12345678-1234-4567-8901-12345678901G')).toBe(false);
+      expect(isAGuid('12345678-1234-4567-8901-12345678901!')).toBe(false);
+      expect(isAGuid('12345678-1234-4567-8901-12345678901 ')).toBe(false);
+      expect(isAGuid('ABCDEFGH-ABCD-4567-8901-123456789012')).toBe(false);
+    });
+
+    it('should handle null or undefined gracefully (throws error)', () => {
+      expect(() => isAGuid(null as any)).toThrow();
+      expect(() => isAGuid(undefined as any)).toThrow();
+    });
   });
 });


### PR DESCRIPTION
## Commit Type
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
This PR improves the handoff naming system in the Logic Apps designer by replacing predictable source/target-based IDs with unique GUID-based identifiers. This change enhances uniqueness and prevents potential naming conflicts in complex workflows.

## Impact of Change
- **Users**: No visible changes to user experience - handoffs continue to work the same way
- **Developers**: Handoff IDs are now generated using `customLengthGuid(8)` instead of `handoff_${sourceId}_${targetId}` pattern
- **System**: Improved uniqueness of handoff identifiers, reduced risk of ID collisions

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Development environment with handoff operations

### Changes Made:
1. **Handoff ID Generation**: Updated `addAgentHandoff` to use `customLengthGuid(8)` for generating unique handoff identifiers
2. **Component Cleanup**: Removed unnecessary handoff selection logic from `handoffEdge.tsx` that relied on predictable naming
3. **Test Coverage**: Added comprehensive unit tests for GUID utilities including validation that `customLengthGuid` doesn't contain dashes
4. **Code Quality**: Removed debug logging from `customLengthGuid` implementation

## Contributors
@ccastrotrejo @rllyy97 

## Screenshots/Videos

