### PR TITLE
chore(vscode): remove authentication API proposal flag 

### DIFF
--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -1031,7 +1031,6 @@
     "ms-dotnettools.csharp",
     "ms-dotnettools.csdevkit"
   ],
-  "enabledApiProposals": ["authenticationChallenges"],
   "activationEvents": [
     "onView:azureWorkspace",
     "onView:azureResourceGroups",


### PR DESCRIPTION
Cherry-pick of the following PR: #8320
## Commit Type
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Remove the `enabledApiProposals` entry from the VS Code extension manifest now that we no longer rely on the `authenticationChallenges` proposal, keeping the extension compliant with marketplace requirements.

## Impact of Change
- **Users**: None
- **Developers**: Eliminates the need to publish with proposed API opt-in and avoids warnings during reviews
- **System**: No runtime impact; manifest metadata only

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in: N/A (manifest-only change)

## Contributors
N/A

## Screenshots/Videos
N/A
