### PR TITLE
fix(vscode): Handle null node parameter in custom code functions build process

### DIFF
--- a/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
+++ b/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
@@ -12,6 +12,7 @@ import {
   tryGetLogicAppCustomCodeFunctionsProjects,
 } from '../utils/customCodeUtils';
 import * as vscode from 'vscode';
+import { isNullOrUndefined } from '@microsoft/logic-apps-shared';
 
 /**
  * Builds a custom code functions project.
@@ -20,11 +21,18 @@ import * as vscode from 'vscode';
  * @returns {Promise<void>} - A promise that resolves when the build process is complete.
  */
 export async function buildCustomCodeFunctionsProject(context: IActionContext, node: vscode.Uri): Promise<void> {
+  const workspaceFolderPath = await getWorkspaceRoot(context);
+
+  const nodePath = node?.fsPath || workspaceFolderPath;
+  if (isNullOrUndefined(nodePath)) {
+    return;
+  }
+
   context.telemetry.properties.lastStep = 'isCustomCodeFunctionsProject';
-  if (await isCustomCodeFunctionsProject(node.fsPath)) {
+  if (await isCustomCodeFunctionsProject(nodePath)) {
     try {
       context.telemetry.properties.lastStep = 'buildCustomCodeProject';
-      await buildCustomCodeProject(node.fsPath);
+      await buildCustomCodeProject(nodePath);
       context.telemetry.properties.result = 'Succeeded';
     } catch (error) {
       context.telemetry.properties.result = 'Failed';
@@ -34,12 +42,12 @@ export async function buildCustomCodeFunctionsProject(context: IActionContext, n
   }
 
   context.telemetry.properties.lastStep = 'tryGetLogicAppCustomCodeFunctionsProjects';
-  const customCodeProjectPaths = await tryGetLogicAppCustomCodeFunctionsProjects(node.fsPath);
+  const customCodeProjectPaths = await tryGetLogicAppCustomCodeFunctionsProjects(nodePath);
   if (!customCodeProjectPaths || customCodeProjectPaths.length === 0) {
     const errorMessage = 'No custom code functions projects found for the logic app folder "{0}".';
     context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.error = errorMessage.replace('{0}', node.fsPath);
-    ext.outputChannel.appendLog(localize('azureLogicAppsStandard.noCustomCodeFunctionsProjectsFound', errorMessage, node.fsPath));
+    context.telemetry.properties.error = errorMessage.replace('{0}', nodePath);
+    ext.outputChannel.appendLog(localize('azureLogicAppsStandard.noCustomCodeFunctionsProjectsFound', errorMessage, nodePath));
     return;
   }
 

--- a/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
+++ b/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
@@ -25,6 +25,10 @@ export async function buildCustomCodeFunctionsProject(context: IActionContext, n
 
   const nodePath = node?.fsPath || workspaceFolderPath;
   if (isNullOrUndefined(nodePath)) {
+    const errorMessage = localize('noProjectPathBuildCustomCode', 'No project path found to build custom code functions project.');
+    context.telemetry.properties.result = 'Failed';
+    context.telemetry.properties.error = errorMessage;
+    ext.outputChannel.appendLog(errorMessage);
     return;
   }
 

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { workflowFileName } from '../../constants';
 import { localize } from '../../localize';
-import type { RemoteWorkflowTreeItem } from '../tree/remoteWorkflowsTree/RemoteWorkflowTreeItem';
 import { isPathEqual, isSubpath } from './fs';
 import {
   isLogicAppProject,
@@ -301,11 +300,11 @@ async function selectLogicAppWorkspaceFolderWithoutCustomCode(
  * @param {vscode.Uri | undefined} node - Workflow node.
  * @returns {vscode.Uri | undefined} Workflow node.
  */
-export const getWorkflowNode = (node: vscode.Uri | RemoteWorkflowTreeItem | undefined): vscode.Uri | RemoteWorkflowTreeItem | undefined => {
+export const getWorkflowNode = <T>(node: T): T => {
   if (isNullOrUndefined(node)) {
     const activeFile = vscode?.window?.activeTextEditor?.document;
     if (activeFile?.fileName.endsWith(workflowFileName)) {
-      return activeFile.uri;
+      return activeFile.uri as T;
     }
   }
 

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { workflowFileName } from '../../constants';
 import { localize } from '../../localize';
+import type { RemoteWorkflowTreeItem } from '../tree/remoteWorkflowsTree/RemoteWorkflowTreeItem';
 import { isPathEqual, isSubpath } from './fs';
 import {
   isLogicAppProject,
@@ -300,11 +301,11 @@ async function selectLogicAppWorkspaceFolderWithoutCustomCode(
  * @param {vscode.Uri | undefined} node - Workflow node.
  * @returns {vscode.Uri | undefined} Workflow node.
  */
-export const getWorkflowNode = <T>(node: T): T => {
+export const getWorkflowNode = (node: vscode.Uri | RemoteWorkflowTreeItem | undefined): vscode.Uri | RemoteWorkflowTreeItem | undefined => {
   if (isNullOrUndefined(node)) {
     const activeFile = vscode?.window?.activeTextEditor?.document;
     if (activeFile?.fileName.endsWith(workflowFileName)) {
-      return activeFile.uri as T;
+      return activeFile.uri;
     }
   }
 


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Fixes an issue in the build custom code functions process where the function would fail when the node parameter is null or undefined. Added proper null checking and fallback to workspace root path to prevent build failures.

## Impact of Change
- **Users**: Improved reliability when building custom code functions - build process will no longer fail unexpectedly
- **Developers**: More robust error handling in VS Code extension build commands
- **System**: No impact on runtime, only improves build stage reliability

## Test Plan
- [x] Manual testing completed
- **Tested in**: VS Code extension with custom code functions projects, verified build process works with and without valid node parameters

## Contributors
@ccastrotrejo

## Screenshots/Videos
N/A - Internal build process improvement