### PR TITLE
chore(vscode): add production signing configuration to pipeline

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -77,7 +77,9 @@ extends:
                 signing:
                   enabled: ${{ parameters.enableSigning }}
                   signType: real # options are 'real' & 'test'
+                  signWithProd: true
                   zipSources: false
+                  azureSubscription: "MicroBuild Signing Task (DevDiv)"
               outputs:
                 - output: pipelineArtifact
                   targetPath: $(build.artifactstagingdirectory)/build/Root


### PR DESCRIPTION
Cherry-pick of the following PR - #8262

## Commit Type
- [x] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Adds production signing configuration to the VS Code extension pipeline by enabling `signWithProd: true` and specifying the `azureSubscription: "MicroBuild Signing Task (DevDiv)"`. This ensures the VS Code extension is properly signed with production certificates during the build process.

## Impact of Change
- **Users**: No user-facing changes
- **Developers**: VS Code extension builds will now be signed with production certificates
- **System**: Improved security and trust for the VS Code extension distribution

## Test Plan
- [x] Manual testing completed
- [x] Tested in: Azure DevOps pipeline configuration

## Contributors
@ccastrotrejo

## Screenshots/Videos
N/A - Pipeline configuration change only