### PR TITLE
fix(vscode): Changed validate call on workflow save to use saved data instead of panel metadata

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -217,8 +217,16 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
             this.panelMetadata.azureDetails?.tenantId,
             this.panelMetadata.azureDetails?.workflowManagementBaseUrl
           );
-          const localSettingsValues = (await getLocalSettingsJson(activateContext, localSettingsPath, true)).Values || {};
-          await this.validateWorkflow(activateContext, JSON.parse(readFileSync(this.workflowFilePath, 'utf8')), localSettingsValues);
+          const savedLocalSettingsValues = (await getLocalSettingsJson(activateContext, localSettingsPath, true)).Values || {};
+          let savedWorkflow: any;
+
+          try {
+            savedWorkflow = JSON.parse(readFileSync(this.workflowFilePath, 'utf8'));
+          } catch (error) {
+            window.showErrorMessage(`Failed to parse workflow file as JSON: ${(error as Error).message}`);
+          }
+
+          await this.validateWorkflow(activateContext, savedWorkflow, savedLocalSettingsValues);
         });
         break;
       }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x ] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixes an issue where data being passed to the validatePartial API route would not pick up data recently saved in the same designer session.

This addresses https://github.com/Azure/LogicAppsUX/issues/7968

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any --> Most
- **Developers**: <!-- API changes, new patterns, etc. --> NA
- **System**: <!-- Performance, architecture, dependencies --> NA

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
