### PR TITLE
fix(vscode): resolve file system connection callback and improve type safety

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -31,6 +31,7 @@ import { HTTP_METHODS } from '@microsoft/logic-apps-shared';
 import { openUrl, type IActionContext } from '@microsoft/vscode-azext-utils';
 import type {
   AzureConnectorDetails,
+  CompleteFileSystemConnectionData,
   FileSystemConnectionInfo,
   IDesignerPanelMetadata,
   Parameter,
@@ -76,13 +77,14 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
       exec(`net use ${rootFolder} ${password} /user:${username}`, (error) => {
         if (error) {
           resolve({ errorMessage: JSON.stringify(error.message) });
+        } else {
+          resolve({
+            connection: {
+              ...connectionInfo,
+              connectionParameters: { mountPath: rootFolder },
+            },
+          });
         }
-        resolve({
-          connection: {
-            ...connectionInfo,
-            connectionParameters: { mountPath: rootFolder },
-          },
-        });
       });
     });
   };
@@ -233,13 +235,14 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
         {
           const connectionName = msg.connectionName;
           const { connection, errorMessage } = await this.createFileSystemConnection(msg.connectionInfo);
+          const completeData: CompleteFileSystemConnectionData = {
+            connectionName,
+            connection,
+            error: errorMessage,
+          };
           this.sendMsgToWebview({
             command: ExtensionCommand.completeFileSystemConnection,
-            data: {
-              connectionName,
-              connection,
-              errorMessage,
-            },
+            data: completeData,
           });
         }
         break;

--- a/apps/vs-code-react/src/run-service/types.ts
+++ b/apps/vs-code-react/src/run-service/types.ts
@@ -1,6 +1,12 @@
 import type { InitializePayload, Status } from '../state/WorkflowSlice';
 import type { ApiHubServiceDetails, SchemaType, IFileSysTreeItem } from '@microsoft/logic-apps-shared';
-import type { MapDefinitionData, ExtensionCommand, ConnectionsData, IDesignerPanelMetadata } from '@microsoft/vscode-extension-logic-apps';
+import type {
+  MapDefinitionData,
+  ExtensionCommand,
+  ConnectionsData,
+  IDesignerPanelMetadata,
+  CompleteFileSystemConnectionData,
+} from '@microsoft/vscode-extension-logic-apps';
 
 export interface IApiService {
   getWorkflows(subscriptionId: string, iseId?: string, location?: string): Promise<WorkflowsList[]>;
@@ -268,7 +274,7 @@ export interface SetIsWorkflowDirtyMessage {
 
 export interface CompleteFileSystemConnectionMessage {
   command: typeof ExtensionCommand.completeFileSystemConnection;
-  data: { connectionName: string; connection: any; error: string };
+  data: CompleteFileSystemConnectionData;
 }
 
 export interface UpdatePanelMetadataMessage {

--- a/apps/vs-code-react/src/state/DesignerSlice.ts
+++ b/apps/vs-code-react/src/state/DesignerSlice.ts
@@ -1,5 +1,10 @@
 import type { ApiHubServiceDetails, ListDynamicValue, UnitTestDefinition } from '@microsoft/logic-apps-shared';
-import type { ConnectionsData, ICallbackUrlResponse, IDesignerPanelMetadata } from '@microsoft/vscode-extension-logic-apps';
+import type {
+  CompleteFileSystemConnectionData,
+  ConnectionsData,
+  ICallbackUrlResponse,
+  IDesignerPanelMetadata,
+} from '@microsoft/vscode-extension-logic-apps';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
@@ -113,13 +118,13 @@ export const designerSlice = createSlice({
       const { connectionName, resolve, reject } = action.payload;
       state.fileSystemConnections[connectionName] = { resolveConnection: resolve, rejectConnection: reject };
     },
-    updateFileSystemConnection: (state, action: PayloadAction<{ connectionName: string; connection: any; error: string }>) => {
+    updateFileSystemConnection: (state, action: PayloadAction<CompleteFileSystemConnectionData>) => {
       const { connectionName, connection, error } = action.payload;
       if (connection && state.fileSystemConnections[connectionName]) {
         state.fileSystemConnections[connectionName].resolveConnection(connection);
       }
       if (error && state.fileSystemConnections[connectionName]) {
-        state.fileSystemConnections[connectionName].rejectConnection(error);
+        state.fileSystemConnections[connectionName].rejectConnection({ message: error });
       }
       delete state.fileSystemConnections[connectionName];
     },

--- a/libs/vscode-extension/src/lib/models/workflow.ts
+++ b/libs/vscode-extension/src/lib/models/workflow.ts
@@ -29,6 +29,12 @@ export interface IDesignerPanelMetadata {
   extensionBundleVersion?: string;
 }
 
+export interface CompleteFileSystemConnectionData {
+  connectionName: string;
+  connection: any;
+  error: string;
+}
+
 export interface StandardApp {
   statelessRunMode?: string;
   definition: LogicAppsV2.WorkflowDefinition;


### PR DESCRIPTION
Cherr-pick of the following PR #7985
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Fixes a critical bug in the file system connection logic where the success callback was always executed regardless of error state, and improves type safety by replacing generic `any` types with proper TypeScript interfaces.

The main issues resolved:
1. **Missing else clause**: The success callback was executing even when an error occurred in the `net use` command
2. **Poor type safety**: `updateFileSystemConnection` action used `any` type instead of the proper `CompleteFileSystemConnectionData` interface
3. **Debug code cleanup**: Removed console.log statements that were left from debugging

## Impact of Change
- **Users**: VS Code extension users will now see proper error handling when file system connections fail
- **Developers**: Improved type safety and cleaner error handling patterns
- **System**: More reliable file system connection management in VS Code extension

## Test Plan
- [x] Manual testing completed
- [x] Tested in: VS Code extension with file system connections (both success and error scenarios)

## Contributors

## Screenshots/Videos
<img width="2612" height="1950" alt="CleanShot 2025-08-06 at 11 51 22@2x" src="https://github.com/user-attachments/assets/63097968-cf12-485d-852c-bae28c6277af" />

Fixes #7984 
