### PR TITLE
feat(Clone): Adding resource services and connecting handleClone call with props

### DIFF
--- a/apps/Standalone/src/clonetostandard/app/clonetostandard.tsx
+++ b/apps/Standalone/src/clonetostandard/app/clonetostandard.tsx
@@ -5,7 +5,9 @@ import { useMcpStandardStyles } from './styles';
 import { ArmParser } from '../../designer/app/AzureLogicAppsDesigner/Utilities/ArmParser';
 import { useWorkflowAndArtifactsConsumption } from '../../designer/app/AzureLogicAppsDesigner/Services/WorkflowAndArtifacts';
 import { WorkflowUtility } from '../../designer/app/AzureLogicAppsDesigner/Utilities/Workflow';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
+import { BaseResourceService } from '@microsoft/logic-apps-shared';
+import { HttpClient } from '../../designer/app/AzureLogicAppsDesigner/Services/HttpClient';
 
 export const CloneToStandard = () => {
   const styles = useMcpStandardStyles();
@@ -24,6 +26,8 @@ export const CloneToStandard = () => {
     console.log('Close button clicked');
   }, []);
 
+  const services = useMemo(() => getServices(), []);
+
   return (
     <CloneWizardProvider locale="en-US" theme={theme}>
       <div className={`${styles.container} ${styles.fadeIn}`}>
@@ -37,6 +41,7 @@ export const CloneToStandard = () => {
                   logicAppName: resourceDetails.resourceName,
                   location: canonicalLocation,
                 }}
+                services={services}
               >
                 <CloneWizard onExportCall={onExportCall} onClose={onClose} />
                 <div id="mcp-layer-host" className={styles.layerHost} />
@@ -47,4 +52,17 @@ export const CloneToStandard = () => {
       </div>
     </CloneWizardProvider>
   );
+};
+
+const apiVersion = '2020-06-01';
+const httpClient = new HttpClient();
+
+const getServices = (): any => {
+  const armUrl = 'https://management.azure.com';
+
+  const resourceService = new BaseResourceService({ baseUrl: armUrl, httpClient, apiVersion });
+
+  return {
+    resourceService,
+  };
 };

--- a/apps/Standalone/src/clonetostandard/app/clonetostandard.tsx
+++ b/apps/Standalone/src/clonetostandard/app/clonetostandard.tsx
@@ -17,10 +17,15 @@ export const CloneToStandard = () => {
 
   const resourceDetails = new ArmParser(workflowId ?? '');
 
-  //TODO: props passed in will be defined to be defined later on api integration
-  const onExportCall = useCallback(async () => {
-    console.log('TODO: on submit');
-  }, []);
+  const onExportCall = useCallback(
+    async (
+      sourceApps: { subscriptionId: string; resourceGroup: string; logicAppName: string }[],
+      destinationApp: { subscriptionId: string; resourceGroup: string; logicAppName: string }
+    ) => {
+      console.log('TODO: on submit', sourceApps, destinationApp);
+    },
+    []
+  );
 
   const onClose = useCallback(() => {
     console.log('Close button clicked');
@@ -43,7 +48,7 @@ export const CloneToStandard = () => {
                 }}
                 services={services}
               >
-                <CloneWizard onExportCall={onExportCall} onClose={onClose} />
+                <CloneWizard onCloneCall={onExportCall} onClose={onClose} />
                 <div id="mcp-layer-host" className={styles.layerHost} />
               </CloneDataProvider>
             </div>

--- a/libs/designer/src/lib/core/actions/bjsworkflow/clone.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/clone.ts
@@ -1,0 +1,32 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import {
+  DevLogger,
+  type ILoggerService,
+  InitLoggerService,
+  InitResourceService,
+  type IResourceService,
+} from '@microsoft/logic-apps-shared';
+
+export interface CloneServiceOptions {
+  resourceService?: IResourceService;
+  loggerService?: ILoggerService;
+}
+
+export const initializeCloneServices = createAsyncThunk('initializeCloneServices', async (services: CloneServiceOptions) => {
+  initializeServices(services);
+  const loggerServices: ILoggerService[] = [];
+  if (services.loggerService) {
+    loggerServices.push(services.loggerService);
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    loggerServices.push(new DevLogger());
+  }
+  InitLoggerService(loggerServices);
+  return true;
+});
+
+const initializeServices = ({ resourceService }: CloneServiceOptions) => {
+  if (resourceService) {
+    InitResourceService(resourceService);
+  }
+};

--- a/libs/designer/src/lib/core/clonetostandard/clonedataprovider.tsx
+++ b/libs/designer/src/lib/core/clonetostandard/clonedataprovider.tsx
@@ -1,11 +1,13 @@
 import type React from 'react';
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
-import type { AppDispatch } from '../state/clonetostandard/store';
+import { useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from '../state/clonetostandard/store';
 import { type ResourceState, setResourceData } from '../state/clonetostandard/resourceslice';
+import { initializeCloneServices, type CloneServiceOptions } from '../actions/bjsworkflow/clone';
 
 export interface ExportDataProviderProps {
   resourceDetails: ResourceState;
+  services: CloneServiceOptions;
   children?: React.ReactNode;
 }
 
@@ -13,12 +15,25 @@ const DataProviderInner = ({ children }: { children?: React.ReactNode }) => {
   return <>{children}</>;
 };
 
-export const CloneDataProvider = ({ resourceDetails, children }: ExportDataProviderProps) => {
+export const CloneDataProvider = ({ resourceDetails, services, children }: ExportDataProviderProps) => {
   const dispatch = useDispatch<AppDispatch>();
+  const { servicesInitialized } = useSelector((state: RootState) => ({
+    servicesInitialized: state.cloneOptions.servicesInitialized,
+  }));
+
+  useEffect(() => {
+    if (!servicesInitialized) {
+      dispatch(initializeCloneServices(services));
+    }
+  }, [dispatch, servicesInitialized, services]);
 
   useEffect(() => {
     dispatch(setResourceData(resourceDetails));
   }, [dispatch, resourceDetails]);
+
+  if (!servicesInitialized) {
+    return null;
+  }
 
   return <DataProviderInner>{children}</DataProviderInner>;
 };

--- a/libs/designer/src/lib/core/state/clonetostandard/cloneoptionsslice.ts
+++ b/libs/designer/src/lib/core/state/clonetostandard/cloneoptionsslice.ts
@@ -1,0 +1,28 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { initializeCloneServices } from '../../../core/actions/bjsworkflow/clone';
+import { resetCloneState } from '../global';
+
+export interface McpOptionsState {
+  servicesInitialized: boolean;
+  disableConfiguration: boolean;
+  reInitializeServices?: boolean;
+}
+
+const initialState: McpOptionsState = {
+  servicesInitialized: false,
+  disableConfiguration: true,
+};
+
+export const cloneOptionsSlice = createSlice({
+  name: 'cloneOptions',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(resetCloneState, () => initialState);
+    builder.addCase(initializeCloneServices.fulfilled, (state, action) => {
+      state.servicesInitialized = action.payload;
+    });
+  },
+});
+
+export default cloneOptionsSlice.reducer;

--- a/libs/designer/src/lib/core/state/clonetostandard/cloneslice.ts
+++ b/libs/designer/src/lib/core/state/clonetostandard/cloneslice.ts
@@ -40,7 +40,7 @@ export const cloneSlice = createSlice({
       state.destinationApp.resourceGroup = action.payload;
     },
     setDestinationWorkflowAppDetails: (state, action: PayloadAction<{ name: string; location: string }>) => {
-      state.destinationApp.workflowAppName = action.payload.name;
+      state.destinationApp.logicAppName = action.payload.name;
       state.destinationApp.location = action.payload.location;
     },
   },

--- a/libs/designer/src/lib/core/state/clonetostandard/store.ts
+++ b/libs/designer/src/lib/core/state/clonetostandard/store.ts
@@ -1,10 +1,12 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import resourceReducer from './resourceslice';
 import cloneReducer from './cloneslice';
+import cloneOptionsReducer from './cloneoptionsslice';
 
 const rootReducer = combineReducers({
   resource: resourceReducer,
   clone: cloneReducer,
+  cloneOptions: cloneOptionsReducer,
 });
 
 export const setupStore = (preloadedState?: Partial<RootState>) => {

--- a/libs/designer/src/lib/core/state/global.ts
+++ b/libs/designer/src/lib/core/state/global.ts
@@ -11,6 +11,7 @@ export const resetNodesLoadStatus = createAction('resetNodesLoadStatus');
 export const setStateAfterUndoRedo = createAction<UndoRedoPartialRootState>('setStateAfterUndoRedo');
 export const resetTemplatesState = createAction('resetTemplatesState');
 export const resetMcpState = createAction('resetMcpState');
+export const resetCloneState = createAction('resetCloneState');
 
 export const useIsDesignerDirty = () => {
   const isWorkflowDirty = useIsWorkflowDirty();

--- a/libs/designer/src/lib/ui/clonetostandard/resourcepicker.tsx
+++ b/libs/designer/src/lib/ui/clonetostandard/resourcepicker.tsx
@@ -27,8 +27,8 @@ export const CloneResourcePicker = () => {
       onSubscriptionSelect={(value) => dispatch(setDestinationSubscription(value))}
       onResourceGroupSelect={(value) => dispatch(setDestinationResourceGroup(value))}
       onLocationSelect={(_value) => {}}
-      onLogicAppSelect={(value) => dispatch(setDestinationWorkflowAppDetails(value))}
-      onLogicAppInstanceSelect={(_value) => {}}
+      onLogicAppSelect={(_value) => {}}
+      onLogicAppInstanceSelect={(value) => dispatch(setDestinationWorkflowAppDetails(value))}
     />
   );
 };

--- a/libs/designer/src/lib/ui/clonetostandard/wizard/clonewizard.tsx
+++ b/libs/designer/src/lib/ui/clonetostandard/wizard/clonewizard.tsx
@@ -2,17 +2,44 @@ import { Button, Field, Text } from '@fluentui/react-components';
 import type { RootState } from '../../../core/state/clonetostandard/store';
 import { useSelector } from 'react-redux';
 import { CloneResourcePicker } from '../resourcepicker';
+import { useCallback } from 'react';
+
+export type CloneCallHandler = (
+  sourceApps: { subscriptionId: string; resourceGroup: string; logicAppName: string }[],
+  destinationApp: { subscriptionId: string; resourceGroup: string; logicAppName: string }
+) => Promise<void>;
 
 export const CloneWizard = ({
-  onExportCall,
+  onCloneCall,
   onClose,
 }: {
-  onExportCall: () => void;
+  onCloneCall: CloneCallHandler;
   onClose: () => void;
 }) => {
   const {
     resource: { subscriptionId, resourceGroup, location, logicAppName },
+    clone: {
+      destinationApp: { resourceGroup: destResourceGroup, logicAppName: destLogicAppName },
+    },
   } = useSelector((state: RootState) => state);
+
+  const onCloneClick = useCallback(async () => {
+    await onCloneCall(
+      [
+        {
+          subscriptionId,
+          resourceGroup,
+          logicAppName,
+        },
+      ],
+      {
+        subscriptionId,
+        resourceGroup: destResourceGroup,
+        logicAppName: destLogicAppName,
+      }
+    );
+  }, [onCloneCall, subscriptionId, resourceGroup, logicAppName, destResourceGroup, destLogicAppName]);
+
   return (
     <div>
       placeholder
@@ -46,7 +73,7 @@ export const CloneWizard = ({
       <br />
       <div>
         <Text size={500}>Test section</Text>
-        <Button onClick={onExportCall}>On Export</Button>
+        <Button onClick={onCloneClick}>On Export</Button>
         <Button onClick={onClose}>On Close</Button>
       </div>
     </div>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [X] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [X] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Resource service is initialized to be able to properly fetch the resource picker logic apps. Using these information in the store, it is connected to the handleClone props in standalone; this is currently just console logging, but will be implemented further to connect to the API in the next PR.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: resource picker is working properly
- **Developers**: resource service is connected to properly fetch logic apps
- **System**: none

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
