### PR TITLE
Add single flag to enable/disable Codeful feature in VS Code Designer

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/NewCodeProjectTypeStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/NewCodeProjectTypeStep.ts
@@ -6,7 +6,6 @@ import { ext } from '../../../../extensionVariables';
 import { WorkflowStateTypeStep } from '../../createCodeless/createCodelessSteps/WorkflowStateTypeStep';
 import { WorkflowProjectCreateStep } from '../../createNewProject/createProjectSteps/WorkflowProjectCreateStep';
 import { WorkflowCodeTypeStep } from '../../createWorkflow/WorkflowCodeTypeStep';
-// import { WorkflowCodeTypeStep } from '../../createWorkflow/WorkflowCodeTypeStep';
 import { addInitVSCodeSteps } from '../../initProjectForVSCode/InitVSCodeLanguageStep';
 import { FunctionAppFilesStep } from '../createCodeProjectSteps/createFunction/FunctionAppFilesStep';
 import { FunctionAppNameStep } from '../createCodeProjectSteps/createFunction/FunctionAppNameStep';

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/NewCodeProjectTypeStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/NewCodeProjectTypeStep.ts
@@ -2,8 +2,10 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { ext } from '../../../../extensionVariables';
 import { WorkflowStateTypeStep } from '../../createCodeless/createCodelessSteps/WorkflowStateTypeStep';
 import { WorkflowProjectCreateStep } from '../../createNewProject/createProjectSteps/WorkflowProjectCreateStep';
+import { WorkflowCodeTypeStep } from '../../createWorkflow/WorkflowCodeTypeStep';
 // import { WorkflowCodeTypeStep } from '../../createWorkflow/WorkflowCodeTypeStep';
 import { addInitVSCodeSteps } from '../../initProjectForVSCode/InitVSCodeLanguageStep';
 import { FunctionAppFilesStep } from '../createCodeProjectSteps/createFunction/FunctionAppFilesStep';
@@ -137,15 +139,19 @@ export class NewCodeProjectTypeStep extends AzureWizardPromptStep<IProjectWizard
     await addInitVSCodeSteps(context, executeSteps, false);
 
     if (!this.skipWorkflowStateTypeStep) {
-      context.isCodeless = true; // default to codeless workflow, disabling codeful option
-      // promptSteps.push(
-      //   // disabling in main
-      //   await WorkflowCodeTypeStep.create(context, {
-      //     isProjectWizard: true,
-      //     templateId: this.templateId,
-      //     triggerSettings: this.functionSettings,
-      //   })
-      // );
+      if (ext.codefulEnabled) {
+        promptSteps.push(
+          //   disabling in main
+          await WorkflowCodeTypeStep.create(context, {
+            isProjectWizard: true,
+            templateId: this.templateId,
+            triggerSettings: this.functionSettings,
+          })
+        );
+      } else {
+        context.isCodeless = true; // default to codeless workflow, disabling codeful option
+      }
+
       promptSteps.push(
         await WorkflowStateTypeStep.create(context, {
           isProjectWizard: true,

--- a/apps/vs-code-designer/src/app/commands/createWorkflow/createWorkflow.ts
+++ b/apps/vs-code-designer/src/app/commands/createWorkflow/createWorkflow.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { projectTemplateKeySetting } from '../../../constants';
+import { ext } from '../../../extensionVariables';
 import { getProjFiles } from '../../utils/dotnet/dotnet';
 import { addLocalFuncTelemetry, checkSupportedFuncVersion } from '../../utils/funcCoreTools/funcVersion';
 import { verifyAndPromptToCreateProject } from '../../utils/verifyIsProject';
@@ -70,7 +71,16 @@ export async function createWorkflow(
     projectTemplateKey,
   });
 
-  // wizardContext.isCodeless = true; // default to codeless workflow, disabling codeful option until Public Preview
+  // default to codeless workflow, disabling codeful option until Public Preview
+  // Check if codeful is enabled
+  if (ext.codefulEnabled) {
+    // Codeful workflows are enabled
+    context.telemetry.properties.codefulEnabled = 'true';
+  } else {
+    // Default to codeless workflow
+    wizardContext.isCodeless = true;
+    context.telemetry.properties.codefulEnabled = 'false';
+  }
 
   const wizard: AzureWizard<IFunctionWizardContext> = new AzureWizard(wizardContext, {
     promptSteps: [

--- a/apps/vs-code-designer/src/extensionVariables.ts
+++ b/apps/vs-code-designer/src/extensionVariables.ts
@@ -42,6 +42,7 @@ type DesignTimeInstance = {
 // biome-ignore lint/style/noNamespace:
 export namespace ext {
   export let context: ExtensionContext;
+  export let codefulEnabled: boolean;
   export const designTimeInstances: Map<string, DesignTimeInstance> = new Map();
   export let workflowDotNetProcess: cp.ChildProcess | undefined;
   export let workflowNodeProcess: cp.ChildProcess | undefined;

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -81,6 +81,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   ext.context = context;
+  ext.codefulEnabled = true; // flag that prevents codeful use until public preview
   ext.extensionVersion = getExtensionVersion();
   ext.telemetryReporter = new TelemetryReporter(telemetryString);
   context.subscriptions.push(ext.telemetryReporter);


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Confusing to enable and disable codeful in two separate sections- now simple flag in main.ts can be easily changed

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: none
- **Developers**: easier to enable and disable codeful create options
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
