### PR TITLE
fix(Designer): Removed message param from handoff

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/handoff.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/handoff.ts
@@ -24,12 +24,12 @@ export default {
           'x-ms-visibility': 'hideInUI',
           'x-ms-is-node-id': true,
         },
-        message: {
-          type: 'string',
-          title: 'Message',
-          description: 'Message to send to the agent',
-          'x-ms-visibility': 'important',
-        },
+        // message: {
+        //   type: 'string',
+        //   title: 'Message',
+        //   description: 'Message to send to the agent',
+        //   'x-ms-visibility': 'important',
+        // },
       },
     },
     isInputsOptional: false,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Removed message param from handoff.
Only temporary until backend supports it again.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users will no longer see message param on handoffs
- **Developers**: No change
- **System**: No change

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
<img width="411" height="666" alt="image" src="https://github.com/user-attachments/assets/7f2abe10-8fe5-43d3-b0c3-20d405bc991d" />
