### PR TITLE
fix(DesignerV2): Improved RunHistory collapse toggle

### DIFF
--- a/Localize/lang/strings.json
+++ b/Localize/lang/strings.json
@@ -1426,7 +1426,7 @@
   "XulI0a": "Describe the goal or purpose for this workflow. To edit this description later, open the trigger details pane.",
   "Xv5CGN": "(UTC-05:00) Indiana (East)",
   "Xx/naD": "Required. The name of the action whose body outputs you want.",
-  "Xy40uA": "Add your MCP server",
+  "Xy40uA": "Add MCP server",
   "Xz88HV": "Associated workflows",
   "Y/bcmG": "Password",
   "Y5XAbg": "Select a Swagger Function App resource",

--- a/libs/designer-v2/src/lib/ui/RunDisplay.tsx
+++ b/libs/designer-v2/src/lib/ui/RunDisplay.tsx
@@ -1,12 +1,12 @@
-import { Button, makeStyles } from '@fluentui/react-components';
+import { Button, makeStyles, tokens } from '@fluentui/react-components';
 import { setRunHistoryCollapsed } from '../core/state/panel/panelSlice';
 import { useRunInstance } from '../core/state/workflow/workflowSelectors';
 import { RunHistoryEntryInfo } from './panel';
 import { useIsRunHistoryCollapsed } from '../core/state/panel/panelSelectors';
 import { useDispatch } from 'react-redux';
 
-import { bundleIcon, TaskListLtrFilled, TaskListLtrRegular } from '@fluentui/react-icons';
-const HistoryIcon = bundleIcon(TaskListLtrFilled, TaskListLtrRegular);
+import { bundleIcon, ChevronDoubleRightFilled, ChevronDoubleRightRegular } from '@fluentui/react-icons';
+const ExpandIcon = bundleIcon(ChevronDoubleRightFilled, ChevronDoubleRightRegular);
 
 const useRunDisplayStyles = makeStyles({
   root: {
@@ -29,7 +29,7 @@ export const RunDisplay = () => {
 
   const styles = useRunDisplayStyles();
 
-  if (!selectedRun) {
+  if (!selectedRun && !isRunHistoryCollapsed) {
     return null;
   }
 
@@ -37,14 +37,17 @@ export const RunDisplay = () => {
     <div className={styles.root}>
       {isRunHistoryCollapsed ? (
         <Button
-          appearance="outline"
           onClick={() => dispatch(setRunHistoryCollapsed(false))}
-          icon={<HistoryIcon />}
+          icon={<ExpandIcon />}
           size="large"
-          style={{ height: '48px' }}
+          style={{
+            border: 'none',
+            boxShadow: tokens.shadow8,
+            height: '48px',
+          }}
         />
       ) : null}
-      <RunHistoryEntryInfo run={selectedRun as any} />
+      {selectedRun ? <RunHistoryEntryInfo run={selectedRun as any} /> : null}
     </div>
   );
 };

--- a/libs/designer-v2/src/lib/ui/panel/runHistoryPanel/runHistoryPanel.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/runHistoryPanel/runHistoryPanel.tsx
@@ -36,8 +36,8 @@ import {
   bundleIcon,
   ArrowClockwiseFilled,
   ArrowClockwiseRegular,
-  DismissFilled,
-  DismissRegular,
+  ChevronDoubleLeftFilled,
+  ChevronDoubleLeftRegular,
   ArrowLeftFilled,
   ArrowLeftRegular,
 } from '@fluentui/react-icons';
@@ -51,7 +51,7 @@ import StatusIndicator from './statusIndicator';
 // MARK: End Imports
 
 const RefreshIcon = bundleIcon(ArrowClockwiseFilled, ArrowClockwiseRegular);
-const DismissIcon = bundleIcon(DismissFilled, DismissRegular);
+const CollapseIcon = bundleIcon(ChevronDoubleLeftFilled, ChevronDoubleLeftRegular);
 const ReturnIcon = bundleIcon(ArrowLeftFilled, ArrowLeftRegular);
 
 const runIdRegex = /^\d{29}CU\d{2,8}$/;
@@ -324,7 +324,9 @@ export const RunHistoryPanel = () => {
 
   // MARK: Components
 
-  const CloseButton = () => <Button appearance="subtle" onClick={() => dispatch(setRunHistoryCollapsed(true))} icon={<DismissIcon />} />;
+  const CollapseButton = () => (
+    <Button appearance="subtle" onClick={() => dispatch(setRunHistoryCollapsed(true))} icon={<CollapseIcon />} />
+  );
 
   const RefreshButton = () => (
     <Button
@@ -369,7 +371,7 @@ export const RunHistoryPanel = () => {
             </Button>
           )}
           <div style={{ flexGrow: 1 }} />
-          <CloseButton />
+          <CollapseButton />
         </DrawerHeaderNavigation>
         {inRunList ? (
           <DrawerHeaderTitle>{runListTitle}</DrawerHeaderTitle>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Run history expand is now visible with no run selected
Run history collapse and expand buttons updated

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Improved RunHistory collapse toggle
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
<img width="501" height="225" alt="image" src="https://github.com/user-attachments/assets/7171577b-c7c2-47d5-a09b-f1fdebb9a555" />
<img width="377" height="135" alt="image" src="https://github.com/user-attachments/assets/07603384-7ab5-42db-8cb6-3262c02226f2" />
