### PR TITLE
fix(DesignerV2): Fixed issue with graph rebuild when leaving monitoring views

### DIFF
--- a/libs/designer-v2/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer-v2/src/lib/core/BJSWorkflowProvider.tsx
@@ -7,6 +7,7 @@ import {
   useAreDesignerOptionsInitialized,
   useAreServicesInitialized,
   useMonitoringView,
+	useReadOnly,
 } from './state/designerOptions/designerOptionsSelectors';
 import { initializeServices } from './state/designerOptions/designerOptionsSlice';
 import { initUnitTestDefinition } from './state/unitTest/unitTestSlice';
@@ -47,6 +48,7 @@ const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({
 }) => {
   const dispatch = useDispatch<AppDispatch>();
 
+	const isReadOnly = useReadOnly();
   const isMonitoringView = useMonitoringView();
 
   useDeepCompareEffect(() => {
@@ -58,7 +60,7 @@ const DataProviderInner: React.FC<BJSWorkflowProviderProps> = ({
     dispatch(initCustomCode(customCode));
     dispatch(initializeGraphState({ workflowDefinition: workflow, runInstance, isMultiVariableEnabled }));
     dispatch(initUnitTestDefinition(deserializeUnitTestDefinition(unitTestDefinition ?? null, workflow)));
-  }, [workflowId, runInstance, workflow, customCode, unitTestDefinition, isMonitoringView]);
+	}, [workflowId, runInstance, workflow, customCode, unitTestDefinition, isReadOnly, isMonitoringView]);
 
   // Store app settings in query to access outside of functional components
   useQuery({


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixed issue with graph build race condition, where switching from monitoring to editing would initialize the graph incorrectly due to the `isMonitoring` flag not yet being updated.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Switching from monitoring to editing will show graph as expected
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97 

## Screenshots/Videos
<!-- Visual changes only -->
N/A
