### PR TITLE
fix(DesignerV2): Fixed react-flow `NoteNode` visibility and interaction issues

### DIFF
--- a/libs/designer-ui/src/lib/styles.less
+++ b/libs/designer-ui/src/lib/styles.less
@@ -227,7 +227,6 @@
 
 .react-flow__node {
   cursor: default !important;
-  pointer-events: none !important;
   & > div {
     pointer-events: initial;
   }

--- a/libs/designer-v2/src/lib/ui/CustomNodes/NoteNode/index.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/NoteNode/index.tsx
@@ -63,7 +63,7 @@ const NoteNode = ({ id, dragging }: NodeProps) => {
   );
 
   return (
-    <div style={{ zIndex: '-1' }}>
+    <>
       <Card
         className={mergeClasses(styles.noteCard, dragging && styles.draggingNote)}
         style={{
@@ -100,7 +100,7 @@ const NoteNode = ({ id, dragging }: NodeProps) => {
           <Button icon={<DeleteIcon />} size="small" appearance="transparent" onClick={deleteCallback} />
         </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/libs/designer-v2/src/lib/ui/DesignerReactFlow.tsx
+++ b/libs/designer-v2/src/lib/ui/DesignerReactFlow.tsx
@@ -23,7 +23,7 @@ import type { AppDispatch } from '../core';
 import { clearPanel, expandDiscoveryPanel } from '../core/state/panel/panelSlice';
 import { addOperationRunAfter } from '../core/actions/bjsworkflow/runafter';
 import { useClampPan, useIsA2AWorkflow } from '../core/state/designerView/designerViewSelectors';
-import { DEFAULT_NODE_SIZE } from '../core/utils/graph';
+import { DEFAULT_NODE_SIZE, DEFAULT_NOTE_SIZE } from '../core/utils/graph';
 import { DraftEdge } from './connections/draftEdge';
 import { useReadOnly } from '../core/state/designerOptions/designerOptionsSelectors';
 import { useLayout } from '../core/graphlayout';
@@ -163,6 +163,10 @@ const DesignerReactFlow = (props: any) => {
           position: nodePositions?.[id] ?? note.metadata.position,
           draggable: !isReadOnly,
           dragHandle: '.note-drag-handle',
+          measured: {
+            width: note.metadata.width ?? DEFAULT_NOTE_SIZE.width,
+            height: note.metadata.height ?? DEFAULT_NOTE_SIZE.height,
+          },
         }) as Node
     );
   }, [notes, nodePositions, isReadOnly]);
@@ -378,7 +382,9 @@ const DesignerReactFlow = (props: any) => {
           actionChanges.push(change);
         }
       }
-      dispatch(updateNodeSizes(actionChanges));
+      if (actionChanges.length > 0) {
+        dispatch(updateNodeSizes(actionChanges));
+      }
     },
     [dispatch, notes]
   );

--- a/libs/designer-v2/src/lib/ui/styles.less
+++ b/libs/designer-v2/src/lib/ui/styles.less
@@ -81,7 +81,6 @@
   
 	&.react-flow__node-NOTE_NODE {
     z-index: -1 !important;
-    visibility: visible !important; // Something in react-flow is setting this to hidden when resizing
 	}
 }
 


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixed react-flow issue that was causing nodes to quickly cycle between hidden / visible
Fixed issue with z-indexing causing drag interaction interruptions

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Will be able to drag note nodes around as expected
- **Developers**: No change
- **System**: No change

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97 

## Screenshots/Videos
<!-- Visual changes only -->
N/A