### PR TITLE
fix(Designer): Modified `aioperations` operation connector ids for standard

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/operationmanifest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/operationmanifest.ts
@@ -5,6 +5,7 @@ import type { BaseOperationManifestServiceOptions } from '../base/operationmanif
 import { getBuiltInOperationInfo, isBuiltInOperation, supportedBaseManifestObjects } from '../base/operationmanifest';
 import { getHybridAppBaseRelativeUrl, hybridApiVersion, isHybridLogicApp } from './hybrid';
 import { getClientBuiltInConnectors } from '../base/search';
+import { aiOperationsGroup } from './operations/operationgroups';
 
 export interface StandardOperationManifestServiceOptions extends BaseOperationManifestServiceOptions {
   getCachedOperation?: (connectorName: string, operationName: string) => Promise<any>;
@@ -23,7 +24,31 @@ export class StandardOperationManifestService extends BaseOperationManifestServi
 
   override async getOperationInfo(definition: any, isTrigger: boolean): Promise<OperationInfo> {
     if (isBuiltInOperation(definition)) {
-      return getBuiltInOperationInfo(definition, isTrigger);
+      const normalizedOperationType = definition.type?.toLowerCase();
+      switch (normalizedOperationType) {
+        case 'chunktext':
+          return {
+            connectorId: aiOperationsGroup.id,
+            operationId: 'chunktext',
+          };
+        case 'parsedocument':
+          return {
+            connectorId: aiOperationsGroup.id,
+            operationId: 'parsedocument',
+          };
+        case 'parsedocumentwithmetadata':
+          return {
+            connectorId: aiOperationsGroup.id,
+            operationId: 'parsedocumentwithmetadata',
+          };
+        case 'chunktextwithmetadata':
+          return {
+            connectorId: aiOperationsGroup.id,
+            operationId: 'chunktextwithmetadata',
+          };
+        default:
+          return getBuiltInOperationInfo(definition, isTrigger);
+      }
     }
     if (isServiceProviderOperation(definition.type)) {
       return {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/operations/operationgroups.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/operations/operationgroups.ts
@@ -1,0 +1,11 @@
+export const aiOperationsGroup = {
+  id: 'connectionProviders/aiOperations',
+  name: 'aiOperations',
+  properties: {
+    brandColor: '#8c6cff',
+    description: 'AI Operations',
+    displayName: 'AI Operations',
+    iconUri: 'https://logicapps.azureedge.net/icons/aioperations/icon.svg',
+    capabilities: ['actions'],
+  },
+};


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
`AI Operation` connector operations will now load properly after initial serialization in standard.
The previous connector ID was incorrect.
Fixes https://github.com/Azure/LogicAppsUX/issues/8239

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: `AI Operation` connector operations will now load properly 
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97, @bjbennet 

## Screenshots/Videos
<!-- Visual changes only -->
<img width="559" height="561" alt="image" src="https://github.com/user-attachments/assets/76dd1f1a-d7bf-431c-ae3d-a0256e7b81be" />

