### PR TITLE
feat(designer): Support native and managed MCP server for standard logic apps designer panel

### DIFF
--- a/libs/designer-ui/src/lib/card/subgraphCard/index.tsx
+++ b/libs/designer-ui/src/lib/card/subgraphCard/index.tsx
@@ -9,7 +9,7 @@ import type { SubgraphType } from '@microsoft/logic-apps-shared';
 import { SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
 import { useIntl } from 'react-intl';
 import type { MouseEventHandler } from 'react';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 
 interface SubgraphCardProps {
   id: string;
@@ -20,7 +20,7 @@ interface SubgraphCardProps {
   handleCollapse?: (includeNested?: boolean) => void;
   selectionMode?: CardProps['selectionMode'];
   readOnly?: boolean;
-  onClick?(id?: string): void;
+  onClick?(id?: string, rect?: DOMRect): void;
   onContextMenu?: MouseEventHandler<HTMLElement>;
   onDeleteClick?(): void;
   showAddButton?: boolean;
@@ -49,6 +49,8 @@ export const SubgraphCard: React.FC<SubgraphCardProps> = ({
   active = true,
 }) => {
   const intl = useIntl();
+
+  const buttonRef = useRef<HTMLDivElement>(null);
 
   const mainKeyboardInteraction = useCardKeyboardInteraction(() => onClick?.(data.id), onDeleteClick);
   const collapseKeyboardInteraction = useCardKeyboardInteraction(handleCollapse);
@@ -168,6 +170,7 @@ export const SubgraphCard: React.FC<SubgraphCardProps> = ({
     const title = subgraphType === SUBGRAPH_TYPES['AGENT_ADD_CONDITON'] ? addActionLabel : addCaseLabel;
     return (
       <div
+        ref={buttonRef}
         style={{
           display: 'grid',
           placeItems: 'center',
@@ -175,7 +178,11 @@ export const SubgraphCard: React.FC<SubgraphCardProps> = ({
           height: '100%',
         }}
       >
-        <ActionButtonV2 title={title} onClick={() => onClick?.()} tabIndex={nodeIndex} />
+        <ActionButtonV2
+          title={title}
+          onClick={() => onClick?.(undefined, buttonRef.current?.getBoundingClientRect())}
+          tabIndex={nodeIndex}
+        />
       </div>
     );
   }

--- a/libs/designer-ui/src/lib/panel/recommendationpanel/helpers.ts
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/helpers.ts
@@ -4,7 +4,7 @@ import { getConnectorCategoryString } from '../../utils';
 import { isBuiltInConnector, isCustomConnector } from '../../connectors';
 import type { OperationActionData } from './interfaces';
 
-export const getDefaultRuntimeCategories = (): OperationRuntimeCategory[] => {
+export const getDefaultRuntimeCategories = (excludeBuiltin?: boolean): OperationRuntimeCategory[] => {
   const intl = getIntl();
 
   const all = intl.formatMessage({
@@ -36,10 +36,10 @@ export const getDefaultRuntimeCategories = (): OperationRuntimeCategory[] => {
       key: 'all',
       text: all,
     },
-    {
+    ... excludeBuiltin ? [] : [{
       key: 'inapp',
       text: builtIn,
-    },
+    }],
     {
       key: 'shared',
       text: shared,

--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationGroupDetails/searchResult/searchResult.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationGroupDetails/searchResult/searchResult.tsx
@@ -7,7 +7,7 @@ import { SearchResultSortOptions } from '../../../types';
 import { OperationSearchGroup } from '../../operationSearchGroup';
 import { List } from '@fluentui/react';
 import { Spinner, Text } from '@fluentui/react-components';
-import type { DiscoveryOpArray } from '@microsoft/logic-apps-shared';
+import type { DiscoveryOpArray, DiscoveryOperation, DiscoveryResultTypes } from '@microsoft/logic-apps-shared';
 import type { PropsWithChildren } from 'react';
 import React, { useMemo } from 'react';
 import { useIntl } from 'react-intl';
@@ -29,6 +29,7 @@ export type SearchResultsGridProps = {
   setGroupByConnector: (groupByConnector: boolean) => void;
   filters: Record<string, string>;
   setFilters: (filters: Record<string, string>) => void;
+  isAddingMcpServer?: boolean;
 };
 
 const maxOperationsToDisplay = RecommendationPanelConstants.SEARCH_VIEW.MAX_OPERATIONS_IN_SEARCH_GROUP;
@@ -45,6 +46,7 @@ export const SearchResultsGrid: React.FC<PropsWithChildren<SearchResultsGridProp
   displayRuntimeInfo,
   filters,
   setFilters,
+  isAddingMcpServer,
 }: SearchResultsGridProps) => {
   const intl = useIntl();
 
@@ -159,9 +161,11 @@ export const SearchResultsGrid: React.FC<PropsWithChildren<SearchResultsGridProp
           setFilters={setFilters}
           isSearchResult={true}
           setGroupedByConnector={setGroupByConnector}
-          groupedByConnector={groupByConnector}
+          groupedByConnector={groupByConnector && !isAddingMcpServer}
           resultsSorting={resultsSorting}
           setResultsSorting={setResultsSorting}
+          excludeBuiltin={isAddingMcpServer ? true : false}
+          hideGroupBy={isAddingMcpServer ? true : false}
         />
         <div className="msla-no-results-container">
           <img src={NoResultsSvg} alt={noResultsText?.toString()} />
@@ -178,9 +182,11 @@ export const SearchResultsGrid: React.FC<PropsWithChildren<SearchResultsGridProp
         setFilters={setFilters}
         isSearchResult={true}
         setGroupedByConnector={setGroupByConnector}
-        groupedByConnector={groupByConnector}
+        groupedByConnector={groupByConnector && !isAddingMcpServer}
         resultsSorting={resultsSorting}
         setResultsSorting={setResultsSorting}
+        excludeBuiltin={!!isAddingMcpServer}
+        hideGroupBy={!!isAddingMcpServer}
       />
       {isLoadingMore && (
         <div style={{ marginBottom: '16px' }}>
@@ -202,6 +208,7 @@ export const SearchResultsGrid: React.FC<PropsWithChildren<SearchResultsGridProp
             onOperationSelected={onOperationClick}
             showConnectorName={!groupByConnector}
             displayRuntimeInfo={displayRuntimeInfo}
+            hideFavorites={isAddingMcpServer}
           />
         </>
       )}

--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/index.tsx
@@ -1,6 +1,7 @@
 import { DesignerSearchBox } from '../../../searchbox';
 import { useIntl } from 'react-intl';
 import { OperationTypeFilter } from '../operationTypeFilter';
+import { Button } from '@fluentui/react-components';
 
 interface OperationSearchHeaderProps {
   searchCallback: (s: string) => void;
@@ -9,6 +10,8 @@ interface OperationSearchHeaderProps {
   setFilters?: (filters: Record<string, string>) => void;
   isTriggerNode: boolean;
   hideOperations?: boolean;
+  isAddingMcpServer?: boolean;
+  onAddMcpServerClick?: () => void;
 }
 
 export const OperationSearchHeader = ({
@@ -18,8 +21,16 @@ export const OperationSearchHeader = ({
   setFilters,
   isTriggerNode,
   hideOperations,
+  isAddingMcpServer,
+  onAddMcpServerClick,
 }: OperationSearchHeaderProps) => {
   const intl = useIntl();
+
+  const addMcpText = intl.formatMessage({
+    defaultMessage: 'Add custom MCP',
+    id: 'Xy40uA',
+    description: 'Button text for adding custom MCP server'
+  });
 
   const actionTypeFilters = isTriggerNode
     ? [
@@ -43,30 +54,39 @@ export const OperationSearchHeader = ({
       ];
 
   const searchPlaceholderText = intl.formatMessage(
-    hideOperations
+    isAddingMcpServer
       ? {
-          defaultMessage: 'Search for a connector',
-          id: 'CLJuAQ',
-          description: 'Placeholder text for Connector search bar',
+          defaultMessage: 'Search for an MCP server',
+          id: 'Nl4O59',
+          description: 'Placeholder text for MCP Server search bar',
         }
-      : isTriggerNode
-        ? {
-            defaultMessage: 'Search for a trigger or connector',
-            id: 'CLJuAQ',
-            description: 'Placeholder text for Trigger/Connector search bar',
-          }
-        : {
-            defaultMessage: 'Search for an action or connector',
-            id: 'py9dSW',
-            description: 'Placeholder text for Operation/Connector search bar',
-          }
+      : hideOperations
+          ? {
+              defaultMessage: 'Search for a connector',
+              id: 'CLJuAQ',
+              description: 'Placeholder text for Connector search bar',
+            }
+          : isTriggerNode
+            ? {
+                defaultMessage: 'Search for a trigger or connector',
+                id: 'CLJuAQ',
+                description: 'Placeholder text for Trigger/Connector search bar',
+              }
+            : {
+                defaultMessage: 'Search for an action or connector',
+                id: 'py9dSW',
+                description: 'Placeholder text for Operation/Connector search bar',
+              }
   );
 
   return (
     <div className="msla-sub-heading-container">
       <div className="msla-sub-heading">
         <DesignerSearchBox searchCallback={searchCallback} searchTerm={searchTerm} placeholder={searchPlaceholderText} />
-        <OperationTypeFilter actionTypeFilters={actionTypeFilters} filters={filters} disabled={isTriggerNode} setFilters={setFilters} />
+        {isAddingMcpServer
+          ? <Button appearance={'primary'} size="small" onClick={onAddMcpServerClick}>{addMcpText}</Button>
+          : <OperationTypeFilter actionTypeFilters={actionTypeFilters} filters={filters} disabled={isTriggerNode} setFilters={setFilters} />
+        }
       </div>
     </div>
   );

--- a/libs/designer-ui/src/lib/panel/recommendationpanel/runtimeFilterTagList/index.tsx
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/runtimeFilterTagList/index.tsx
@@ -15,6 +15,8 @@ interface RuntimeFilterTagListProperties {
   setGroupedByConnector?: (newValue: boolean) => void;
   resultsSorting?: SearchResultSortOption;
   setResultsSorting?: (newValue: SearchResultSortOption) => void;
+  excludeBuiltin?: boolean;
+  hideGroupBy?: boolean;
 }
 
 export const RuntimeFilterTagList = ({
@@ -25,10 +27,12 @@ export const RuntimeFilterTagList = ({
   setFilters,
   setResultsSorting,
   setGroupedByConnector,
+  excludeBuiltin,
+  hideGroupBy,
 }: RuntimeFilterTagListProperties) => {
   const intl = useIntl();
 
-  const runtimeFilters = getDefaultRuntimeCategories().map((category) => ({
+  const runtimeFilters = getDefaultRuntimeCategories(excludeBuiltin).map((category) => ({
     key: `runtime-${category.key}`,
     text: category.text,
     value: category.key,
@@ -102,14 +106,16 @@ export const RuntimeFilterTagList = ({
                 checked={resultsSorting !== SearchResultSortOptions.unsorted}
               />
             </Tooltip>
-            <Tooltip content={groupByConnectorTooltipText} relationship="label">
-              <ToggleButton
-                appearance="subtle"
-                icon={groupedByConnector ? <GridFilled /> : <GridRegular />}
-                checked={groupedByConnector}
-                onClick={handleGroupByConnectorClick}
-              />
-            </Tooltip>
+            {!hideGroupBy && (
+              <Tooltip content={groupByConnectorTooltipText} relationship="label">
+                <ToggleButton
+                  appearance="subtle"
+                  icon={groupedByConnector ? <GridFilled /> : <GridRegular />}
+                  checked={groupedByConnector}
+                  onClick={handleGroupByConnectorClick}
+                />
+              </Tooltip>
+            )}
           </div>
         ) : null}
       </div>

--- a/libs/designer/src/lib/common/constants.ts
+++ b/libs/designer/src/lib/common/constants.ts
@@ -409,6 +409,7 @@ export default {
       GETPASTTIME: 'getpasttime',
       HTTP: 'http',
       AGENT: 'agent',
+      MANAGED: 'managed',
       JSON_TO_JSON: 'jsontojson',
       JSON_TO_TEXT: 'jsontotext',
       POWERAPP: 'powerapp',

--- a/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/add.ts
@@ -64,6 +64,7 @@ import type { Dispatch } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { batch } from 'react-redux';
 import { operationSupportsSplitOn } from '../../utils/outputs';
+import { isManagedMcpOperation } from '../../state/workflow/helper';
 
 type AddOperationPayload = {
   operation: DiscoveryOperation<DiscoveryResultTypes> | undefined;
@@ -95,13 +96,11 @@ export const addOperation = createAsyncThunk('addOperation', async (payload: Add
     if (payload.isAddingMcpServer) {
       dispatch(addMcpServer(newPayload as any));
     } else {
-      if (isAddingAgentTool) {
-        if (newToolId && newToolGraphId) {
-          if (agentToolMetadata?.newAdditiveSubgraphId && agentToolMetadata?.subGraphManifest) {
-            initializeSubgraphFromManifest(agentToolMetadata.newAdditiveSubgraphId, agentToolMetadata?.subGraphManifest, dispatch);
-          }
-          dispatch(addAgentTool({ toolId: newToolId, graphId: newToolGraphId }));
+      if (isAddingAgentTool && newToolId && newToolGraphId) {
+        if (agentToolMetadata?.newAdditiveSubgraphId && agentToolMetadata?.subGraphManifest) {
+          initializeSubgraphFromManifest(agentToolMetadata.newAdditiveSubgraphId, agentToolMetadata?.subGraphManifest, dispatch);
         }
+        dispatch(addAgentTool({ toolId: newToolId, graphId: newToolGraphId }));
       }
 
       dispatch(addNode(newPayload as any));
@@ -183,7 +182,7 @@ export const initializeOperationDetails = async (
   let initData: NodeData;
   let swagger: SwaggerParser | undefined = undefined;
   let parsedManifest: ManifestParser | undefined = undefined;
-  const isManagedMcpClient = type?.toLowerCase() === 'mcpclienttool' && kind?.toLowerCase() === "managed";
+  const isManagedMcpClient = isManagedMcpOperation({ type, kind });
 
   if (isManagedMcpClient) {
     // managed mcp client ignores the swagger and uses a fixed set of parameters similar to manifest based native mcp client

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -51,6 +51,7 @@ import type { Dispatch } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { openPanel, setIsCreatingConnection, setIsPanelLoading } from '../../state/panel/panelSlice';
 import type { PanelMode } from '../../state/panel/panelTypes';
+import { isManagedMcpOperation } from '../../state/workflow/helper';
 export interface ConnectionPayload {
   nodeId: string;
   connector: Connector;
@@ -365,7 +366,7 @@ export const getConnectionMappingForNode = (
         return mapping;
       }
     }
-    if (equals(operation.type, 'McpClientTool') && equals(operation.kind, 'Managed')) {
+    if (isManagedMcpOperation(operation)) {
       const connectionReferenceKey = (operation as any).inputs.connectionReference.connectionName;
       if (connectionReferenceKey !== undefined) {
         const mapping = Promise.resolve({ [nodeId]: connectionReferenceKey });

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -85,6 +85,7 @@ import type { InputParameter, OutputParameter, LogicAppsV2, OperationManifest } 
 import type { Dispatch } from '@reduxjs/toolkit';
 import { operationSupportsSplitOn } from '../../utils/outputs';
 import { initializeConnectorOperationDetails } from './agent';
+import { isManagedMcpOperation } from '../../state/workflow/helper';
 
 export interface NodeDataWithOperationMetadata extends NodeData {
   manifest?: OperationManifest;
@@ -140,7 +141,7 @@ export const initializeOperationMetadata = async (
       triggerNodeId = operationId;
     }
 
-    if (equals(operation.type, 'mcpclienttool') && equals(operation.kind, 'managed')) {
+    if (isManagedMcpOperation(operation)) {
       promises.push(initializeOperationDetailsForManagedMcpServer(operationId, operation, references, workflowKind, dispatch));
     } else if (operation.type === Constants.NODE.TYPE.CONNECTOR) {
       promises.push(initializeConnectorOperationDetails(operationId, operation as LogicAppsV2.ConnectorAction, workflowKind, dispatch));

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -75,7 +75,7 @@ import type {
 import merge from 'lodash.merge';
 import { createTokenValueSegment } from '../../utils/parameters/segment';
 import { ConnectorManifest } from './agent';
-import { isA2AWorkflow } from '../../../core/state/workflow/helper';
+import { isA2AWorkflow, isManagedMcpOperation } from '../../../core/state/workflow/helper';
 
 export interface SerializeOptions {
   skipValidation: boolean;
@@ -283,7 +283,7 @@ export const serializeOperation = async (
   }
 
   let serializedOperation: LogicAppsV2.OperationDefinition;
-  const isManagedMcpClient = operation.type?.toLowerCase() === 'mcpclienttool' && operation.kind?.toLowerCase() === "managed";
+  const isManagedMcpClient = isManagedMcpOperation(operation);
 
   if (isManagedMcpClient) {
     serializedOperation = await serializeManagedMcpOperation(rootState, operationId);

--- a/libs/designer/src/lib/core/queries/browse.ts
+++ b/libs/designer/src/lib/core/queries/browse.ts
@@ -1,4 +1,4 @@
-import type { Connector, DiscoveryOpArray } from '@microsoft/logic-apps-shared';
+import type { Connector, DiscoveryOpArray, DiscoveryOperation, DiscoveryResultTypes } from '@microsoft/logic-apps-shared';
 import {
   SearchService,
   cleanConnectorId,
@@ -147,6 +147,31 @@ const useCustomOperationsLazyQuery = () =>
       ...queryOpts,
       ...pagedOpts,
     }
+  );
+
+export const useMcpServersQuery = () =>
+  useQuery(
+    ['allOperations', 'mcpServers'],
+    async () => {
+      const searchService = SearchService();
+      if (searchService.getMcpServers) {
+        const data = await searchService.getMcpServers();
+
+        const processedData = data.map<DiscoveryOperation<DiscoveryResultTypes>>((operation: any) => ({
+          ...operation,
+          properties: {
+            ...operation.properties,
+            operationType: 'McpClientTool',
+            operationKind: 'Managed',
+          },
+        }));
+
+        return { data: processedData };
+      }
+
+      return { data: [] };
+    },
+    queryOpts
   );
 
 const useBuiltInOperationsQuery = () =>

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -56,6 +56,7 @@ export interface DesignerOptionsState {
   showEdgeDrawing?: boolean;
   panelTabHideKeys?: PANEL_TAB_NAMES[];
   showPerformanceDebug?: boolean;
+  mcpClientToolEnabled?: boolean;
 }
 
 export interface ServiceOptions {

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
@@ -62,6 +62,10 @@ export const useShowPerformanceDebug = () => {
   return useSelector((state: RootState) => state.designerOptions.showPerformanceDebug ?? false);
 };
 
+export const useMcpClientToolEnabled = () => {
+  return useSelector((state: RootState) => state.designerOptions.mcpClientToolEnabled ?? true);
+};
+
 export const useAreDesignerOptionsInitialized = () => {
   return useSelector((state: RootState) => state.designerOptions?.designerOptionsInitialized ?? false);
 };

--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -43,6 +43,7 @@ export const initialDesignerOptionsState: DesignerOptionsState = {
   showConnectionsPanel: false,
   showEdgeDrawing: false,
   panelTabHideKeys: [],
+  mcpClientToolEnabled: false,
   hostOptions: {
     displayRuntimeInfo: true,
     suppressCastingForSerialize: false,
@@ -174,6 +175,7 @@ export const designerOptionsSlice = createSlice({
         ...action.payload.hostOptions,
       };
       state.showPerformanceDebug = action.payload.showPerformanceDebug;
+      state.mcpClientToolEnabled = action.payload.mcpClientToolEnabled;
       state.designerOptionsInitialized = true;
       state.isVSCode = action.payload.isVSCode ?? false;
     },

--- a/libs/designer/src/lib/core/state/designerView/designerViewInterfaces.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewInterfaces.ts
@@ -18,4 +18,6 @@ export interface EdgeContextMenuObject {
   isLeaf?: boolean;
   location: { x: number; y: number };
   isHandoff?: boolean;
+  isAgentTool?: boolean;
+  subgraphId?: string;
 }

--- a/libs/designer/src/lib/core/state/panel/panelSelectors.ts
+++ b/libs/designer/src/lib/core/state/panel/panelSelectors.ts
@@ -86,3 +86,5 @@ export const usePanelLocation = () => useSelector(createSelector(getPanelState, 
 export const usePreviousPanelMode = () => useSelector(createSelector(getPanelState, (state) => state.previousPanelMode));
 
 export const useIsAddingAgentTool = () => useSelector(createSelector(getPanelState, (state) => state.discoveryContent.isAddingAgentTool));
+
+export const useIsAddingMcpServer = () => useSelector(createSelector(getPanelState, (state) => state.discoveryContent.isAddingMcpServer))

--- a/libs/designer/src/lib/core/state/panel/panelSlice.ts
+++ b/libs/designer/src/lib/core/state/panel/panelSlice.ts
@@ -191,6 +191,7 @@ export const panelSlice = createSlice({
         focusReturnElementId?: string;
         isParallelBranch?: boolean;
         isAgentTool?: boolean;
+        isAddingMcpServer?: boolean;
         nodeId: string;
         relationshipIds: RelationshipIds;
       }>
@@ -205,6 +206,7 @@ export const panelSlice = createSlice({
       state.discoveryContent.relationshipIds = relationshipIds;
       state.discoveryContent.selectedNodeIds = [nodeId];
       state.discoveryContent.isAddingAgentTool = isAgentTool;
+      state.discoveryContent.isAddingMcpServer = action.payload.isAddingMcpServer ?? false;
 
       LoggerService().log({
         level: LogEntryLevel.Verbose,

--- a/libs/designer/src/lib/core/state/panel/panelTypes.ts
+++ b/libs/designer/src/lib/core/state/panel/panelTypes.ts
@@ -40,6 +40,7 @@ export interface DiscoveryPanelContentState {
   isAddingTrigger: boolean;
   isParallelBranch: boolean;
   isAddingAgentTool?: boolean;
+  isAddingMcpServer?: boolean;
   agentToolMetadata?: { newAdditiveSubgraphId: string; subGraphManifest: OperationManifest };
   panelMode: 'Discovery';
   relationshipIds: RelationshipIds;

--- a/libs/designer/src/lib/core/state/workflow/helper.ts
+++ b/libs/designer/src/lib/core/state/workflow/helper.ts
@@ -1,6 +1,7 @@
 import { equals, SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
 import type { WorkflowNode } from '../../../core/parsers/models/workflowNode';
 import { WorkflowKind, type NodeMetadata, type WorkflowState } from './workflowInterfaces';
+import Constants from '../../../common/constants';
 
 /**
  * Recursively clones a node while pruning (removing) any nodes that are in the nodesToRemove set.
@@ -128,6 +129,10 @@ export const collapseFlowTree = (
 
   return { graph: prunedTree, collapsedMapping: collapsedMappingArrays };
 };
+
+export const isManagedMcpOperation = (operation: { type?: string; kind?: string }) => {
+  return equals(operation?.type, Constants.NODE.TYPE.MCP_CLIENT) && equals(operation?.kind, Constants.NODE.KIND.MANAGED);
+}
 
 export const isA2AWorkflow = (state: WorkflowState): boolean => {
   const workflowKind = state.workflowKind;

--- a/libs/designer/src/lib/core/state/workflow/workflowInterfaces.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowInterfaces.ts
@@ -16,6 +16,8 @@ export interface NodeMetadata {
   subgraphRunData?: Record<string, { actionResults: LogicAppsV2.WorkflowRunAction[] }>;
   runIndex?: number;
   handoffs?: Record<string, string>;
+  toolRunIndex?: number;
+  toolRunData?: LogicAppsV2.WorkflowRunAction;
 }
 export interface NodesMetadata {
   [nodeId: string]: NodeMetadata;

--- a/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
@@ -479,6 +479,9 @@ export const useRetryHistory = (id: string): LogicAppsV2.RetryHistory[] | undefi
 export const useRunData = (id: string): LogicAppsV2.WorkflowRunAction | LogicAppsV2.WorkflowRunTrigger | undefined =>
   useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.runData));
 
+export const useToolRunData = (id: string): LogicAppsV2.WorkflowRunAction | LogicAppsV2.WorkflowRunTrigger | undefined =>
+  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.toolRunData));
+
 export const useSubgraphRunData = (id: string): Record<string, { actionResults: LogicAppsV2.WorkflowRunAction[] }> | undefined =>
   useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.subgraphRunData));
 
@@ -518,6 +521,17 @@ export const useRunIndex = (id: string | undefined): number | undefined => {
         return undefined;
       }
       return getRecordEntry(state.nodesMetadata, id)?.runIndex ?? undefined;
+    })
+  );
+};
+
+export const useToolRunIndex = (id: string | undefined): number | undefined => {
+  return useSelector(
+    createSelector(getWorkflowState, (state: WorkflowState) => {
+      if (!id) {
+        return undefined;
+      }
+      return getRecordEntry(state.nodesMetadata, id)?.toolRunIndex ?? undefined;
     })
   );
 };

--- a/libs/designer/src/lib/ui/DesignerReactFlow.tsx
+++ b/libs/designer/src/lib/ui/DesignerReactFlow.tsx
@@ -8,6 +8,7 @@ import {
   guid,
   removeIdTag,
   WORKFLOW_NODE_TYPES,
+  SUBGRAPH_TYPES,
   type WorkflowNodeType,
 } from '@microsoft/logic-apps-shared';
 import { useDispatch } from 'react-redux';
@@ -45,17 +46,57 @@ const DesignerReactFlow = (props: any) => {
   const dispatch = useDispatch<AppDispatch>();
   const isInitialized = useNodesInitialized();
 
+  const nodesMetadata = useNodesMetadata();
+
+  // Dynamic node type mapping that considers both node type and subgraph type
+  const getNodeComponent = useCallback((nodeType: WorkflowNodeType, nodeId?: string) => {
+    // For SUBGRAPH_NODE, check the subgraph type to determine component
+    if (nodeType === 'SUBGRAPH_NODE' && nodeId) {
+      const nodeMetadata = nodesMetadata[nodeId];
+      const subgraphType = nodeMetadata?.subgraphType;
+      
+      // Use different components based on subgraph type
+      switch (subgraphType) {
+        case SUBGRAPH_TYPES.MCP_CLIENT:
+          return OperationNode;
+        case SUBGRAPH_TYPES.AGENT_CONDITION:
+        default:
+          return GraphNode; // Default subgraph rendering
+      }
+    }
+    
+    // Default static mapping for non-subgraph nodes
+    const staticMapping: Partial<Record<WorkflowNodeType, React.ComponentType<any>>> = {
+      OPERATION_NODE: OperationNode,
+      GRAPH_NODE: GraphNode,
+      SUBGRAPH_NODE: GraphNode, // Fallback, should be handled above
+      SCOPE_CARD_NODE: ScopeCardNode,
+      SUBGRAPH_CARD_NODE: SubgraphCardNode,
+      HIDDEN_NODE: HiddenNode,
+      PLACEHOLDER_NODE: PlaceholderNode,
+      COLLAPSED_NODE: CollapsedNode,
+    };
+    
+    return staticMapping[nodeType];
+  }, [nodesMetadata]);
+
+  // Create nodeTypes object for ReactFlow
   type NodeTypesObj = Partial<Record<WorkflowNodeType, React.ComponentType<any>>>;
-  const nodeTypes: NodeTypesObj = {
-    OPERATION_NODE: OperationNode,
-    GRAPH_NODE: GraphNode,
-    SUBGRAPH_NODE: GraphNode,
-    SCOPE_CARD_NODE: ScopeCardNode,
-    SUBGRAPH_CARD_NODE: SubgraphCardNode,
-    HIDDEN_NODE: HiddenNode,
-    PLACEHOLDER_NODE: PlaceholderNode,
-    COLLAPSED_NODE: CollapsedNode,
-  };
+  const nodeTypes: NodeTypesObj = useMemo(() => {
+    return {
+      OPERATION_NODE: OperationNode,
+      GRAPH_NODE: GraphNode,
+      SUBGRAPH_NODE: (props: any) => {
+        const Component = getNodeComponent('SUBGRAPH_NODE', props.id);
+        return Component ? <Component {...props} /> : <GraphNode {...props} />;
+      },
+      SCOPE_CARD_NODE: ScopeCardNode,
+      SUBGRAPH_CARD_NODE: SubgraphCardNode,
+      HIDDEN_NODE: HiddenNode,
+      PLACEHOLDER_NODE: PlaceholderNode,
+      COLLAPSED_NODE: CollapsedNode,
+    };
+  }, [getNodeComponent]);
 
   const edgeTypes = {
     BUTTON_EDGE: ButtonEdge,
@@ -181,8 +222,6 @@ const DesignerReactFlow = (props: any) => {
       document.removeEventListener('keydown', tabListener);
     }, tabCountTimeout * 1000);
   }, [isInitialized]);
-
-  const nodesMetadata = useNodesMetadata();
 
   const isA2AWorkflow = useIsA2AWorkflow();
   const allAgentIds = useAllAgentIds();

--- a/libs/designer/src/lib/ui/common/DeleteModal/DeleteModal.tsx
+++ b/libs/designer/src/lib/ui/common/DeleteModal/DeleteModal.tsx
@@ -1,12 +1,12 @@
 import type { AppDispatch } from '../../../core';
 import { useNodeMetadata, useNodeDisplayName, storeStateToUndoRedoHistory } from '../../../core';
-import { deleteOperation, deleteGraphNode } from '../../../core/actions/bjsworkflow/delete';
+import { deleteOperation, deleteGraphNode, deleteMcpServerNode } from '../../../core/actions/bjsworkflow/delete';
 import { useShowDeleteModalNodeId } from '../../../core/state/designerView/designerViewSelectors';
 import { setShowDeleteModalNodeId } from '../../../core/state/designerView/designerViewSlice';
 import { useWorkflowNode } from '../../../core/state/workflow/workflowSelectors';
 import { deleteAgentTool, deleteSwitchCase } from '../../../core/state/workflow/workflowSlice';
 import { DeleteNodeModal } from '@microsoft/designer-ui';
-import { WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
+import { SUBGRAPH_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
 import { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
@@ -28,10 +28,20 @@ const DeleteModal = () => {
       return;
     }
     const { type, subGraphLocation } = nodeData;
+    const { subgraphType } = metadata || {};
 
     if (type === WORKFLOW_NODE_TYPES.OPERATION_NODE) {
-      dispatch(storeStateToUndoRedoHistory({ type: deleteOperation.pending }));
-      dispatch(deleteOperation({ nodeId, isTrigger }));
+      if (subgraphType === SUBGRAPH_TYPES.MCP_CLIENT) {
+        dispatch(
+          deleteMcpServerNode({
+            toolId: nodeId,
+            agentId: graphId,
+          })
+        );
+      } else {
+        dispatch(storeStateToUndoRedoHistory({ type: deleteOperation.pending }));
+        dispatch(deleteOperation({ nodeId, isTrigger }));
+      }
     } else if (type === WORKFLOW_NODE_TYPES.GRAPH_NODE) {
       dispatch(storeStateToUndoRedoHistory({ type: deleteGraphNode.pending }));
       dispatch(

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/DesignerContextualMenu.tsx
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/DesignerContextualMenu.tsx
@@ -200,7 +200,7 @@ export const DesignerContextualMenu = () => {
 
   const subgraphMenuItems: JSX.Element[] = useMemo(
     () => [
-      ...(metadata?.subgraphType === SUBGRAPH_TYPES.SWITCH_CASE || metadata?.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION
+      ...(metadata?.subgraphType === SUBGRAPH_TYPES.SWITCH_CASE || metadata?.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION || metadata?.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT
         ? [<DeleteMenuItem key={'delete'} onClick={deleteClick} showKey />]
         : []),
     ],
@@ -222,7 +222,7 @@ export const DesignerContextualMenu = () => {
       items.push(...(metadata?.subgraphType ? subgraphMenuItems : actionContextMenuItems));
     }
 
-    if (metadata?.subgraphType || isScopeNode) {
+    if ((metadata?.subgraphType && metadata?.subgraphType !== SUBGRAPH_TYPES.MCP_CLIENT) || isScopeNode) {
       // For subgraphs and scope nodes, we show graph context menu items
       items.push(...graphMenuItems);
     }

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -150,18 +150,22 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
       return [parametersTabItem];
     }
 
-    return [
-      monitoringTabItem,
-      parametersTabItem,
-      settingsTabItem,
-      channelsTabItem,
-      handoffTabItem,
-      codeViewTabItem,
-      testingTabItem,
-      aboutTabItem,
-      monitorRetryTabItem,
-      scratchTabItem,
-    ]
+    const availableTabs = nodeMetaData?.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT
+      ? [monitoringTabItem, parametersTabItem, codeViewTabItem, aboutTabItem]
+      : [
+          monitoringTabItem,
+          parametersTabItem,
+          settingsTabItem,
+          channelsTabItem,
+          handoffTabItem,
+          codeViewTabItem,
+          testingTabItem,
+          aboutTabItem,
+          monitorRetryTabItem,
+          scratchTabItem,
+        ];
+
+    return availableTabs
       .filter((a) => !panelTabHideKeys.includes(a.id as any))
       .filter((a) => a.visible)
       .sort((a, b) => a.order - b.order);

--- a/libs/designer/src/lib/ui/panel/recommendation/searchView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/searchView.tsx
@@ -31,6 +31,7 @@ type SearchViewProps = {
   setFilters: (filters: Record<string, string>) => void;
   onOperationClick: (id: string, apiId?: string) => void;
   displayRuntimeInfo: boolean;
+  isAddingMcpServer?: boolean;
 };
 
 export const SearchView: FC<SearchViewProps> = ({
@@ -43,6 +44,7 @@ export const SearchView: FC<SearchViewProps> = ({
   setFilters,
   onOperationClick,
   displayRuntimeInfo,
+  isAddingMcpServer,
 }) => {
   const isAgenticWorkflow = useIsAgenticWorkflow();
   const shouldEnableParseDocWithMetadata = useShouldEnableParseDocumentWithMetadata();
@@ -147,6 +149,12 @@ export const SearchView: FC<SearchViewProps> = ({
 
   useDebouncedEffect(
     () => {
+      if (isAddingMcpServer && !searchTerm) {
+        setSearchResults(allOperations);
+        setIsLoadingSearchResults(false);
+        return;
+      }
+
       const searchResultsPromise = new DefaultSearchOperationsService(
         allOperations,
         shouldEnableParseDocWithMetadata ?? false
@@ -157,7 +165,7 @@ export const SearchView: FC<SearchViewProps> = ({
         setIsLoadingSearchResults(false);
       });
     },
-    [searchTerm, allOperations, filters, filterAgenticLoops, shouldEnableParseDocWithMetadata],
+    [searchTerm, allOperations, filters, filterAgenticLoops, shouldEnableParseDocWithMetadata, isAddingMcpServer],
     200
   );
 
@@ -178,6 +186,7 @@ export const SearchView: FC<SearchViewProps> = ({
       filters={filters}
       setFilters={setFilters}
       displayRuntimeInfo={displayRuntimeInfo}
+      isAddingMcpServer={isAddingMcpServer}
     />
   );
 };

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
@@ -113,6 +113,32 @@ export abstract class BaseSearchService implements ISearchService {
     return requestPage(uri, [], queryParams);
   }
 
+  async getMcpServers(): Promise<DiscoveryOpArray> {
+    const traceId = LoggerService().startTrace({
+      name: 'Get All Managed MCP Servers',
+      action: 'getAllManagedMcpServers',
+      source: 'connection.ts',
+    });
+
+    const {
+      apiHubServiceDetails: { location, subscriptionId, apiVersion },
+    } = this.options;
+    if (this._isDev) {
+      return Promise.resolve([]);
+    }
+
+    const uri = `/subscriptions/${subscriptionId}/providers/Microsoft.Web/locations/${location}/apiOperations`;
+    const queryParameters: QueryParameters = {
+      'api-version': apiVersion,
+      $filter: "mcpOnly eq true",
+    };
+
+    const operations = await this.getAzureResourceRecursive(uri, queryParameters);
+
+    LoggerService().endTrace(traceId, { status: Status.Success });
+    return operations;
+  }
+
   async getAllAzureOperations(): Promise<DiscoveryOpArray> {
     const traceId = LoggerService().startTrace({
       name: 'Get All Azure Operations',

--- a/libs/logic-apps-shared/src/designer-client-services/lib/search.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/search.ts
@@ -21,6 +21,7 @@ export interface ISearchService {
   getAgentConnectorOperation?(connectorId: string): Promise<DiscoveryOpArray>;
   getBuiltInOperations(): Promise<DiscoveryOpArray>;
   getOperationsByConnector?(connectorId: string, actionType?: string): Promise<DiscoveryOpArray>;
+  getMcpServers?(): Promise<DiscoveryOpArray>;
 }
 
 let service: ISearchService;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/builtinmcpclient.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/builtinmcpclient.ts
@@ -59,7 +59,7 @@ export default {
     connection: {
       required: true,
       type: 'mcp',
-      noPreSelection: true,
+      disableAutoSelection: true,
     },
     connectionReference: {
       referenceKeyFormat: 'mcpconnection',


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
This PR enabled in UI to add MCP Server. It is hidden behind a feature flag that is turned off by default.
This PR also added logic to support MCP server in monitoring view.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: When adding tools inside agent, users will have an additional option to add MCP server. They can either choose a managed mcp server backed by connectors, or select manually enter their MCP server URL.
- **Developers**: API should be available and deployed before UX changes are live. The new MCP Server operation is modeled as a special action. It doesn't have a tool as a parent, and conceptually it represent the action as well as the tool containing it. 
Monitoring view is also updated to show pager for for MCP Server. Since there's no tool existed for this action under the hood, the information about the tool run data and tool run index is saved in this action node instead.
- **System**: None

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->
More test will be added.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
Krrish and Eric helped review the designs

## Screenshots/Videos
<!-- Visual changes only -->

https://github.com/user-attachments/assets/b6e5a768-ef29-44fd-b042-df90ef9e4bd0


<img width="1079" height="617" alt="image" src="https://github.com/user-attachments/assets/232eecfd-c2e5-4c10-be0c-5328bf5d88a0" />
