### PR TITLE
fix(designer): Label Component Auto Capitalization + Migrate to Fluentv9

### DIFF
--- a/libs/designer-ui/src/lib/arrayeditor/expandedsimplearray.tsx
+++ b/libs/designer-ui/src/lib/arrayeditor/expandedsimplearray.tsx
@@ -2,7 +2,7 @@ import type { ComboboxItem, SimpleArrayItem, TokenPickerButtonEditorProps, Value
 import { Combobox, StringEditor } from '..';
 import type { BasePlugins, ChangeState, GetTokenPickerHandler, loadParameterValueFromStringHandler } from '../editor/base';
 import { notEqual } from '../editor/base/utils/helper';
-import { Label, RequiredMarkerSide } from '../label';
+import { Label } from '../label';
 import type { LabelProps } from '../label';
 import type { IContextualMenuProps, IIconProps, IIconStyles } from '@fluentui/react';
 import { IconButton, TooltipHost, DefaultButton } from '@fluentui/react';
@@ -135,7 +135,7 @@ export const ExpandedSimpleArray = ({
 const renderLabel = (index: number, labelName?: string, isRequired?: boolean): JSX.Element => {
   return (
     <div className="msla-array-editor-label">
-      <Label text={`${labelName} - ${index + 1}`} isRequiredField={isRequired ?? false} requiredMarkerSide={RequiredMarkerSide.LEFT} />
+      <Label text={`${labelName} - ${index + 1}`} isRequiredField={isRequired ?? false} />
     </div>
   );
 };

--- a/libs/designer-ui/src/lib/card/parameters/parameters.less
+++ b/libs/designer-ui/src/lib/card/parameters/parameters.less
@@ -43,7 +43,6 @@
   display: inline-block;
   flex: 0 0 @parameter-label-width;
   vertical-align: top;
-  padding-top: 5.5px;
   max-height: (@parameter-inputbox-height + 2px);
   text-transform: capitalize;
 

--- a/libs/designer-ui/src/lib/editor/initializevariable/variableEditor.tsx
+++ b/libs/designer-ui/src/lib/editor/initializevariable/variableEditor.tsx
@@ -15,7 +15,7 @@ import {
 } from '@fluentui/react-icons';
 import { useState } from 'react';
 import { createEmptyLiteralValueSegment, isSingleLiteralValueSegment } from '../base/utils/helper';
-import { guid, RUN_AFTER_COLORS } from '@microsoft/logic-apps-shared';
+import { capitalizeFirstLetter, guid, RUN_AFTER_COLORS } from '@microsoft/logic-apps-shared';
 import constants, { VARIABLE_TYPE } from '../../constants';
 import { isEmptySegments } from '../base/utils/parsesegments';
 import { useTheme } from '@fluentui/react';
@@ -126,7 +126,7 @@ const FieldEditor = ({
   return (
     <div className="msla-input-parameter-field">
       <div className="msla-input-parameter-label">
-        <Label id={id} isRequiredField={isRequired} text={label} />
+        <Label id={id} isRequiredField={isRequired} text={capitalizeFirstLetter(label)} />
       </div>
       <EditorComponent key={key} {...restEditorProps} labelId={`${label} - ${index}`} />
       {errorMessage ? <div className="msla-input-parameter-error">{errorMessage}</div> : null}

--- a/libs/designer-ui/src/lib/identitydropdown/__test__/__snapshots__/identitydropdown.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/identitydropdown/__test__/__snapshots__/identitydropdown.spec.tsx.snap
@@ -5,7 +5,13 @@ exports[`lib/identitydropdown > should render 1`] = `
   className="msla-identity-dropdown-container"
 >
   <label
-    className="ms-Label msla-identity-dropdown-label ___jmchtt0_0000000 ftgm304 f1a3p1vp f1cmbuwj fy9rknc f1lgtm6f f1o700av fhx3js9 fhuq1gn root-109"
+    className="fui-Label msla-identity-dropdown-label ___vyqcke0_1g0peqo fk6fouc f19n0e5 fy9rknc f1lgtm6f ftgm304 f1a3p1vp f1cmbuwj f1o700av fhx3js9 fhuq1gn f1cxpek8 fp9bwmr futqtb8"
+    style={
+      {
+        "paddingBottom": "2px",
+        "paddingTop": "8px",
+      }
+    }
     title="Managed identity"
   >
     Managed identity
@@ -18,7 +24,7 @@ exports[`lib/identitydropdown > should render 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-label="Managed identity"
-      className="ms-Dropdown dropdown-110"
+      className="ms-Dropdown dropdown-109"
       data-is-focusable={true}
       data-ktp-target={true}
       id="Dropdown0"
@@ -34,17 +40,17 @@ exports[`lib/identitydropdown > should render 1`] = `
     >
       <span
         aria-invalid={false}
-        className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-111"
+        className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-110"
         id="Dropdown0-option"
       >
         Select a managed identity
       </span>
       <span
-        className="ms-Dropdown-caretDownWrapper caretDownWrapper-112"
+        className="ms-Dropdown-caretDownWrapper caretDownWrapper-111"
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown caretDown-128"
+          className="ms-Dropdown-caretDown caretDown-127"
           data-icon-name="ChevronDown"
         />
       </span>

--- a/libs/designer-ui/src/lib/label/__test__/__snapshots__/label.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/label/__test__/__snapshots__/label.spec.tsx.snap
@@ -2,7 +2,13 @@
 
 exports[`lib/label > className > should set the "class" attribute 1`] = `
 <label
-  className="ms-Label class-name ___jmchtt0_0000000 ftgm304 f1a3p1vp f1cmbuwj fy9rknc f1lgtm6f f1o700av fhx3js9 fhuq1gn root-109"
+  className="fui-Label class-name ___vyqcke0_1g0peqo fk6fouc f19n0e5 fy9rknc f1lgtm6f ftgm304 f1a3p1vp f1cmbuwj f1o700av fhx3js9 fhuq1gn f1cxpek8 fp9bwmr futqtb8"
+  style={
+    {
+      "paddingBottom": "2px",
+      "paddingTop": "8px",
+    }
+  }
   title="label text"
 >
   label text
@@ -11,8 +17,14 @@ exports[`lib/label > className > should set the "class" attribute 1`] = `
 
 exports[`lib/label > htmlFor > should set the "for" attribute 1`] = `
 <label
-  className="ms-Label ___jmchtt0_0000000 ftgm304 f1a3p1vp f1cmbuwj fy9rknc f1lgtm6f f1o700av fhx3js9 fhuq1gn root-109"
+  className="fui-Label ___vyqcke0_1g0peqo fk6fouc f19n0e5 fy9rknc f1lgtm6f ftgm304 f1a3p1vp f1cmbuwj f1o700av fhx3js9 fhuq1gn f1cxpek8 fp9bwmr futqtb8"
   htmlFor="an-input"
+  style={
+    {
+      "paddingBottom": "2px",
+      "paddingTop": "8px",
+    }
+  }
   title="label text"
 >
   label text
@@ -21,8 +33,14 @@ exports[`lib/label > htmlFor > should set the "for" attribute 1`] = `
 
 exports[`lib/label > id > should set the "id" attribute 1`] = `
 <label
-  className="ms-Label ___jmchtt0_0000000 ftgm304 f1a3p1vp f1cmbuwj fy9rknc f1lgtm6f f1o700av fhx3js9 fhuq1gn root-109"
+  className="fui-Label ___vyqcke0_1g0peqo fk6fouc f19n0e5 fy9rknc f1lgtm6f ftgm304 f1a3p1vp f1cmbuwj f1o700av fhx3js9 fhuq1gn f1cxpek8 fp9bwmr futqtb8"
   id="label-id"
+  style={
+    {
+      "paddingBottom": "2px",
+      "paddingTop": "8px",
+    }
+  }
   title="label text"
 >
   label text
@@ -31,7 +49,13 @@ exports[`lib/label > id > should set the "id" attribute 1`] = `
 
 exports[`lib/label > isRequiredField > should render the required parameter marker if set 1`] = `
 <label
-  className="ms-Label ___jmchtt0_0000000 ftgm304 f1a3p1vp f1cmbuwj fy9rknc f1lgtm6f f1o700av fhx3js9 fhuq1gn root-109"
+  className="fui-Label ___vyqcke0_1g0peqo fk6fouc f19n0e5 fy9rknc f1lgtm6f ftgm304 f1a3p1vp f1cmbuwj f1o700av fhx3js9 fhuq1gn f1cxpek8 fp9bwmr futqtb8"
+  style={
+    {
+      "paddingBottom": "2px",
+      "paddingTop": "8px",
+    }
+  }
   title="label text"
 >
   <span
@@ -46,7 +70,13 @@ exports[`lib/label > isRequiredField > should render the required parameter mark
 
 exports[`lib/label > should construct 1`] = `
 <label
-  className="ms-Label ___jmchtt0_0000000 ftgm304 f1a3p1vp f1cmbuwj fy9rknc f1lgtm6f f1o700av fhx3js9 fhuq1gn root-109"
+  className="fui-Label ___vyqcke0_1g0peqo fk6fouc f19n0e5 fy9rknc f1lgtm6f ftgm304 f1a3p1vp f1cmbuwj f1o700av fhx3js9 fhuq1gn f1cxpek8 fp9bwmr futqtb8"
+  style={
+    {
+      "paddingBottom": "2px",
+      "paddingTop": "8px",
+    }
+  }
   title="label"
 >
   label
@@ -55,7 +85,13 @@ exports[`lib/label > should construct 1`] = `
 
 exports[`lib/label > tooltip > should set the "title" attribute if tooltip is set 1`] = `
 <label
-  className="ms-Label ___jmchtt0_0000000 ftgm304 f1a3p1vp f1cmbuwj fy9rknc f1lgtm6f f1o700av fhx3js9 fhuq1gn root-109"
+  className="fui-Label ___vyqcke0_1g0peqo fk6fouc f19n0e5 fy9rknc f1lgtm6f ftgm304 f1a3p1vp f1cmbuwj f1o700av fhx3js9 fhuq1gn f1cxpek8 fp9bwmr futqtb8"
+  style={
+    {
+      "paddingBottom": "2px",
+      "paddingTop": "8px",
+    }
+  }
   title="title"
 >
   <span

--- a/libs/designer-ui/src/lib/label/index.tsx
+++ b/libs/designer-ui/src/lib/label/index.tsx
@@ -1,4 +1,4 @@
-import { css, Label as FluentLabel, type ILabelStyleProps, type ILabelStyles, type IStyleFunctionOrObject } from '@fluentui/react';
+import { Label as FluentLabel, mergeClasses } from '@fluentui/react-components';
 import type { ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 import { useLabelStyles } from './styles';
@@ -18,7 +18,6 @@ export interface LabelProps {
   tooltip?: string;
   requiredMarkerSide?: RequiredMarkerSide;
   style?: React.CSSProperties;
-  styles?: IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles>;
   disabled?: boolean;
 }
 
@@ -37,20 +36,17 @@ export const Label: React.FC<LabelProps> = ({
   tooltip,
   requiredMarkerSide = RequiredMarkerSide.RIGHT,
   style,
-  styles,
   disabled,
 }) => {
   const classes = useLabelStyles();
-
   return (
     <FluentLabel
-      className={css(className, classes.root)}
+      className={mergeClasses(classes.root, className)}
       htmlFor={htmlFor}
       id={id}
       title={tooltip || text}
       disabled={disabled}
-      style={style}
-      styles={styles}
+      style={{ paddingTop: '8px', paddingBottom: '2px', ...style }}
     >
       {requiredMarkerSide === RequiredMarkerSide.LEFT ? <RequiredParameterMarker isRequiredField={isRequiredField} /> : null}
       {text}

--- a/libs/designer-ui/src/lib/label/styles.ts
+++ b/libs/designer-ui/src/lib/label/styles.ts
@@ -11,6 +11,9 @@ export const useLabelStyles = makeStyles({
     textAlign: 'left',
     wordWrap: 'break-word',
     fontWeight: '600',
+    textTransform: 'none',
+    paddingTop: '8px',
+    paddingBottom: '2px',
   },
   requiredParameterLeft: {
     color: tokens.colorPaletteRedForeground1,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
A CRI came in on the mismatch in capitalization between a property name and the label shown in designer. Looked into it and seems like Fluent-UI's labels auto-capitalize. For this fix, I'll override this property to allow capitalization on the designer to be determined by connector owners. 

Also migrated fluent as part of the v9 migration effort.  

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users should no longer see mismatched capitalization on designer's labels and the actual parameter title
- **Developers**: Label was migrated to FluentV9
- **System**: No System changes

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft 

## Screenshots/Videos
<!-- Visual changes only -->
