### PR TITLE
fix(mcp): Resetting connection store correctly on logic app change

### DIFF
--- a/libs/designer/src/lib/core/actions/bjsworkflow/mcp.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/mcp.ts
@@ -84,11 +84,19 @@ export const resetMcpStateOnResourceChange = createAsyncThunk(
 
     const {
       resource: { subscriptionId, resourceGroup, logicAppName },
+      connection: { connectionsMapping },
     } = getState() as RootState;
     const connectionsData = await getConnectionsInWorkflowApp(subscriptionId, resourceGroup, logicAppName as string, getReactQueryClient());
     const references = convertConnectionsDataToReferences(connectionsData);
     dispatch(initializeConnectionReferences(references));
-    dispatch(initializeConnectionsMappings({}));
+    dispatch(
+      initializeConnectionsMappings(
+        Object.keys(connectionsMapping).reduce((result: Record<string, string | null>, key: string) => {
+          result[key] = null;
+          return result;
+        }, {})
+      )
+    );
     return true;
   }
 );

--- a/libs/designer/src/lib/ui/mcp/details/logicAppSelector.tsx
+++ b/libs/designer/src/lib/ui/mcp/details/logicAppSelector.tsx
@@ -55,9 +55,9 @@ export const LogicAppSelector = () => {
   );
 
   const [selectedResource, setSelectedResource] = useState<string>('');
-  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [searchTerm, setSearchTerm] = useState<string | undefined>('');
 
-  const controlValue = useMemo(() => (searchTerm ? searchTerm : selectedResource) ?? '', [selectedResource, searchTerm]);
+  const controlValue = useMemo(() => (searchTerm !== undefined ? searchTerm : selectedResource) ?? '', [selectedResource, searchTerm]);
 
   const resources = useMemo(() => {
     if (!logicApps?.length) {
@@ -74,7 +74,7 @@ export const LogicAppSelector = () => {
   }, [logicApps]);
 
   const filteredResources = useMemo(() => {
-    if (!searchTerm.trim()) {
+    if (!searchTerm?.trim()) {
       return resources;
     }
 
@@ -127,7 +127,7 @@ export const LogicAppSelector = () => {
               onOptionSelect={(_, data) => {
                 if (data.optionValue && data.optionValue !== NO_ITEM_VALUE) {
                   onLogicAppSelect(data.optionValue);
-                  setSearchTerm('');
+                  setSearchTerm(undefined);
                 }
               }}
               onChange={(e) => {
@@ -136,7 +136,7 @@ export const LogicAppSelector = () => {
             >
               {!isLogicAppsLoading && !filteredResources.length ? (
                 <Option key={'no-items'} value={NO_ITEM_VALUE} disabled>
-                  {searchTerm.trim() ? `${intlText.NO_RESULTS} "${searchTerm}"` : intlText.NO_ITEMS}
+                  {searchTerm?.trim() ? `${intlText.NO_RESULTS} "${searchTerm}"` : intlText.NO_ITEMS}
                 </Option>
               ) : (
                 filteredResources.map((resource) => (


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Fixes an issue where changing Logic Apps incorrectly reset the connection store, preventing users from adding/selecting connections. Also, includes a minor UI fix for selector search terms.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users can now change Logic Apps and select or create connections without being blocked.
- **Developers**: No developer-facing changes.
- **System**: No architectural or performance/system impact.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@DevArjun23 @kewear 

## Screenshots/Videos
NA
