### PR TITLE
fix(designer): handle string error messages and prevent 'in' operator TypeError

### DIFF
--- a/libs/designer/src/lib/common/utilities/__test__/error.test.ts
+++ b/libs/designer/src/lib/common/utilities/__test__/error.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect } from 'vitest';
+import { extractErrorInfo, getMonitoringError, getMonitoringTabError, ErrorRun } from '../error';
+import { MessageBarType } from '@fluentui/react/lib/MessageBar';
+import constants from '../../constants';
+
+// Common test data
+const TEST_CODES = {
+  TEST: 'TEST_CODE',
+  FALLBACK: 'FALLBACK_CODE',
+  FAIL: 'FAIL_CODE',
+  SKIP: 'SKIP_CODE',
+  ERROR: 'ERROR_CODE',
+  TIMEOUT: 'TIMEOUT_ERROR',
+  WRAPPED: 'WRAPPED_CODE',
+  COMPLEX: 'COMPLEX_ERROR',
+  PARTIAL: 'PARTIAL_ERROR',
+  PLAIN: 'PLAIN_ERROR',
+  CUSTOM: 'CUSTOM_ERROR',
+  ONLY: 'ONLY_CODE',
+} as const;
+
+const TEST_MESSAGES = {
+  TEST: 'Test message',
+  FAILED: 'Failed message',
+  SKIPPED: 'Skipped message',
+  ERROR: 'Error message',
+  CUSTOM: 'Custom error message',
+  COMPLEX: 'Complex error message',
+  WRAPPED: 'Wrapped message',
+  FOUNDRY: "Creating foundry agent failed with status: '401' and message: 'The principal lacks required permissions'",
+  CONNECTION: 'Connection failed with 401 unauthorized',
+  ONLY_MESSAGE: 'Only message here',
+  WITHOUT_CODE: 'Error without code',
+  TIMEOUT: 'Request timed out after 30 seconds',
+  OPERATION_SKIPPED: 'Operation skipped',
+  OPERATION_FAILED: 'Failed operation',
+} as const;
+
+const TEST_ERROR_RUNS = {
+  BASIC: { code: TEST_CODES.TEST, message: TEST_MESSAGES.TEST },
+  FAIL: { code: TEST_CODES.FAIL, message: TEST_MESSAGES.FAILED },
+  SKIP: { code: TEST_CODES.SKIP, message: TEST_MESSAGES.SKIPPED },
+  EMPTY_CODE: { code: '', message: TEST_MESSAGES.ONLY_MESSAGE },
+  EMPTY_MESSAGE: { code: TEST_CODES.ONLY, message: '' },
+  BOTH_EMPTY: { code: '', message: '' },
+  TIMEOUT: { code: TEST_CODES.TIMEOUT, message: TEST_MESSAGES.TIMEOUT },
+  OPERATION_FAILED: { code: TEST_CODES.FAIL, message: TEST_MESSAGES.OPERATION_FAILED },
+  OPERATION_SKIPPED: { code: TEST_CODES.SKIP, message: TEST_MESSAGES.OPERATION_SKIPPED },
+  WITHOUT_CODE: { code: '', message: TEST_MESSAGES.WITHOUT_CODE },
+} as const;
+
+const EXPECTED_EMPTY_ERROR_PROPS = {
+  errorLevel: undefined,
+  errorMessage: undefined,
+  code: undefined,
+  message: undefined,
+} as const;
+
+describe('extractErrorInfo', () => {
+  it('should return code and empty message when errorRun is undefined', () => {
+    const result = extractErrorInfo(undefined, TEST_CODES.TEST);
+    expect(result).toEqual({
+      code: TEST_CODES.TEST,
+      message: '',
+    });
+  });
+
+  it('should return code and empty message when errorRun is null', () => {
+    const result = extractErrorInfo(null as any, TEST_CODES.TEST);
+    expect(result).toEqual({
+      code: TEST_CODES.TEST,
+      message: '',
+    });
+  });
+
+  it('should handle string errorRun', () => {
+    const result = extractErrorInfo(TEST_MESSAGES.FOUNDRY as any, 'ORIGINAL_CODE');
+    expect(result).toEqual({
+      code: 'error',
+      message: TEST_MESSAGES.FOUNDRY,
+    });
+  });
+
+  it('should handle ErrorRun object directly', () => {
+    const errorRun: ErrorRun = {
+      code: TEST_CODES.CUSTOM,
+      message: TEST_MESSAGES.CUSTOM,
+    };
+    const result = extractErrorInfo(errorRun, TEST_CODES.FALLBACK);
+    expect(result).toEqual({
+      code: TEST_CODES.CUSTOM,
+      message: TEST_MESSAGES.CUSTOM,
+    });
+  });
+
+  it('should handle wrapped ErrorRun object', () => {
+    const wrappedError = {
+      error: {
+        code: TEST_CODES.WRAPPED,
+        message: TEST_MESSAGES.WRAPPED,
+      },
+    };
+    const result = extractErrorInfo(wrappedError, TEST_CODES.FALLBACK);
+    expect(result).toEqual({
+      code: TEST_CODES.WRAPPED,
+      message: TEST_MESSAGES.WRAPPED,
+    });
+  });
+
+  it('should handle empty string errorRun', () => {
+    const result = extractErrorInfo('' as any, TEST_CODES.FALLBACK);
+    expect(result).toEqual({
+      code: TEST_CODES.FALLBACK,
+      message: '',
+    });
+  });
+
+  it('should handle non-string, non-object values', () => {
+    const result = extractErrorInfo(123 as any, TEST_CODES.FALLBACK);
+    expect(result).toEqual({
+      code: 'unknown',
+      message: '123',
+    });
+  });
+
+  it('should handle boolean errorRun', () => {
+    const result = extractErrorInfo(true as any, TEST_CODES.FALLBACK);
+    expect(result).toEqual({
+      code: 'unknown',
+      message: 'true',
+    });
+  });
+
+  it('should handle plain object without error property', () => {
+    const plainObject = {
+      code: TEST_CODES.PLAIN,
+      message: 'Plain object error',
+    };
+    const result = extractErrorInfo(plainObject as any, TEST_CODES.FALLBACK);
+    expect(result).toEqual({
+      code: TEST_CODES.PLAIN,
+      message: 'Plain object error',
+    });
+  });
+
+  it('should handle object with partial ErrorRun structure', () => {
+    const partialError = {
+      code: TEST_CODES.PARTIAL,
+      // missing message property
+    };
+    const result = extractErrorInfo(partialError as any, TEST_CODES.FALLBACK);
+    expect(result).toEqual({
+      code: TEST_CODES.PARTIAL,
+    });
+  });
+
+  it('should handle nested error object with extra properties', () => {
+    const complexError = {
+      error: {
+        code: TEST_CODES.COMPLEX,
+        message: TEST_MESSAGES.COMPLEX,
+        timestamp: '2023-01-01',
+        severity: 'high',
+      },
+      context: 'some context',
+    };
+    const result = extractErrorInfo(complexError as any, TEST_CODES.FALLBACK);
+    expect(result).toEqual({
+      code: TEST_CODES.COMPLEX,
+      message: TEST_MESSAGES.COMPLEX,
+      timestamp: '2023-01-01',
+      severity: 'high',
+    });
+  });
+});
+
+describe('getMonitoringError', () => {
+  it('should return empty error properties when codeRun is undefined', () => {
+    const result = getMonitoringError(undefined, 'Failed', undefined);
+    expect(result).toEqual(EXPECTED_EMPTY_ERROR_PROPS);
+  });
+
+  it('should return empty error properties when status is Succeeded', () => {
+    const result = getMonitoringError(TEST_ERROR_RUNS.BASIC, constants.FLOW_STATUS.SUCCEEDED, 'CODE_RUN');
+    expect(result).toEqual(EXPECTED_EMPTY_ERROR_PROPS);
+  });
+
+  it('should return empty error properties when status is Running', () => {
+    const result = getMonitoringError(TEST_ERROR_RUNS.BASIC, constants.FLOW_STATUS.RUNNING, 'CODE_RUN');
+    expect(result).toEqual(EXPECTED_EMPTY_ERROR_PROPS);
+  });
+
+  it('should return info level error for skipped status', () => {
+    const result = getMonitoringError(TEST_ERROR_RUNS.SKIP, constants.FLOW_STATUS.SKIPPED, 'CODE_RUN');
+    expect(result).toEqual({
+      errorLevel: MessageBarType.info,
+      errorMessage: `${TEST_CODES.SKIP}. ${TEST_MESSAGES.SKIPPED}`,
+      code: TEST_CODES.SKIP,
+      message: TEST_MESSAGES.SKIPPED,
+    });
+  });
+
+  it('should return severe warning level error for failed status', () => {
+    const result = getMonitoringError(TEST_ERROR_RUNS.FAIL, constants.FLOW_STATUS.FAILED, 'CODE_RUN');
+    expect(result).toEqual({
+      errorLevel: MessageBarType.severeWarning,
+      errorMessage: `${TEST_CODES.FAIL}. ${TEST_MESSAGES.FAILED}`,
+      code: TEST_CODES.FAIL,
+      message: TEST_MESSAGES.FAILED,
+    });
+  });
+
+  it('should format error message with only message when code is empty', () => {
+    const result = getMonitoringError(TEST_ERROR_RUNS.EMPTY_CODE, constants.FLOW_STATUS.FAILED, 'CODE_RUN');
+    expect(result).toEqual({
+      errorLevel: MessageBarType.severeWarning,
+      errorMessage: TEST_MESSAGES.ONLY_MESSAGE,
+      code: '',
+      message: TEST_MESSAGES.ONLY_MESSAGE,
+    });
+  });
+
+  it('should format error message with only code when message is empty', () => {
+    const result = getMonitoringError(TEST_ERROR_RUNS.EMPTY_MESSAGE, constants.FLOW_STATUS.FAILED, 'CODE_RUN');
+    expect(result).toEqual({
+      errorLevel: MessageBarType.severeWarning,
+      errorMessage: TEST_CODES.ONLY,
+      code: TEST_CODES.ONLY,
+      message: '',
+    });
+  });
+
+  it('should handle wrapped error object', () => {
+    const wrappedError = {
+      error: {
+        code: TEST_CODES.WRAPPED,
+        message: TEST_MESSAGES.WRAPPED,
+      },
+    };
+    const result = getMonitoringError(wrappedError, constants.FLOW_STATUS.FAILED, 'CODE_RUN');
+    expect(result).toEqual({
+      errorLevel: MessageBarType.severeWarning,
+      errorMessage: `${TEST_CODES.WRAPPED}. ${TEST_MESSAGES.WRAPPED}`,
+      code: TEST_CODES.WRAPPED,
+      message: TEST_MESSAGES.WRAPPED,
+    });
+  });
+
+  it('should handle string error (via extractErrorInfo)', () => {
+    const result = getMonitoringError(TEST_MESSAGES.CONNECTION as any, constants.FLOW_STATUS.FAILED, 'CODE_RUN');
+    expect(result).toEqual({
+      errorLevel: MessageBarType.severeWarning,
+      errorMessage: `error. ${TEST_MESSAGES.CONNECTION}`,
+      code: 'error',
+      message: TEST_MESSAGES.CONNECTION,
+    });
+  });
+
+  it('should fallback to codeRun when errorRun is undefined', () => {
+    const result = getMonitoringError(undefined, constants.FLOW_STATUS.FAILED, TEST_CODES.FALLBACK);
+    expect(result).toEqual({
+      errorLevel: MessageBarType.severeWarning,
+      errorMessage: TEST_CODES.FALLBACK,
+      code: TEST_CODES.FALLBACK,
+      message: '',
+    });
+  });
+
+  it('should handle undefined statusRun with default severe warning', () => {
+    const result = getMonitoringError(TEST_ERROR_RUNS.BASIC, undefined, 'CODE_RUN');
+    expect(result).toEqual({
+      errorLevel: MessageBarType.severeWarning,
+      errorMessage: `${TEST_CODES.TEST}. ${TEST_MESSAGES.TEST}`,
+      code: TEST_CODES.TEST,
+      message: TEST_MESSAGES.TEST,
+    });
+  });
+});
+
+describe('getMonitoringTabError', () => {
+  it('should return undefined when message is null', () => {
+    const result = getMonitoringTabError(undefined, constants.FLOW_STATUS.SUCCEEDED, 'CODE_RUN');
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when message is undefined from getMonitoringError', () => {
+    const result = getMonitoringTabError(TEST_ERROR_RUNS.BASIC, constants.FLOW_STATUS.SUCCEEDED, undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return formatted error object for valid error', () => {
+    const result = getMonitoringTabError(TEST_ERROR_RUNS.OPERATION_FAILED, constants.FLOW_STATUS.FAILED, 'CODE_RUN');
+    expect(result).toEqual({
+      code: TEST_CODES.FAIL,
+      message: TEST_MESSAGES.OPERATION_FAILED,
+      messageBarType: MessageBarType.severeWarning,
+    });
+  });
+
+  it('should return formatted error object for skipped status with info level', () => {
+    const result = getMonitoringTabError(TEST_ERROR_RUNS.OPERATION_SKIPPED, constants.FLOW_STATUS.SKIPPED, 'CODE_RUN');
+    expect(result).toEqual({
+      code: TEST_CODES.SKIP,
+      message: TEST_MESSAGES.OPERATION_SKIPPED,
+      messageBarType: MessageBarType.info,
+    });
+  });
+
+  it('should handle error with empty code but valid message', () => {
+    const result = getMonitoringTabError(TEST_ERROR_RUNS.WITHOUT_CODE, constants.FLOW_STATUS.FAILED, 'CODE_RUN');
+    expect(result).toEqual({
+      code: '',
+      message: TEST_MESSAGES.WITHOUT_CODE,
+      messageBarType: MessageBarType.severeWarning,
+    });
+  });
+
+  it('should handle error with valid code but empty message', () => {
+    const result = getMonitoringTabError(TEST_ERROR_RUNS.EMPTY_MESSAGE, constants.FLOW_STATUS.FAILED, 'CODE_RUN');
+    expect(result).toEqual({
+      code: TEST_CODES.ONLY,
+      message: '',
+      messageBarType: MessageBarType.severeWarning,
+    });
+  });
+
+  it('should return error object when both message and code are empty strings', () => {
+    const result = getMonitoringTabError(TEST_ERROR_RUNS.BOTH_EMPTY, constants.FLOW_STATUS.FAILED, 'CODE_RUN');
+    expect(result).toEqual({
+      code: '',
+      message: '',
+      messageBarType: MessageBarType.severeWarning,
+    });
+  });
+
+  it('should handle complex error scenarios', () => {
+    const result = getMonitoringTabError(TEST_ERROR_RUNS.TIMEOUT, constants.FLOW_STATUS.TIMEDOUT, 'TIMEOUT_CODE');
+    expect(result).toEqual({
+      code: TEST_CODES.TIMEOUT,
+      message: TEST_MESSAGES.TIMEOUT,
+      messageBarType: MessageBarType.severeWarning,
+    });
+  });
+});

--- a/libs/designer/src/lib/common/utilities/error.ts
+++ b/libs/designer/src/lib/common/utilities/error.ts
@@ -16,7 +16,6 @@ export interface ErrorRun {
 
 /**
  * Extracts and formats monitoring error information from a workflow run.
- *
  * @param errorRun - The error object from the run, can be wrapped in an object with 'error' property or be the ErrorRun itself
  * @param statusRun - The status of the workflow run (e.g., 'Succeeded', 'Failed', 'Skipped')
  * @param codeRun - The error code from the workflow run
@@ -25,11 +24,6 @@ export interface ErrorRun {
  *   - errorMessage: A formatted error message combining code and message
  *   - code: The extracted error code
  *   - message: The extracted error message
- *
- * @remarks
- * - Returns empty error properties if no error code is provided or if the run succeeded/is running
- * - Sets info level for skipped runs, severe warning for all other error cases
- * - Formats the error message based on available code and message content
  */
 export function getMonitoringError(
   errorRun: { error: ErrorRun } | ErrorRun | undefined,
@@ -73,7 +67,6 @@ export function getMonitoringError(
 
 /**
  * Processes monitoring error data and returns a formatted error object for display in the monitoring tab.
- *
  * @param errorRun - The error object containing code and message, or undefined if no error
  * @param errorRun.code - The error code
  * @param errorRun.message - The error message
@@ -112,7 +105,7 @@ export const getMonitoringTabError = (
  *   - code: The error code (defaults to 'error' for strings, 'unknown' for unhandled types, or codeRun if errorRun is undefined)
  *   - message: The error message (empty string if errorRun is undefined)
  */
-export const extractErrorInfo = (errorRun: { error: ErrorRun } | ErrorRun | undefined, codeRun: string | undefined) => {
+export const extractErrorInfo = (errorRun: { error: ErrorRun } | ErrorRun | undefined | string, codeRun: string | undefined) => {
   if (!errorRun) {
     return { code: codeRun, message: '' };
   }

--- a/libs/designer/src/lib/common/utilities/error.ts
+++ b/libs/designer/src/lib/common/utilities/error.ts
@@ -15,11 +15,21 @@ export interface ErrorRun {
 }
 
 /**
- * Translates a monitoring view `errors` prop into designer error props.
- * @arg {{ error: ErrorRun} | ErrorRun  | undefined} errorRun - Operation error run object.
- * @arg {string} statusRun - The operation status, e.g., Failed, Succeeded.
- * @arg {string} codeRun - The operation code.
- * @return {ErrorProps | undefined}
+ * Extracts and formats monitoring error information from a workflow run.
+ *
+ * @param errorRun - The error object from the run, can be wrapped in an object with 'error' property or be the ErrorRun itself
+ * @param statusRun - The status of the workflow run (e.g., 'Succeeded', 'Failed', 'Skipped')
+ * @param codeRun - The error code from the workflow run
+ * @returns An ErrorProps object containing:
+ *   - errorLevel: The severity level of the error (MessageBarType)
+ *   - errorMessage: A formatted error message combining code and message
+ *   - code: The extracted error code
+ *   - message: The extracted error message
+ *
+ * @remarks
+ * - Returns empty error properties if no error code is provided or if the run succeeded/is running
+ * - Sets info level for skipped runs, severe warning for all other error cases
+ * - Formats the error message based on available code and message content
  */
 export function getMonitoringError(
   errorRun: { error: ErrorRun } | ErrorRun | undefined,
@@ -35,7 +45,7 @@ export function getMonitoringError(
     };
   }
 
-  const { code, message } = errorRun ? ('error' in errorRun ? errorRun.error : errorRun) : { code: codeRun, message: '' };
+  const { code, message } = extractErrorInfo(errorRun, codeRun);
 
   let errorLevel: MessageBarType;
   if (statusRun === constants.FLOW_STATUS.SKIPPED) {
@@ -61,6 +71,17 @@ export function getMonitoringError(
   };
 }
 
+/**
+ * Processes monitoring error data and returns a formatted error object for display in the monitoring tab.
+ *
+ * @param errorRun - The error object containing code and message, or undefined if no error
+ * @param errorRun.code - The error code
+ * @param errorRun.message - The error message
+ * @param statusRun - The status of the run, or undefined
+ * @param codeRun - The code of the run, or undefined
+ * @returns An object containing the error code, message, and message bar type for display,
+ *          or undefined if no valid error message is found
+ */
 export const getMonitoringTabError = (
   errorRun: { code: string; message: string } | undefined,
   statusRun: string | undefined,
@@ -77,4 +98,35 @@ export const getMonitoringTabError = (
     message: message as string,
     messageBarType: errorLevel,
   };
+};
+
+/**
+ * Extracts error information from various error formats and normalizes it into a consistent structure.
+ * @param errorRun - The error object which can be:
+ *   - An object containing an error property of type ErrorRun
+ *   - An ErrorRun object directly
+ *   - A string error message
+ *   - undefined
+ * @param codeRun - Optional error code to use when errorRun is undefined
+ * @returns An object containing:
+ *   - code: The error code (defaults to 'error' for strings, 'unknown' for unhandled types, or codeRun if errorRun is undefined)
+ *   - message: The error message (empty string if errorRun is undefined)
+ */
+export const extractErrorInfo = (errorRun: { error: ErrorRun } | ErrorRun | undefined, codeRun: string | undefined) => {
+  if (!errorRun) {
+    return { code: codeRun, message: '' };
+  }
+
+  if (typeof errorRun === 'string') {
+    return { code: 'error', message: errorRun };
+  }
+
+  if (typeof errorRun === 'object' && errorRun !== null) {
+    if ('error' in errorRun) {
+      return errorRun.error;
+    }
+    return errorRun;
+  }
+
+  return { code: 'unknown', message: String(errorRun) };
 };


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Fixed a TypeError that occurred when the error handling code tried to use the 'in' operator on string error messages. The issue happened when `errorRun` contained a string like "Creating foundry agent failed with status: '401'..." instead of an object, causing `Cannot use 'in' operator to search for 'error' in [string]` errors.

The fix extracts error processing logic into a reusable `extractErrorInfo` function with proper type guards to handle various error formats safely.

## Impact of Change
- **Users**: Eliminates runtime errors when foundry agent creation fails with string error messages
- **Developers**: Provides cleaner, more maintainable error handling code with comprehensive test coverage
- **System**: Improves error handling reliability across the designer workflow monitoring system

## Test Plan
- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] Tested in: Local development environment with all 30 test cases passing

**Test Coverage:**
- 30 comprehensive unit tests covering all error scenarios
- Tests for string errors, object errors, wrapped errors, undefined/null values
- Edge cases like empty strings, boolean values, partial objects
- Flow status handling (succeeded, failed, skipped, running)
- Message formatting with various code/message combinations

## Contributors
@carloscastrotrejo - Implementation and testing