### PR TITLE
fix(designer): Add Agent loop in Stateful behind FF

### DIFF
--- a/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -1,6 +1,7 @@
 import { equals, EXP_FLAGS, ExperimentationService, SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
 import type { RootState } from '../../store';
 import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
 
 export const useShowMinimap = () => {
   return useSelector((state: RootState) => state.designerView.showMinimap);
@@ -24,7 +25,13 @@ export const useEdgeContextMenuData = () => {
 
 export const useIsAgenticWorkflow = () => {
   const workflowKind = useSelector((state: RootState) => state.workflow.workflowKind);
-  const isEnabledForStateful = ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_AGENTLOOP_STATEFUL);
+  const isEnabledForStateful = useMemo(() => {
+    try {
+      return ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_AGENTLOOP_STATEFUL);
+    } catch (_e) {
+      return false;
+    }
+  }, []);
   return equals(workflowKind, 'agentic', true) || (equals(workflowKind, 'stateful', true) && isEnabledForStateful);
 };
 

--- a/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -23,13 +23,9 @@ export const useEdgeContextMenuData = () => {
 };
 
 export const useIsAgenticWorkflow = () => {
-  return useSelector((state: RootState) => {
-    const isEnabledForStateful = ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_AGENTLOOP_STATEFUL);
-    return (
-      equals(state.workflow.workflowKind, 'agentic', true) ||
-      (equals(state.workflow.workflowKind, 'stateful', true) && isEnabledForStateful)
-    );
-  });
+  const workflowKind = useSelector((state: RootState) => state.workflow.workflowKind);
+  const isEnabledForStateful = ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_AGENTLOOP_STATEFUL);
+  return equals(workflowKind, 'agentic', true) || (equals(workflowKind, 'stateful', true) && isEnabledForStateful);
 };
 
 export const useIsA2AWorkflow = () => {

--- a/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -1,4 +1,4 @@
-import { equals } from '@microsoft/logic-apps-shared';
+import { equals, EXP_FLAGS, ExperimentationService, SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
 import type { RootState } from '../../store';
 import { useSelector } from 'react-redux';
 
@@ -23,9 +23,21 @@ export const useEdgeContextMenuData = () => {
 };
 
 export const useIsAgenticWorkflow = () => {
-  return useSelector((state: RootState) => equals(state.workflow.workflowKind, 'agentic', false));
+  return useSelector((state: RootState) => {
+    const isEnabledForStateful = ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_AGENTLOOP_STATEFUL);
+    return (
+      equals(state.workflow.workflowKind, 'agentic', true) ||
+      (equals(state.workflow.workflowKind, 'stateful', true) && isEnabledForStateful)
+    );
+  });
 };
 
 export const useIsA2AWorkflow = () => {
   return useSelector((state: RootState) => equals(state.workflow.workflowKind, 'agent', false));
+};
+
+export const useWorkflowHasAgentLoop = () => {
+  return useSelector((state: RootState) => {
+    return Object.values(state.workflow.nodesMetadata).some((node) => node.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION);
+  });
 };

--- a/libs/designer/src/lib/ui/Designer.tsx
+++ b/libs/designer/src/lib/ui/Designer.tsx
@@ -1,7 +1,7 @@
 import { openPanel, useNodesInitialized } from '../core';
 import { usePreloadOperationsQuery, usePreloadConnectorsQuery } from '../core/queries/browse';
 import { useMonitoringView, useReadOnly, useHostOptions, useIsVSCode } from '../core/state/designerOptions/designerOptionsSelectors';
-import { useIsAgenticWorkflow, useIsA2AWorkflow } from '../core/state/designerView/designerViewSelectors';
+import { useIsA2AWorkflow, useWorkflowHasAgentLoop } from '../core/state/designerView/designerViewSelectors';
 import type { AppDispatch, RootState } from '../core/store';
 import Controls from './Controls';
 import Minimap from './Minimap';
@@ -81,12 +81,12 @@ export const Designer = (props: DesignerProps) => {
   );
 
   const isMonitoringView = useMonitoringView();
-  const isAgenticWorkflow = useIsAgenticWorkflow();
+  const workflowHasAgentLoop = useWorkflowHasAgentLoop();
   const isA2AWorkflow = useIsA2AWorkflow(); // Specifically A2A + Handoffs
 
   const hasChat = useMemo(() => {
-    return (isA2AWorkflow || isAgenticWorkflow) && isMonitoringView;
-  }, [isA2AWorkflow, isAgenticWorkflow, isMonitoringView]);
+    return workflowHasAgentLoop && isMonitoringView;
+  }, [isMonitoringView, workflowHasAgentLoop]);
 
   const DND_OPTIONS: any = {
     backends: [

--- a/libs/logic-apps-shared/src/designer-client-services/lib/experimentationFlags.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/experimentationFlags.ts
@@ -7,6 +7,7 @@ export const EXP_FLAGS = {
   ENABLE_NESTED_AGENT: 'enable-nested-agent',
   ENABLE_DYNAMIC_CONNECTIONS: 'enable-dynamic-connections',
   DISABLE_CHANNELS_AGENT_LOOP: 'disable-channels-agentloop',
+  ENABLE_AGENTLOOP_STATEFUL: 'enable-agentloop-stateful',
 };
 
 export async function enableParseDocumentWithMetadata(): Promise<boolean> {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Enable agent loop in stateful workflow behind FF

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users will be able to access/add agent loop in stateful workflow
- **Developers**: Need to make sure backend change for agent loop in stateful is deployment before removing the feature flag
- **System**: Agent loop is accessible in stateful workflows

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
