### PR TITLE
feat(designerv2): Add discard for draft, refactor, and run draft

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
@@ -120,11 +120,10 @@ const DesignerEditor = () => {
   const { data: workflowAppData, isLoading: appLoading } = useWorkflowApp(siteResourceId, useHostingPlan());
   const { data: tenantId } = useCurrentTenantId();
   const { data: objectId } = useCurrentObjectId();
+
+  // State props
   const [designerID, setDesignerID] = useState(guid());
-  const [workflow, setWorkflow] = useState<Workflow>({
-    ...artifactData?.properties.files[Artifact.WorkflowFile],
-    id: guid(),
-  });
+  const [workflow, setWorkflow] = useState<Workflow>(); // Current workflow on the designer
   const [isDesignerView, setIsDesignerView] = useState(true);
   const [isCodeView, setIsCodeView] = useState(false);
   const [isDraftMode, setIsDraftMode] = useState(true);
@@ -135,16 +134,18 @@ const DesignerEditor = () => {
     [artifactData?.properties.files]
   );
   const originalCustomCodeData = useMemo(() => Object.keys(customCodeData ?? {}), [customCodeData]);
+  const prodWorkflow = useMemo(() => artifactData?.properties.files[Artifact.WorkflowFile], [artifactData?.properties.files]);
   const draftWorkflow = useMemo(() => customCodeData?.[Artifact.DraftFile], [customCodeData]);
   const parameters = useMemo(() => artifactData?.properties.files[Artifact.ParametersFile] ?? {}, [artifactData?.properties.files]);
   const notes = useMemo(() => customCodeData?.[VfsArtifact.NotesFile] ?? {}, [customCodeData]);
   const queryClient = getReactQueryClient();
   const displayCopilotChatbot = showChatBot && isDesignerView;
-
   const connectionsData = useMemo(
     () => resolveConnectionsReferences(JSON.stringify(clone(originalConnectionsData ?? {})), parameters, settingsData?.properties ?? {}),
     [originalConnectionsData, parameters, settingsData?.properties]
   );
+  const connectionReferences = WorkflowUtility.convertConnectionsDataToReferences(connectionsData);
+  const { data: runInstanceData } = useRun(runId);
 
   const addConnectionDataInternal = async (connectionAndSetting: ConnectionAndAppSetting): Promise<void> => {
     addConnectionInJson(connectionAndSetting, connectionsData ?? {});
@@ -177,11 +178,32 @@ const DesignerEditor = () => {
     return undefined;
   };
 
-  const connectionReferences = WorkflowUtility.convertConnectionsDataToReferences(connectionsData);
+  const saveDraftWorkflow = useCallback(
+    (workflow: Workflow) => {
+      return deployArtifacts(siteResourceId, workflowName, workflow, undefined, undefined, undefined, true);
+    },
+    [siteResourceId, workflowName]
+  );
 
-  const discardAllChanges = () => {
+  const resetDraftWorkflow = useCallback(async () => {
+    const response = await saveDraftWorkflow(prodWorkflow);
+
+    if (response.status >= 200 && response.status < 300) {
+      // Draft created successfully
+      customCodeRefetch();
+      return Promise.resolve();
+    }
+    return Promise.reject(`Error resetting draft workflow: ${response.statusText}`);
+  }, [customCodeRefetch, prodWorkflow, saveDraftWorkflow]);
+
+  const discardAllChanges = useCallback(() => {
     setDesignerID(guid());
-  };
+
+    if (isDraftMode) {
+      // Need to reset draft workflow to Production workflow
+      resetDraftWorkflow();
+    }
+  }, [isDraftMode, resetDraftWorkflow]);
 
   const canonicalLocation = WorkflowUtility.convertToCanonicalFormat(workflowAppData?.location ?? '');
   const supportsStateful = !equals(workflow?.kind, 'stateless');
@@ -256,10 +278,6 @@ const DesignerEditor = () => {
   };
   const originalParametersData: ParametersData = clone(parameters ?? {});
   const originalNotesData: NotesData = clone(notes ?? {});
-
-  if (isError || settingsIsError) {
-    throw error ?? settingsError;
-  }
 
   const saveWorkflowFromDesigner = useCallback(
     async (
@@ -488,20 +506,6 @@ const DesignerEditor = () => {
     }
   };
 
-  const setProdWorkflow = useCallback(() => {
-    const prodWorkflow = artifactData?.properties.files[Artifact.WorkflowFile];
-    if (prodWorkflow) {
-      setWorkflow(prodWorkflow);
-    }
-  }, [artifactData]);
-
-  const saveDraftWorkflow = useCallback(
-    (workflow: Workflow) => {
-      return deployArtifacts(siteResourceId, workflowName, workflow, undefined, undefined, undefined, true);
-    },
-    [siteResourceId, workflowName]
-  );
-
   // Our iframe root element is given a strange padding (not in this repo), this removes it
   useEffect(() => {
     const root = document.getElementById('root');
@@ -511,11 +515,12 @@ const DesignerEditor = () => {
     }
   }, []);
 
-  const { data: runInstanceData } = useRun(runId);
-
   useEffect(() => {
     if (isMonitoringView && runInstanceData) {
-      setWorkflow((previousWorkflow: Workflow) => {
+      setWorkflow((previousWorkflow?: Workflow) => {
+        if (!previousWorkflow) {
+          return previousWorkflow;
+        }
         return {
           ...previousWorkflow,
           definition: (runInstanceData.properties.workflow as any).properties.definition,
@@ -525,45 +530,31 @@ const DesignerEditor = () => {
   }, [isMonitoringView, runInstanceData]);
 
   useEffect(() => {
-    const prodWorkflow = artifactData?.properties.files[Artifact.WorkflowFile];
-    if (customCodeLoading || artifactsLoading) {
+    if (customCodeLoading || artifactsLoading || !prodWorkflow) {
       return;
     }
 
-    if (draftWorkflow) {
-      setWorkflow(draftWorkflow as any);
-    } else if (prodWorkflow) {
-      // Create default draft from production if draft does not exist
-      saveDraftWorkflow(prodWorkflow).then((response) => {
-        if (response.status >= 200 && response.status < 300) {
-          // Draft created successfully
-          customCodeRefetch();
-        } else {
-          setIsDraftMode(false);
-          // TODO: Handle error
-          setProdWorkflow();
-        }
-      });
-    }
-  }, [
-    artifactData?.properties.files,
-    artifactsLoading,
-    customCodeLoading,
-    customCodeRefetch,
-    draftWorkflow,
-    saveDraftWorkflow,
-    setProdWorkflow,
-  ]);
-
-  useEffect(() => {
     if (isDraftMode) {
       if (draftWorkflow) {
         setWorkflow(draftWorkflow as any);
+      } else {
+        resetDraftWorkflow()
+          .then(() => {
+            // Draft created successfully
+          })
+          .catch((_error) => {
+            setIsDraftMode(false);
+            setWorkflow(prodWorkflow as any);
+          });
       }
     } else {
-      setProdWorkflow();
+      setWorkflow(prodWorkflow as any);
     }
-  }, [draftWorkflow, isDraftMode, setProdWorkflow]);
+  }, [artifactsLoading, customCodeLoading, draftWorkflow, isDraftMode, prodWorkflow, resetDraftWorkflow]);
+
+  if (isError || settingsIsError) {
+    throw error ?? settingsError;
+  }
 
   if (artifactsLoading || appLoading || settingsLoading || customCodeLoading) {
     return <></>;
@@ -659,6 +650,7 @@ const DesignerEditor = () => {
                         saveDraftWorkflow={saveWorkflowFromDesigner}
                         onRun={onRun}
                         isDarkMode={isDarkMode}
+                        isDraftMode={isDraftMode}
                       />
                     </div>
                   </div>

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -27,9 +27,10 @@ export interface FloatingRunButtonProps {
   saveDraftWorkflow: (workflowDefinition: Workflow, customCodeData: any, onSuccess: () => void) => Promise<any>;
   onRun?: (runId: string) => void;
   isDarkMode: boolean;
+  isDraftMode?: boolean;
 }
 
-export const FloatingRunButton = ({ id: _id, saveDraftWorkflow, onRun, isDarkMode }: FloatingRunButtonProps) => {
+export const FloatingRunButton = ({ id: _id, saveDraftWorkflow, onRun, isDarkMode, isDraftMode }: FloatingRunButtonProps) => {
   const intl = useIntl();
 
   const dispatch = useDispatch();
@@ -92,7 +93,7 @@ export const FloatingRunButton = ({ id: _id, saveDraftWorkflow, onRun, isDarkMod
       callbackInfo.method = method;
       // Wait 0.5 seconds, running too fast after saving causes 500 error
       await new Promise((resolve) => setTimeout(resolve, 500));
-      const runResponse = await RunService().runTrigger(callbackInfo);
+      const runResponse = await RunService().runTrigger(callbackInfo, undefined, isDraftMode);
       const runId = runResponse?.responseHeaders?.['x-ms-workflow-run-id'] ?? runResponse?.headers?.['x-ms-workflow-run-id'];
       onRun?.(runId);
     } catch (_error: any) {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/run.ts
@@ -7,7 +7,7 @@ export interface IRunService {
   getMoreRuns(continuationToken: string): Promise<Runs>;
   getRun(runId: string): Promise<Run | RunError>;
   getRuns(): Promise<Runs>;
-  runTrigger(callbackInfo: CallbackInfo, options?: any): Promise<any>;
+  runTrigger(callbackInfo: CallbackInfo, options?: any, isDraftMode?: boolean): Promise<any>;
   getActionLinks(action: any, nodeId: string): Promise<any>;
   getScopeRepetitions(
     action: { nodeId: string; runId: string | undefined },

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
@@ -345,7 +345,7 @@ export class StandardRunService implements IRunService {
    * @param {CallbackInfo} callbackInfo - Information to call Api to trigger workflow.
    * @param {any} options - Options for the trigger call including headers, queries and body.
    */
-  async runTrigger(callbackInfo: CallbackInfo, options?: any): Promise<any> {
+  async runTrigger(callbackInfo: CallbackInfo, options?: any, isDraftMode?: boolean): Promise<any> {
     const { httpClient } = this.options;
     const method = isCallbackInfoWithRelativePath(callbackInfo) ? callbackInfo.method : HTTP_METHODS.POST;
     const uri = getCallbackUrl(callbackInfo);
@@ -366,7 +366,7 @@ export class StandardRunService implements IRunService {
       const mergedParams = { ...uriParams, ...(options?.queries ?? {}) };
 
       return await this.getHttpRequestByMethod(httpClient, method, {
-        uri: baseUri,
+        uri: isDraftMode ? `${baseUri}draft` : baseUri,
         noAuth: true,
         returnHeaders: true,
         headers: options?.headers,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Add discard functionality for Draft state, and add run behavior

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users can now discard and reset their draft. They can also run the draft.
- **Developers**: Run API for draft should be deployed before the UX changes go in.
- **System**: None

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
