### PR TITLE
fix(vscode): Build custom code on deploy, handle error when fails to attach to custom code worker 

### DIFF
--- a/apps/vs-code-designer/src/app/commands/__test__/buildCustomCodeFunctionsProject.test.ts
+++ b/apps/vs-code-designer/src/app/commands/__test__/buildCustomCodeFunctionsProject.test.ts
@@ -138,6 +138,6 @@ describe('buildWorkspaceCustomCodeFunctionsProjects', () => {
     expect(window.showWarningMessage).toHaveBeenCalledWith(testErrorMessage);
     expect(window.showInformationMessage).not.toHaveBeenCalled();
     expect(context.telemetry.properties.result).toBe('Failed');
-    expect(context.telemetry.properties.error).toBeDefined();
+    expect(context.telemetry.properties.errorMessage).toBeDefined();
   });
 });

--- a/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
+++ b/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
@@ -25,10 +25,10 @@ export async function buildCustomCodeFunctionsProject(context: IActionContext, n
 
   const nodePath = node?.fsPath || workspaceFolderPath;
   if (isNullOrUndefined(nodePath)) {
-    const errorMessage = localize('noProjectPathBuildCustomCode', 'No project path found to build custom code functions project.');
+    const errorMessage = 'No project path found to build custom code functions project.';
     context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.error = errorMessage;
-    ext.outputChannel.appendLog(errorMessage);
+    context.telemetry.properties.errorMessage = errorMessage;
+    ext.outputChannel.appendLog(localize('noProjectPathBuildCustomCode', errorMessage));
     return;
   }
 
@@ -40,7 +40,7 @@ export async function buildCustomCodeFunctionsProject(context: IActionContext, n
       context.telemetry.properties.result = 'Succeeded';
     } catch (error) {
       context.telemetry.properties.result = 'Failed';
-      context.telemetry.properties.error = error.message;
+      context.telemetry.properties.errorMessage = error.message ?? error;
     }
     return;
   }
@@ -50,7 +50,7 @@ export async function buildCustomCodeFunctionsProject(context: IActionContext, n
   if (!customCodeProjectPaths || customCodeProjectPaths.length === 0) {
     const errorMessage = 'No custom code functions projects found for the logic app folder "{0}".';
     context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.error = errorMessage.replace('{0}', nodePath);
+    context.telemetry.properties.errorMessage = errorMessage.replace('{0}', nodePath);
     ext.outputChannel.appendLog(localize('azureLogicAppsStandard.noCustomCodeFunctionsProjectsFound', errorMessage, nodePath));
     return;
   }
@@ -61,7 +61,7 @@ export async function buildCustomCodeFunctionsProject(context: IActionContext, n
     context.telemetry.properties.result = 'Succeeded';
   } catch (error) {
     context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.error = error.message;
+    context.telemetry.properties.errorMessage = error.message ?? error;
   }
 }
 
@@ -88,7 +88,7 @@ export async function buildWorkspaceCustomCodeFunctionsProjects(context: IAction
     context.telemetry.properties.result = 'Succeeded';
   } catch (error) {
     context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.error = error.message;
+    context.telemetry.properties.errorMessage = error.message;
   }
 }
 

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -69,7 +69,7 @@ import {
 } from '@microsoft/vscode-azext-utils';
 import type { AzExtTreeItem, IActionContext, AzExtParentTreeItem, IErrorHandlerContext, IParsedError } from '@microsoft/vscode-azext-utils';
 import type { Uri } from 'vscode';
-import { pickCustomCodeNetHostProcess } from './pickCustomCodeNetHostProcess';
+import { pickCustomCodeNetHostProcess } from './pickCustomCodeWorkerProcess';
 import { debugLogicApp } from './debugLogicApp';
 import { syncCloudSettings } from './syncCloudSettings';
 import { getDebugSymbolDll } from '../utils/debug';

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
@@ -18,14 +18,10 @@ export async function openDesigner(context: IAzureConnectorsContext, node: Uri |
   const workflowNode = getWorkflowNode(node);
 
   if (workflowNode instanceof Uri) {
-    try {
-      const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
-      // Only build custom code projects on open designer if custom code binaries don't already exist in the logic app folder
-      if (!(await fse.pathExists(path.join(logicAppNode.fsPath, 'lib', 'custom')))) {
-        await buildCustomCodeFunctionsProject(context, logicAppNode);
-      }
-    } catch {
-      // Ignore error if thrown, forego building custom code project
+    const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
+    // Only build custom code projects on open designer if custom code binaries don't already exist in the logic app folder
+    if (!(await fse.pathExists(path.join(logicAppNode.fsPath, 'lib', 'custom')))) {
+      await buildCustomCodeFunctionsProject(context, logicAppNode);
     }
 
     openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode);


### PR DESCRIPTION
Cherry-pick of the following PR - #8307

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Fixes edge case where custom code project is never built before running "deploy" command. Checks whether build is needed prior to deploying. Also fixes issue where an error will occur when attempting to attach to custom code worker process when there is no local function action in workflow. Addresses #8274 and #8273.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes bugs (1) where custom code is not built (empty {la}\lib\custom\*) when deploying, and (2) where error occurs on debugging custom code project with no local function actions
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge 
