### PR TITLE
fix(vscode): Add pre-build check for whether custom code artifacts exist

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as path from 'path';
-import * as fse from 'fs-extra';
 import { RemoteWorkflowTreeItem } from '../../../tree/remoteWorkflowsTree/RemoteWorkflowTreeItem';
 import { getWorkflowNode } from '../../../utils/workspace';
 import type { IAzureConnectorsContext } from '../azureConnectorWizard';
@@ -11,6 +10,7 @@ import { OpenDesignerForAzureResource } from './openDesignerForAzureResource';
 import OpenDesignerForLocalProject from './openDesignerForLocalProject';
 import { Uri } from 'vscode';
 import { buildCustomCodeFunctionsProject } from '../../buildCustomCodeFunctionsProject';
+import { customCodeArtifactsExist } from '../../../utils/customCodeUtils';
 
 export async function openDesigner(context: IAzureConnectorsContext, node: Uri | RemoteWorkflowTreeItem | undefined): Promise<void> {
   let openDesignerObj: OpenDesignerForLocalProject | OpenDesignerForAzureResource;
@@ -20,7 +20,7 @@ export async function openDesigner(context: IAzureConnectorsContext, node: Uri |
   if (workflowNode instanceof Uri) {
     const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
     // Only build custom code projects on open designer if custom code binaries don't already exist in the logic app folder
-    if (!(await fse.pathExists(path.join(logicAppNode.fsPath, 'lib', 'custom')))) {
+    if (!(await customCodeArtifactsExist(logicAppNode.fsPath))) {
       await buildCustomCodeFunctionsProject(context, logicAppNode);
     }
 


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Add a pre-build check that the lib\custom\<func-name>\functions.json exists for all custom code projects (to determine whether build is necessary). Fixes issue where build is sometimes erroneously skipped

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes issue with inconsistent build on open designer behavior
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge @wsilveiranz 
