### PR TITLE
fix(designer): Show Agent for A2A workflows in SearchView

### DIFF
--- a/libs/designer/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineButtons.test.tsx.snap
+++ b/libs/designer/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineButtons.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`TimelineButtons > should render with disabled buttons when fetching rep
   className="flex-col"
 >
   <button
-    className="fui-Button r1alrhcs nav-button ___1neb2cq_lqsl7t0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f1et0tmh fb3rf2x f1wi8ngl f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
+    className="fui-Button r1alrhcs nav-button ___2wxle20_kbb1rc0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f4dhi0o fb3rf2x fequ9m0 f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fuigjrg fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
     disabled={true}
     onClick={[Function]}
     type="button"
@@ -217,7 +217,7 @@ exports[`TimelineButtons > should render with disabled buttons when fetching rep
     Previous task
   </button>
   <button
-    className="fui-Button r1alrhcs nav-button ___1neb2cq_lqsl7t0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f1et0tmh fb3rf2x f1wi8ngl f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
+    className="fui-Button r1alrhcs nav-button ___2wxle20_kbb1rc0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f4dhi0o fb3rf2x fequ9m0 f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fuigjrg fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
     disabled={true}
     onClick={[Function]}
     type="button"
@@ -264,7 +264,7 @@ exports[`TimelineButtons > should render with disabled buttons when no repetitio
   className="flex-col"
 >
   <button
-    className="fui-Button r1alrhcs nav-button ___1neb2cq_lqsl7t0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f1et0tmh fb3rf2x f1wi8ngl f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
+    className="fui-Button r1alrhcs nav-button ___2wxle20_kbb1rc0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f4dhi0o fb3rf2x fequ9m0 f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fuigjrg fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
     disabled={true}
     onClick={[Function]}
     type="button"
@@ -304,7 +304,7 @@ exports[`TimelineButtons > should render with disabled buttons when no repetitio
     Previous task
   </button>
   <button
-    className="fui-Button r1alrhcs nav-button ___1neb2cq_lqsl7t0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f1et0tmh fb3rf2x f1wi8ngl f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
+    className="fui-Button r1alrhcs nav-button ___2wxle20_kbb1rc0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f4dhi0o fb3rf2x fequ9m0 f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fuigjrg fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
     disabled={true}
     onClick={[Function]}
     type="button"
@@ -391,7 +391,7 @@ exports[`TimelineButtons > should render with disabled next button at last task 
     Previous task
   </button>
   <button
-    className="fui-Button r1alrhcs nav-button ___1neb2cq_lqsl7t0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f1et0tmh fb3rf2x f1wi8ngl f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
+    className="fui-Button r1alrhcs nav-button ___2wxle20_kbb1rc0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f4dhi0o fb3rf2x fequ9m0 f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fuigjrg fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
     disabled={true}
     onClick={[Function]}
     type="button"
@@ -438,7 +438,7 @@ exports[`TimelineButtons > should render with disabled previous button at first 
   className="flex-col"
 >
   <button
-    className="fui-Button r1alrhcs nav-button ___1neb2cq_lqsl7t0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f1et0tmh fb3rf2x f1wi8ngl f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
+    className="fui-Button r1alrhcs nav-button ___2wxle20_kbb1rc0 f1c21dwh f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1s2aq7o f9ql6rf f1s2uweq fr80ssc f1ukrpxl fecsdlb fvgxktp f19vpps7 fv5swzo f1al02dq f3h1zc4 f1h0usnq fs4ktlq f16h9ulv fx2bmrt fcvwxyo f1ol4fw6 f1q1lw4e f1dwjv2g f1kc2mi9 f4dhi0o fb3rf2x fequ9m0 f44lkw9 fdrzuqr f15x8b5r fphbwmw f8w4c43 f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fuigjrg fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1y0svfh fihuait fnxhupq fx507ft fyd6l6x f1062rbf"
     disabled={true}
     onClick={[Function]}
     type="button"

--- a/libs/designer/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineContent.test.tsx.snap
+++ b/libs/designer/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineContent.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`TimelineContent > should render error carets for failed repetitions 1`]
     </div>
   </div>
   <div
-    className="fui-Slider ___13bkkjq_w68bbx0 f10pi13n fwk3njj f1sdsnyy f122n59 f1oiokrs ftqa4ok f2hkw1w f1b1k54r f4ne723 fh7aioi fqqcjud f1k55ka9 fgclinu fycbxed f16pcs8n ffht0p2 f1p0ul1q f1c901ms f1alokd7 fmj8fco f1iwowo3 f1hxpdv8 fm5xmfm f1dmxpeg femsgmt f1a78h9h fuok0yf f1pzv1zu fktlcaf fiadc6h f4l8x3l f671q34 fvfzmw5 faw1t00 fxdgx5 fii04fa f36hzz8 f1volkfw f1xddb6 fcdikl fhpzgm6 f1q6pm3h"
+    className="fui-Slider ___1uql6nb_ys3xc50 f10pi13n fwk3njj f1sdsnyy f122n59 f1oiokrs ftqa4ok f2hkw1w f1b1k54r f4ne723 fh7aioi fqqcjud f1k55ka9 fgclinu fycbxed f16pcs8n ffht0p2 f1p0ul1q f1c901ms f1alokd7 fmj8fco f1iwowo3 f1pffoy2 fm5xmfm fs6b7xr femsgmt f1a78h9h fh1udnr fuok0yf f1pzv1zu fktlcaf fiadc6h f4l8x3l f671q34 fvfzmw5 faw1t00 fxdgx5 fii04fa f36hzz8 f1volkfw f1xddb6 fcdikl fhpzgm6 f1q6pm3h"
     style={
       {
         "--fui-Slider--direction": "0deg",
@@ -87,7 +87,7 @@ exports[`TimelineContent > should render error carets for failed repetitions 1`]
     }
   >
     <input
-      className="fui-Slider__input ___adw2kq0_3dha4n0 f1k6fduh fk73vx1 f16hsg94 f1nzqi2z fwpfdsa fuur7zz f1mk8lai f1s184ao f1l02sjl f174ca62 f1r9mf01"
+      className="fui-Slider__input ___1mpauhz_171a63j f1k6fduh fk73vx1 f16hsg94 f1nzqi2z fwpfdsa fuur7zz f1mk8lai f1s184ao f1l02sjl f174ca62 f1mm7lwf fdkxjay f1ry0dy"
       id="slider-r7"
       max={1}
       min={0}
@@ -98,10 +98,10 @@ exports[`TimelineContent > should render error carets for failed repetitions 1`]
       value={0}
     />
     <div
-      className="fui-Slider__rail ___qnotkj0_1hvujaz f1kijzfu f1aehjj5 faunodf f88nxoq fd46tj4 f1e2fz10 f10pi13n fdgv6k0 fizngqt fpvhumw f1yog68k f13sgyd8 fzhtfnv f1j7ml58 fx36ao7 fux3rle fqxfnkd f1l02sjl f1rik0od f14xwovp febq2dz"
+      className="fui-Slider__rail ___as1w300_ykzy540 f1kijzfu f1aehjj5 faunodf f88nxoq fd46tj4 f1e2fz10 f10pi13n fdgv6k0 fizngqt fpvhumw f1yog68k f13sgyd8 fzhtfnv f1j7ml58 fx36ao7 fux3rle fqxfnkd f1l02sjl f1rik0od f14xwovp fdehrcx"
     />
     <div
-      className="fui-Slider__thumb ___43lhpn0_1ar0uxf faunodf f88nxoq fd46tj4 f1e2fz10 f1euv43f f174ca62 f1yfdkfd f1aehjj5 f1s6fcnf fdgv6k0 f44lkw9 fof7hq0 foksa45 f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fielpny fyl8oag fzhtfnv f1fsco4d f5cv5a3 feeniun"
+      className="fui-Slider__thumb ___inkfel0_1u4if40 ftx3jue faunodf f88nxoq fd46tj4 f1e2fz10 f1euv43f f174ca62 f1yfdkfd f1aehjj5 f1s6fcnf fdgv6k0 f44lkw9 fof7hq0 foksa45 f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fielpny fyl8oag fzhtfnv f1fsco4d f5cv5a3 f1k2fpdo"
     />
   </div>
   <div
@@ -132,7 +132,7 @@ exports[`TimelineContent > should render loading state 1`] = `
 >
   <div
     aria-labelledby="spinnerr1"
-    className="fui-Spinner r82apo5"
+    className="fui-Spinner rpp59a7"
     role="progressbar"
     style={
       {
@@ -163,7 +163,7 @@ exports[`TimelineContent > should render loading state when collapsed 1`] = `
 >
   <div
     aria-labelledby="spinnerr2"
-    className="fui-Spinner r82apo5"
+    className="fui-Spinner rpp59a7"
     role="progressbar"
     style={
       {
@@ -307,7 +307,7 @@ exports[`TimelineContent > should render with default props 1`] = `
     </div>
   </div>
   <div
-    className="fui-Slider ___13bkkjq_w68bbx0 f10pi13n fwk3njj f1sdsnyy f122n59 f1oiokrs ftqa4ok f2hkw1w f1b1k54r f4ne723 fh7aioi fqqcjud f1k55ka9 fgclinu fycbxed f16pcs8n ffht0p2 f1p0ul1q f1c901ms f1alokd7 fmj8fco f1iwowo3 f1hxpdv8 fm5xmfm f1dmxpeg femsgmt f1a78h9h fuok0yf f1pzv1zu fktlcaf fiadc6h f4l8x3l f671q34 fvfzmw5 faw1t00 fxdgx5 fii04fa f36hzz8 f1volkfw f1xddb6 fcdikl fhpzgm6 f1q6pm3h"
+    className="fui-Slider ___1uql6nb_ys3xc50 f10pi13n fwk3njj f1sdsnyy f122n59 f1oiokrs ftqa4ok f2hkw1w f1b1k54r f4ne723 fh7aioi fqqcjud f1k55ka9 fgclinu fycbxed f16pcs8n ffht0p2 f1p0ul1q f1c901ms f1alokd7 fmj8fco f1iwowo3 f1pffoy2 fm5xmfm fs6b7xr femsgmt f1a78h9h fh1udnr fuok0yf f1pzv1zu fktlcaf fiadc6h f4l8x3l f671q34 fvfzmw5 faw1t00 fxdgx5 fii04fa f36hzz8 f1volkfw f1xddb6 fcdikl fhpzgm6 f1q6pm3h"
     style={
       {
         "--fui-Slider--direction": "0deg",
@@ -318,7 +318,7 @@ exports[`TimelineContent > should render with default props 1`] = `
     }
   >
     <input
-      className="fui-Slider__input ___adw2kq0_3dha4n0 f1k6fduh fk73vx1 f16hsg94 f1nzqi2z fwpfdsa fuur7zz f1mk8lai f1s184ao f1l02sjl f174ca62 f1r9mf01"
+      className="fui-Slider__input ___1mpauhz_171a63j f1k6fduh fk73vx1 f16hsg94 f1nzqi2z fwpfdsa fuur7zz f1mk8lai f1s184ao f1l02sjl f174ca62 f1mm7lwf fdkxjay f1ry0dy"
       id="slider-r0"
       max={1}
       min={0}
@@ -329,10 +329,10 @@ exports[`TimelineContent > should render with default props 1`] = `
       value={0}
     />
     <div
-      className="fui-Slider__rail ___qnotkj0_1hvujaz f1kijzfu f1aehjj5 faunodf f88nxoq fd46tj4 f1e2fz10 f10pi13n fdgv6k0 fizngqt fpvhumw f1yog68k f13sgyd8 fzhtfnv f1j7ml58 fx36ao7 fux3rle fqxfnkd f1l02sjl f1rik0od f14xwovp febq2dz"
+      className="fui-Slider__rail ___as1w300_ykzy540 f1kijzfu f1aehjj5 faunodf f88nxoq fd46tj4 f1e2fz10 f10pi13n fdgv6k0 fizngqt fpvhumw f1yog68k f13sgyd8 fzhtfnv f1j7ml58 fx36ao7 fux3rle fqxfnkd f1l02sjl f1rik0od f14xwovp fdehrcx"
     />
     <div
-      className="fui-Slider__thumb ___43lhpn0_1ar0uxf faunodf f88nxoq fd46tj4 f1e2fz10 f1euv43f f174ca62 f1yfdkfd f1aehjj5 f1s6fcnf fdgv6k0 f44lkw9 fof7hq0 foksa45 f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fielpny fyl8oag fzhtfnv f1fsco4d f5cv5a3 feeniun"
+      className="fui-Slider__thumb ___inkfel0_1u4if40 ftx3jue faunodf f88nxoq fd46tj4 f1e2fz10 f1euv43f f174ca62 f1yfdkfd f1aehjj5 f1s6fcnf fdgv6k0 f44lkw9 fof7hq0 foksa45 f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fielpny fyl8oag fzhtfnv f1fsco4d f5cv5a3 f1k2fpdo"
     />
   </div>
   <div
@@ -371,7 +371,7 @@ exports[`TimelineContent > should render with empty repetitions map 1`] = `
     }
   />
   <div
-    className="fui-Slider ___13bkkjq_w68bbx0 f10pi13n fwk3njj f1sdsnyy f122n59 f1oiokrs ftqa4ok f2hkw1w f1b1k54r f4ne723 fh7aioi fqqcjud f1k55ka9 fgclinu fycbxed f16pcs8n ffht0p2 f1p0ul1q f1c901ms f1alokd7 fmj8fco f1iwowo3 f1hxpdv8 fm5xmfm f1dmxpeg femsgmt f1a78h9h fuok0yf f1pzv1zu fktlcaf fiadc6h f4l8x3l f671q34 fvfzmw5 faw1t00 fxdgx5 fii04fa f36hzz8 f1volkfw f1xddb6 fcdikl fhpzgm6 f1q6pm3h"
+    className="fui-Slider ___1uql6nb_ys3xc50 f10pi13n fwk3njj f1sdsnyy f122n59 f1oiokrs ftqa4ok f2hkw1w f1b1k54r f4ne723 fh7aioi fqqcjud f1k55ka9 fgclinu fycbxed f16pcs8n ffht0p2 f1p0ul1q f1c901ms f1alokd7 fmj8fco f1iwowo3 f1pffoy2 fm5xmfm fs6b7xr femsgmt f1a78h9h fh1udnr fuok0yf f1pzv1zu fktlcaf fiadc6h f4l8x3l f671q34 fvfzmw5 faw1t00 fxdgx5 fii04fa f36hzz8 f1volkfw f1xddb6 fcdikl fhpzgm6 f1q6pm3h"
     style={
       {
         "--fui-Slider--direction": "0deg",
@@ -382,7 +382,7 @@ exports[`TimelineContent > should render with empty repetitions map 1`] = `
     }
   >
     <input
-      className="fui-Slider__input ___adw2kq0_3dha4n0 f1k6fduh fk73vx1 f16hsg94 f1nzqi2z fwpfdsa fuur7zz f1mk8lai f1s184ao f1l02sjl f174ca62 f1r9mf01"
+      className="fui-Slider__input ___1mpauhz_171a63j f1k6fduh fk73vx1 f16hsg94 f1nzqi2z fwpfdsa fuur7zz f1mk8lai f1s184ao f1l02sjl f174ca62 f1mm7lwf fdkxjay f1ry0dy"
       id="slider-r3"
       max={1}
       min={0}
@@ -393,10 +393,10 @@ exports[`TimelineContent > should render with empty repetitions map 1`] = `
       value={0}
     />
     <div
-      className="fui-Slider__rail ___qnotkj0_1hvujaz f1kijzfu f1aehjj5 faunodf f88nxoq fd46tj4 f1e2fz10 f10pi13n fdgv6k0 fizngqt fpvhumw f1yog68k f13sgyd8 fzhtfnv f1j7ml58 fx36ao7 fux3rle fqxfnkd f1l02sjl f1rik0od f14xwovp febq2dz"
+      className="fui-Slider__rail ___as1w300_ykzy540 f1kijzfu f1aehjj5 faunodf f88nxoq fd46tj4 f1e2fz10 f10pi13n fdgv6k0 fizngqt fpvhumw f1yog68k f13sgyd8 fzhtfnv f1j7ml58 fx36ao7 fux3rle fqxfnkd f1l02sjl f1rik0od f14xwovp fdehrcx"
     />
     <div
-      className="fui-Slider__thumb ___43lhpn0_1ar0uxf faunodf f88nxoq fd46tj4 f1e2fz10 f1euv43f f174ca62 f1yfdkfd f1aehjj5 f1s6fcnf fdgv6k0 f44lkw9 fof7hq0 foksa45 f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fielpny fyl8oag fzhtfnv f1fsco4d f5cv5a3 feeniun"
+      className="fui-Slider__thumb ___inkfel0_1u4if40 ftx3jue faunodf f88nxoq fd46tj4 f1e2fz10 f1euv43f f174ca62 f1yfdkfd f1aehjj5 f1s6fcnf fdgv6k0 f44lkw9 fof7hq0 foksa45 f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fielpny fyl8oag fzhtfnv f1fsco4d f5cv5a3 f1k2fpdo"
     />
   </div>
   <div
@@ -455,7 +455,7 @@ exports[`TimelineContent > should render with multiple task groups 1`] = `
     </div>
   </div>
   <div
-    className="fui-Slider ___13bkkjq_w68bbx0 f10pi13n fwk3njj f1sdsnyy f122n59 f1oiokrs ftqa4ok f2hkw1w f1b1k54r f4ne723 fh7aioi fqqcjud f1k55ka9 fgclinu fycbxed f16pcs8n ffht0p2 f1p0ul1q f1c901ms f1alokd7 fmj8fco f1iwowo3 f1hxpdv8 fm5xmfm f1dmxpeg femsgmt f1a78h9h fuok0yf f1pzv1zu fktlcaf fiadc6h f4l8x3l f671q34 fvfzmw5 faw1t00 fxdgx5 fii04fa f36hzz8 f1volkfw f1xddb6 fcdikl fhpzgm6 f1q6pm3h"
+    className="fui-Slider ___1uql6nb_ys3xc50 f10pi13n fwk3njj f1sdsnyy f122n59 f1oiokrs ftqa4ok f2hkw1w f1b1k54r f4ne723 fh7aioi fqqcjud f1k55ka9 fgclinu fycbxed f16pcs8n ffht0p2 f1p0ul1q f1c901ms f1alokd7 fmj8fco f1iwowo3 f1pffoy2 fm5xmfm fs6b7xr femsgmt f1a78h9h fh1udnr fuok0yf f1pzv1zu fktlcaf fiadc6h f4l8x3l f671q34 fvfzmw5 faw1t00 fxdgx5 fii04fa f36hzz8 f1volkfw f1xddb6 fcdikl fhpzgm6 f1q6pm3h"
     style={
       {
         "--fui-Slider--direction": "0deg",
@@ -466,7 +466,7 @@ exports[`TimelineContent > should render with multiple task groups 1`] = `
     }
   >
     <input
-      className="fui-Slider__input ___adw2kq0_3dha4n0 f1k6fduh fk73vx1 f16hsg94 f1nzqi2z fwpfdsa fuur7zz f1mk8lai f1s184ao f1l02sjl f174ca62 f1r9mf01"
+      className="fui-Slider__input ___1mpauhz_171a63j f1k6fduh fk73vx1 f16hsg94 f1nzqi2z fwpfdsa fuur7zz f1mk8lai f1s184ao f1l02sjl f174ca62 f1mm7lwf fdkxjay f1ry0dy"
       id="slider-r4"
       max={2}
       min={0}
@@ -477,10 +477,10 @@ exports[`TimelineContent > should render with multiple task groups 1`] = `
       value={0}
     />
     <div
-      className="fui-Slider__rail ___qnotkj0_1hvujaz f1kijzfu f1aehjj5 faunodf f88nxoq fd46tj4 f1e2fz10 f10pi13n fdgv6k0 fizngqt fpvhumw f1yog68k f13sgyd8 fzhtfnv f1j7ml58 fx36ao7 fux3rle fqxfnkd f1l02sjl f1rik0od f14xwovp febq2dz"
+      className="fui-Slider__rail ___as1w300_ykzy540 f1kijzfu f1aehjj5 faunodf f88nxoq fd46tj4 f1e2fz10 f10pi13n fdgv6k0 fizngqt fpvhumw f1yog68k f13sgyd8 fzhtfnv f1j7ml58 fx36ao7 fux3rle fqxfnkd f1l02sjl f1rik0od f14xwovp fdehrcx"
     />
     <div
-      className="fui-Slider__thumb ___43lhpn0_1ar0uxf faunodf f88nxoq fd46tj4 f1e2fz10 f1euv43f f174ca62 f1yfdkfd f1aehjj5 f1s6fcnf fdgv6k0 f44lkw9 fof7hq0 foksa45 f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fielpny fyl8oag fzhtfnv f1fsco4d f5cv5a3 feeniun"
+      className="fui-Slider__thumb ___inkfel0_1u4if40 ftx3jue faunodf f88nxoq fd46tj4 f1e2fz10 f1euv43f f174ca62 f1yfdkfd f1aehjj5 f1s6fcnf fdgv6k0 f44lkw9 fof7hq0 foksa45 f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fielpny fyl8oag fzhtfnv f1fsco4d f5cv5a3 f1k2fpdo"
     />
   </div>
   <div

--- a/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/__snapshots__/CopyTooltip.spec.tsx.snap
+++ b/libs/designer/src/lib/ui/common/DesignerContextualMenu/__test__/__snapshots__/CopyTooltip.spec.tsx.snap
@@ -29,6 +29,9 @@ exports[`CopyTooltip > should position the tooltip based on the provided locatio
     >
       Copied!
     </div>
+    <span
+      hidden=""
+    />
   </div>
 </body>
 `;
@@ -62,6 +65,9 @@ exports[`CopyTooltip > should render the tooltip with the correct content 1`] = 
     >
       Copied!
     </div>
+    <span
+      hidden=""
+    />
   </div>
 </body>
 `;

--- a/libs/designer/src/lib/ui/menuItems/__test__/__snapshots__/collapseMenuItem.spec.tsx.snap
+++ b/libs/designer/src/lib/ui/menuItems/__test__/__snapshots__/collapseMenuItem.spec.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`lib/ui/menuItems/collapseMenuItem > should render correctly when isCollapsed is false 1`] = `
 <div
-  className="fui-MenuItem r11normc"
+  className="fui-MenuItem rfoezjv"
   data-automation-id="msla-collapse-menu-option"
   onClick={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
-  onMouseEnter={[Function]}
+  onMouseMove={[Function]}
   role="menuitem"
   tabIndex={0}
 >
@@ -53,12 +53,12 @@ exports[`lib/ui/menuItems/collapseMenuItem > should render correctly when isColl
 
 exports[`lib/ui/menuItems/collapseMenuItem > should render correctly when isCollapsed is true 1`] = `
 <div
-  className="fui-MenuItem r11normc"
+  className="fui-MenuItem rfoezjv"
   data-automation-id="msla-collapse-menu-option"
   onClick={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
-  onMouseEnter={[Function]}
+  onMouseMove={[Function]}
   role="menuitem"
   tabIndex={0}
 >

--- a/libs/designer/src/lib/ui/menuItems/__test__/__snapshots__/pinMenuItem.spec.tsx.snap
+++ b/libs/designer/src/lib/ui/menuItems/__test__/__snapshots__/pinMenuItem.spec.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`lib/ui/menuItems/pinMenuItem > should render for actions if pinned=false 1`] = `
 <div
-  className="fui-MenuItem r11normc"
+  className="fui-MenuItem rfoezjv"
   data-automation-id="msla-pin-menu-option"
   onClick={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
-  onMouseEnter={[Function]}
+  onMouseMove={[Function]}
   role="menuitem"
   tabIndex={0}
 >
@@ -53,12 +53,12 @@ exports[`lib/ui/menuItems/pinMenuItem > should render for actions if pinned=fals
 
 exports[`lib/ui/menuItems/pinMenuItem > should render for actions if pinned=true 1`] = `
 <div
-  className="fui-MenuItem r11normc"
+  className="fui-MenuItem rfoezjv"
   data-automation-id="msla-pin-menu-option"
   onClick={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
-  onMouseEnter={[Function]}
+  onMouseMove={[Function]}
   role="menuitem"
   tabIndex={0}
 >

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__tests__/__snapshots__/inputsPanel.spec.tsx.snap
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__tests__/__snapshots__/inputsPanel.spec.tsx.snap
@@ -172,7 +172,7 @@ exports[`InputsPanel > should render error state 1`] = `
     </div>
     <div
       aria-orientation="horizontal"
-      class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+      class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
       role="separator"
     />
   </div>
@@ -351,7 +351,7 @@ exports[`InputsPanel > should render loading state 1`] = `
     </div>
     <div
       aria-orientation="horizontal"
-      class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+      class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
       role="separator"
     />
   </div>
@@ -530,7 +530,7 @@ exports[`InputsPanel > should render the InputsPanel with inputs 1`] = `
     </div>
     <div
       aria-orientation="horizontal"
-      class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+      class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
       role="separator"
     />
   </div>
@@ -609,7 +609,7 @@ exports[`InputsPanel > should render the InputsPanel with no inputs 1`] = `
     </div>
     <div
       aria-orientation="horizontal"
-      class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+      class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
       role="separator"
     />
   </div>

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__tests__/__snapshots__/outputsPanel.spec.tsx.snap
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__tests__/__snapshots__/outputsPanel.spec.tsx.snap
@@ -175,7 +175,7 @@ exports[`OutputsPanel > Should render OutputsPanel with error state 1`] = `
         </div>
         <div
           aria-orientation="horizontal"
-          class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+          class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
           role="separator"
         />
       </div>
@@ -352,7 +352,7 @@ exports[`OutputsPanel > Should render OutputsPanel with error state 1`] = `
       </div>
       <div
         aria-orientation="horizontal"
-        class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+        class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
         role="separator"
       />
     </div>
@@ -586,7 +586,7 @@ exports[`OutputsPanel > Should render OutputsPanel with loading state 1`] = `
         </div>
         <div
           aria-orientation="horizontal"
-          class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+          class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
           role="separator"
         />
       </div>
@@ -763,7 +763,7 @@ exports[`OutputsPanel > Should render OutputsPanel with loading state 1`] = `
       </div>
       <div
         aria-orientation="horizontal"
-        class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+        class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
         role="separator"
       />
     </div>
@@ -897,7 +897,7 @@ exports[`OutputsPanel > Should render OutputsPanel with no outputs 1`] = `
         </div>
         <div
           aria-orientation="horizontal"
-          class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+          class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
           role="separator"
         />
       </div>
@@ -974,7 +974,7 @@ exports[`OutputsPanel > Should render OutputsPanel with no outputs 1`] = `
       </div>
       <div
         aria-orientation="horizontal"
-        class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+        class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
         role="separator"
       />
     </div>
@@ -1208,7 +1208,7 @@ exports[`OutputsPanel > Should render OutputsPanel with outputs 1`] = `
         </div>
         <div
           aria-orientation="horizontal"
-          class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+          class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
           role="separator"
         />
       </div>
@@ -1385,7 +1385,7 @@ exports[`OutputsPanel > Should render OutputsPanel with outputs 1`] = `
       </div>
       <div
         aria-orientation="horizontal"
-        class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+        class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
         role="separator"
       />
     </div>
@@ -1698,7 +1698,7 @@ exports[`OutputsPanel > Should render OutputsPanel without uri 1`] = `
         </div>
         <div
           aria-orientation="horizontal"
-          class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+          class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
           role="separator"
         />
       </div>
@@ -1837,7 +1837,7 @@ exports[`OutputsPanel > Should render OutputsPanel without uri 1`] = `
       </div>
       <div
         aria-orientation="horizontal"
-        class="fui-Divider ___14drqcq_2rxt2r0 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
+        class="fui-Divider ___14drqcq_z8b5q40 f122n59 f1ewtqcl f22iagw f1063pyq fqerorx f10pi13n fk6fouc fy9rknc figsok6 fwrc4pm f17mccla fyl8oag f16vkdww fhsnbul f1gw3sf2 f1ly5f7u f1s3tz6t f1wl9k8s f13zj6fq fkfq4zb f1vccso1 f1geml7w f1r7kh1m fjml6kk f16j7guv fx01ahm fl8d8yv fj1a37q fly5x3f f163fonl f51yk4v f13rof3u f8rth92 f6czdpx f1iyka9k fzynn9s fekrn8e f1kyqvp9 fesgyo"
         role="separator"
       />
     </div>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
We had 2 checks that were preventing agent loops from showing agentic loops for a2a workflows. Now I've added as a supported action as well as made the filter include a2a workflows instead of just agentic workflows.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users were unable to see Agentic loop as an action when searching for it in a2a workflows.
- **Developers**: small dev change to prevent the warning `missing queryFn ['allRuns']` in useAllRuns
- **System**: No System changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@eric-b-wu

## Screenshots/Videos
<!-- Visual changes only -->
