### PR TITLE
fix(DesignerV2): Fixed issue with switching kinds when the first child is an agent

### DIFF
--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/add.ts
@@ -66,6 +66,7 @@ import { operationSupportsSplitOn } from '../../utils/outputs';
 import { isA2AWorkflow } from '../../state/workflow/helper';
 import { openKindChangeDialog } from '../../state/modal/modalSlice';
 import constants from '../../../common/constants';
+import { addOperationRunAfter, removeOperationRunAfter } from './runafter';
 
 type AddOperationPayload = {
   operation: DiscoveryOperation<DiscoveryResultTypes> | undefined;
@@ -87,6 +88,7 @@ export const addOperation = createAsyncThunk('addOperation', async (payload: Add
 
     const workflowState = (getState() as RootState).workflow;
 
+    // Catch workflow kind conflicts before adding node
     if (isTrigger) {
       const isA2ATrigger = equals(operation.type, 'Request') && equals(operation.kind, 'Agent');
       if (equals(workflowState.workflowKind, WorkflowKind.STATELESS) && isA2ATrigger) {
@@ -106,7 +108,6 @@ export const addOperation = createAsyncThunk('addOperation', async (payload: Add
             dispatch(openKindChangeDialog({ type: 'toStateful' }));
             return;
           }
-          dispatch(setWorkflowKind(WorkflowKind.STATEFUL));
         }
       } else if (isA2ATrigger) {
         const allAgentIds = Object.keys(workflowState.operations).filter((id) =>
@@ -121,7 +122,6 @@ export const addOperation = createAsyncThunk('addOperation', async (payload: Add
           dispatch(openKindChangeDialog({ type: 'toA2A' }));
           return;
         }
-        dispatch(setWorkflowKind(WorkflowKind.AGENT));
       }
     }
 
@@ -160,6 +160,50 @@ export const addOperation = createAsyncThunk('addOperation', async (payload: Add
       actionMetadata,
       !isAddingHandoff
     );
+
+    // Adjust workflow for kind change if needed
+    if (isTrigger) {
+      const isA2ATrigger = equals(operation.type, 'Request') && equals(operation.kind, 'Agent');
+
+      if (isA2AWorkflow(workflowState)) {
+        if (!isA2ATrigger) {
+          dispatch(setWorkflowKind(WorkflowKind.STATEFUL));
+          // If trigger child is agent, agent needs to have its runAfter cleared
+          const edges = workflowState.graph?.edges ?? [];
+          const triggerChildId = edges.find((edge) => edge.source === constants.NODE.TYPE.PLACEHOLDER_TRIGGER)?.target;
+          if (triggerChildId) {
+            const childNodeOperationData = workflowState.operations?.[triggerChildId];
+            const childIsAgent = equals(childNodeOperationData.type, constants.NODE.TYPE.AGENT);
+            const currentRunAfterId = Object.keys((childNodeOperationData as any).runAfter)?.[0];
+            if (childIsAgent && currentRunAfterId) {
+              dispatch(
+                removeOperationRunAfter({
+                  parentOperationId: currentRunAfterId,
+                  childOperationId: triggerChildId,
+                })
+              );
+            }
+          }
+        }
+      } else if (isA2ATrigger) {
+        dispatch(setWorkflowKind(WorkflowKind.AGENT));
+        // If trigger child is agent, agent needs to run after trigger
+        const edges = workflowState.graph?.edges ?? [];
+        const triggerChildId = edges.find((edge) => edge.source === constants.NODE.TYPE.PLACEHOLDER_TRIGGER)?.target;
+        if (triggerChildId) {
+          const childNodeOperationData = workflowState.operations?.[triggerChildId];
+          const childIsAgent = equals(childNodeOperationData.type, constants.NODE.TYPE.AGENT);
+          if (childIsAgent) {
+            dispatch(
+              addOperationRunAfter({
+                parentOperationId: actionId,
+                childOperationId: triggerChildId,
+              })
+            );
+          }
+        }
+      }
+    }
 
     dispatch(setFocusNode(nodeId));
     if (isAddingAgentTool && newToolId) {

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
@@ -117,6 +117,7 @@ export const workflowSlice = createSlice({
           graph.edges = graph.edges.map((edge) => {
             if (equals(edge.source, constants.NODE.TYPE.PLACEHOLDER_TRIGGER)) {
               // eslint-disable-next-line no-param-reassign
+              edge.id = `${action.payload.nodeId}-${edge.target}`;
               edge.source = action.payload.nodeId;
             }
             return edge;
@@ -582,9 +583,8 @@ export const workflowSlice = createSlice({
     },
     removeRunAfter: (state: WorkflowState, action: PayloadAction<{ childOperationId: string; parentOperationId: string }>) => {
       const { childOperationId, parentOperationId } = action.payload;
-      const parentOperation = getRecordEntry(state.operations, parentOperationId);
       const childOperation: LogicAppsV2.ActionDefinition | undefined = getRecordEntry(state.operations, childOperationId);
-      if (!parentOperation || !childOperation) {
+      if (!childOperation) {
         return;
       }
       delete childOperation.runAfter?.[parentOperationId];


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixed issue with switching kinds when the first child is an agent

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users will be able to switch kinds properly with an agent as the first child
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A