### PR TITLE
fix(vs-code): prevent null error in Logic App AppInsights creation

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createProject/createProjectSteps/projectTypeStep.ts
+++ b/apps/vs-code-designer/src/app/commands/createProject/createProjectSteps/projectTypeStep.ts
@@ -123,6 +123,12 @@ export class ProjectTypeStep extends AzureWizardPromptStep<IProjectWizardContext
       executeSteps.push(new CustomCodeProjectCreateStep());
       await addInitVSCodeSteps(context, executeSteps, true);
 
+      if (ext.codefulEnabled) {
+        promptSteps.push(new WorkflowCodeTypeStep());
+      } else {
+        context.isCodeless = true; // default to codeless workflow, disabling codeful option
+      }
+
       promptSteps.push(
         await WorkflowKindStep.create(context, {
           isProjectWizard: true,

--- a/apps/vs-code-designer/src/app/tree/subscriptionTree/subscriptionTreeItem.ts
+++ b/apps/vs-code-designer/src/app/tree/subscriptionTree/subscriptionTreeItem.ts
@@ -234,6 +234,12 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
       wizardContext.newAppInsightsName = newName;
     }
 
+    // TODO (ccastrotrejo): Revisit this as the azureappservice library gets updated in the future
+    // Patch: Ensure newAppInsightsName is not null/undefined to prevent nonNullProp errors
+    if (!wizardContext.newAppInsightsName) {
+      wizardContext.newAppInsightsName = '';
+    }
+
     if (ext.deploymentFolderPath) {
       let resourceGroupName: string | undefined;
 


### PR DESCRIPTION
Cherry-pick of the following PR - #8258

## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Fixes a null reference error that occurs during Logic App creation when `newAppInsightsName` is null or undefined. This happens in advanced creation or hybrid scenarios where the AppInsightsCreateStep tries to access the name using `nonNullProp()` but the value hasn't been set.

The fix adds a simple patch that ensures `newAppInsightsName` is set to an empty string when it's null/undefined, preventing the error while allowing the creation step to be properly skipped.

## Impact of Change
- **Users**: Users creating Logic Apps in advanced mode will no longer encounter the "Expected value to be neither null nor undefined: newAppInsightsName" error
- **Developers**: No API changes or new patterns introduced
- **System**: Minimal impact, just prevents error condition in VS Code extension

## Test Plan
- [x] Manual testing completed
- [x] Tested in: VS Code extension Logic App creation flow


## Fixes #8219 


## Contributors
@ccastrotrejo