### PR TITLE
fix(Designer): File Picker not serializing after selecting item

### DIFF
--- a/libs/designer-ui/src/lib/picker/filepickerEditor.tsx
+++ b/libs/designer-ui/src/lib/picker/filepickerEditor.tsx
@@ -94,7 +94,16 @@ export const FilePickerEditor = ({
     }
     if (showPicker) {
       setSelectedItem(selectedItem.value);
-      setPickerDisplayValue([createLiteralValueSegment(getDisplayValueFromSelectedItem(selectedItem.value))]);
+      const displayValue = getDisplayValueFromSelectedItem(selectedItem.value);
+      setPickerDisplayValue([createLiteralValueSegment(displayValue)]);
+
+      editorBlur?.({
+        value: [createLiteralValueSegment(getValueFromSelectedItem(selectedItem.value))],
+        viewModel: {
+          displayValue,
+          selectedItem: selectedItem.value,
+        },
+      });
       setShowPicker(false);
 
       LoggerService().log({


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Previously editor was being focused and thus onBlur would cause serialization. However, seemed to be a regression to not cause the editor blur. Instead moving the logic to happen on file/folder selection.

Fixes https://github.com/Azure/LogicAppsUX/issues/8045

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes a bug causing the filepicker editor to not serialize after selecting a folder
- **Developers**: no dev changes
- **System**: no system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@eric-b-wu

## Screenshots/Videos
<!-- Visual changes only -->
