### PR TITLE
fix(localization): Remove duplicate entries from language files

### DIFF
--- a/Localize/loc/de/strings.json.lcl
+++ b/Localize/loc/de/strings.json.lcl
@@ -20380,7 +20380,6 @@
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
-      <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Search...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">

--- a/Localize/loc/ja/strings.json.lcl
+++ b/Localize/loc/ja/strings.json.lcl
@@ -20350,7 +20350,6 @@
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
-      <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Search...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">

--- a/Localize/loc/ko/strings.json.lcl
+++ b/Localize/loc/ko/strings.json.lcl
@@ -20350,7 +20350,6 @@
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
-      <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Search...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">

--- a/Localize/loc/pt-BR/strings.json.lcl
+++ b/Localize/loc/pt-BR/strings.json.lcl
@@ -20398,7 +20398,6 @@
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
-      <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Search...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">

--- a/Localize/loc/ru/strings.json.lcl
+++ b/Localize/loc/ru/strings.json.lcl
@@ -20422,7 +20422,6 @@
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
-      <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Search...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">

--- a/Localize/loc/tr/strings.json.lcl
+++ b/Localize/loc/tr/strings.json.lcl
@@ -20374,7 +20374,6 @@
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
-      <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Search...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">

--- a/Localize/loc/zh-Hans/strings.json.lcl
+++ b/Localize/loc/zh-Hans/strings.json.lcl
@@ -20350,7 +20350,6 @@
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
-      <Item ItemId=";w3BZ0u" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Search...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Removes duplicate entries found in localization files across multiple language files. These duplicates could cause conflicts and inconsistencies in the translation system.

## Impact of Change
- **Users**: None (no user-facing change)
- **Developers**: Reduced noise in localization files; decreased possibility of key collisions
- **System**: Slightly cleaner localization dictionary; no runtime/system impact

## Test Plan
- [x] Manual testing completed
- **Tested in**: Verified application strings load with no missing keys after duplicate removal

## Contributors
@ccastrotrejo

## Screenshots/Videos
N/A - Internal file cleanup