### PR TITLE
fix(DesignerV2): Fixed add trigger issue, added FloatingRunButton disabled prop

### DIFF
--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -47,6 +47,7 @@ export interface FloatingRunButtonProps {
   onRun?: (runId: string) => void;
   isDarkMode: boolean;
   isDraftMode?: boolean;
+  isDisabled?: boolean;
 }
 
 export const FloatingRunButton = ({
@@ -56,6 +57,7 @@ export const FloatingRunButton = ({
   onRun,
   isDarkMode,
   isDraftMode,
+  isDisabled,
 }: FloatingRunButtonProps) => {
   const intl = useIntl();
   const dispatch = useDispatch();
@@ -215,7 +217,7 @@ export const FloatingRunButton = ({
     appearance: 'primary',
     shape: 'circular',
     size: 'large',
-    disabled: runIsLoading || runWithPayloadIsLoading || !isAllowedTriggerType,
+    disabled: isDisabled || runIsLoading || runWithPayloadIsLoading || !isAllowedTriggerType,
     style: {
       position: 'absolute',
       bottom: '16px',
@@ -257,13 +259,13 @@ export const FloatingRunButton = ({
             onClick: () => {
               runMutate();
             },
-            disabled: runIsLoading || runWithPayloadIsLoading || !isAllowedTriggerType,
+            disabled: isDisabled || runIsLoading || runWithPayloadIsLoading || !isAllowedTriggerType,
           }}
           menuButton={{
             icon: runWithPayloadIsLoading ? <Spinner size="tiny" /> : <RunWithPayloadIcon />,
             onClick: () => setPopoverOpen(true),
             ref: buttonRef,
-            disabled: runIsLoading || runWithPayloadIsLoading || !canBeRunWithPayload,
+            disabled: isDisabled || runIsLoading || runWithPayloadIsLoading || !canBeRunWithPayload,
           }}
         >
           {runText}

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -170,7 +170,7 @@ export const RecommendationPanelContext = (props: CommonPanelProps) => {
           return;
         }
 
-        const shouldAddAsTrigger = forceAsTrigger ?? false;
+        const shouldAddAsTrigger = forceAsTrigger ?? operation?.properties?.trigger !== undefined;
 
         if (shouldAddAsTrigger) {
           // Always add as trigger when explicitly requested (for trigger operations)


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixed issue where when adding triggers from search, they would be added under a request trigger.
Also added a `isDisabled` prop to the FloatingRunButton

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixed trigger add bug
- **Developers**: Can now disable FRB from outside component
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A
