### PR TITLE
fix(designer): [Cherry-pick] Enable channel tab by default and add a disable flag i…

### DIFF
--- a/libs/designer/src/lib/common/hooks/experimentation.ts
+++ b/libs/designer/src/lib/common/hooks/experimentation.ts
@@ -1,4 +1,4 @@
-import { enableChannelsInAgentLoop, enableDynamicConnections } from '@microsoft/logic-apps-shared';
+import { disableChannelsInAgentLoop, enableDynamicConnections } from '@microsoft/logic-apps-shared';
 import { useEffect, useState } from 'react';
 
 export function useShouldEnableDynamicConnections(): boolean | null {
@@ -23,7 +23,7 @@ export function useChannelsTabForAgentLoop(): boolean {
   useEffect(() => {
     const check = async () => {
       try {
-        const result = await enableChannelsInAgentLoop();
+        const result = await disableChannelsInAgentLoop();
         setEnabled(result);
       } catch (_e) {
         // If the check fails, it is not enabled

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -44,7 +44,7 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
   const isA2AWorkflow = useIsA2AWorkflow();
   const parameterValidationErrors = useParameterValidationErrors(nodeId);
   const settingValidationErrors = useSettingValidationErrors(nodeId);
-  const enableChannelsTab = useChannelsTabForAgentLoop();
+  const disableChannelsTab = useChannelsTabForAgentLoop();
 
   const tabProps: PanelTabProps = useMemo(
     () => ({
@@ -98,9 +98,9 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
     () => ({
       ...channelsTab(intl, tabProps),
       // Note: Channels tab is disabled until we have the teams integration ready
-      visible: enableChannelsTab && isAgentNode && !isA2AWorkflow,
+      visible: !disableChannelsTab && isAgentNode && !isA2AWorkflow,
     }),
-    [intl, tabProps, isAgentNode, isA2AWorkflow, enableChannelsTab]
+    [intl, tabProps, isAgentNode, isA2AWorkflow, disableChannelsTab]
   );
 
   const handoffTabItem = useMemo(

--- a/libs/logic-apps-shared/src/designer-client-services/lib/experimentationFlags.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/experimentationFlags.ts
@@ -6,7 +6,7 @@ export const EXP_FLAGS = {
   ENABLE_FOUNDRY_SERVICE_CONNECTION: 'enable-foundry-service-connection',
   ENABLE_NESTED_AGENT: 'enable-nested-agent',
   ENABLE_DYNAMIC_CONNECTIONS: 'enable-dynamic-connections',
-  ENABLE_CHANNELS_AGENT_LOOP: 'enable-channels-agentloop',
+  DISABLE_CHANNELS_AGENT_LOOP: 'disable-channels-agentloop',
 };
 
 export async function enableParseDocumentWithMetadata(): Promise<boolean> {
@@ -29,6 +29,6 @@ export async function enableDynamicConnections(): Promise<boolean> {
   return ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_DYNAMIC_CONNECTIONS);
 }
 
-export async function enableChannelsInAgentLoop(): Promise<boolean> {
-  return ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_CHANNELS_AGENT_LOOP);
+export async function disableChannelsInAgentLoop(): Promise<boolean> {
+  return ExperimentationService().isFeatureEnabled(EXP_FLAGS.DISABLE_CHANNELS_AGENT_LOOP);
 }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Since we are deploying before the A2A integration, channels need to be enabled by default and then disable it once A2A is done (next release)

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users will continue to access the channels tab in this release
- **Developers**: None
- **System**: None

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
