### PR TITLE
fix(designer): Prevent deletionConnection occurring on Non-Arm Connections

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
@@ -244,8 +244,10 @@ export class StandardConnectionService extends BaseConnectionService implements 
       source: 'connection.ts',
     });
 
+    const isArmResource = isArmResourceId(connector.id);
+
     try {
-      const connection = isArmResourceId(connector.id)
+      const connection = isArmResource
         ? await this._createConnectionInApiHub(connectionName, connector.id, connectionInfo, shouldTestConnection)
         : await this.createConnectionInLocal(connectionName, connector, connectionInfo, parametersMetadata as ConnectionParametersMetadata);
 
@@ -257,7 +259,9 @@ export class StandardConnectionService extends BaseConnectionService implements 
       });
       return connection;
     } catch (error) {
-      this.deleteConnection(connectionId);
+      if (isArmResource) {
+        this.deleteConnection(connectionId);
+      }
       const errorMessage = `Failed to create connection: ${this.tryParseErrorMessage(error)}`;
       LoggerService().log({
         level: LogEntryLevel.Error,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
We delete the created connection for every newly created connection that errors. However, this delete is also happening for local connections as well. With connectors such as sql having both builtin and managed connectors, this would make it so that a failed builtin in sql connection could delete a managed connection. To prevent this from happening because we don't create builtin connections in ARM we can prevent the deletion from happening.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: If users fail to create a builtin connection ex sql service provider connection, no delete connection occurs
- **Developers**: Slightly modifying the delete path for creating connections
- **System**: No system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@Eric-B-Wu 

## Screenshots/Videos
<!-- Visual changes only -->
