### PR TITLE
fix(mcp): Fixing the encode parameter path for dataverse connector

### DIFF
--- a/libs/designer/src/lib/core/mcp/utils/serializer.ts
+++ b/libs/designer/src/lib/core/mcp/utils/serializer.ts
@@ -11,7 +11,11 @@ import {
   deleteObjectProperties,
   clone,
 } from '@microsoft/logic-apps-shared';
-import { parameterHasValue, parameterValueToString } from '../../utils/parameters/helper';
+import {
+  parameterHasValue,
+  parameterValueToString,
+  shouldEncodeParameterValueForOperationBasedOnMetadata,
+} from '../../utils/parameters/helper';
 import type { Settings } from '../../actions/bjsworkflow/settings';
 import type { NodeOperation, NodeInputs, OperationMetadataState } from '../../state/operation/operationMetadataSlice';
 import {
@@ -107,7 +111,12 @@ const getOperationDefinitionAndTriggerInputs = async (
       }
     }
 
-    updatedInput.value = parameterValueToString(updatedInput, true /* isDefinitionValue */);
+    updatedInput.value = parameterValueToString(
+      updatedInput,
+      true /* isDefinitionValue */,
+      /* idReplacements */ {},
+      shouldEncodeParameterValueForOperationBasedOnMetadata(operationInfo)
+    );
     return updatedInput;
   });
 

--- a/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
+++ b/libs/designer/src/lib/ui/mcp/parameters/ParameterEditor.tsx
@@ -24,6 +24,7 @@ import {
   loadDynamicTreeItemsForParameter,
   loadDynamicValuesForParameter,
   parameterValueToString,
+  shouldEncodeParameterValueForOperationBasedOnMetadata,
 } from '../../../core/utils/parameters/helper';
 import { useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from '../../../core/state/mcp/store';
@@ -107,7 +108,9 @@ export const ParameterEditor = ({
           ...parameter,
           value,
         } as ParameterInfo,
-        /* isDefinitionValue */ true
+        /* isDefinitionValue */ false,
+        /* idReplacements */ {},
+        shouldEncodeParameterValueForOperationBasedOnMetadata(operationInfo)
       ) ?? ''
     );
   };


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Skipping encoding non path parameters for dataverse connector simliar to designer. Fixes #8023 

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Can use dataverse connectors without bugs in mcp
- **Developers**: NA
- **System**: NA

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@kewear 

## Screenshots/Videos
NA
