### PR TITLE
refactor(designer): clear run data only from agent nodes and subgraphs

### DIFF
--- a/libs/designer/src/lib/core/state/workflow/helper.ts
+++ b/libs/designer/src/lib/core/state/workflow/helper.ts
@@ -1,6 +1,6 @@
-import { equals } from '@microsoft/logic-apps-shared';
+import { equals, SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
 import type { WorkflowNode } from '../../../core/parsers/models/workflowNode';
-import { WorkflowKind, type WorkflowState } from './workflowInterfaces';
+import { WorkflowKind, type NodeMetadata, type WorkflowState } from './workflowInterfaces';
 
 /**
  * Recursively clones a node while pruning (removing) any nodes that are in the nodesToRemove set.
@@ -135,4 +135,8 @@ export const isA2AWorkflow = (state: WorkflowState): boolean => {
 
 export const isAgentWorkflow = (kind: string): boolean => {
   return equals(kind, WorkflowKind.AGENTIC) || equals(kind, WorkflowKind.AGENT);
+};
+
+export const shouldClearNodeRunData = (node: NodeMetadata) => {
+  return node?.runData && (node.graphId !== 'root' || node.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION);
 };

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -34,7 +34,6 @@ import {
   WORKFLOW_NODE_TYPES,
   containsIdTag,
   containsCaseTag,
-  SUBGRAPH_TYPES,
 } from '@microsoft/logic-apps-shared';
 import type { MessageLevel } from '@microsoft/designer-ui';
 import { getDurationStringPanelMode } from '@microsoft/designer-ui';
@@ -45,7 +44,7 @@ import type { NodeChange, NodeDimensionChange } from '@xyflow/system';
 import type { UndoRedoPartialRootState } from '../undoRedo/undoRedoTypes';
 import { initializeInputsOutputsBinding } from '../../actions/bjsworkflow/monitoring';
 import { updateAgenticSubgraph, type UpdateAgenticGraphPayload } from '../../parsers/updateAgenticGraph';
-import { isA2AWorkflow } from './helper';
+import { isA2AWorkflow, shouldClearNodeRunData } from './helper';
 
 export interface AddImplicitForeachPayload {
   nodeId: string;
@@ -494,7 +493,9 @@ export const workflowSlice = createSlice({
     },
     clearAllRepetitionRunData: (state: WorkflowState) => {
       for (const node of Object.values(state.nodesMetadata)) {
-        if (node.runData && (node.graphId !== 'root' || node.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION)) {
+        // Preserve run data for root nodes, except when they are agent condition subgraphs and their children.
+        // This is because root nodes typically represent the main workflow and their run data is needed for display for a2a agents
+        if (shouldClearNodeRunData(node)) {
           delete node.runData;
           delete node.runIndex;
         }

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -34,6 +34,7 @@ import {
   WORKFLOW_NODE_TYPES,
   containsIdTag,
   containsCaseTag,
+  SUBGRAPH_TYPES,
 } from '@microsoft/logic-apps-shared';
 import type { MessageLevel } from '@microsoft/designer-ui';
 import { getDurationStringPanelMode } from '@microsoft/designer-ui';
@@ -493,7 +494,7 @@ export const workflowSlice = createSlice({
     },
     clearAllRepetitionRunData: (state: WorkflowState) => {
       for (const node of Object.values(state.nodesMetadata)) {
-        if (node.runData) {
+        if (node.runData && (node.graphId !== 'root' || node.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION)) {
           delete node.runData;
           delete node.runIndex;
         }


### PR DESCRIPTION
## Commit Type
- [x] refactor - Code restructuring without behavior change

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Refactored the `clearAllRepetitionRunData` action to only clear run data from nodes that are specifically related to agents (non-root graph nodes and agent condition subgraph nodes), rather than clearing data from all nodes indiscriminately.

## Impact of Change
- **Users**: No user-facing changes
- **Developers**: Modified workflow state management logic for run data clearing
- **System**: Improved data management by preserving run data for non-agent nodes

## Test Plan
- [x] Manual testing completed
- [x] Tested in: Local development environment with workflow state management

## Contributors
N/A

## Screenshots/Videos
<img width="5116" height="2658" alt="CleanShot 2025-08-08 at 18 32 39@2x" src="https://github.com/user-attachments/assets/50968a64-cc1e-497e-9397-e1c696289d81" />
