### PR TITLE
fix(Designer): Fixed root node run-after setting in scopes (5.165)

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -459,11 +459,12 @@ const serializeSwaggerBasedOperation = async (rootState: RootState, operationId:
   const operationInfo = getRecordEntry(rootState.operations.operationInfo, operationId) as NodeOperation;
   const { type, kind } = operationInfo;
   const isTrigger = isTriggerNode(operationId, rootState.workflow.nodesMetadata);
+  const isRoot = isRootNode(operationId, rootState.workflow.nodesMetadata);
   const inputsToSerialize = getOperationInputsToSerialize(rootState, operationId);
   const nodeSettings = getRecordEntry(rootState.operations.settings, operationId) ?? {};
   const nodeStaticResults = getRecordEntry(rootState.operations.staticResults, operationId) ?? ({} as NodeStaticResults);
   const operationFromWorkflow = getRecordEntry(rootState.workflow.operations, operationId) as LogicAppsV2.OperationDefinition;
-  const runAfter = isTrigger ? undefined : getRunAfter(operationFromWorkflow, idReplacements);
+  const runAfter = isRoot ? undefined : getRunAfter(operationFromWorkflow, idReplacements);
   const recurrence =
     isTrigger && equals(type, Constants.NODE.TYPE.API_CONNECTION)
       ? constructInputValues('recurrence.$.recurrence', inputsToSerialize, false /* encodePathComponents */)


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixed a root node run-after setting bug.
Recently we switched `isTrigger` to be separate from our `isRoot` flag in this PR: https://github.com/Azure/LogicAppsUX/pull/8084
There was one spot where we were previously checking for isRoot but were calling it isTrigger, so I swapped it out to only happen on triggers when it needed to happen on all root nodes.
This has been fixed in this PR.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users will no longer get a validation error when saving workflows with "shared" nodes inside scopes
- **Developers**: No change
- **System**: No change

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97, @edwardyhe
