### PR TITLE
chore(vscode): disable codeful workflow creation option

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/NewCodeProjectTypeStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/NewCodeProjectTypeStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { WorkflowStateTypeStep } from '../../createCodeless/createCodelessSteps/WorkflowStateTypeStep';
 import { WorkflowProjectCreateStep } from '../../createNewProject/createProjectSteps/WorkflowProjectCreateStep';
-import { WorkflowCodeTypeStep } from '../../createWorkflow/WorkflowCodeTypeStep';
+// import { WorkflowCodeTypeStep } from '../../createWorkflow/WorkflowCodeTypeStep';
 import { addInitVSCodeSteps } from '../../initProjectForVSCode/InitVSCodeLanguageStep';
 import { FunctionAppFilesStep } from '../createCodeProjectSteps/createFunction/FunctionAppFilesStep';
 import { FunctionAppNameStep } from '../createCodeProjectSteps/createFunction/FunctionAppNameStep';
@@ -137,14 +137,15 @@ export class NewCodeProjectTypeStep extends AzureWizardPromptStep<IProjectWizard
     await addInitVSCodeSteps(context, executeSteps, false);
 
     if (!this.skipWorkflowStateTypeStep) {
-      promptSteps.push(
-        // disabling in main
-        await WorkflowCodeTypeStep.create(context, {
-          isProjectWizard: true,
-          templateId: this.templateId,
-          triggerSettings: this.functionSettings,
-        })
-      );
+      context.isCodeless = true; // default to codeless workflow, disabling codeful option
+      // promptSteps.push(
+      //   // disabling in main
+      //   await WorkflowCodeTypeStep.create(context, {
+      //     isProjectWizard: true,
+      //     templateId: this.templateId,
+      //     triggerSettings: this.functionSettings,
+      //   })
+      // );
       promptSteps.push(
         await WorkflowStateTypeStep.create(context, {
           isProjectWizard: true,


### PR DESCRIPTION
## Commit Type
- [x] chore - Maintenance/tooling

## Risk Level  
- [x] Low - Minor changes, limited scope

## What & Why
Disables the codeful workflow creation option in the VS Code extension by defaulting to codeless workflows and commenting out the WorkflowCodeTypeStep prompt. This removes the user choice between codeful and codeless workflow types during project creation.

## Impact of Change
- **Users**: Users can no longer create codeful workflows through VS Code extension - only codeless workflows are available
- **Developers**: WorkflowCodeTypeStep import and usage commented out, context.isCodeless forced to true
- **System**: Reduces complexity in workflow creation flow by removing one option path

## Test Plan
- [ ] Unit tests added/updated  
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: VS Code extension workflow creation flow

## Contributors

## Screenshots/Videos