### PR TITLE
feat(vscode): Enable Managed Service Identity (MSI) authentication by default for Azure Logic Apps connections

### DIFF
--- a/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
@@ -26,7 +26,12 @@ import { localize } from '../../../localize';
 import { LogicAppResourceTree } from '../../tree/LogicAppResourceTree';
 import { SlotTreeItem } from '../../tree/slotsTree/SlotTreeItem';
 import { SubscriptionTreeItem } from '../../tree/subscriptionTree/subscriptionTreeItem';
-import { createAclInConnectionIfNeeded, getConnectionsJson } from '../../utils/codeless/connection';
+import {
+  createAclInConnectionIfNeeded,
+  getConnectionsJson,
+  updateAuthenticationInConnections,
+  updateAuthenticationParameters,
+} from '../../utils/codeless/connection';
 import { getParametersJson } from '../../utils/codeless/parameter';
 import { isPathEqual, writeFormattedJson } from '../../utils/fs';
 import { addLocalFuncTelemetry } from '../../utils/funcCoreTools/funcVersion';
@@ -348,24 +353,6 @@ async function getProjectPathToDeploy(
   let resolvedConnections: ConnectionsData;
   let connectionsData: ConnectionsData;
 
-  function updateAuthenticationParameters(authValue: any): void {
-    if (connectionsData.managedApiConnections && Object.keys(connectionsData.managedApiConnections).length) {
-      for (const referenceKey of Object.keys(connectionsData.managedApiConnections)) {
-        parametersJson[`${referenceKey}-Authentication`].value = authValue;
-        actionContext.telemetry.properties.updateAuth = `updated "${referenceKey}-Authentication" parameter to ManagedServiceIdentity`;
-      }
-    }
-  }
-
-  function updateAuthenticationInConnections(authValue: any): void {
-    if (connectionsData.managedApiConnections && Object.keys(connectionsData.managedApiConnections).length) {
-      for (const referenceKey of Object.keys(connectionsData.managedApiConnections)) {
-        connectionsData.managedApiConnections[referenceKey].authentication = authValue;
-        actionContext.telemetry.properties.updateAuth = `updated "${referenceKey}" connection authentication to ManagedServiceIdentity`;
-      }
-    }
-  }
-
   try {
     connectionsData = JSON.parse(connectionsJson);
     const authValue = { type: 'ManagedServiceIdentity' };
@@ -378,16 +365,14 @@ async function getProjectPathToDeploy(
       secret: `@appsetting('${workflowAppAADClientSecret}')`,
     };
 
+    const parameterAuthValue = identityWizardContext?.useAdvancedIdentity ? advancedIdentityAuthValue : authValue;
     if (parameterizeConnectionsSetting) {
-      identityWizardContext?.useAdvancedIdentity
-        ? updateAuthenticationParameters(advancedIdentityAuthValue)
-        : updateAuthenticationParameters(authValue);
+      // Parameterized projects
+      await updateAuthenticationParameters(connectionsData, parameterAuthValue, parametersJson, actionContext);
     } else {
-      identityWizardContext?.useAdvancedIdentity
-        ? updateAuthenticationInConnections(advancedIdentityAuthValue)
-        : updateAuthenticationInConnections(authValue);
+      // Non-parameterized projects
+      await updateAuthenticationInConnections(connectionsData, parameterAuthValue, actionContext);
     }
-
     resolvedConnections = resolveConnectionsReferences(connectionsJson, parametersJson, targetAppSettings);
   } catch {
     actionContext.telemetry.properties.noAuthUpdate = 'No authentication update was made';

--- a/apps/vs-code-designer/src/app/utils/codeless/__test__/updateConnectionsMSI.test.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/__test__/updateConnectionsMSI.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import type { ConnectionsData } from '@microsoft/vscode-extension-logic-apps';
+import { updateAuthenticationParameters, updateAuthenticationInConnections } from '../../codeless/connection';
+
+describe('connections/auth updates', () => {
+  describe('updateAuthenticationParameters', () => {
+    it('Should update parameters.json values for all managed API connections and set telemetry', async () => {
+      const connectionsData: ConnectionsData = {
+        managedApiConnections: {
+          msnweather: {} as any,
+          office365: {} as any,
+        },
+      };
+
+      const parametersJson: any = {
+        'msnweather-Authentication': { value: { type: 'Raw', scheme: 'Key' } },
+        'office365-Authentication': { value: { type: 'Raw', scheme: 'Key' } },
+      };
+
+      const authValue = { type: 'ManagedServiceIdentity' };
+
+      const actionContext: any = {
+        telemetry: { properties: {} },
+      };
+
+      await updateAuthenticationParameters(connectionsData, authValue, parametersJson, actionContext);
+
+      expect(parametersJson['msnweather-Authentication'].value).toEqual(authValue);
+      expect(parametersJson['office365-Authentication'].value).toEqual(authValue);
+
+      expect(actionContext.telemetry.properties.updateAuth).toBe('updated "office365-Authentication" parameter to ManagedServiceIdentity');
+    });
+
+    it('Should do nothing when managedApiConnections is empty', async () => {
+      const connectionsData: ConnectionsData = {
+        managedApiConnections: {},
+      };
+
+      const parametersJson: any = {};
+      const authValue = { type: 'ManagedServiceIdentity' };
+
+      const actionContext: any = {
+        telemetry: { properties: {} },
+      };
+
+      await updateAuthenticationParameters(connectionsData, authValue, parametersJson, actionContext);
+
+      // No keys updated, no telemetry set
+      expect(Object.keys(parametersJson).length).toBe(0);
+      expect(actionContext.telemetry.properties.updateAuth).toBeUndefined();
+    });
+
+    it('Should not throw when actionContext is undefined', async () => {
+      const connectionsData: ConnectionsData = {
+        managedApiConnections: {
+          api1: {} as any,
+        },
+      };
+
+      const parametersJson: any = {
+        'api1-Authentication': { value: { type: 'Raw', scheme: 'Key' } },
+      };
+
+      const authValue = { type: 'ManagedServiceIdentity' };
+
+      await updateAuthenticationParameters(connectionsData, authValue, parametersJson /* no ctx */);
+
+      expect(parametersJson['api1-Authentication'].value).toEqual(authValue);
+    });
+  });
+
+  describe('updateAuthenticationInConnections', () => {
+    it('Should write authentication directly into each managed API connection and set telemetry', async () => {
+      const connectionsData: ConnectionsData = {
+        managedApiConnections: {
+          storage: { authentication: { type: 'Raw', scheme: 'Key' } } as any,
+          keyvault: { authentication: { type: 'Raw', scheme: 'Key' } } as any,
+        },
+      };
+
+      const authValue = { type: 'ManagedServiceIdentity' };
+
+      const actionContext: any = {
+        telemetry: { properties: {} },
+      };
+
+      await updateAuthenticationInConnections(connectionsData, authValue, actionContext);
+
+      expect(connectionsData.managedApiConnections!.storage.authentication).toEqual(authValue);
+      expect(connectionsData.managedApiConnections!.keyvault.authentication).toEqual(authValue);
+
+      expect(actionContext.telemetry.properties.updateAuth).toBe('updated "keyvault" connection authentication to ManagedServiceIdentity');
+    });
+
+    it('Should do nothing when managedApiConnections is missing', async () => {
+      const connectionsData = {} as ConnectionsData;
+      const authValue = { type: 'ManagedServiceIdentity' };
+
+      const actionContext: any = {
+        telemetry: { properties: {} },
+      };
+
+      await updateAuthenticationInConnections(connectionsData, authValue, actionContext);
+
+      expect(actionContext.telemetry.properties.updateAuth).toBeUndefined();
+    });
+
+    it('Should not throw when actionContext is undefined', async () => {
+      const connectionsData: ConnectionsData = {
+        managedApiConnections: {
+          contoso: { authentication: { type: 'Raw', scheme: 'Key' } } as any,
+        },
+      };
+
+      const authValue = { type: 'ManagedServiceIdentity' };
+
+      await updateAuthenticationInConnections(connectionsData, authValue /* no ctx */);
+
+      expect(connectionsData.managedApiConnections!.contoso.authentication).toEqual(authValue);
+    });
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/codeless/connection.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/connection.ts
@@ -189,7 +189,7 @@ async function getConnectionReference(
     connectionProperties,
   } = reference;
 
-  const useMsi = ext.useMSI; // Check if MSI is enabled from extension settings
+  const useMsi = ext.useMSI;
 
   return axios
     .post(


### PR DESCRIPTION
[Work Item: Add MSI authentication support and enable by default for Logic Apps connections](https://msazure.visualstudio.com/One/_workitems/edit/35560952)
## Commit Type
- [x] feature - New functionality

## Risk Level
- [x] low - Minor changes, low user/system impact

## What & Why

This PR adds **Managed Service Identity (MSI)** authentication support for Azure Logic Apps connections and **enables it by default** for all users. 

Previously, the extension only supported key-based authentication, which required storing connection keys in application settings. With MSI, Azure services can authenticate using Azure Active Directory identities without managing secrets.

**Key Changes:**
- Added `isMSIEnabled()` helper function to check if MSI is enabled
- Modified connection creation to use MSI authentication when enabled
- Connection keys are now only stored in settings when MSI is disabled
- Changed default from `ext.useMSI = false` to `ext.useMSI = true`

## Impact of Change

- **Users**: 
  - **Breaking Change**: New installations will use MSI by default instead of key-based authentication
  - Existing users with `ext.useMSI = false` will continue using key-based auth
  - MSI provides better security by eliminating stored connection keys
  - Requires proper Azure role assignments for MSI to work

- **Developers**: 
  - New `isMSIEnabled()` function available for checking MSI status
  - Connection reference model now supports both `ManagedServiceIdentity` and `Raw` authentication types
  - Settings are only populated with connection keys when MSI is disabled

- **System**: 
  - Reduced secret storage when MSI is used
  - Telemetry updates to track MSI configuration
  - Connection key generation now conditional based on MSI status

## Test Plan

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed
- [ ] Tested in: <!-- Please specify:
  - Fresh install with MSI enabled
  - Upgrade scenario with existing key-based connections
  - MSI authentication flow end-to-end
  - Fallback to key-based when MSI is disabled
  - Azure environments with proper MSI role assignments -->

