### PR TITLE
fix(designer): Update a2a trigger property names + Prevent Adding actions below agent if single agent (6.165)

### DIFF
--- a/libs/designer/src/lib/ui/common/EdgeContextualMenu/EdgeContextualMenu.tsx
+++ b/libs/designer/src/lib/ui/common/EdgeContextualMenu/EdgeContextualMenu.tsx
@@ -74,8 +74,7 @@ export const EdgeContextualMenu = () => {
   }, [nodeMetadata, parentId]);
 
   const upstreamNodesOfChild = useUpstreamNodes(removeIdTag(childId ?? newParentId ?? ''), graphId, childId);
-  const upstreamNodesOfParent = useUpstreamNodes(removeIdTag(newParentId ?? ''), graphId, newParentId);
-  const hasUpstreamAgenticLoop = useHasUpstreamAgenticLoop(upstreamNodesOfParent);
+  const hasUpstreamAgenticLoop = useHasUpstreamAgenticLoop(upstreamNodesOfChild);
 
   const isAddAgentHandoff = isA2AWorkflow && graphId === 'root' && hasUpstreamAgenticLoop;
   const isAddActionDisabled = isA2AWorkflow && graphId === 'root' && hasUpstreamAgenticLoop;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/a2arequest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/a2arequest.ts
@@ -24,13 +24,13 @@ export default {
           },
           'x-ms-visibility': 'important',
         },
-        name: {
+        agentName: {
           type: 'string',
           title: 'Name',
           description: 'Enter a name for this A2A request',
           'x-ms-visibility': 'important',
         },
-        description: {
+        agentDescription: {
           type: 'string',
           title: 'Description',
           description: 'Enter a description for this A2A request',


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->

Update parameter names for a2a trigger from name to agentName and description to agentDescription

There was a regression where we would be able to create non-agent actions below agent loops in Agent workflows when fixing another bug. This fixes that issues,

## Impact of Change
<!-- Who/what is affected? -->
Users: Fixes a validation error for when saving an a2a trigger with name or description + Users should be prevented from creating actions below agent loops in agent workflows
Developers: no dev changes
System: no system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@eric-b-wu

## Screenshots/Videos
<!-- Visual changes only -->
