### PR TITLE
feat(vscode): disable codeful feature flag

### DIFF
--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -81,7 +81,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   ext.context = context;
-  ext.codefulEnabled = true; // flag that prevents codeful use until public preview
+  ext.codefulEnabled = false; // flag that prevents codeful use until public preview
   ext.extensionVersion = getExtensionVersion();
   ext.telemetryReporter = new TelemetryReporter(telemetryString);
   context.subscriptions.push(ext.telemetryReporter);


### PR DESCRIPTION
## Commit Type
- [x] feature - New functionality

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Disabled the codeful feature in VS Code Designer by setting the `codefulEnabled` flag to `false`. This prevents codeful functionality from being used until public preview is ready.

## Impact of Change
- **Users**: Codeful feature will no longer be available in VS Code Designer
- **Developers**: No API changes, simple flag toggle
- **System**: No performance impact, minimal change to configuration

## Test Plan
- [x] Manual testing completed
- [x] Tested in: VS Code Designer extension

## Contributors
@ccastrotrejo

## Screenshots/Videos
N/A - Configuration change only