### PR TITLE
fix(DesignerV2): Fixes httpclient response header property issue

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/HttpClient.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/HttpClient.ts
@@ -154,7 +154,7 @@ function isArmResourceId(resourceId: string): boolean {
 function parseResponse(response: any, options: HttpRequestOptions<any>) {
   if (options?.returnHeaders) {
     return {
-      headers: response?.headers,
+      responseHeaders: response?.headers,
       ...response.data,
     };
   }

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -93,7 +93,7 @@ export const FloatingRunButton = ({ id: _id, saveDraftWorkflow, onRun, isDarkMod
       // Wait 0.5 seconds, running too fast after saving causes 500 error
       await new Promise((resolve) => setTimeout(resolve, 500));
       const runResponse = await RunService().runTrigger(callbackInfo);
-      const runId = runResponse?.headers?.['x-ms-workflow-run-id'];
+      const runId = runResponse?.responseHeaders?.['x-ms-workflow-run-id'] ?? runResponse?.headers?.['x-ms-workflow-run-id'];
       onRun?.(runId);
     } catch (_error: any) {
       return;

--- a/libs/vscode-extension/src/lib/services/httpClient.ts
+++ b/libs/vscode-extension/src/lib/services/httpClient.ts
@@ -42,7 +42,7 @@ export class HttpClient implements IHttpClient {
 
     if (options.returnHeaders) {
       return {
-        headers: response.headers,
+        responseHeaders: response.headers,
         ...response.data,
       };
     }
@@ -127,7 +127,7 @@ export class HttpClient implements IHttpClient {
     }).catch((error) => {
       return {
         status: error.response.status,
-        headers: options.returnHeaders ? error.response.headers : undefined,
+        responseHeaders: options.returnHeaders ? error.response.headers : undefined,
         ...error.response.data,
       };
     });
@@ -154,7 +154,7 @@ export class HttpClient implements IHttpClient {
 
     if (options.returnHeaders) {
       return {
-        headers: response.headers,
+        responseHeaders: response.headers,
         ...response.data,
       };
     }
@@ -209,7 +209,7 @@ function parseResponse(response: any, options: HttpRequestOptions<any>) {
 
   if (options?.returnHeaders) {
     return {
-      headers: response?.headers,
+      responseHeaders: response?.headers,
       ...responseData,
     };
   }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixes issue with response headers on VSCode httpClient
Response headers are now under property `responseHeaders` rather than `headers`

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes issue with response headers on VSCode httpClient
- **Developers**: Response headers are now under property `responseHeaders` rather than `headers`
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A
