### PR TITLE
fix(Designer): Search Service use API ID instead of name for operation grouping

### DIFF
--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationGroupDetails/searchResult/searchResult.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationGroupDetails/searchResult/searchResult.tsx
@@ -7,7 +7,7 @@ import { SearchResultSortOptions } from '../../../types';
 import { OperationSearchGroup } from '../../operationSearchGroup';
 import { List } from '@fluentui/react';
 import { Spinner, Text } from '@fluentui/react-components';
-import type { DiscoveryOpArray, OperationApi } from '@microsoft/logic-apps-shared';
+import type { DiscoveryOpArray } from '@microsoft/logic-apps-shared';
 import type { PropsWithChildren } from 'react';
 import React, { useMemo } from 'react';
 import { useIntl } from 'react-intl';
@@ -50,35 +50,30 @@ export const SearchResultsGrid: React.FC<PropsWithChildren<SearchResultsGridProp
 
   const [resultsSorting, setResultsSorting] = React.useState<SearchResultSortOption>(SearchResultSortOptions.unsorted);
 
-  const getApiNameWithFallback = (api: OperationApi): string => {
-    return api.name ?? api.id;
-  };
-
-  const apiNames = useMemo(
+  const apiIds = useMemo(
     () =>
-      Array.from(
-        new Set(
-          operationSearchResults
-            .filter((r) => r !== undefined)
-            .map((res) => getApiNameWithFallback(res.properties.api))
-            .sort((a, b) =>
-              resultsSorting === SearchResultSortOptions.unsorted
-                ? 0
-                : resultsSorting === SearchResultSortOptions.ascending
-                  ? a.localeCompare(b)
-                  : b.localeCompare(a)
-            )
-        )
-      ),
+      Array.from(new Set(operationSearchResults.filter((r) => r !== undefined).map((res) => res.properties.api.id))).sort((a, b) => {
+        if (resultsSorting === SearchResultSortOptions.unsorted) {
+          return 0;
+        }
+
+        // Get display names for sorting
+        const aApi = operationSearchResults.find((res) => res.properties.api.id === a)?.properties.api;
+        const bApi = operationSearchResults.find((res) => res.properties.api.id === b)?.properties.api;
+        const aName = aApi?.displayName ?? aApi?.name ?? a;
+        const bName = bApi?.displayName ?? bApi?.name ?? b;
+
+        return resultsSorting === SearchResultSortOptions.ascending ? aName.localeCompare(bName) : bName.localeCompare(aName);
+      }),
     [operationSearchResults, resultsSorting]
   );
 
   const onRenderOperationGroup = React.useCallback(
-    (apiName: string | undefined, _index: number | undefined) => {
-      if (!apiName) {
+    (apiId: string | undefined, _index: number | undefined) => {
+      if (!apiId) {
         return;
       }
-      const operations = operationSearchResults.filter((res) => res?.properties.api.name === apiName);
+      const operations = operationSearchResults.filter((res) => res?.properties.api.id === apiId);
       if (operations.length === 0) {
         return null;
       }
@@ -86,7 +81,7 @@ export const SearchResultsGrid: React.FC<PropsWithChildren<SearchResultsGridProp
       return (
         <div style={{ marginBottom: '24px' }}>
           <OperationSearchGroup
-            key={apiName}
+            key={apiId}
             operationApi={api}
             operationActionsData={operations.map((operation) => getOperationCardDataFromOperation(operation))}
             onConnectorClick={onConnectorClick}
@@ -186,8 +181,8 @@ export const SearchResultsGrid: React.FC<PropsWithChildren<SearchResultsGridProp
       )}
       {groupByConnector ? (
         <>
-          <AriaSearchResultsAlert resultCount={apiNames.length} resultDescription={connectorText} />
-          <List items={apiNames} onRenderCell={onRenderOperationGroup} />
+          <AriaSearchResultsAlert resultCount={apiIds.length} resultDescription={connectorText} />
+          <List items={apiIds} onRenderCell={onRenderOperationGroup} />
         </>
       ) : (
         <>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->

  Fix bug where operations with the same name from different connectors were being incorrectly merged together
   in search results. The issue occurred because operations were being grouped by API name instead of API ID,
  causing conflicts when different connectors had operations with identical names (e.g., "putQueue" from both
  Azure Queue Storage Service Provider and Azure Queues Managed API).

## Impact of Change
<!-- Who/what is affected? -->
- **Users**:  Search results now correctly group operations by their unique connector, preventing operations from
   different connectors being mixed together
- **Developers**:  Operation grouping logic now uses api.id as the unique identifier instead of api.name
- **System**: More accurate search result rendering and proper connector-based operation organization

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@hartra344

## Screenshots/Videos
<!-- Visual changes only -->
