### PR TITLE
fix(designer): Fix double entry on handoffs

### DIFF
--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/handoff.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/handoff.ts
@@ -15,8 +15,8 @@ import Constants from '../../../common/constants';
  * Generates a handoff tool name following the pattern: handoff_to_<agent-name>
  * If the name exceeds 64 characters, falls back to the GUID-based pattern
  */
-function generateHandoffToolName(targetId: string): string {
-  const preferredName = `handoff_to_${targetId}`;
+function generateHandoffToolName(targetId: string, sourceId: string): string {
+  const preferredName = `handoff_to_${targetId}_from_${sourceId}`;
 
   if (preferredName.length <= Constants.HANDOFF_TOOL_NAME_MAX_LENGTH) {
     return preferredName;
@@ -41,7 +41,7 @@ export const addAgentHandoff = createAsyncThunk('addAgentHandoff', async (payloa
       operationId: agentOperation.id,
     });
 
-    const newToolId = generateHandoffToolName(targetId);
+    const newToolId = generateHandoffToolName(targetId, sourceId);
     const newHandoffId = `handoff_${customLengthGuid(8)}`;
 
     // Initialize subgraph manifest

--- a/libs/designer/src/lib/core/actions/bjsworkflow/handoff.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/handoff.ts
@@ -15,8 +15,8 @@ import Constants from '../../../common/constants';
  * Generates a handoff tool name following the pattern: handoff_to_<agent-name>
  * If the name exceeds 64 characters, falls back to the GUID-based pattern
  */
-function generateHandoffToolName(targetId: string): string {
-  const preferredName = `handoff_to_${targetId}`;
+function generateHandoffToolName(targetId: string, sourceId: string): string {
+  const preferredName = `handoff_to_${targetId}_from_${sourceId}`;
 
   if (preferredName.length <= Constants.HANDOFF_TOOL_NAME_MAX_LENGTH) {
     return preferredName;
@@ -41,7 +41,7 @@ export const addAgentHandoff = createAsyncThunk('addAgentHandoff', async (payloa
       operationId: agentOperation.id,
     });
 
-    const newToolId = generateHandoffToolName(targetId);
+    const newToolId = generateHandoffToolName(targetId, sourceId);
     const newHandoffId = `handoff_${customLengthGuid(8)}`;
 
     // Initialize subgraph manifest


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Handoff tool name were being duplicated if a handoff to target already existed thus adding multiple hand-off tools

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users will be able to add handoff to same agents from multiple agents without issues
- **Developers**: None
- **System**: None

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
