### PR TITLE
fix(vscode): Migrated from ps-tree to using powershell to find childprocess

### DIFF
--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -46,8 +46,8 @@ import * as portfinder from 'portfinder';
 import * as vscode from 'vscode';
 import { Uri, window, workspace, type MessageItem } from 'vscode';
 import { findChildProcess } from '../../commands/pickFuncProcess';
-import pstree from 'ps-tree';
 import find_process from 'find-process';
+import { getChildProcessesWithScript } from '../findChildProcess/findChildProcess';
 
 export async function startDesignTimeApi(projectPath: string): Promise<void> {
   await callWithTelemetryAndErrorHandling('azureLogicAppsStandard.startDesignTimeApi', async (actionContext: IActionContext) => {
@@ -194,12 +194,8 @@ async function checkFuncProcessId(projectPath: string): Promise<boolean> {
   }
 
   if (os.platform() === Platform.windows) {
-    await new Promise<void>((resolve) => {
-      pstree(process.pid, (_err: Error | null, children: Array<{ PID: string; COMMAND?: string; COMM?: string }>) => {
-        correctId = children.some((p) => p.PID === childFuncPid && (p.COMMAND || p.COMM) === 'func.exe');
-        resolve();
-      });
-    });
+    const children = await getChildProcessesWithScript(process.pid);
+    correctId = children.some((p) => p.processId.toString() === childFuncPid && p.name === 'func.exe');
   } else {
     await find_process('pid', process.pid).then((list) => {
       if (list.length > 0) {

--- a/apps/vs-code-designer/src/app/utils/findChildProcess/findChildProcess.ts
+++ b/apps/vs-code-designer/src/app/utils/findChildProcess/findChildProcess.ts
@@ -1,0 +1,70 @@
+import * as cp from 'child_process';
+import * as path from 'path';
+import { ext } from '../../../extensionVariables';
+
+interface ProcessInfo {
+  processId: number;
+  name: string;
+  parentProcessId: number;
+}
+
+async function runPowerShellScript(scriptPath: string, ...args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Escape arguments for PowerShell
+    const escapedArgs = args.map((arg) => `"${arg.replace(/"/g, '`"')}"`).join(' ');
+    const command = `powershell.exe -NoProfile -NoLogo -ExecutionPolicy Bypass -File "${scriptPath}" ${escapedArgs}`;
+
+    ext.outputChannel.appendLog(`Executing PowerShell script: ${command}`);
+
+    const child = cp.exec(
+      command,
+      {
+        timeout: 10000,
+        encoding: 'utf8',
+        maxBuffer: 1024 * 1024, // 1MB buffer
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          ext.outputChannel.appendLog(`PowerShell script error: ${error.message}`);
+          if (stderr) {
+            ext.outputChannel.appendLog(`PowerShell stderr: ${stderr}`);
+          }
+          reject(error);
+          return;
+        }
+
+        resolve(stdout.trim());
+      }
+    );
+
+    // Backup timeout
+    setTimeout(() => {
+      if (!child.killed) {
+        child.kill('SIGKILL');
+        reject(new Error('PowerShell script execution timed out'));
+      }
+    }, 12000);
+  });
+}
+
+export async function getChildProcessesWithScript(parentProcessId: number): Promise<ProcessInfo[]> {
+  try {
+    const scriptPath = path.join(__dirname, 'assets', 'scripts', 'get-child-processes.ps1');
+    const output = await runPowerShellScript(scriptPath, parentProcessId.toString());
+
+    if (!output || output === '[]') {
+      return [];
+    }
+
+    const rawData = JSON.parse(output);
+    const dataArray = Array.isArray(rawData) ? rawData : [rawData];
+
+    return dataArray.map((item: any) => ({
+      processId: item.ProcessId,
+      name: item.Name,
+      parentProcessId: item.ParentProcessId,
+    }));
+  } catch (error) {
+    throw new Error(`Failed to execute Powershell script to get the func child process: ${error.message}`);
+  }
+}

--- a/apps/vs-code-designer/src/assets/scripts/get-child-processes.ps1
+++ b/apps/vs-code-designer/src/assets/scripts/get-child-processes.ps1
@@ -1,0 +1,21 @@
+$parentProcessId = $args[0]
+
+try {
+    function Get-ChildProcesses ($ParentProcessId) {
+        $filter = "parentprocessid = '$($ParentProcessId)'"
+        Get-CIMInstance -ClassName win32_process -filter $filter | Foreach-Object {
+            $_
+            if ($_.ParentProcessId -ne $_.ProcessId) {
+                Get-ChildProcesses $_.ProcessId
+            }
+        }
+    }
+    $processes = Get-ChildProcesses $parentProcessId | Select ProcessId, Name, ParentProcessId
+    if ($processes) {
+        $processes | ConvertTo-Json -Depth 2
+    } else {
+        '[]'
+    }
+} catch {
+    '[]'
+}


### PR DESCRIPTION
Cherry-pick of the following PR - #8368
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Windows 11 installations have removed wmic by default. We were using ps-tree which had wmic as a dependency and caused vscode users to be unable to open designer. We have removed the dependency on ps-tree by using powershell to find the child func process. Permanent fix for https://github.com/Azure/LogicAppsUX/issues/8349

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any --> Users should no longer need to install WMIC manually in order to get vscode designer working on Windows.
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: Windows 11 with and without WMIC installed.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@ccastrotrejo @lambrianmsft 

## Screenshots/Videos
<!-- Visual changes only -->
