### PR TITLE
fix(Designer): Move exp flag back to false

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/experimentation.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/experimentation.ts
@@ -2,7 +2,7 @@ import type { IExperimentationService } from '../experimentation';
 
 export class BaseExperimentationService implements IExperimentationService {
   isFeatureEnabled(_featureGateName: string) {
-    return Promise.resolve(true);
+    return Promise.resolve(false);
   }
 
   getFeatureValue(_featureGateName: string, _type: 'string' | 'number' | 'boolean') {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Updating exp flag back to default to false due to when not initializing an exp flag it'll always set features to true.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Parter teams will have exp flags default to false.
- **Developers**: no dev changes
- **System**: no system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@takyyon

## Screenshots/Videos
<!-- Visual changes only -->
