### PR TITLE
fix: correct version output variable usage in pipeline

### DIFF
--- a/.azure-pipelines/templates/package.yml
+++ b/.azure-pipelines/templates/package.yml
@@ -1,17 +1,20 @@
 steps:
-  - script: |
-      VERSION=$(npx tsx scripts/get-current-version.ts "$(Build.SourceBranchName)")
-      echo "Current version: $VERSION"
-      echo "##vso[task.setvariable variable=current_version;isOutput=true]$VERSION"
+  - pwsh: |
+      $version = $(npx tsx scripts/get-current-version.ts "$(Build.SourceBranchName)")
+      Write-Host "Current version: $version"
+      Write-Host "##vso[task.setvariable variable=current_version;isOutput=true]$version"
     displayName: "Get Current Version"
     workingDirectory: $(working_directory)
     condition: succeeded()
     name: version
+    id: get_version
 
-  - script: node scripts/update-versions.js $(version.current_version)
+  - script: node scripts/update-versions.js $(current_version)
     displayName: "Update Version in Package Files"
     workingDirectory: $(working_directory)
     condition: succeeded()
+    env:
+      current_version: $(get_version.current_version)
 
   - pwsh: |
       (Get-Content apps/vs-code-designer/src/package.json -Raw) -replace '"aiKey":\s*"[^"]*"', '"aiKey": "$(AI_KEY)"' | Set-Content apps/vs-code-designer/src/package.json -NoNewline


### PR DESCRIPTION
Fixes output variable passing for version in ADO pipeline. Uses job-level output variable syntax for compatibility with Windows agents.