### PR TITLE
fix(standalone): Agent Changes to Match Production

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/CodeView.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/CodeView.tsx
@@ -17,6 +17,7 @@ const CodeViewEditor = forwardRef(({ workflowKind, isConsumption }: CodeViewProp
   const dispatch = useDispatch<AppDispatch>();
   const isWorkflowIsDirty = useIsWorkflowDirty();
   const [code, setCode] = useState<string | undefined>();
+  const [changesMade, setChangesMade] = useState(false);
 
   useMount(async () => {
     const serializedWorkflowDefinition = await serializeBJSWorkflow(DesignerStore.getState(), {
@@ -47,11 +48,13 @@ const CodeViewEditor = forwardRef(({ workflowKind, isConsumption }: CodeViewProp
     }
     if (e.value !== undefined) {
       setCode(e.value);
+      setChangesMade(true);
     }
   };
 
   useImperativeHandle(ref, () => ({
     getValue: () => code,
+    hasChanges: () => changesMade,
   }));
 
   return (

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -68,6 +68,7 @@ import {
   TriggerDescriptionDialog,
   getMissingRoleDefinitions,
   roleQueryKeys,
+  isAgenticWorkflow,
 } from '@microsoft/logic-apps-designer';
 import axios from 'axios';
 import isEqual from 'lodash.isequal';
@@ -121,7 +122,7 @@ const DesignerEditor = () => {
     id: guid(),
   });
   const [designerView, setDesignerView] = useState(true);
-  const codeEditorRef = useRef<{ getValue: () => string | undefined }>(null);
+  const codeEditorRef = useRef<{ getValue: () => string | undefined; hasChanges: () => boolean }>(null);
   const originalConnectionsData = useMemo(() => data?.properties.files[Artifact.ConnectionsFile] ?? {}, [data?.properties.files]);
   const originalCustomCodeData = useMemo(() => Object.keys(customCodeData ?? {}), [customCodeData]);
   const parameters = useMemo(() => data?.properties.files[Artifact.ParametersFile] ?? {}, [data?.properties.files]);
@@ -233,84 +234,6 @@ const DesignerEditor = () => {
     [dispatch]
   );
 
-  const workflowDefinition = useMemo(() => {
-    if (equals(workflow?.kind ?? '', 'Agentic', true)) {
-      if (workflow?.definition) {
-        const { actions, triggers, outputs, parameters } = workflow.definition;
-        if (
-          Object.keys(actions ?? {}).length === 0 &&
-          Object.keys(triggers ?? {}).length === 0 &&
-          Object.keys(outputs ?? {}).length === 0 &&
-          Object.keys(parameters ?? {}).length === 0
-        ) {
-          return {
-            ...workflow.definition,
-            actions: {
-              Default_Agent: {
-                type: 'Agent',
-                limit: {},
-                inputs: {
-                  parameters: {
-                    deploymentId: '',
-                    messages: '',
-                    agentModelType: 'AzureOpenAI',
-                    agentModelSettings: {
-                      agentHistoryReductionSettings: {
-                        agentHistoryReductionType: 'maximumTokenCountReduction',
-                        maximumTokenCount: 128000,
-                      },
-                    },
-                  },
-                  modelConfigurations: {
-                    model1: {
-                      referenceName: '',
-                    },
-                  },
-                },
-                tools: {},
-                runAfter: {},
-              },
-            },
-          };
-        }
-      } else {
-        return {
-          $schema: 'https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#',
-          contentVersion: '1.0.0.0',
-          actions: {
-            Default_Agent: {
-              type: 'Agent',
-              limit: {},
-              inputs: {
-                parameters: {
-                  deploymentId: '',
-                  messages: '',
-                  agentModelType: 'AzureOpenAI',
-                  agentModelSettings: {
-                    agentHistoryReductionSettings: {
-                      agentHistoryReductionType: 'maximumTokenCountReduction',
-                      maximumTokenCount: 128000,
-                    },
-                  },
-                },
-                modelConfigurations: {
-                  model1: {
-                    referenceName: '',
-                  },
-                },
-              },
-              tools: {},
-              runAfter: {},
-            },
-          },
-          outputs: {},
-          triggers: {},
-        };
-      }
-    }
-    return workflow?.definition;
-  }, [workflow?.definition, workflow?.kind]);
-
   if (isLoading || appLoading || settingsLoading || customCodeLoading) {
     return <></>;
   }
@@ -388,7 +311,7 @@ const DesignerEditor = () => {
         ...connectionsData?.serviceProviderConnections,
         ...newServiceProviderConnections,
       };
-      if (workflow?.kind?.toLowerCase() === 'agentic') {
+      if (isAgenticWorkflow(workflow?.kind ?? '')) {
         (connectionsData as ConnectionsData).agentConnections = {
           ...connectionsData?.agentConnections,
           ...newAgentConnections,
@@ -483,7 +406,9 @@ const DesignerEditor = () => {
     } else {
       try {
         const codeToConvert = JSON.parse(codeEditorRef.current?.getValue() ?? '');
-        await validateWorkflowStandard(siteResourceId, workflowName, codeToConvert);
+        if (codeEditorRef.current?.hasChanges() && !isEqual(codeToConvert, workflow)) {
+          await validateWorkflowStandard(siteResourceId, workflowName, codeToConvert);
+        }
         setWorkflow((prevState) => ({
           ...prevState,
           definition: codeToConvert.definition,
@@ -525,7 +450,7 @@ const DesignerEditor = () => {
         {workflow?.definition ? (
           <BJSWorkflowProvider
             workflow={{
-              definition: workflowDefinition,
+              definition: workflow?.definition,
               connectionReferences,
               parameters,
               kind: workflow?.kind,

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -406,7 +406,7 @@ const DesignerEditor = () => {
     } else {
       try {
         const codeToConvert = JSON.parse(codeEditorRef.current?.getValue() ?? '');
-        if (codeEditorRef.current?.hasChanges() && !isEqual(codeToConvert, workflow)) {
+        if (codeEditorRef.current?.hasChanges() && !isEqual(codeToConvert, { definition: workflow?.definition, kind: workflow?.kind })) {
           await validateWorkflowStandard(siteResourceId, workflowName, codeToConvert);
         }
         setWorkflow((prevState) => ({

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
@@ -1,6 +1,6 @@
 import type { RootState } from '../../store';
 import { useSelector } from 'react-redux';
-import { useAgenticWorkflow } from '../designerView/designerViewSelectors';
+import { useIsAgenticWorkflow } from '../designerView/designerViewSelectors';
 import { useOperationInfo } from '../selectors/actionMetadataSelector';
 import { useEffect, useState } from 'react';
 import { equals } from '@microsoft/logic-apps-shared';
@@ -71,7 +71,7 @@ export const useAreServicesInitialized = () => {
 };
 
 export const useSupportedChannels = (nodeId: string) => {
-  const isAgenticWorkflow = useAgenticWorkflow();
+  const isAgenticWorkflow = useIsAgenticWorkflow();
   const operationInfo = useOperationInfo(nodeId);
   const [supportedChannels, setSupportedChannels] = useState<any[]>([]);
 

--- a/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -22,7 +22,7 @@ export const useEdgeContextMenuData = () => {
   return useSelector((state: RootState) => state.designerView.edgeContextMenuData);
 };
 
-export const useAgenticWorkflow = () => {
+export const useIsAgenticWorkflow = () => {
   return useSelector((state: RootState) => equals(state.workflow.workflowKind, 'agentic', false));
 };
 

--- a/libs/designer/src/lib/core/state/workflow/helper.ts
+++ b/libs/designer/src/lib/core/state/workflow/helper.ts
@@ -1,6 +1,6 @@
 import { equals } from '@microsoft/logic-apps-shared';
 import type { WorkflowNode } from '../../../core/parsers/models/workflowNode';
-import type { WorkflowState } from './workflowInterfaces';
+import { WorkflowKind, type WorkflowState } from './workflowInterfaces';
 
 /**
  * Recursively clones a node while pruning (removing) any nodes that are in the nodesToRemove set.
@@ -131,4 +131,8 @@ export const collapseFlowTree = (
 
 export const isA2AWorkflow = (state: WorkflowState): boolean => {
   return equals(state.workflowKind, 'agent');
+};
+
+export const isAgenticWorkflow = (kind: string): boolean => {
+  return equals(kind, WorkflowKind.AGENTIC) || equals(kind, WorkflowKind.AGENT);
 };

--- a/libs/designer/src/lib/index.tsx
+++ b/libs/designer/src/lib/index.tsx
@@ -21,4 +21,5 @@ export { default as Constants } from './common/constants';
 export { serializeWorkflow as serializeBJSWorkflow } from './core/actions/bjsworkflow/serializer';
 export { updateCallbackUrl } from './core/actions/bjsworkflow/initialize';
 export { ReactQueryProvider } from './core/ReactQueryProvider';
+export { isAgenticWorkflow } from './core/state/workflow/helper';
 export { isOpenApiSchemaVersion, getSKUDefaultHostOptions } from './common/utilities/Utils';

--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -1,7 +1,7 @@
 import { openPanel, useNodesInitialized } from '../core';
 import { usePreloadOperationsQuery, usePreloadConnectorsQuery } from '../core/queries/browse';
 import { useMonitoringView, useReadOnly, useHostOptions, useIsVSCode } from '../core/state/designerOptions/designerOptionsSelectors';
-import { useAgenticWorkflow, useIsA2AWorkflow } from '../core/state/designerView/designerViewSelectors';
+import { useIsAgenticWorkflow, useIsA2AWorkflow } from '../core/state/designerView/designerViewSelectors';
 import type { AppDispatch, RootState } from '../core/store';
 import Controls from './Controls';
 import Minimap from './Minimap';
@@ -81,7 +81,7 @@ export const Designer = (props: DesignerProps) => {
   );
 
   const isMonitoringView = useMonitoringView();
-  const isAgenticWorkflow = useAgenticWorkflow();
+  const isAgenticWorkflow = useIsAgenticWorkflow();
   const isA2AWorkflow = useIsA2AWorkflow(); // Specifically A2A + Handoffs
 
   const hasChat = useMemo(() => {

--- a/libs/designer/src/lib/ui/common/EdgeContextualMenu/EdgeContextualMenu.tsx
+++ b/libs/designer/src/lib/ui/common/EdgeContextualMenu/EdgeContextualMenu.tsx
@@ -16,7 +16,7 @@ import {
 import { useIntl } from 'react-intl';
 import { useOnViewportChange } from '@xyflow/react';
 
-import { useAgenticWorkflow, useEdgeContextMenuData, useIsA2AWorkflow } from '../../../core/state/designerView/designerViewSelectors';
+import { useIsAgenticWorkflow, useEdgeContextMenuData, useIsA2AWorkflow } from '../../../core/state/designerView/designerViewSelectors';
 import { addOperation, useNodeDisplayName, useNodeMetadata, type AppDispatch } from '../../../core';
 import { expandDiscoveryPanel } from '../../../core/state/panel/panelSlice';
 import { retrieveClipboardData } from '../../../core/utils/clipboard';
@@ -48,7 +48,7 @@ export const EdgeContextualMenu = () => {
   const intl = useIntl();
 
   const menuData = useEdgeContextMenuData();
-  const isAgenticWorkflow = useAgenticWorkflow();
+  const isAgenticWorkflow = useIsAgenticWorkflow();
   const isA2AWorkflow = useIsA2AWorkflow();
   const graphId = useMemo(() => menuData?.graphId, [menuData]);
   const parentId = useMemo(() => menuData?.parentId, [menuData]);

--- a/libs/designer/src/lib/ui/panel/recommendation/actionSpotlight.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/actionSpotlight.tsx
@@ -12,7 +12,7 @@ import { equals, LOCAL_STORAGE_KEYS, type Connector, type DiscoveryOpArray } fro
 import { getOperationCardDataFromOperation, getOperationGroupCardDataFromConnector } from './helpers';
 import { useIntl } from 'react-intl';
 import { SpotlightCategoryType, SpotlightSection } from '@microsoft/designer-ui';
-import { useAgenticWorkflow } from '../../../core/state/designerView/designerViewSelectors';
+import { useIsAgenticWorkflow } from '../../../core/state/designerView/designerViewSelectors';
 export interface ActionSpotlightProps {
   onConnectorSelected: (connectorId: string, origin?: string) => void;
   onOperationSelected: (operationId: string, apiId?: string) => void;
@@ -41,7 +41,7 @@ export const ActionSpotlight = (props: ActionSpotlightProps) => {
   const isWithinAgenticLoop = useIsWithinAgenticLoop(parentGraphId);
 
   const isAgentTool = useIsAddingAgentTool();
-  const isAgenticWorkflow = useAgenticWorkflow();
+  const isAgenticWorkflow = useIsAgenticWorkflow();
 
   const favoriteOperationIds = useDiscoveryPanelFavoriteOperations();
   const {

--- a/libs/designer/src/lib/ui/panel/recommendation/searchView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/searchView.tsx
@@ -14,7 +14,7 @@ import type { FC } from 'react';
 import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useDiscoveryPanelRelationshipIds, useIsAddingAgentTool } from '../../../core/state/panel/panelSelectors';
-import { useAgenticWorkflow } from '../../../core/state/designerView/designerViewSelectors';
+import { useIsAgenticWorkflow } from '../../../core/state/designerView/designerViewSelectors';
 import { useShouldEnableACASession, useShouldEnableNestedAgent, useShouldEnableParseDocumentWithMetadata } from './hooks';
 import { DefaultSearchOperationsService } from './SearchOpeationsService';
 import constants from '../../../common/constants';
@@ -43,7 +43,7 @@ export const SearchView: FC<SearchViewProps> = ({
   onOperationClick,
   displayRuntimeInfo,
 }) => {
-  const isAgenticWorkflow = useAgenticWorkflow();
+  const isAgenticWorkflow = useIsAgenticWorkflow();
   const shouldEnableParseDocWithMetadata = useShouldEnableParseDocumentWithMetadata();
   const shouldEnableACASession = useShouldEnableACASession();
   const shouldEnableNestedAgent = useShouldEnableNestedAgent();


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->

This change aligns the behavior in standalone with production:

- **Workflow Default Agent**: Standalone no longer defaults the workflow definition to a `default agent` on load. This matches production behavior, where the default agent is set during workflow creation.
  
- **Agentic Workflow Serialization**: Added a new `isAgenticWorkflow` utility to handle both `Agent` and `Agentic` kinds when serializing agent connection data. This mirrors logic used in production.
  
- **Editable Code View Validation**: In standalone, when switching from code view back to designer, validation will now only run if changes were made—improving performance and reducing unnecessary processing.

- **Hook Rename**: Renamed `useAgenticWorkflow` to `useIsAgenticWorkflow` for clarity and consistency.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No direct user-facing impact, but behavior is more consistent across environments.
- **Developers**:
  - New utility: `isAgenticWorkflow` to cover both agent and agentic kind
  - Validation behavior change in Editable Code View
  - Hook renamed to improve readability
- **System**: Improved alignment between standalone and production logic; easier to maintain and reason about.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@Eric-B-Wu 

## Screenshots/Videos
<!-- Visual changes only -->
