### PR TITLE
fix(DesignerV2): Fixed run-history reopening bug

### DIFF
--- a/libs/designer-v2/src/lib/ui/panel/runHistoryPanel/runHistoryPanel.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/runHistoryPanel/runHistoryPanel.tsx
@@ -264,9 +264,7 @@ export const RunHistoryPanel = () => {
   const [inRunList, setInRunList] = useState(true);
 
   useEffect(() => {
-    if (selectedRunInstance) {
-      setInRunList(false);
-    }
+    setInRunList(!selectedRunInstance);
   }, [selectedRunInstance]);
 
   return (


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixed issue where the run history would not be in the run list if you selected a run, switched to the editor, and switched back to the run history.  Instead of an empty run log you now see the run list.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Stated above
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A
