### PR TITLE
Set mcp feature flag's default value to false

### DIFF
--- a/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
@@ -63,7 +63,7 @@ export const useShowPerformanceDebug = () => {
 };
 
 export const useMcpClientToolEnabled = () => {
-  return useSelector((state: RootState) => state.designerOptions.mcpClientToolEnabled ?? true);
+  return useSelector((state: RootState) => state.designerOptions.mcpClientToolEnabled ?? false);
 };
 
 export const useAreDesignerOptionsInitialized = () => {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Changes the default value of the mcp feature flag to 'false' to ensure the feature is only enabled explicitly via designer opt-in.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
No impact as the designer will turn on/off this feature accordingly
- **Developers**: <!-- API changes, new patterns, etc. -->
Need to opt in for this feature
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
