### PR TITLE
chore(Designer): Adding telemetry for grantType allowedValues length not one

### DIFF
--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -36,6 +36,8 @@ import {
   isEmptyString,
   customLengthGuid,
   ExtensionProperties,
+  LoggerService,
+  LogEntryLevel,
 } from '@microsoft/logic-apps-shared';
 import type {
   GatewayServiceConfig,
@@ -463,7 +465,18 @@ export const CreateConnection = (props: CreateConnectionProps) => {
       const servicePrincipalValue = SERVICE_PRINCIPLE_CONSTANTS.GRANT_TYPE_VALUES.CLIENT_CREDENTIALS;
       let outputGrantType = oauthValue;
       if (isMultiAuth) {
-        const allowedValue = (grantTypeParameter as ConnectionParameterSetParameter)?.allowedValues?.[0];
+        const allowedValues = (grantTypeParameter as ConnectionParameterSetParameter)?.allowedValues;
+        const allowedValue = allowedValues?.[0];
+
+        if (allowedValues?.length !== 1) {
+          LoggerService().log({
+            level: LogEntryLevel.Warning,
+            area: 'createConnection.onCreate',
+            message: 'grantTypeParameter allowedValue is not a single value',
+            args: [`connectorId:${connectorId}`, `allowedValues:${allowedValues?.map((v) => v.value)?.join(',')}`],
+          });
+        }
+
         if (allowedValue) {
           outputGrantType = allowedValue?.value;
         }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [X] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [X] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Adding telemetry log for warning in case there is more than one allowedValues for the grantType, since we are parsing to take the first value of the allowedValue

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: none
- **Developers**: none
- **System**: none

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@preetriti1 

## Screenshots/Videos
<!-- Visual changes only -->
