### PR TITLE
fix(vscode): Optimize design time api startup time

### DIFF
--- a/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
+++ b/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
@@ -39,7 +39,7 @@ export async function validateAndInstallBinaries(context: IActionContext) {
       context.telemetry.properties.lastStep = 'getGlobalSetting';
       progress.report({ increment: 10, message: 'Get Settings' });
 
-      const dependencyTimeout = (await getDependencyTimeout()) * 1000;
+      const dependencyTimeout = getDependencyTimeout() * 1000;
 
       context.telemetry.properties.dependencyTimeout = `${dependencyTimeout} milliseconds`;
       if (!getGlobalSetting<string>(autoRuntimeDependenciesPathSettingKey)) {

--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -66,23 +66,18 @@ export async function startDesignTimeApi(projectPath: string): Promise<void> {
     const url = `http://localhost:${designTimeInst.port}${designerStartApi}`;
     if (designTimeInst.isStarting && !isNewDesignTime) {
       await waitForDesignTimeStartUp(projectPath, url, new Date().getTime());
+      actionContext.telemetry.properties.isDesignTimeUp = 'true';
+      await validateRunningFuncProcess(projectPath);
+      return;
     }
 
-    if (await isDesignTimeUp(url)) {
+    if (!isNewDesignTime && (await isDesignTimeUp(url))) {
       actionContext.telemetry.properties.isDesignTimeUp = 'true';
-      const correctFuncProcess = await checkFuncProcessId(projectPath);
-      if (!correctFuncProcess) {
-        stopDesignTimeApi(projectPath);
-        await startDesignTimeApi(projectPath);
-      }
+      await validateRunningFuncProcess(projectPath);
       return;
     }
 
     try {
-      window.showInformationMessage(
-        localize('azureFunctions.designTimeApi', 'Starting workflow design-time API, which might take a few seconds.'),
-        'OK'
-      );
       ext.outputChannel.appendLog('Starting Design Time Api');
 
       const designTimeDirectory: Uri | undefined = await getOrCreateDesignTimeDirectory(designTimeDirectoryName, projectPath);
@@ -103,41 +98,44 @@ export async function startDesignTimeApi(projectPath: string): Promise<void> {
         },
       };
 
-      if (designTimeDirectory) {
-        await createJsonFile(designTimeDirectory, hostFileName, hostFileContent);
-        await createJsonFile(designTimeDirectory, localSettingsFileName, settingsFileContent);
-        await addOrUpdateLocalAppSettings(
-          actionContext,
-          designTimeDirectory.fsPath,
-          {
-            [appKindSetting]: logicAppKind,
-            [ProjectDirectoryPathKey]: projectPath,
-            [workerRuntimeKey]: WorkerRuntime.Node,
-          },
-          true
-        );
-        await updateFuncIgnore(projectPath, [`${designTimeDirectoryName}/`]);
-        const cwd: string = designTimeDirectory.fsPath;
-        const portArgs = `--port ${designTimeInst.port}`;
-        startDesignTimeProcess(ext.outputChannel, cwd, getFunctionsCommand(), 'host', 'start', portArgs);
-        await waitForDesignTimeStartUp(projectPath, url, new Date().getTime(), true);
-        ext.pinnedBundleVersion.set(projectPath, false);
-        const hostfilepath: Uri = Uri.file(path.join(cwd, hostFileName));
-        const data = JSON.parse(fs.readFileSync(hostfilepath.fsPath, 'utf-8'));
-        if (data.extensionBundle) {
-          const versionWithoutSpaces = data.extensionBundle.version.replace(/\s+/g, '');
-          const rangeWithoutSpaces = defaultVersionRange.replace(/\s+/g, '');
-          if (data.extensionBundle.id === extensionBundleId && versionWithoutSpaces === rangeWithoutSpaces) {
-            ext.currentBundleVersion.set(projectPath, ext.latestBundleVersion);
-          } else if (data.extensionBundle.id === extensionBundleId && versionWithoutSpaces !== rangeWithoutSpaces) {
-            ext.currentBundleVersion.set(projectPath, extractPinnedVersion(data.extensionBundle.version) ?? data.extensionBundle.version);
-            ext.pinnedBundleVersion.set(projectPath, true);
-          }
-        }
-        actionContext.telemetry.properties.startDesignTimeApi = 'true';
-      } else {
+      if (!designTimeDirectory) {
         throw new Error(localize('DesignTimeDirectoryError', 'Failed to create design-time directory.'));
       }
+
+      await createJsonFile(designTimeDirectory, hostFileName, hostFileContent);
+      await createJsonFile(designTimeDirectory, localSettingsFileName, settingsFileContent);
+      await addOrUpdateLocalAppSettings(
+        actionContext,
+        designTimeDirectory.fsPath,
+        {
+          [appKindSetting]: logicAppKind,
+          [ProjectDirectoryPathKey]: projectPath,
+          [workerRuntimeKey]: WorkerRuntime.Node,
+        },
+        true
+      );
+      const cwd: string = designTimeDirectory.fsPath;
+      const portArgs = `--port ${designTimeInst.port}`;
+
+      startDesignTimeProcess(ext.outputChannel, cwd, getFunctionsCommand(), 'host', 'start', portArgs);
+      await waitForDesignTimeStartUp(projectPath, url, new Date().getTime(), true);
+      actionContext.telemetry.properties.isDesignTimeUp = 'true';
+
+      ext.pinnedBundleVersion.set(projectPath, false);
+      const hostfilepath: Uri = Uri.file(path.join(cwd, hostFileName));
+      const data = JSON.parse(fs.readFileSync(hostfilepath.fsPath, 'utf-8'));
+      if (data.extensionBundle) {
+        const versionWithoutSpaces = data.extensionBundle.version.replace(/\s+/g, '');
+        const rangeWithoutSpaces = defaultVersionRange.replace(/\s+/g, '');
+        if (data.extensionBundle.id === extensionBundleId && versionWithoutSpaces === rangeWithoutSpaces) {
+          ext.currentBundleVersion.set(projectPath, ext.latestBundleVersion);
+        } else if (data.extensionBundle.id === extensionBundleId && versionWithoutSpaces !== rangeWithoutSpaces) {
+          ext.currentBundleVersion.set(projectPath, extractPinnedVersion(data.extensionBundle.version) ?? data.extensionBundle.version);
+          ext.pinnedBundleVersion.set(projectPath, true);
+        }
+      }
+      actionContext.telemetry.properties.startDesignTimeApi = 'true';
+      updateFuncIgnore(projectPath, [`${designTimeDirectoryName}/`]);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : error;
       const viewOutput: MessageItem = { title: localize('viewOutput', 'View output') };
@@ -165,7 +163,22 @@ function extractPinnedVersion(input: string): string | null {
   return null;
 }
 
-export async function checkFuncProcessId(projectPath: string): Promise<boolean> {
+async function validateRunningFuncProcess(projectPath: string): Promise<void> {
+  const correctFuncProcess = await checkFuncProcessId(projectPath);
+  if (!correctFuncProcess) {
+    ext.outputChannel.appendLog(
+      localize(
+        'invalidChildFuncPid',
+        'Invalid func child process PID set for project at "{0}". Restarting workflow design-time API.',
+        projectPath
+      )
+    );
+    stopDesignTimeApi(projectPath);
+    await startDesignTimeApi(projectPath);
+  }
+}
+
+async function checkFuncProcessId(projectPath: string): Promise<boolean> {
   let correctId = false;
   let { process, childFuncPid } = ext.designTimeInstances.get(projectPath);
   let retries = 0;
@@ -216,10 +229,15 @@ export async function waitForDesignTimeStartUp(
   initialTime: number,
   setDesignTimeInst = false
 ): Promise<void> {
-  while (!(await isDesignTimeUp(url)) && new Date().getTime() - initialTime < designerApiLoadTimeout) {
-    await delay(2000);
+  let isDesignTimeStarted = false;
+  while (new Date().getTime() - initialTime < designerApiLoadTimeout) {
+    if (await isDesignTimeUp(url)) {
+      isDesignTimeStarted = true;
+      break;
+    }
+    await delay(1000);
   }
-  if (await isDesignTimeUp(url)) {
+  if (isDesignTimeStarted) {
     if (!ext.designTimeInstances.has(projectPath)) {
       return Promise.reject();
     }

--- a/apps/vs-code-designer/src/app/utils/delay.ts
+++ b/apps/vs-code-designer/src/app/utils/delay.ts
@@ -4,5 +4,5 @@
  *--------------------------------------------------------------------------------------------*/
 
 export async function delay(ms: number): Promise<void> {
-  await new Promise<void>((resolve: () => void) => setTimeout(resolve, ms));
+  return new Promise<void>((resolve: () => void) => setTimeout(resolve, ms));
 }

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -103,8 +103,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
     runPostWorkflowCreateStepsFromCache();
     runPostExtractStepsFromCache();
-    logSubscriptions(activateContext);
-    logExtensionSettings(activateContext);
 
     if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
       await convertToWorkspace(activateContext);
@@ -151,6 +149,9 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.registerUriHandler(new UriHandler());
     perfStats.loadEndTime = Date.now();
     activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
+
+    logSubscriptions(activateContext);
+    logExtensionSettings(activateContext);
   });
 }
 

--- a/apps/vs-code-designer/src/onboarding.ts
+++ b/apps/vs-code-designer/src/onboarding.ts
@@ -21,7 +21,7 @@ import * as vscode from 'vscode';
  * @param {IActionContext} activateContext - Activation context.
  */
 export const onboardBinaries = async (activateContext: IActionContext) => {
-  callWithTelemetryAndErrorHandling(extensionCommand.validateAndInstallBinaries, async (actionContext: IActionContext) => {
+  await callWithTelemetryAndErrorHandling(extensionCommand.validateAndInstallBinaries, async (actionContext: IActionContext) => {
     await runWithDurationTelemetry(actionContext, extensionCommand.validateAndInstallBinaries, async () => {
       const binariesInstallation = useBinariesDependencies();
       if (binariesInstallation) {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Fix some inefficiencies in startDesignTimeApi - avoid cost of checking if design time is up (~2s locally) in case where this is a known new instance, update funcignore async, avoid unneeded requests

## Impact of Change
- **Users**: Lower startup time for design time API (tested improvement of 2-4s locally)
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge 

