### PR TITLE
fix(mcp): Revert Max Width of Logic App Selector

### DIFF
--- a/libs/designer/src/lib/ui/mcp/details/styles.ts
+++ b/libs/designer/src/lib/ui/mcp/details/styles.ts
@@ -14,7 +14,6 @@ export const useMcpDetailsStyles = makeStyles({
     flex: 5,
   },
   comboboxContainer: {
-    maxWidth: '800px',
     width: '100%',
     marginLeft: 'auto',
   },


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Changing max width of the logic app selector

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Dropdown width will take up parent container length instead of confined by max width.
- **Developers**: no dev changes
- **System**: no system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@eric-b-wu

## Screenshots/Videos
<!-- Visual changes only -->
