### PR TITLE
fix(DesignerV2): Fixed standalone draft save issues

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Models/Workflow.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Models/Workflow.ts
@@ -16,7 +16,7 @@ export const Artifact = {
   ParametersFile: 'parameters.json',
   WorkflowFile: 'workflow.json',
   HostFile: 'host.json',
-  DraftFile: 'draft.json',
+  DraftFile: 'workflow-draft.json',
   DraftConnectionsFile: 'connections-draft.json',
   DraftParametersFile: 'parameters-draft.json',
 } as const;

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
@@ -179,7 +179,7 @@ const DesignerEditor = () => {
 
   const saveDraftWorkflow = useCallback(
     (workflow: Workflow) => {
-      return deployArtifacts(siteResourceId, workflowName, workflow.definition, undefined, undefined, undefined, true);
+      return deployArtifacts(siteResourceId, workflowName, workflow, undefined, undefined, undefined, true);
     },
     [siteResourceId, workflowName]
   );


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixes some of the draft saving issues we had in standalone
- Draft workflow file path matches portal
- Draft workflow object is now the correct object, previously was causing invalid data in the workflow file

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: N/A
- **Developers**: Draft functionality is fixed in standalone
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
n/a