### PR TITLE
chore: Update release pipeline to use Github_Token instead of personal PAT

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: 'Checkout Github Action'
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.AUTOMATION_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Set up Node.js
@@ -145,7 +145,7 @@ jobs:
       - name: 'Create GitHub Release'
         id: create-release
         env:
-          GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create ${{ steps.version.outputs.tag_name }} \
             --title "Release ${{ steps.version.outputs.tag_name }}" \
@@ -201,7 +201,7 @@ jobs:
 
       - name: 'Upload VSIX to Release'
         env:
-          GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ needs.create-release.outputs.tag_name }} apps/vs-code-designer/dist/*.vsix --clobber
 

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -160,6 +160,8 @@ jobs:
     permissions:
       contents: read
       id-token: write # for Azure login
+      packages: write
+      deployments: write
     steps:
       - name: 'Checkout Github Action'
         uses: actions/checkout@v4

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -49,6 +49,7 @@ jobs:
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
       tag_name: ${{ steps.version.outputs.tag_name }}
+    permissions: write-all
     steps:
       - name: 'Checkout Github Action'
         uses: actions/checkout@v4

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -158,10 +158,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: E2ETesting
     permissions:
-      contents: read
+      contents: write
       id-token: write # for Azure login
-      packages: write
-      deployments: write
     steps:
       - name: 'Checkout Github Action'
         uses: actions/checkout@v4


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Updating the Github action workflow to use Github token

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: None
- **Developers**: None
- **System**: Release will now use Github_token instead of PAT

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
