### PR TITLE
fix(vscode): improve extension bundle path parsing for multi-line command output

### DIFF
--- a/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
@@ -1,9 +1,10 @@
-import { getBundleVersionNumber } from '../bundleFeed';
+import { getBundleVersionNumber, getExtensionBundleFolder } from '../bundleFeed';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as cp from 'child_process';
 import { extensionBundleId } from '../../../constants';
+import * as cpUtils from '../funcCoreTools/cpUtils';
 
 // Mock localize
 vi.mock('../../localize', () => ({
@@ -15,16 +16,275 @@ vi.mock('../funcCoreTools/funcVersion', () => ({
   getFunctionsCommand: vi.fn(() => 'func'),
 }));
 
+// Mock cpUtils
+vi.mock('../funcCoreTools/cpUtils', () => ({
+  executeCommand: vi.fn(),
+}));
+
+// Mock extensionVariables
+vi.mock('../../../extensionVariables', () => ({
+  ext: {
+    outputChannel: {
+      appendLog: vi.fn(),
+      show: vi.fn(),
+    },
+    telemetryReporter: {
+      sendTelemetryEvent: vi.fn(),
+    },
+  },
+}));
+
+// Mock vscode
+vi.mock('vscode', () => ({
+  workspace: {
+    workspaceFolders: [
+      {
+        uri: {
+          fsPath: '/mock/workspace',
+        },
+      },
+    ],
+  },
+}));
+
 const mockedFse = vi.mocked(fse);
 const mockedExecSync = vi.mocked(cp.execSync);
+const mockedExecuteCommand = vi.mocked(cpUtils.executeCommand);
+
+describe('getExtensionBundleFolder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('successful path extraction', () => {
+    it('should extract path from multi-line output with Windows path', async () => {
+      const mockOutput =
+        'local.settings.json found in root directory (c:\\Users\\test\\project).\r\n' +
+        "Resolving worker runtime to 'dotnet'.\r\n" +
+        'C:\\Users\\test\\.azure-functions-core-tools\\Functions\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle.Workflows\\1.138.54\r\n';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Users\\test\\.azure-functions-core-tools\\Functions\\ExtensionBundles\\');
+      expect(mockedExecuteCommand).toHaveBeenCalledWith(expect.anything(), '/mock/workspace', 'func', 'GetExtensionBundlePath');
+    });
+
+    it('should extract path from single line output', async () => {
+      const mockOutput =
+        'C:\\Users\\test\\.azure-functions-core-tools\\Functions\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle\\4.17.0\r\n';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Users\\test\\.azure-functions-core-tools\\Functions\\ExtensionBundles\\');
+    });
+
+    it('should handle Unix-style paths', async () => {
+      const mockOutput =
+        'local.settings.json found in root directory (/home/user/project).\n' +
+        "Resolving worker runtime to 'node'.\n" +
+        '/home/user/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/1.138.54\n';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('/home/user/.azure-functions-core-tools/Functions/ExtensionBundles/');
+    });
+
+    it('should extract path with different bundle types', async () => {
+      const mockOutput =
+        'C:\\Users\\test\\.azure-functions-core-tools\\Functions\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle\\4.17.0\r\n';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Users\\test\\.azure-functions-core-tools\\Functions\\ExtensionBundles\\');
+    });
+
+    it('should handle output with mixed line endings', async () => {
+      const mockOutput =
+        'Info message 1.\r\n' +
+        'Info message 2.\n' +
+        'C:\\Users\\test\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle.Workflows\\1.0.0\r\n';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Users\\test\\ExtensionBundles\\');
+    });
+
+    it('should trim whitespace from output', async () => {
+      const mockOutput =
+        '  \n' +
+        '  local.settings.json found.  \n' +
+        '  C:\\Users\\test\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle\\1.0.0  \n' +
+        '  \n';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Users\\test\\ExtensionBundles\\');
+    });
+
+    it('should handle mixed forward/back slashes in Windows paths', async () => {
+      // Forward slashes are valid on Windows, and the regex should match them via the [\\/] pattern
+      const mockOutput =
+        'C:\\Users/test/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/1.138.54\n';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Users/test/.azure-functions-core-tools/Functions/ExtensionBundles/');
+    });
+  });
+
+  describe('fallback path extraction', () => {
+    it('should use fallback when regex does not match but path starts with drive letter', async () => {
+      // Path that doesn't match the primary regex perfectly but has the bundle ID
+      const mockOutput = 'C:\\Test\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle\\1.0.0';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Test\\ExtensionBundles\\');
+    });
+
+    it('should use lastIndexOf for fallback to handle multiple occurrences', async () => {
+      const mockOutput =
+        'Found Microsoft.Azure.Functions.ExtensionBundle in config.\n' +
+        'C:\\Path\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle\\1.0.0';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      // Should use the last occurrence
+      expect(result).toBe('C:\\Path\\ExtensionBundles\\');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw error when no path line is found in output', async () => {
+      const mockOutput =
+        'local.settings.json found in root directory.\n' + "Resolving worker runtime to 'dotnet'.\n" + 'Some other message.';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      await expect(getExtensionBundleFolder()).rejects.toThrow('Could not find path to extension bundle');
+    });
+
+    it('should throw error when path line has no ExtensionBundles', async () => {
+      const mockOutput = 'C:\\Users\\test\\SomeOtherFolder\\';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      await expect(getExtensionBundleFolder()).rejects.toThrow('Could not find path to extension bundle');
+    });
+
+    it('should throw error when regex and fallback both fail', async () => {
+      const mockOutput = 'ExtensionBundles\\SomeFolder\\1.0.0';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      await expect(getExtensionBundleFolder()).rejects.toThrow('Could not find path to extension bundle.');
+    });
+
+    it('should handle executeCommand throwing an error', async () => {
+      mockedExecuteCommand.mockRejectedValue(new Error('Command failed'));
+
+      await expect(getExtensionBundleFolder()).rejects.toThrow('Could not find path to extension bundle.');
+    });
+
+    it('should handle empty output', async () => {
+      mockedExecuteCommand.mockResolvedValue('');
+
+      await expect(getExtensionBundleFolder()).rejects.toThrow('Could not find path to extension bundle.');
+    });
+
+    it('should handle output with only whitespace', async () => {
+      mockedExecuteCommand.mockResolvedValue('   \n  \r\n  \n   ');
+
+      await expect(getExtensionBundleFolder()).rejects.toThrow('Could not find path to extension bundle.');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle path with parentheses in directory names', async () => {
+      const mockOutput =
+        'local.settings.json found in root directory (C:\\Users\\test (admin)\\project).\n' +
+        'C:\\Users\\test (admin)\\.azure-functions\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle\\1.0.0';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Users\\test (admin)\\.azure-functions\\ExtensionBundles\\');
+    });
+
+    it('should handle path with spaces', async () => {
+      const mockOutput = 'C:\\Program Files\\Azure Functions\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle.Workflows\\1.0.0';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Program Files\\Azure Functions\\ExtensionBundles\\');
+    });
+
+    it('should handle very long version numbers', async () => {
+      const mockOutput = 'C:\\Users\\test\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle.Workflows\\1.138.54.12345.67890';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\Users\\test\\ExtensionBundles\\');
+    });
+
+    it('should handle multiple ExtensionBundles mentions in info messages', async () => {
+      const mockOutput =
+        'Looking for ExtensionBundles in default location.\n' +
+        'ExtensionBundles configuration loaded.\n' +
+        'C:\\Users\\test\\.azure-functions\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle\\4.17.0';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      // Should find the actual path, not the info messages
+      expect(result).toBe('C:\\Users\\test\\.azure-functions\\ExtensionBundles\\');
+    });
+
+    it('should handle case-insensitive path matching on Windows', async () => {
+      const mockOutput = 'C:\\users\\test\\ExtensionBundles\\Microsoft.Azure.Functions.ExtensionBundle\\1.0.0';
+
+      mockedExecuteCommand.mockResolvedValue(mockOutput);
+
+      const result = await getExtensionBundleFolder();
+
+      expect(result).toBe('C:\\users\\test\\ExtensionBundles\\');
+    });
+  });
+});
 
 describe('getBundleVersionNumber', () => {
-  const mockBundleFolderRoot = '/mock/bundle/root';
+  const mockBundleFolderRoot = 'C:\\mock\\bundle\\root\\ExtensionBundles\\';
   const mockBundleFolder = path.join(mockBundleFolderRoot, extensionBundleId);
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockedExecSync.mockReturnValue(`${mockBundleFolderRoot}Microsoft.Azure.Functions.ExtensionBundle\n`);
+    // Mock getExtensionBundleFolder to return a proper Windows path
+    const mockCommandOutput = `C:\\mock\\bundle\\root\\ExtensionBundles\\${extensionBundleId}\\1.0.0\n`;
+    mockedExecuteCommand.mockResolvedValue(mockCommandOutput);
   });
 
   it('should return the highest version number from available bundle folders', async () => {
@@ -105,7 +365,7 @@ describe('getBundleVersionNumber', () => {
     expect(result).toBe('1.0.0.1');
   });
 
-  it('should call execSync to get the bundle root path', async () => {
+  it('should call executeCommand to get the bundle root path', async () => {
     const mockFolders = ['1.0.0'];
     mockedFse.readdir.mockResolvedValue(mockFolders as any);
     mockedFse.stat.mockImplementation(() => {
@@ -116,6 +376,6 @@ describe('getBundleVersionNumber', () => {
 
     await getBundleVersionNumber();
 
-    expect(mockedExecSync).toHaveBeenCalledWith('func GetExtensionBundlePath', { encoding: 'utf8' });
+    expect(mockedExecuteCommand).toHaveBeenCalledWith(expect.anything(), '/mock/workspace', 'func', 'GetExtensionBundlePath');
   });
 });

--- a/apps/vs-code-designer/src/app/utils/bundleFeed.ts
+++ b/apps/vs-code-designer/src/app/utils/bundleFeed.ts
@@ -14,8 +14,8 @@ import * as vscode from 'vscode';
 import { localize } from '../../localize';
 import { ext } from '../../extensionVariables';
 import { getFunctionsCommand } from './funcCoreTools/funcVersion';
-import * as cp from 'child_process';
 import * as fse from 'fs-extra';
+import { executeCommand } from './funcCoreTools/cpUtils';
 /**
  * Gets bundle extension feed.
  * @param {IActionContext} context - Command context.
@@ -327,25 +327,53 @@ export async function getBundleVersionNumber(): Promise<string> {
  * @returns {string} Extension bundle folder path.
  */
 export async function getExtensionBundleFolder(): Promise<string> {
-  const command = `${getFunctionsCommand()} GetExtensionBundlePath`;
+  const command = getFunctionsCommand();
   const outputChannel = ext.outputChannel;
-
-  if (outputChannel) {
-    outputChannel.appendLog(localize('runningCommand', 'Running command: "{0}"...', command));
-  }
+  const workingDirectory = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
   let extensionBundlePath = '';
   try {
-    extensionBundlePath = await cp.execSync(command, { encoding: 'utf8' });
-  } catch (error) {
-    if (outputChannel) {
-      outputChannel.appendLog(localize('bundleCommandError', 'Could not find path to extension bundle'));
-      outputChannel.appendLog(JSON.stringify(error));
-    }
-    throw new Error(localize('bundlePathError', 'Could not find path to extension bundle.'));
-  }
+    const result = await executeCommand(outputChannel, workingDirectory, command, 'GetExtensionBundlePath');
 
-  extensionBundlePath = extensionBundlePath.trim().split('Microsoft.Azure.Functions.ExtensionBundle')[0];
+    // Split by newlines and find the line that contains the actual path
+    const lines = result
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    // The path line should contain "ExtensionBundles" and look like a valid path
+    const pathLine = lines.find(
+      (line) => line.includes('ExtensionBundles') && (line.match(/^[A-Z]:\\/i) || line.startsWith('/')) // Windows or Unix path
+    );
+
+    if (!pathLine) {
+      const pathError = new Error('Could not find extension bundle path in command output.');
+      ext.telemetryReporter.sendTelemetryEvent('BundlePathNotFound', { value: pathError.message });
+      throw pathError;
+    }
+
+    const bundlePathMatch = pathLine.match(/^(.+?[\\/]ExtensionBundles[/\\])/i);
+    if (bundlePathMatch) {
+      extensionBundlePath = bundlePathMatch[1];
+    } else {
+      const splitIndex = pathLine.lastIndexOf('Microsoft.Azure.Functions.ExtensionBundle');
+      if (splitIndex !== -1) {
+        extensionBundlePath = pathLine.substring(0, splitIndex);
+      } else {
+        const parseError = new Error('Could not parse extension bundle path from output.');
+        ext.telemetryReporter.sendTelemetryEvent('bundlePathParseError', { value: parseError.message });
+        throw parseError;
+      }
+    }
+  } catch (error) {
+    const bundleCommandError = new Error('Could not find path to extension bundle.');
+    if (outputChannel) {
+      outputChannel.appendLog(bundleCommandError.message);
+      outputChannel.appendLog(JSON.stringify(error));
+      ext.telemetryReporter.sendTelemetryEvent('bundleCommandError', { value: bundleCommandError.message });
+    }
+    throw new Error(bundleCommandError.message);
+  }
 
   if (outputChannel) {
     outputChannel.appendLog(localize('extensionBundlePath', 'Extension bundle path: "{0}"...', extensionBundlePath));


### PR DESCRIPTION
Cherry-pick of the following PR #8325 

## Commit Type
- [x] fix - Bug fix

## Risk Level
- [X] Medium - Moderate changes, some user impact

## What & Why
The `getExtensionBundleFolder()` function was failing to correctly parse the extension bundle path when the Azure Functions Core Tools command returned multi-line output. The previous implementation used `execSync` directly and expected a single-line response, but in practice, the command often returns additional informational messages before the actual path.

This PR refactors the path extraction logic to:
- Handle multi-line command output by splitting and filtering lines
- Detect Windows and Unix-style paths correctly
- Use improved regex matching to extract the ExtensionBundles folder path
- Add fallback parsing logic for edge cases
- Replace direct `child_process.execSync` call with the `executeCommand` utility for better consistency
- Add telemetry events for debugging path extraction failures

## Impact of Change
- **Users**: VS Code extension users will experience more reliable extension bundle path detection, reducing errors when running Logic Apps locally
- **Developers**: The code is now more maintainable with better error handling and clearer parsing logic
- **System**: No performance impact; improved reliability in path detection

## Test Plan
- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] Tested in: Added comprehensive unit tests covering:
  - Multi-line output parsing (Windows and Unix paths)
  - Mixed line endings (\r\n, \n)
  - Paths with spaces and special characters
  - Error handling for malformed output
  - Fallback parsing logic
  - Edge cases with multiple ExtensionBundles mentions

## Contributors
@andrew-eldridge @wsilveiranz 

## Screenshots
<img width="5120" height="2880" alt="CleanShot 2025-10-06 at 12 35 03@2x" src="https://github.com/user-attachments/assets/9b813255-524d-4942-89c6-54fdce7fa819" />



Fixes #8319 

