### PR TITLE
fix(Designer): A2A - Handoff edge fix for new agent parents and children

### DIFF
--- a/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
@@ -506,6 +506,18 @@ export const useRootTriggerId = (): string =>
     })
   );
 
+export const useIsAgentLoop = (id?: string): boolean => {
+  return useSelector(
+    createSelector(getWorkflowState, (state: WorkflowState) => {
+      if (!id) {
+        return false;
+      }
+      const type = getRecordEntry(state.operations, id)?.type;
+      return equals(type, commonConstants.NODE.TYPE.AGENT);
+    })
+  );
+};
+
 export const useIsWithinAgenticLoop = (id?: string): boolean => {
   return useSelector(
     createSelector(getWorkflowState, (state: WorkflowState) => {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Modified the logic around adding handoffs vs run-afters for new agents.
Now we check both the parent and child when deciding whether to add a handoff.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Handoffs are now added for agents as parents and children when adding a new agent.
- **Developers**: No change
- **System**: No change

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
![handoff_edge_fix](https://github.com/user-attachments/assets/68086437-c13a-41e8-8b26-5480a8a6419d)
