### PR TITLE
fix(designer):tenent property is not saved in connection

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
@@ -946,7 +946,7 @@ function convertToMcpConnectionsData(
     processValue(connectionParametersSet.values, 'password', true);
     processValue(connectionParametersSet.values, 'pfx', true);
     processValue(connectionParametersSet.values, 'authority', false);
-    processValue(connectionParametersSet.values, 'tenantId', false);
+    processValue(connectionParametersSet.values, 'tenant', false);
     processValue(connectionParametersSet.values, 'audience', false);
     processValue(connectionParametersSet.values, 'clientId', false);
     processValue(connectionParametersSet.values, 'secret', true);


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
During connection serialization, the serialization logic expect the property name to be tenantId, while the manifest declares it to be tenant. This PR fixes the mismatch by changing the serialization to match manifest, so the property is properly serialized.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
tenant will be able to serialized properly
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
