### PR TITLE
fix(ci): update replace-in-file command syntax in Azure pipeline

### DIFF
--- a/.azure-pipelines/templates/package.yml
+++ b/.azure-pipelines/templates/package.yml
@@ -15,7 +15,7 @@ steps:
     workingDirectory: $(working_directory)
     condition: succeeded()
 
-  - script: npx replace-in-file --from="setInGitHubBuild" --to="$(AI_KEY)" --files="apps/vs-code-designer/src/main.ts"
+  - script: npx replace-in-file setInGitHubBuild $(AI_KEY) apps/vs-code-designer/src/main.ts
     displayName: "Replace Placeholder with Telemetry Key"
     workingDirectory: $(working_directory)
     condition: succeeded()


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Updates the `npx replace-in-file` command syntax in the Azure pipeline template to use the simpler positional arguments format instead of the `--from` and `--to` flags. This follows the recent cross-platform compatibility fix pattern established in PR #7956.

## Impact of Change
- **Users**: No user-facing changes
- **Developers**: Improved CI/CD pipeline reliability
- **System**: More consistent replace-in-file command execution in Azure pipelines

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Azure pipeline configuration validation

## Contributors

## Screenshots/Videos
