### PR TITLE
chore(ci): improve changelog workflow with auto-versioning and better error handling

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -78,17 +78,15 @@ jobs:
       - name: 'Determine Version'
         id: determine-version
         run: |
-          # Get version from from old tag
-          if [ -z "$NEW_TAG" ]; then
-            OLD_TAG="${{ github.event.inputs.old_tag }}"
-            # Extract version numbers (remove 'v' prefix)
-            VERSION_NUM=${OLD_TAG#v}
-            # Increment patch version
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION_NUM"
-            PATCH=$((PATCH + 1))
-            NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
-            echo "Auto-incremented version from $OLD_TAG to $NEW_TAG"
-          fi
+          # Get version from old tag and auto-increment patch version
+          OLD_TAG="${{ github.event.inputs.old_tag }}"
+          # Extract version numbers (remove 'v' prefix)
+          VERSION_NUM=${OLD_TAG#v}
+          # Increment patch version
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION_NUM"
+          PATCH=$((PATCH + 1))
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "Auto-incremented version from $OLD_TAG to $NEW_TAG"
           
           echo "Using tag: $NEW_TAG"
           echo "NEW_TAG=$NEW_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Commit Type
- [x] chore - Maintenance/tooling

## Risk Level
- [x] Medium - Moderate changes, some user impact

## What & Why
This PR improves the changelog update workflow by:
1. **Auto-versioning**: Removed manual `new_tag` input parameter - the workflow now automatically increments the patch version from the provided `old_tag`
2. **Better maintainability**: Migrated release notes generation from bash/Python scripts to GitHub Actions script (JavaScript)
3. **Improved workflow**: Changed the process to create and push a branch first, then allow manual PR creation (instead of automatic PR creation)
4. **Enhanced git log parsing**: More robust parsing of conventional commits and PR numbers from git history

## Impact of Change
- **Users**: No direct impact - this is an internal automation workflow
- **Developers**: The changelog workflow is now easier to maintain and understand. Developers using this workflow will need to manually create PRs from the generated branch instead of having PRs automatically created
- **System**: More reliable changelog generation with better error handling and clearer process flow

## Test Plan
- [x] Manual testing completed
- [x] Tested in: GitHub Actions workflow execution
- [x] Verified branch creation and changelog updates work correctly

## Contributors
@ccastrotrejo