### PR TITLE
fix(vscode): [Cherry-pick] Build custom code on deploy, handle error when fails to …

### DIFF
--- a/apps/vs-code-designer/src/app/commands/__test__/buildCustomCodeFunctionsProject.test.ts
+++ b/apps/vs-code-designer/src/app/commands/__test__/buildCustomCodeFunctionsProject.test.ts
@@ -138,6 +138,6 @@ describe('buildWorkspaceCustomCodeFunctionsProjects', () => {
     expect(window.showWarningMessage).toHaveBeenCalledWith(testErrorMessage);
     expect(window.showInformationMessage).not.toHaveBeenCalled();
     expect(context.telemetry.properties.result).toBe('Failed');
-    expect(context.telemetry.properties.error).toBeDefined();
+    expect(context.telemetry.properties.errorMessage).toBeDefined();
   });
 });

--- a/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
+++ b/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
@@ -12,6 +12,7 @@ import {
   tryGetLogicAppCustomCodeFunctionsProjects,
 } from '../utils/customCodeUtils';
 import * as vscode from 'vscode';
+import { isNullOrUndefined } from '@microsoft/logic-apps-shared';
 
 /**
  * Builds a custom code functions project.
@@ -20,26 +21,37 @@ import * as vscode from 'vscode';
  * @returns {Promise<void>} - A promise that resolves when the build process is complete.
  */
 export async function buildCustomCodeFunctionsProject(context: IActionContext, node: vscode.Uri): Promise<void> {
+  const workspaceFolderPath = await getWorkspaceRoot(context);
+
+  const nodePath = node?.fsPath || workspaceFolderPath;
+  if (isNullOrUndefined(nodePath)) {
+    const errorMessage = 'No project path found to build custom code functions project.';
+    context.telemetry.properties.result = 'Failed';
+    context.telemetry.properties.errorMessage = errorMessage;
+    ext.outputChannel.appendLog(localize('noProjectPathBuildCustomCode', errorMessage));
+    return;
+  }
+
   context.telemetry.properties.lastStep = 'isCustomCodeFunctionsProject';
-  if (await isCustomCodeFunctionsProject(node.fsPath)) {
+  if (await isCustomCodeFunctionsProject(nodePath)) {
     try {
       context.telemetry.properties.lastStep = 'buildCustomCodeProject';
-      await buildCustomCodeProject(node.fsPath);
+      await buildCustomCodeProject(nodePath);
       context.telemetry.properties.result = 'Succeeded';
     } catch (error) {
       context.telemetry.properties.result = 'Failed';
-      context.telemetry.properties.error = error.message;
+      context.telemetry.properties.errorMessage = error.message ?? error;
     }
     return;
   }
 
   context.telemetry.properties.lastStep = 'tryGetLogicAppCustomCodeFunctionsProjects';
-  const customCodeProjectPaths = await tryGetLogicAppCustomCodeFunctionsProjects(node.fsPath);
+  const customCodeProjectPaths = await tryGetLogicAppCustomCodeFunctionsProjects(nodePath);
   if (!customCodeProjectPaths || customCodeProjectPaths.length === 0) {
     const errorMessage = 'No custom code functions projects found for the logic app folder "{0}".';
     context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.error = errorMessage.replace('{0}', node.fsPath);
-    ext.outputChannel.appendLog(localize('azureLogicAppsStandard.noCustomCodeFunctionsProjectsFound', errorMessage, node.fsPath));
+    context.telemetry.properties.errorMessage = errorMessage.replace('{0}', nodePath);
+    ext.outputChannel.appendLog(localize('azureLogicAppsStandard.noCustomCodeFunctionsProjectsFound', errorMessage, nodePath));
     return;
   }
 
@@ -49,7 +61,7 @@ export async function buildCustomCodeFunctionsProject(context: IActionContext, n
     context.telemetry.properties.result = 'Succeeded';
   } catch (error) {
     context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.error = error.message;
+    context.telemetry.properties.errorMessage = error.message ?? error;
   }
 }
 
@@ -76,7 +88,7 @@ export async function buildWorkspaceCustomCodeFunctionsProjects(context: IAction
     context.telemetry.properties.result = 'Succeeded';
   } catch (error) {
     context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.error = error.message;
+    context.telemetry.properties.errorMessage = error.message;
   }
 }
 

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -69,7 +69,7 @@ import {
 } from '@microsoft/vscode-azext-utils';
 import type { AzExtTreeItem, IActionContext, AzExtParentTreeItem, IErrorHandlerContext, IParsedError } from '@microsoft/vscode-azext-utils';
 import type { Uri } from 'vscode';
-import { pickCustomCodeNetHostProcess } from './pickCustomCodeNetHostProcess';
+import { pickCustomCodeNetHostProcess } from './pickCustomCodeWorkerProcess';
 import { debugLogicApp } from './debugLogicApp';
 import { syncCloudSettings } from './syncCloudSettings';
 import { getDebugSymbolDll } from '../utils/getDebugSymbolDll';

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
@@ -18,14 +18,10 @@ export async function openDesigner(context: IAzureConnectorsContext, node: Uri |
   const workflowNode = getWorkflowNode(node);
 
   if (workflowNode instanceof Uri) {
-    try {
-      const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
-      // Only build custom code projects on open designer if custom code binaries don't already exist in the logic app folder
-      if (!(await fse.pathExists(path.join(logicAppNode.fsPath, 'lib', 'custom')))) {
-        await buildCustomCodeFunctionsProject(context, logicAppNode);
-      }
-    } catch {
-      // Ignore error if thrown, forego building custom code project
+    const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
+    // Only build custom code projects on open designer if custom code binaries don't already exist in the logic app folder
+    if (!(await fse.pathExists(path.join(logicAppNode.fsPath, 'lib', 'custom')))) {
+      await buildCustomCodeFunctionsProject(context, logicAppNode);
     }
 
     openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode);


### PR DESCRIPTION
…attach to custom code worker (#8307)

* add custom code build on deploy

* fix bug with custom code debugger when missing local function action in workflow

* address pr comments

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Cherry-pick custom code bugfixes into hotfix branch

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fix bugs related to error thrown when attempting to attach to custom code worker for workflow with no local function actions, build artifacts missing on deploy
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge 
