### PR TITLE
refactor(ci): simplify version handling in package template

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -88,6 +88,8 @@ extends:
               - template: .azure-pipelines/templates/setup.yml@LogicAppsUX
               - template: .azure-pipelines/templates/build.yml@LogicAppsUX
               - template: .azure-pipelines/templates/package.yml@LogicAppsUX
+                parameters:
+                  publishVersion: ${{ parameters.publishVersion }}
               - template: .azure-pipelines/templates/sign.yml@LogicAppsUX
               - template: .azure-pipelines/templates/stage-artifacts.yml@LogicAppsUX
                 parameters:

--- a/.azure-pipelines/templates/package.yml
+++ b/.azure-pipelines/templates/package.yml
@@ -1,20 +1,12 @@
+parameters:
+  - name: publishVersion
+    type: string
+    
 steps:
-  - pwsh: |
-      $version = $(npx tsx scripts/get-current-version.ts "$(Build.SourceBranchName)")
-      Write-Host "Current version: $version"
-      Write-Host "##vso[task.setvariable variable=current_version;isOutput=true]$version"
-    displayName: "Get Current Version"
-    workingDirectory: $(working_directory)
-    condition: succeeded()
-    name: version
-    id: get_version
-
-  - script: node scripts/update-versions.js $(current_version)
+  - script: node scripts/update-versions.js ${{ parameters.publishVersion }}
     displayName: "Update Version in Package Files"
     workingDirectory: $(working_directory)
     condition: succeeded()
-    env:
-      current_version: $(get_version.current_version)
 
   - pwsh: |
       (Get-Content apps/vs-code-designer/src/package.json -Raw) -replace '"aiKey":\s*"[^"]*"', '"aiKey": "$(AI_KEY)"' | Set-Content apps/vs-code-designer/src/package.json -NoNewline


### PR DESCRIPTION
## Commit Type
- [x] refactor - Code restructuring without behavior change

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Refactored the Azure DevOps pipeline to simplify version handling by accepting `publishVersion` as a parameter instead of calculating it inline. This removes the need for complex PowerShell scripts to determine the current version and streamlines the package template workflow.

## Impact of Change
- **Users**: No user-facing changes
- **Developers**: Simplified CI/CD pipeline configuration, easier to maintain and debug
- **System**: Cleaner pipeline execution with reduced complexity in version management

## Test Plan
- [x] Manual testing completed
- [x] Tested in: Azure DevOps pipeline configuration review

## Contributors

## Screenshots/Videos