### PR TITLE
fix(Mcp): Replace and sanitize names of workflows to be created to match format

### DIFF
--- a/apps/Standalone/src/mcp/app/McpStandard.tsx
+++ b/apps/Standalone/src/mcp/app/McpStandard.tsx
@@ -91,7 +91,7 @@ export const McpStandard = () => {
   const onRegisterMcpServer = useCallback(async (createData: McpServerCreateData, onCompleted?: () => void) => {
     const { logicAppId, workflows, connectionsData } = createData;
     const workflowsToCreate = Object.keys(workflows).map((key) => ({
-      name: key.replace(/[^\w-]/g, ''), // Replace invalid characters in workflow name
+      name: key,
       workflow: workflows[key],
     }));
 

--- a/libs/designer/src/lib/core/mcp/utils/__test__/serializer.spec.ts
+++ b/libs/designer/src/lib/core/mcp/utils/__test__/serializer.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { getWorkflowNameFromOperation } from '../serializer';
+
+describe('getWorkflowNameFromOperation', () => {
+  describe('when operationSummary is provided', () => {
+    it('should use operationSummary when provided', () => {
+      const result = getWorkflowNameFromOperation('Send Email', 'send-email-action');
+      expect(result).toBe('Send_Email');
+    });
+
+    it('should handle operationSummary with parentheses and version numbers', () => {
+      const result = getWorkflowNameFromOperation('Send email (V4)', 'send-email-action');
+      expect(result).toBe('Send_email_V4');
+    });
+
+    it('should handle operationSummary with special characters', () => {
+      const result = getWorkflowNameFromOperation('Send Email & Notification!', 'send-email-action');
+      expect(result).toBe('Send_Email_Notification');
+    });
+
+    it('should handle operationSummary with multiple consecutive underscores', () => {
+      const result = getWorkflowNameFromOperation('Send___Email___Action', 'send-email-action');
+      expect(result).toBe('Send_Email_Action');
+    });
+
+    it('should handle operationSummary with only special characters', () => {
+      const result = getWorkflowNameFromOperation('***!!!***', 'send-email-action');
+      expect(result).toBe('send-email-action');
+    });
+  });
+
+  describe('when operationSummary is undefined', () => {
+    it('should use operationId when operationSummary is undefined', () => {
+      const result = getWorkflowNameFromOperation(undefined, 'send-email-action');
+      expect(result).toBe('send-email-action');
+    });
+
+    it('should handle operationId with special characters', () => {
+      const result = getWorkflowNameFromOperation(undefined, 'send@email#action!');
+      expect(result).toBe('send_email_action');
+    });
+
+    it('should handle operationId with leading and trailing underscores', () => {
+      const result = getWorkflowNameFromOperation(undefined, '_send_email_action_');
+      expect(result).toBe('send_email_action');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle operationId with only special characters', () => {
+      const result = getWorkflowNameFromOperation(undefined, '!@#$%^&*()');
+      expect(result).toBe('');
+    });
+
+    it('should preserve valid characters and hyphens', () => {
+      const result = getWorkflowNameFromOperation('Valid-Name_123', 'operation-id');
+      expect(result).toBe('Valid-Name_123');
+    });
+
+    it('should handle Unicode characters', () => {
+      const result = getWorkflowNameFromOperation('Send😀Email', 'operation-id');
+      expect(result).toBe('Send_Email');
+    });
+  });
+});

--- a/libs/designer/src/lib/core/mcp/utils/__test__/serializer.spec.ts
+++ b/libs/designer/src/lib/core/mcp/utils/__test__/serializer.spec.ts
@@ -25,7 +25,7 @@ describe('getWorkflowNameFromOperation', () => {
 
     it('should handle operationSummary with only special characters', () => {
       const result = getWorkflowNameFromOperation('***!!!***', 'send-email-action');
-      expect(result).toBe('send-email-action');
+      expect(result).toBe('');
     });
   });
 

--- a/libs/designer/src/lib/core/mcp/utils/serializer.ts
+++ b/libs/designer/src/lib/core/mcp/utils/serializer.ts
@@ -209,7 +209,7 @@ const transformSwaggerSchema = (schema: any): any => {
   return updatedSchema;
 };
 
-const getWorkflowNameFromOperation = (operationSummary: string | undefined, operationId: string): string => {
+export const getWorkflowNameFromOperation = (operationSummary: string | undefined, operationId: string): string => {
   return (operationSummary ?? operationId)
     .replace(/[^\w-]+/g, '_') // Replace invalid characters with underscores
     .replace(/__+/g, '_') // Replace multiple underscores with a single underscore

--- a/libs/designer/src/lib/core/mcp/utils/serializer.ts
+++ b/libs/designer/src/lib/core/mcp/utils/serializer.ts
@@ -210,7 +210,10 @@ const transformSwaggerSchema = (schema: any): any => {
 };
 
 const getWorkflowNameFromOperation = (operationSummary: string | undefined, operationId: string): string => {
-  return operationSummary ? operationSummary.replaceAll(' ', '_') : operationId;
+  return (operationSummary ?? operationId)
+    .replace(/[^\w-]+/g, '_') // Replace invalid characters with underscores
+    .replace(/__+/g, '_') // Replace multiple underscores with a single underscore
+    .replace(/^_+|_+$/g, ''); // Trim leading and trailing underscores
 };
 
 const getConnectionsDataToSerialize = async (


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [X] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [X] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Restructuring workflow name(s) at the McpWizard level to be able to log the structured workflow names for telemetry purposes. As well, instead of replacing invalid characters with white characters, replacing with underscore and formatting to remove extra underscore & at front/end.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: When workflow(s) are created, they will see updated names
- **Developers**: none
- **System**: none

## Test Plan
<!-- How was this tested? -->
- [X] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@DevArjun23 

## Screenshots/Videos
<!-- Visual changes only -->
