### PR TITLE
fix(vscode): fix telemetry names for createUnitTest/saveBlankUnitTest

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -245,9 +245,7 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
         break;
       }
       case ExtensionCommand.saveBlankUnitTest: {
-        await callWithTelemetryAndErrorHandling('SaveBlankUnitTestFromDesigner', async (activateContext: IActionContext) => {
-          await saveBlankUnitTest(activateContext, Uri.file(this.workflowFilePath), msg.definition);
-        });
+        await saveBlankUnitTest(Uri.file(this.workflowFilePath), msg.definition);
         break;
       }
       case ExtensionCommand.saveUnitTest: {

--- a/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openMonitoringView/openMonitoringViewForLocal.ts
@@ -31,7 +31,6 @@ import * as vscode from 'vscode';
 import type { WebviewPanel } from 'vscode';
 import { Uri, ViewColumn } from 'vscode';
 import { getArtifactsInLocalProject } from '../../../utils/codeless/artifacts';
-import { saveBlankUnitTest } from '../unitTest/saveBlankUnitTest';
 import { getBundleVersionNumber } from '../../../utils/bundleFeed';
 
 export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
@@ -149,11 +148,7 @@ export default class OpenMonitoringViewForLocal extends OpenMonitoringViewBase {
         break;
       }
       case ExtensionCommand.createUnitTest: {
-        await createUnitTest(this.context, vscode.Uri.file(this.workflowFilePath), message.runId, message.definition);
-        break;
-      }
-      case ExtensionCommand.saveBlankUnitTest: {
-        await saveBlankUnitTest(this.context, vscode.Uri.file(this.workflowFilePath), message.definition);
+        await createUnitTest(vscode.Uri.file(this.workflowFilePath), message.runId, message.definition);
         break;
       }
       case ExtensionCommand.fileABug: {

--- a/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openOverview.ts
@@ -23,8 +23,6 @@ import { sendRequest } from '../../utils/requestUtils';
 import { getWorkflowNode } from '../../utils/workspace';
 import type { IAzureConnectorsContext } from './azureConnectorWizard';
 import { openMonitoringView } from './openMonitoringView/openMonitoringView';
-import { createUnitTest } from './unitTest/createUnitTest';
-import { saveBlankUnitTest } from './unitTest/saveBlankUnitTest';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { ICallbackUrlResponse } from '@microsoft/vscode-extension-logic-apps';
 import { ExtensionCommand, ProjectName } from '@microsoft/vscode-extension-logic-apps';
@@ -160,15 +158,6 @@ export async function openOverview(context: IAzureConnectorsContext, node: vscod
             });
           }
         }, 5000);
-        break;
-      }
-
-      case ExtensionCommand.createUnitTest: {
-        await createUnitTest(context, workflowNode as vscode.Uri, message.runId);
-        break;
-      }
-      case ExtensionCommand.saveBlankUnitTest: {
-        await saveBlankUnitTest(this.context as IAzureConnectorsContext, vscode.Uri.file(this.workflowFilePath), message.definition);
         break;
       }
       default:

--- a/apps/vs-code-designer/src/app/commands/workflows/unitTest/__test__/saveBlankUnitTest.test.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/unitTest/__test__/saveBlankUnitTest.test.ts
@@ -85,11 +85,6 @@ describe('saveBlankUnitTest', () => {
     // Stub directory creation
     vi.spyOn(fs, 'ensureDir').mockResolvedValue();
 
-    // Stub telemetry logging functions
-    vi.spyOn(unitTestUtils, 'logTelemetry').mockImplementation(() => {});
-    vi.spyOn(unitTestUtils, 'logError').mockImplementation(() => {});
-    vi.spyOn(unitTestUtils, 'logSuccess').mockImplementation(() => {});
-
     // Stub isMultiRootWorkspace to simulate a valid multi-root environment
     vi.spyOn(workspaceUtils, 'isMultiRootWorkspace').mockReturnValue(true);
     vi.spyOn(ConvertWorkspace, 'convertToWorkspace').mockResolvedValue(true);
@@ -117,9 +112,9 @@ describe('saveBlankUnitTest', () => {
   });
 
   test('should successfully create a blank unit test', async () => {
-    await saveBlankUnitTest(dummyContext, dummyNode, dummyUnitTestDefinition);
+    await saveBlankUnitTest(dummyNode, dummyUnitTestDefinition);
 
-    expect(unitTestUtils.logTelemetry).toHaveBeenCalledWith(dummyContext, expect.objectContaining({ unitTestSaveStatus: 'Success' }));
+    expect(dummyContext.telemetry.properties.unitTestSaveStatus).toBe('Success');
     expect(unitTestUtils.promptForUnitTestName).toHaveBeenCalledTimes(1);
     expect(fs.ensureDir).toHaveBeenCalled();
 
@@ -133,10 +128,10 @@ describe('saveBlankUnitTest', () => {
     vi.spyOn(workspaceUtils, 'isMultiRootWorkspace').mockReturnValue(false);
     vi.spyOn(ConvertWorkspace, 'convertToWorkspace').mockResolvedValue(false);
 
-    await saveBlankUnitTest(dummyContext, dummyNode, dummyUnitTestDefinition);
+    await saveBlankUnitTest(dummyNode, dummyUnitTestDefinition);
 
     expect(unitTestUtils.promptForUnitTestName).toHaveBeenCalledTimes(0);
-    expect(unitTestUtils.logTelemetry).toHaveBeenCalledWith(dummyContext, expect.objectContaining({ multiRootWorkspaceValid: 'false' }));
+    expect(dummyContext.telemetry.properties.multiRootWorkspaceValid).toBe('false');
     expect(updateSolutionWithProjectSpy).not.toHaveBeenCalled();
     expect(dummyContext.telemetry.properties.result).toBe('Canceled');
   });
@@ -145,7 +140,7 @@ describe('saveBlankUnitTest', () => {
     const testError = new Error('Test error');
     vi.spyOn(unitTestUtils, 'parseUnitTestOutputs').mockRejectedValueOnce(testError);
 
-    await saveBlankUnitTest(dummyContext, dummyNode, dummyUnitTestDefinition);
+    await saveBlankUnitTest(dummyNode, dummyUnitTestDefinition);
 
     expect(updateSolutionWithProjectSpy).not.toHaveBeenCalled();
     expect(dummyContext.telemetry.properties.result).toBe('Failed');

--- a/apps/vs-code-designer/src/app/utils/__test__/unitTestUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/unitTestUtils.test.ts
@@ -25,7 +25,6 @@ import {
   parseErrorBeforeTelemetry,
   generateCSharpClasses,
   generateClassCode,
-  logTelemetry,
   getOperationMockClassContent,
   buildClassDefinition,
   mapJsonTypeToCSharp,
@@ -560,22 +559,6 @@ describe('unitTests', () => {
       expect(classCode).toContain('public class ChildClass');
       expect(classCode).toContain('public string NestedProperty { get; set; }');
       expect(classCode).toContain('this.NestedProperty = string.Empty;');
-    });
-  });
-
-  describe('logTelemetry function', () => {
-    it('should add properties to context.telemetry.properties', () => {
-      const context = { telemetry: { properties: {} } } as unknown as IActionContext;
-      logTelemetry(context, { key1: 'value1', key2: 'value2' });
-      expect(context.telemetry.properties).toEqual({ key1: 'value1', key2: 'value2' });
-    });
-
-    it('should merge properties when called multiple times', () => {
-      const context = { telemetry: { properties: { key1: 'initialValue' } } } as unknown as IActionContext;
-      logTelemetry(context, { key2: 'value2' });
-      expect(context.telemetry.properties).toEqual({ key1: 'initialValue', key2: 'value2' });
-      logTelemetry(context, { key1: 'updatedValue', key3: 'value3' });
-      expect(context.telemetry.properties).toEqual({ key1: 'updatedValue', key2: 'value2', key3: 'value3' });
     });
   });
 

--- a/apps/vs-code-designer/src/app/utils/unitTests.ts
+++ b/apps/vs-code-designer/src/app/utils/unitTests.ts
@@ -490,17 +490,6 @@ export async function validateRunId(runId: string): Promise<void> {
 }
 
 /**
- * Logs messages and telemetry for successful operations.
- * @param {IActionContext} context - The action context.
- * @param {string} property - The property name for telemetry.
- * @param {string} message - The message to log.
- */
-export function logSuccess(context: IActionContext, property: string, message: string): void {
-  context.telemetry.properties[property] = 'Success';
-  ext.outputChannel.appendLog(message);
-}
-
-/**
  * Logs errors and telemetry for failed operations.
  * @param {IActionContext} context - The action context.
  * @param {Error} error - The error to log.
@@ -601,15 +590,6 @@ export const validateUnitTestName = async (
 
   return undefined;
 };
-
-/**
- * Logs telemetry properties for unit test creation.
- * @param {IActionContext} context - The action context.
- * @param {Record<string, string | undefined>} properties - Telemetry properties.
- */
-export function logTelemetry(context: IActionContext, properties: Record<string, string | undefined>): void {
-  Object.assign(context.telemetry.properties, properties);
-}
 
 /**
  * Handles errors by logging them and displaying user-facing messages.
@@ -1329,16 +1309,10 @@ export async function updateTestsSln(testsDirectory: string, logicAppCsprojPath:
  * Logs telemetry if the workflow is not within the project folder and throws an error.
  * @param projectPath - The absolute file system path of the project.
  * @param workflowPath - The workflow file path.
- * @param telemetryContext - (Optional) The telemetry or action context for logging events.
  * @throws {Error} Throws an error if the workflow file is not inside the project folder.
  */
-export function validateWorkflowPath(projectPath: string, workflowPath: string, telemetryContext?: any): void {
+export function validateWorkflowPath(projectPath: string, workflowPath: string): void {
   if (!workflowPath) {
-    if (telemetryContext) {
-      logTelemetry(telemetryContext, {
-        validationError: 'undefinedWorkflowPath',
-      });
-    }
     throw new Error(localize('error.undefinedWorkflowPath', 'The provided workflow path is undefined.'));
   }
 
@@ -1351,14 +1325,6 @@ export function validateWorkflowPath(projectPath: string, workflowPath: string, 
 
   // If 'relativePath' suggests the file is outside of 'projectPath'...
   if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-    // Log telemetry if provided.
-    if (telemetryContext) {
-      logTelemetry(telemetryContext, {
-        validationError: 'wrongWorkspace',
-        expectedProjectPath: normalizedProjectPath,
-        actualWorkflowPath: normalizedWorkflowPath,
-      });
-    }
     throw new Error(
       localize(
         'error.wrongWorkspace',


### PR DESCRIPTION

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Ensure telemetry context for saveBlankUnitTest/createUnitTest have names 'azureLogicAppsStandard.saveBlankUnitTest' and 'azureLogicAppsStandard.createUnitTest', respectively. Remove unused unit test command handlers in overview/monitoring view/designer

## Impact of Change
- **Users**: N/A
- **Developers**: Ensure telemetry is logged correctly for unit test commands, clean up existing code
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge 
