### PR TITLE
fix(designer): Simple Query builder to initialize in Basic Mode

### DIFF
--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -625,7 +625,7 @@ export const toSimpleQueryBuilderViewModel = (
   itemValue: RowItemProps | undefined;
   isRowFormat: boolean;
 } => {
-  if (!input || input?.length === 0) {
+  if (!input?.length) {
     return {
       isOldFormat: true,
       isRowFormat: true,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
When users select a parameter with the simple query builder, we want to initialize in basic mode instead of advanced mode. Fixes https://github.com/Azure/LogicAppsUX/issues/7869

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Most users end up using "Basic" mode, so this fixes ease-of-use
- **Developers**: no dev changes
- **System**: no system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@Eric-B-Wu

## Screenshots/Videos
<!-- Visual changes only -->
