### PR TITLE
feat(designerv2): Add run draft for non A2A workflows

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
@@ -179,7 +179,7 @@ const DesignerEditor = () => {
 
   const saveDraftWorkflow = useCallback(
     (workflow: Workflow) => {
-      return deployArtifacts(siteResourceId, workflowName, workflow, undefined, undefined, undefined, true);
+      return deployArtifacts(siteResourceId, workflowName, workflow.definition, undefined, undefined, undefined, true);
     },
     [siteResourceId, workflowName]
   );
@@ -203,6 +203,13 @@ const DesignerEditor = () => {
       resetDraftWorkflow();
     }
   }, [isDraftMode, resetDraftWorkflow]);
+
+  const onRunSelected = useCallback(
+    (runId: string) => {
+      dispatch(changeRunId(runId));
+    },
+    [dispatch]
+  );
 
   const canonicalLocation = WorkflowUtility.convertToCanonicalFormat(workflowAppData?.location ?? '');
   const supportsStateful = !equals(workflow?.kind, 'stateless');
@@ -257,13 +264,6 @@ const DesignerEditor = () => {
       });
     }
   }, [artifactData?.properties.files, isMonitoringView, toggleMonitoringView]);
-
-  const onRunSelected = useCallback(
-    (runId: string) => {
-      dispatch(changeRunId(runId));
-    },
-    [dispatch]
-  );
 
   const onRun = useCallback(
     (runId: string | undefined) => {
@@ -646,7 +646,8 @@ const DesignerEditor = () => {
                   <div style={{ display: 'flex', flexDirection: 'row', flexGrow: 1, height: '80%', position: 'relative' }}>
                     <Designer />
                     <FloatingRunButton
-                      id={workflowId}
+                      siteResourceId={siteResourceId}
+                      workflowName={workflowName}
                       saveDraftWorkflow={saveWorkflowFromDesigner}
                       onRun={onRun}
                       isDarkMode={isDarkMode}

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -175,7 +175,9 @@ export const FloatingRunButton = ({
           {...buttonCommonProps}
           primaryActionButton={{
             icon: runIsLoading ? <Spinner size="tiny" /> : <RunIcon />,
-            onClick: runMutate(isDraftMode),
+            onClick: () => {
+              runMutate(isDraftMode);
+            },
           }}
           menuButton={
             canBeRunWithPayload

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -4,7 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import { Button, Spinner, SplitButton } from '@fluentui/react-components';
 import { bundleIcon, FlashFilled, FlashRegular, FlashSettingsFilled, FlashSettingsRegular } from '@fluentui/react-icons';
 import type { Workflow } from '@microsoft/logic-apps-shared';
-import { canRunBeInvokedWithPayload, isNullOrEmpty, RunService, WorkflowService } from '@microsoft/logic-apps-shared';
+import { canRunBeInvokedWithPayload, HTTP_METHODS, isNullOrEmpty, RunService, WorkflowService } from '@microsoft/logic-apps-shared';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   getCustomCodeFilesWithData,
@@ -23,14 +23,22 @@ const RunIcon = bundleIcon(FlashFilled, FlashRegular);
 const RunWithPayloadIcon = bundleIcon(FlashSettingsFilled, FlashSettingsRegular);
 
 export interface FloatingRunButtonProps {
-  id?: string;
+  siteResourceId?: string;
+  workflowName?: string;
   saveDraftWorkflow: (workflowDefinition: Workflow, customCodeData: any, onSuccess: () => void) => Promise<any>;
   onRun?: (runId: string) => void;
   isDarkMode: boolean;
   isDraftMode?: boolean;
 }
 
-export const FloatingRunButton = ({ id: _id, saveDraftWorkflow, onRun, isDarkMode, isDraftMode }: FloatingRunButtonProps) => {
+export const FloatingRunButton = ({
+  siteResourceId,
+  workflowName,
+  saveDraftWorkflow,
+  onRun,
+  isDarkMode,
+  isDraftMode,
+}: FloatingRunButtonProps) => {
   const intl = useIntl();
 
   const dispatch = useDispatch();
@@ -39,7 +47,10 @@ export const FloatingRunButton = ({ id: _id, saveDraftWorkflow, onRun, isDarkMod
 
   const operationState = useSelector((state: RootState) => state.operations);
 
-  const canBeRunWithPayload = useMemo(() => canRunBeInvokedWithPayload(operationState?.operationInfo), [operationState?.operationInfo]);
+  const canBeRunWithPayload = useMemo(
+    () => !isDraftMode && canRunBeInvokedWithPayload(operationState?.operationInfo),
+    [isDraftMode, operationState?.operationInfo]
+  );
 
   const saveWorkflow = useCallback(async () => {
     try {
@@ -81,7 +92,7 @@ export const FloatingRunButton = ({ id: _id, saveDraftWorkflow, onRun, isDarkMod
     mutate: runMutate,
     isLoading: runIsLoading,
     // error: runError,
-  } = useMutation(async () => {
+  } = useMutation(async (isDraftMode?: boolean) => {
     try {
       const saveResponse = await saveWorkflow();
       const triggerId = Object.keys(saveResponse?.definition?.triggers || {})?.[0];
@@ -91,9 +102,19 @@ export const FloatingRunButton = ({ id: _id, saveDraftWorkflow, onRun, isDarkMod
       const callbackInfo = await WorkflowService().getCallbackUrl(triggerId);
       const method = saveResponse?.definition?.triggers?.[triggerId]?.inputs?.method || 'POST';
       callbackInfo.method = method;
+
+      if (isDraftMode) {
+        if (siteResourceId && workflowName) {
+          callbackInfo.value = `${siteResourceId}/hostruntime/runtime/webhooks/workflow/api/management/workflows/${workflowName}/triggers/${triggerId}/runDraft`;
+          callbackInfo.method = HTTP_METHODS.POST;
+        } else {
+          // TODO: Handle/throw error
+        }
+      }
+
       // Wait 0.5 seconds, running too fast after saving causes 500 error
       await new Promise((resolve) => setTimeout(resolve, 500));
-      const runResponse = await RunService().runTrigger(callbackInfo, undefined, isDraftMode);
+      const runResponse = await RunService().runTrigger(callbackInfo, undefined);
       const runId = runResponse?.responseHeaders?.['x-ms-workflow-run-id'] ?? runResponse?.headers?.['x-ms-workflow-run-id'];
       onRun?.(runId);
     } catch (_error: any) {
@@ -154,7 +175,7 @@ export const FloatingRunButton = ({ id: _id, saveDraftWorkflow, onRun, isDarkMod
           {...buttonCommonProps}
           primaryActionButton={{
             icon: runIsLoading ? <Spinner size="tiny" /> : <RunIcon />,
-            onClick: runMutate,
+            onClick: runMutate(isDraftMode),
           }}
           menuButton={
             canBeRunWithPayload

--- a/libs/logic-apps-shared/src/designer-client-services/lib/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/run.ts
@@ -7,7 +7,7 @@ export interface IRunService {
   getMoreRuns(continuationToken: string): Promise<Runs>;
   getRun(runId: string): Promise<Run | RunError>;
   getRuns(): Promise<Runs>;
-  runTrigger(callbackInfo: CallbackInfo, options?: any, isDraftMode?: boolean): Promise<any>;
+  runTrigger(callbackInfo: CallbackInfo, options?: any): Promise<any>;
   getActionLinks(action: any, nodeId: string): Promise<any>;
   getScopeRepetitions(
     action: { nodeId: string; runId: string | undefined },


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Users can now run draft workflows without payload

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Able to run draft workflow
- **Developers**: Need to make sure draft api is deployed 
- **System**: NA

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
