### PR TITLE
fix(designer): Dark Scope card nodes on hover

### DIFF
--- a/libs/designer-ui/src/lib/card/scopeCard/scopeCard.less
+++ b/libs/designer-ui/src/lib/card/scopeCard/scopeCard.less
@@ -54,20 +54,7 @@
     align-items: flex-start;
     background-color: var(--brand-color, black);
     width: 80%;
-    position: relative;
     .node-button-interaction();
-
-    &:hover::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgba(0, 0, 0, 0.20);
-      pointer-events: none;
-      border-radius: 2px;
-    }
   }
 
   .msla-scope-card-title-box {
@@ -79,8 +66,6 @@
     justify-content: flex-start;
 		box-sizing: border-box;
 		padding-right: 2px;
-    position: relative;
-    z-index: 1;
   }
 
   .panel-card-content-icon-section {
@@ -120,8 +105,6 @@
 
   .msla-panel-card-error-wrapper {
     width: 100%;
-    position: relative;
-    z-index: 1;
   }
 
   .msla-panel-card-error {

--- a/libs/designer-v2/src/lib/ui/CustomNodes/components/card/card.styles.ts
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/components/card/card.styles.ts
@@ -37,10 +37,10 @@ export const useCardStyles = makeStyles({
     background: 'var(--action-brand-color)',
 
     '&:hover': {
-      background: 'color-mix(in hsl, var(--action-brand-color), black 10%)',
+      background: 'color-mix(in hsl, var(--action-brand-color), black 25%)',
     },
     '&:active': {
-      background: 'color-mix(in hsl, var(--action-brand-color), black 20%)',
+      background: 'color-mix(in hsl, var(--action-brand-color), black 35%)',
     },
   },
   small: {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Agent Loop scope has a darker color and is harder to see, so this has a darker hover effect to make it more obvious a scope node can be selected.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Slightly better usability for people working with scope cards.
- **Developers**:  no dev changes
- **System**: no system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
