### PR TITLE
fix(vscode): Add lock to prevent simultaneous start multiple design time inst on same project

### DIFF
--- a/apps/vs-code-designer/src/app/commands/dataMapper/FxWorkflowRuntime.ts
+++ b/apps/vs-code-designer/src/app/commands/dataMapper/FxWorkflowRuntime.ts
@@ -73,7 +73,7 @@ export async function startBackendRuntime(projectPath: string, context: IActionC
         const portArgs = `--port ${designTimeInst.port}`;
         startDesignTimeProcess(ext.outputChannel, cwd, getFunctionsCommand(), 'host', 'start', portArgs);
 
-        await waitForDesignTimeStartUp(projectPath, url, new Date().getTime());
+        await waitForDesignTimeStartUp(projectPath, url, new Date().getTime(), true);
       } else {
         throw new Error("Workflow folder doesn't exist");
       }

--- a/apps/vs-code-designer/src/extensionVariables.ts
+++ b/apps/vs-code-designer/src/extensionVariables.ts
@@ -36,6 +36,7 @@ type DesignTimeInstance = {
   process?: cp.ChildProcess;
   childFuncPid?: string;
   port?: number;
+  isStarting?: boolean;
 };
 
 // biome-ignore lint/style/noNamespace:


### PR DESCRIPTION

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Add lock to fix issue where opening the designer too quickly on startup results in multiple design time instances being started for the same project simultaneously, resulting in unnecessary design time restarts

## Impact of Change
- **Users**: Reduce latency when opening designer immediately on startup, avoid unnecessary design time restarts
- **Developers**: N/A
- **System**: N/A

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge 
