### PR TITLE
fix(vscode): Temporarily remove validatePartial, startRuntimeApi to mitigate designer issues

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -46,7 +46,6 @@ import type { WebviewPanel, ProgressOptions } from 'vscode';
 import { saveBlankUnitTest } from '../unitTest/saveBlankUnitTest';
 import { createHttpHeaders } from '@azure/core-rest-pipeline';
 import { getBundleVersionNumber } from '../../../utils/bundleFeed';
-import { startRuntimeApi } from '../../../utils/startRuntimeApi';
 
 export default class OpenDesignerForLocalProject extends OpenDesignerBase {
   private readonly workflowFilePath: string;
@@ -108,7 +107,8 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
     }
 
     await startDesignTimeApi(this.projectPath);
-    await startRuntimeApi(this.projectPath);
+    // TODO(aeldridge): Temporarily removed starting runtime due to conflicts with debugger launch tasks. Re-add once fixed.
+    // await startRuntimeApi(this.projectPath);
 
     if (!ext.designTimeInstances.has(this.projectPath)) {
       throw new Error(localize('designTimeNotRunning', `Design time is not running for project ${this.projectPath}.`));
@@ -118,16 +118,16 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
       throw new Error(localize('designTimePortNotFound', 'Design time port not found.'));
     }
 
-    if (!ext.runtimeInstances.has(this.projectPath)) {
-      throw new Error(localize('runtimeNotRunning', `Runtime is not running for project ${this.projectPath}.`));
-    }
-    const runtimePort = ext.runtimeInstances.get(this.projectPath).port;
-    if (!runtimePort) {
-      throw new Error(localize('runtimePortNotFound', 'Runtime port not found.'));
-    }
+    // if (!ext.runtimeInstances.has(this.projectPath)) {
+    //   throw new Error(localize('runtimeNotRunning', `Runtime is not running for project ${this.projectPath}.`));
+    // }
+    // const runtimePort = ext.runtimeInstances.get(this.projectPath).port;
+    // if (!runtimePort) {
+    //   throw new Error(localize('runtimePortNotFound', 'Runtime port not found.'));
+    // }
 
     this.baseUrl = `http://localhost:${designTimePort}${managementApiPrefix}`;
-    this.workflowRuntimeBaseUrl = `http://localhost:${runtimePort}${managementApiPrefix}`;
+    // this.workflowRuntimeBaseUrl = `http://localhost:${runtimePort}${managementApiPrefix}`;
 
     this.panel = window.createWebviewPanel(
       this.panelGroupKey, // Key used to reference the panel
@@ -208,17 +208,20 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
             runId: this.runId,
           },
         });
-        await callWithTelemetryAndErrorHandling('InitializeWorkflowFromDesigner', async (activateContext: IActionContext) => {
-          if (!this.isUnitTest) {
-            await this.validateWorkflow(activateContext, this.panelMetadata.workflowContent, this.panelMetadata.localSettings);
-          }
-        });
+
+        // TODO(aeldridge): Temporarily removed validation due to 500 responses from validatePartial endpoint. Re-add once fixed.
+        // await callWithTelemetryAndErrorHandling('InitializeWorkflowFromDesigner', async (activateContext: IActionContext) => {
+        //   if (!this.isUnitTest) {
+        //     await this.validateWorkflow(activateContext, this.panelMetadata.workflowContent, this.panelMetadata.localSettings);
+        //   }
+        // });
         break;
       }
       case ExtensionCommand.save: {
         await callWithTelemetryAndErrorHandling('SaveWorkflowFromDesigner', async (activateContext: IActionContext) => {
-          const projectPath = await getLogicAppProjectRoot(activateContext, this.workflowFilePath);
-          const localSettingsPath: string = path.join(projectPath, localSettingsFileName);
+          // TODO(aeldridge): Temporarily removed validation due to 500 responses from validatePartial endpoint. Re-add once fixed.
+          // const projectPath = await getLogicAppProjectRoot(activateContext, this.workflowFilePath);
+          // const localSettingsPath: string = path.join(projectPath, localSettingsFileName);
           await this.saveWorkflow(
             activateContext,
             this.workflowFilePath,
@@ -228,16 +231,16 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
             this.panelMetadata.azureDetails?.tenantId,
             this.panelMetadata.azureDetails?.workflowManagementBaseUrl
           );
-          const savedLocalSettingsValues = (await getLocalSettingsJson(activateContext, localSettingsPath, true)).Values || {};
-          let savedWorkflow: any;
+          // const savedLocalSettingsValues = (await getLocalSettingsJson(activateContext, localSettingsPath, true)).Values || {};
+          // let savedWorkflow: any;
 
-          try {
-            savedWorkflow = JSON.parse(readFileSync(this.workflowFilePath, 'utf8'));
-          } catch (error) {
-            window.showErrorMessage(`Failed to parse workflow file as JSON: ${(error as Error).message}`);
-          }
+          // try {
+          //   savedWorkflow = JSON.parse(readFileSync(this.workflowFilePath, 'utf8'));
+          // } catch (error) {
+          //   window.showErrorMessage(`Failed to parse workflow file as JSON: ${(error as Error).message}`);
+          // }
 
-          await this.validateWorkflow(activateContext, savedWorkflow, savedLocalSettingsValues);
+          // await this.validateWorkflow(activateContext, savedWorkflow, savedLocalSettingsValues);
         });
         break;
       }


### PR DESCRIPTION
Cherry-pick of the following PR #8350
Fixes #8354, #8355

temporarily remove validatePartial, startRuntimeApi on open designer as mitigation

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Cherry-pick designer issue mitigations to hotfix branch

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Mitigation for issues blocking opening designer and launching debugger
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge 
