### PR TITLE
fix(designer): Hide Agent Instructions for A2A Workflows

### DIFF
--- a/__mocks__/workflows/BasicA2A.json
+++ b/__mocks__/workflows/BasicA2A.json
@@ -12,14 +12,6 @@
               {
                 "role": "System",
                 "content": "This is a system message."
-              },
-              {
-                "role": "User",
-                "content": "This is a user message."
-              },
-              {
-                "role": "User",
-                "content": "You are a helpful assistant."
               }
             ]
           },
@@ -121,14 +113,6 @@
               {
                 "role": "system",
                 "content": "This is the best system message."
-              },
-              {
-                "role": "user",
-                "content": "test user messsage"
-              },
-              {
-                "role": "user",
-                "content": "You are a helpful assistant."
               }
             ],
             "agentModelSettings": {

--- a/libs/designer-ui/src/lib/agentinstruction/index.tsx
+++ b/libs/designer-ui/src/lib/agentinstruction/index.tsx
@@ -16,6 +16,7 @@ export const NavigateIcon = bundleIcon(Open12Regular, Open12Filled);
 interface AgentInstructionEditorProps extends BaseEditorProps {
   serializeValue?: ChangeHandler;
   onCastParameter: CastHandler;
+  hideUserInstructions?: boolean;
 }
 
 export const AgentInstructionEditor = ({
@@ -23,6 +24,7 @@ export const AgentInstructionEditor = ({
   className,
   onCastParameter,
   serializeValue,
+  hideUserInstructions = false,
   ...props
 }: AgentInstructionEditorProps): JSX.Element => {
   const intl = useIntl();
@@ -92,19 +94,23 @@ export const AgentInstructionEditor = ({
           editorBlur={(newState: ChangeState) => handleValueChange(newState, AGENT_INSTRUCTION_TYPES.SYSTEM)}
           valueType={constants.SWAGGER.TYPE.STRING}
         />
-        <Label text={userItemLabel} />
-        <ArrayEditor
-          {...props}
-          isRequired={false}
-          label={userItemLabel}
-          placeholder={userPlaceholder}
-          itemSchema={{ key: 'userMessage', type: 'string' }}
-          arrayType={ArrayType.SIMPLE}
-          castParameter={onCastParameter}
-          initialValue={userMessage}
-          getTokenPicker={props.getTokenPicker as GetTokenPickerHandler}
-          onChange={(newState: ChangeState) => handleValueChange(newState, AGENT_INSTRUCTION_TYPES.USER)}
-        />
+        {!hideUserInstructions && (
+          <>
+            <Label text={userItemLabel} />
+            <ArrayEditor
+              {...props}
+              isRequired={false}
+              label={userItemLabel}
+              placeholder={userPlaceholder}
+              itemSchema={{ key: 'userMessage', type: 'string' }}
+              arrayType={ArrayType.SIMPLE}
+              castParameter={onCastParameter}
+              initialValue={userMessage}
+              getTokenPicker={props.getTokenPicker as GetTokenPickerHandler}
+              onChange={(newState: ChangeState) => handleValueChange(newState, AGENT_INSTRUCTION_TYPES.USER)}
+            />
+          </>
+        )}
       </div>
       {errorMessage ? (
         <MessageBar key={'warning'} intent={'warning'} className={styles.editorWarning}>

--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -217,6 +217,7 @@ export const TokenField = ({
           tokenPickerButtonProps={tokenpickerButtonProps}
           agentParameterButtonProps={agentParameterButtonProps}
           tokenMapping={tokenMapping}
+          hideUserInstructions={editorOptions?.hideUserInstructions}
           loadParameterValueFromString={loadParameterValueFromString}
           serializeValue={onValueChange}
           getTokenPicker={getTokenPicker}

--- a/libs/designer/src/lib/common/constants.ts
+++ b/libs/designer/src/lib/common/constants.ts
@@ -177,6 +177,7 @@ export default {
   DEFAULT_MAX_STATE_HISTORY_SIZE: 0,
   DEFAULT_SCHEMA: SCHEMA.GA_20160601,
   EDITOR: {
+    AGENT_INSTRUCTION: 'agentinstruction',
     ARRAY: 'array',
     AUTHENTICATION: 'authentication',
     CODE: 'code',

--- a/libs/designer/src/lib/ui/mcp/details/logicAppSelector.tsx
+++ b/libs/designer/src/lib/ui/mcp/details/logicAppSelector.tsx
@@ -120,17 +120,12 @@ export const LogicAppSelector = () => {
             <Combobox
               className={styles.combobox}
               disabled={isLogicAppsLoading}
-              value={searchTerm !== '' ? searchTerm : selectedResource}
+              value={searchTerm}
               placeholder={isLogicAppsLoading ? intlText.LOADING : intlText.SEARCH_PLACEHOLDER}
-              onOpenChange={(_, data) => {
-                if (!data.open) {
-                  setSearchTerm('');
-                }
-              }}
               onOptionSelect={(_, data) => {
                 if (data.optionValue && data.optionValue !== NO_ITEM_VALUE) {
                   onLogicAppSelect(data.optionValue);
-                  setSearchTerm('');
+                  setSearchTerm(data.optionValue);
                 }
               }}
               onChange={(e) => {

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -25,6 +25,7 @@ import {
   useNodeMetadata,
   useReplacedIds,
 } from '../../../../../core/state/workflow/workflowSelectors';
+import { useIsA2AWorkflow } from '../../../../../core/state/designerView/designerViewSelectors';
 import type { AppDispatch, RootState } from '../../../../../core/store';
 import { getConnectionReference } from '../../../../../core/utils/connectors/connections';
 import { isRootNodeInGraph } from '../../../../../core/utils/graph';
@@ -386,6 +387,7 @@ export const ParameterSection = ({
     });
   const nodeGraphId = getRecordEntry(nodesMetadata, nodeId)?.graphId;
   const isWithinAgenticLoop = useIsWithinAgenticLoop(nodeGraphId);
+  const isA2AWorkflow = useIsA2AWorkflow();
   const rootState = useSelector((state: RootState) => state);
   const displayNameResult = useConnectorName(operationInfo);
   const panelLocation = usePanelLocation();
@@ -849,7 +851,8 @@ export const ParameterSection = ({
         param,
         upstreamNodeIds ?? [],
         variables,
-        deploymentsForCognitiveServiceAccount ?? []
+        deploymentsForCognitiveServiceAccount ?? [],
+        isA2AWorkflow
       );
 
       const createNewResourceEditorProps = getCustomEditorForNewResource(
@@ -986,7 +989,8 @@ export const getEditorAndOptions = (
   parameter: ParameterInfo,
   upstreamNodeIds: string[],
   variables: Record<string, VariableDeclaration[]>,
-  deploymentsForCognitiveServiceAccount: any[] = []
+  deploymentsForCognitiveServiceAccount: any[] = [],
+  isA2AWorkflow?: boolean
 ): { editor?: string; editorOptions?: any } => {
   const customEditor = EditorService()?.getEditor({
     operationInfo,
@@ -1027,6 +1031,17 @@ export const getEditorAndOptions = (
     return {
       editor,
       editorOptions: { options },
+    };
+  }
+
+  // Hide user instruction editor for A2A workflows
+  if (equals(editor, constants.EDITOR.AGENT_INSTRUCTION) && isA2AWorkflow) {
+    return {
+      editor,
+      editorOptions: {
+        ...editorOptions,
+        hideUserInstructions: true,
+      },
     };
   }
 

--- a/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/browseView.tsx
@@ -4,8 +4,6 @@ import { SearchService, getRecordEntry, type Connector } from '@microsoft/logic-
 import { BrowseGrid, isBuiltInConnector, isCustomConnector, RuntimeFilterTagList } from '@microsoft/designer-ui';
 import { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
-import { useDiscoveryPanelRelationshipIds } from '../../../core/state/panel/panelSelectors';
-import { useAgenticWorkflow } from '../../../core/state/designerView/designerViewSelectors';
 import { useShouldEnableACASession } from './hooks';
 
 const defaultFilterConnector = (connector: Connector, runtimeFilter: string): boolean => {
@@ -64,20 +62,15 @@ export interface BrowseViewProps {
 
 export const BrowseView = (props: BrowseViewProps) => {
   const { filters, displayRuntimeInfo, setFilters } = props;
-  const isAgenticWorkflow = useAgenticWorkflow();
-  const isRoot = useDiscoveryPanelRelationshipIds().graphId === 'root';
   const shouldEnableACASession = useShouldEnableACASession();
 
   const dispatch = useDispatch();
 
   const { data: allConnectors, isLoading } = useAllConnectors();
 
-  const isAgentConnectorAllowed = useCallback(
-    (connector: Connector): boolean => {
-      return !((!isAgenticWorkflow || !isRoot) && connector.id === 'connectionProviders/agent');
-    },
-    [isAgenticWorkflow, isRoot]
-  );
+  const isAgentConnectorAllowed = useCallback((connector: Connector): boolean => {
+    return connector.id !== 'connectionProviders/agent';
+  }, []);
 
   const isACASessionAllowed = useCallback(
     (connector: Connector): boolean => {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
 A2A Workflows won't support user instructions. This change conditionally hides the user instructions section in the Agent Instruction editor when the workflow kind is 'agent' (A2A workflow), while keeping the system instructions visible.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: A2A workflow users will no longer see the "User Instructions" section in the Agent Instruction
  editor.
- **Developers**: Added `hideUserInstructions` prop to AgentInstructionEditor component and updated parameter flow from ParametersTab through SettingTokenField to conditionally hide user instructions based on workflow type
- **System**:  No performance impact

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@Eric-B-Wu 
## Screenshots/Videos
<!-- Visual changes only -->
