### PR TITLE
feat(designerV2): Add agent MCP client tool support (serialization/deserialization/monitoringview)

### DIFF
--- a/libs/designer-v2/src/lib/common/constants.ts
+++ b/libs/designer-v2/src/lib/common/constants.ts
@@ -371,6 +371,7 @@ export default {
       JOIN: 'join',
       LIQUID: 'liquid',
       MANUAL: 'manual',
+      MCP_CLIENT: 'mcpclienttool',
       OPEN_API_CONNECTION: 'openapiconnection',
       OPEN_API_CONNECTION_WEBHOOK: 'openapiconnectionwebhook',
       OPEN_API_CONNECTION_NOTIFICATION: 'openapiconnectionnotification',
@@ -420,6 +421,8 @@ export default {
       VIRTUALAGENT: 'virtualagent',
       XML_TO_JSON: 'xmltojson',
       XML_TO_TEXT: 'xmltotext',
+      MANAGED: 'managed',
+      BUILTIN: 'builtin',
     },
     PHASE: {
       NOT_SPECIFIED: 'NOTSPECIFIED',
@@ -812,6 +815,7 @@ export default {
     JOIN: 'Join',
     LIQUID: 'Liquid',
     MANUAL: 'Manual', // 2015-08-01-preview
+    MCP_CLIENT: 'McpClientTool',
     OPEN_API_CONNECTION: 'OpenApiConnection',
     OPEN_API_CONNECTION_WEBHOOK: 'OpenApiConnectionWebhook',
     OPEN_API_CONNECTION_NOTIFICATION: 'OpenApiConnectionNotification',

--- a/libs/designer-v2/src/lib/common/hooks/__test__/agent.spec.tsx
+++ b/libs/designer-v2/src/lib/common/hooks/__test__/agent.spec.tsx
@@ -1,0 +1,93 @@
+import { describe, test, expect } from 'vitest';
+import { isAgentSubgraphFromMetadata } from '../agent';
+import { SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
+import type { NodesMetadata } from '../../../core/state/workflow/workflowInterfaces';
+
+describe('isAgentSubgraphFromMetadata', () => {
+  test('should return true for a node inside an AGENT_CONDITION subgraph', () => {
+    const nodesMetadata: NodesMetadata = {
+      node1: {
+        graphId: 'agent-tool-1',
+        parentNodeId: 'agent-tool-1',
+        actionCount: 0,
+      },
+      'agent-tool-1': {
+        graphId: 'agent1',
+        parentNodeId: 'agent1',
+        subgraphType: SUBGRAPH_TYPES.AGENT_CONDITION,
+        actionCount: 0,
+      },
+      agent1: {
+        graphId: 'root',
+        parentNodeId: undefined,
+        actionCount: 1,
+      },
+    };
+
+    const result = isAgentSubgraphFromMetadata('node1', nodesMetadata);
+
+    expect(result).toBe(true);
+  });
+
+  test('should return true for a mcp client node', () => {
+    const nodesMetadata: NodesMetadata = {
+      'mcp-tool-1': {
+        graphId: 'agent1',
+        parentNodeId: 'agent1',
+        subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
+        actionCount: 0,
+      },
+      agent1: {
+        graphId: 'root',
+        parentNodeId: undefined,
+        actionCount: 1,
+      },
+    };
+
+    const result = isAgentSubgraphFromMetadata('mcp-tool-1', nodesMetadata);
+
+    expect(result).toBe(true);
+  });
+
+  test('should return false for a node not in an agent subgraph', () => {
+    const nodesMetadata: NodesMetadata = {
+      'regular-node': {
+        graphId: 'root',
+        parentNodeId: undefined,
+        actionCount: 0,
+      },
+    };
+
+    const result = isAgentSubgraphFromMetadata('regular-node', nodesMetadata);
+
+    expect(result).toBe(false);
+  });
+
+  test('should return false when node metadata is missing', () => {
+    const nodesMetadata: NodesMetadata = {};
+
+    const result = isAgentSubgraphFromMetadata('non-existent-node', nodesMetadata);
+
+    expect(result).toBe(false);
+  });
+
+  test('should return false when nodeId is undefined', () => {
+    const nodesMetadata: NodesMetadata = {
+      'some-node': {
+        graphId: 'root',
+        parentNodeId: undefined,
+        actionCount: 0,
+      },
+    };
+
+    const result = isAgentSubgraphFromMetadata(undefined, nodesMetadata);
+
+    expect(result).toBe(false);
+  });
+
+  test('should return false when nodesMetadata is undefined', () => {
+    const result = isAgentSubgraphFromMetadata('some-node', undefined);
+
+    expect(result).toBe(false);
+  });
+});

--- a/libs/designer-v2/src/lib/common/hooks/agent.ts
+++ b/libs/designer-v2/src/lib/common/hooks/agent.ts
@@ -23,7 +23,13 @@ export function isAgentSubgraphFromMetadata(nodeId?: string, nodesMetadata?: Nod
     return false;
   }
 
-  let nodeGraphId = getRecordEntry(nodesMetadata, nodeId)?.graphId;
+  const metadata = getRecordEntry(nodesMetadata, nodeId);
+  const isMcpClientTool = metadata?.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT;
+  if (isMcpClientTool) {
+    return true;
+  }
+
+  let nodeGraphId = metadata?.graphId;
   while (nodeId && nodeGraphId) {
     const nodeMetadata = getRecordEntry(nodesMetadata, nodeGraphId);
     if (!nodeMetadata) {

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/operationdeserializer.spec.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/operationdeserializer.spec.ts
@@ -1,0 +1,268 @@
+import { initializeOperationDetailsForManagedMcpServer } from '../operationdeserializer';
+import { describe, vi, beforeEach, it, expect } from 'vitest';
+import { getConnectorWithSwagger } from '../../../queries/connections';
+import { getOperationManifest } from '../../../queries/operation';
+
+vi.mock('../../../queries/connections', () => ({
+  getConnectorWithSwagger: vi.fn(),
+}));
+
+vi.mock('../../../queries/operation', () => ({
+  getOperationManifest: vi.fn(),
+  getOperationInfo: vi.fn(),
+}));
+
+// Mock initialize functions that are called for parameter processing
+vi.mock('../initialize', () => ({
+  getInputParametersFromManifest: vi.fn(() => ({
+    inputs: {},
+    dependencies: {},
+  })),
+  getOutputParametersFromManifest: vi.fn(() => ({
+    outputs: {},
+    dependencies: {},
+  })),
+}));
+
+vi.mock('../settings', () => ({
+  getOperationSettings: vi.fn(() => ({})),
+}));
+
+vi.mock('@microsoft/logic-apps-shared', async () => {
+  const actual = await vi.importActual('@microsoft/logic-apps-shared');
+  return {
+    ...actual,
+    LoggerService: vi.fn(() => ({
+      log: vi.fn(),
+    })),
+  };
+});
+
+const mockGetConnectorWithSwagger = vi.mocked(getConnectorWithSwagger);
+const mockGetOperationManifest = vi.mocked(getOperationManifest);
+
+describe('operationdeserializer', () => {
+  describe('initializeOperationDetailsForManagedMcpServer', () => {
+    const mockDispatch = vi.fn();
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+
+      mockGetConnectorWithSwagger.mockResolvedValue({
+        connector: {
+          id: '/connectors/mcpclient',
+          name: 'mcpclient',
+          type: 'Microsoft.Web/connections',
+          properties: {
+            displayName: 'MCP Client',
+            iconUri: 'https://example.com/icon.png',
+            brandColor: '#0078d4',
+            connectionParameters: {},
+            runtimeUrls: ['https://example.com/runtime'],
+            swagger: {
+              swagger: '2.0',
+              info: { title: 'MCP Client', version: '1.0' },
+              host: 'example.com',
+              basePath: '/',
+              schemes: ['https'],
+              paths: {
+                '/servers/filesystem': {
+                  post: {
+                    operationId: 'test-operation',
+                    summary: 'File operations',
+                    parameters: [],
+                    responses: {},
+                  },
+                },
+              },
+            },
+          },
+        } as any,
+        parsedSwagger: {
+          getOperations: () => ({
+            'test-operation': {
+              operationId: 'test-operation',
+              path: '/servers/filesystem',
+              method: 'POST',
+              summary: 'File operations',
+            },
+          }),
+        } as any,
+      });
+
+      mockGetOperationManifest.mockResolvedValue({
+        properties: {
+          iconUri: 'https://example.com/icon.png',
+          brandColor: '#0078d4',
+          inputs: {
+            properties: {
+              toolName: { type: 'string', title: 'Tool Name' },
+              parameters: { type: 'object', title: 'Parameters' },
+            },
+          },
+          outputs: {
+            properties: {
+              result: { type: 'object', title: 'Result' },
+            },
+          },
+        },
+      } as any);
+    });
+
+    it('should handle missing connection reference gracefully', async () => {
+      const nodeId = 'test-mcp-node';
+      const operation = {
+        type: 'McpClientTool',
+        kind: 'Managed',
+        inputs: {
+          connectionReference: {
+            connectionName: 'missing-connection',
+          },
+          parameters: {
+            mcpServerPath: '/servers/filesystem',
+          },
+        },
+      };
+      const references = {};
+      const workflowKind = 'agent';
+
+      const result = await initializeOperationDetailsForManagedMcpServer(nodeId, operation, references, workflowKind, mockDispatch);
+
+      expect(result).toBeUndefined();
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'operationMetadata/updateErrorDetails',
+          payload: expect.objectContaining({
+            id: 'test-mcp-node',
+            errorInfo: expect.objectContaining({
+              message: expect.stringMatching(/Incomplete information for operation/),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should handle missing mcpServerPath parameter', async () => {
+      const nodeId = 'test-mcp-node';
+      const operation = {
+        type: 'McpClientTool',
+        kind: 'Managed',
+        inputs: {
+          connectionReference: {
+            connectionName: 'mcp-connection',
+          },
+          parameters: {},
+        },
+      };
+      const references = {
+        'mcp-connection': {
+          api: {
+            id: '/connectors/mcpclient',
+          },
+          connection: {
+            id: '/subscriptions/test/resourceGroups/test/providers/Microsoft.Web/connections/mcp-connection',
+          },
+        },
+      };
+      const workflowKind = 'agent';
+
+      const result = await initializeOperationDetailsForManagedMcpServer(nodeId, operation, references, workflowKind, mockDispatch);
+
+      expect(result).toBeUndefined();
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'operationMetadata/updateErrorDetails',
+          payload: expect.objectContaining({
+            id: 'test-mcp-node',
+            errorInfo: expect.objectContaining({
+              message: expect.stringMatching(/Could not fetch operation input info from swagger and definition/),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should successfully process MCP operation with comprehensive mocking', async () => {
+      const nodeId = 'test-mcp-node';
+      const operation = {
+        type: 'McpClientTool',
+        kind: 'Managed',
+        inputs: {
+          connectionReference: {
+            connectionName: 'mcp-connection',
+          },
+          parameters: {
+            mcpServerPath: '/servers/filesystem',
+            toolName: 'list_files',
+            userParam1: 'value1',
+            userParam2: 'value2',
+          },
+        },
+      };
+      const references = {
+        'mcp-connection': {
+          api: {
+            id: '/connectors/mcpclient',
+          },
+          connection: {
+            id: '/subscriptions/test/resourceGroups/test/providers/Microsoft.Web/connections/mcp-connection',
+          },
+        },
+      };
+      const workflowKind = 'agent';
+
+      const result = await initializeOperationDetailsForManagedMcpServer(nodeId, operation, references, workflowKind, mockDispatch);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveLength(1);
+
+      const nodeData = result![0];
+      expect(nodeData).toEqual({
+        id: nodeId,
+        nodeInputs: expect.any(Object),
+        nodeOutputs: expect.any(Object),
+        nodeDependencies: expect.objectContaining({
+          inputs: expect.any(Object),
+          outputs: expect.any(Object),
+        }),
+        operationMetadata: expect.objectContaining({
+          brandColor: expect.any(String),
+          iconUri: expect.any(String),
+        }),
+        settings: expect.any(Object),
+        staticResult: undefined,
+      });
+
+      expect(nodeData.id).toBe(nodeId);
+      expect(nodeData.nodeInputs).toEqual({});
+      expect(nodeData.nodeOutputs).toEqual({});
+      expect(nodeData.nodeDependencies.inputs).toEqual({});
+      expect(nodeData.nodeDependencies.outputs).toEqual({});
+      expect(nodeData.settings).toEqual({});
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'operationMetadata/initializeOperationInfo',
+          payload: expect.objectContaining({
+            id: nodeId,
+            connectorId: '/connectors/mcpclient',
+            operationId: 'test-operation',
+            type: 'McpClientTool',
+            kind: 'Managed',
+          }),
+        })
+      );
+
+      expect(mockGetConnectorWithSwagger).toHaveBeenCalledWith(expect.stringContaining('mcpclient'));
+
+      expect(mockGetOperationManifest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connectorId: 'connectionProviders/mcpclient',
+          operationId: 'nativemcpclient',
+          type: 'McpClientTool',
+          kind: 'Builtin',
+        })
+      );
+    });
+  });
+});

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/add.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/add.ts
@@ -78,6 +78,7 @@ type AddOperationPayload = {
   presetParameterValues?: Record<string, any>;
   actionMetadata?: Record<string, any>;
   isAddingHandoff?: boolean;
+  isAddingMcpServer?: boolean;
 };
 
 export const addOperation = createAsyncThunk('addOperation', async (payload: AddOperationPayload, { dispatch, getState }) => {

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/delete.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/delete.ts
@@ -9,7 +9,7 @@ import { clearPanel, setAlternateSelectedNode } from '../../state/panel/panelSli
 import { setValidationError } from '../../state/setting/settingSlice';
 import { deinitializeStaticResultProperty } from '../../state/staticresultschema/staticresultsSlice';
 import { deinitializeTokensAndVariables } from '../../state/tokens/tokensSlice';
-import { clearFocusNode, deleteNode } from '../../state/workflow/workflowSlice';
+import { clearFocusNode, deleteMcpServer, deleteNode } from '../../state/workflow/workflowSlice';
 import { getParameterFromName } from '../../utils/parameters/helper';
 import { updateAllUpstreamNodes } from './initialize';
 import { WORKFLOW_NODE_TYPES, getRecordEntry } from '@microsoft/logic-apps-shared';
@@ -167,3 +167,17 @@ export const deleteGraphNode = createAsyncThunk('deleteGraph', async (deletePayl
   recursiveGraphDelete(graphNode);
   return;
 });
+
+export const deleteMcpServerNode = createAsyncThunk(
+  'deleteMcpServer',
+  async (deletePayload: { agentId: string; toolId: string; clearFocus?: boolean }, { dispatch }) => {
+    const { agentId, toolId, clearFocus = true } = deletePayload;
+
+    if (clearFocus) {
+      dispatch(clearFocusNode());
+      dispatch(clearPanel());
+    }
+
+    dispatch(deleteMcpServer({ agentId, toolId }));
+  }
+);

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -76,11 +76,16 @@ import {
   parseErrorMessage,
   cleanResourceId,
   deepCompareObjects,
+  unmap,
+  removeConnectionPrefix,
+  getBrandColorFromConnector,
+  getIconUriFromConnector,
 } from '@microsoft/logic-apps-shared';
 import type { InputParameter, OutputParameter, LogicAppsV2, OperationManifest } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
 import { operationSupportsSplitOn } from '../../utils/outputs';
 import { initializeConnectorOperationDetails } from './agent';
+import { isManagedMcpOperation } from '../../state/workflow/helper';
 
 export interface NodeDataWithOperationMetadata extends NodeData {
   manifest?: OperationManifest;
@@ -135,7 +140,10 @@ export const initializeOperationMetadata = async (
     if (isTrigger) {
       triggerNodeId = operationId;
     }
-    if (operation.type === Constants.NODE.TYPE.CONNECTOR) {
+
+    if (isManagedMcpOperation(operation)) {
+      promises.push(initializeOperationDetailsForManagedMcpServer(operationId, operation, references, workflowKind, dispatch));
+    } else if (operation.type === Constants.NODE.TYPE.CONNECTOR) {
       promises.push(initializeConnectorOperationDetails(operationId, operation as LogicAppsV2.ConnectorAction, workflowKind, dispatch));
     } else if (operationManifestService.isSupported(operation.type, operation.kind)) {
       promises.push(initializeOperationDetailsForManifest(operationId, operation, customCode, !!isTrigger, workflowKind, dispatch));
@@ -219,6 +227,120 @@ const initializeConnectorsForReferences = async (references: ConnectionReference
   }
 
   return (await Promise.all(connectorPromises)).filter((result) => !!result) as ConnectorWithParsedSwagger[];
+};
+
+export const initializeOperationDetailsForManagedMcpServer = async (
+  nodeId: string,
+  operation: LogicAppsV2.ActionDefinition | LogicAppsV2.TriggerDefinition,
+  references: ConnectionReferences,
+  workflowKind: WorkflowKind,
+  dispatch: Dispatch
+): Promise<NodeDataWithOperationMetadata[] | undefined> => {
+  try {
+    const referenceName = (operation as any)?.inputs?.connectionReference?.connectionName || '';
+
+    const reference = references[referenceName];
+    if (!reference || !reference.api || !reference.api.id) {
+      throw new Error(`Incomplete information for operation '${nodeId}'`);
+    }
+    const connectorId = cleanResourceId(reference.api.id);
+
+    const { connector, parsedSwagger } = await getConnectorWithSwagger(connectorId);
+    if (!parsedSwagger) {
+      throw new Error(`Could not fetch swagger for connector - ${connectorId}`);
+    }
+
+    const mcpServerPath = (operation as any).inputs?.parameters?.mcpServerPath;
+    if (!mcpServerPath) {
+      throw new Error('Could not fetch operation input info from swagger and definition');
+    }
+
+    const filteredOperations: any = unmap(parsedSwagger.getOperations())
+      .filter((operation) => equals(removeConnectionPrefix(operation.path), mcpServerPath))
+      .map((operation) => operation.operationId);
+
+    const operationId = filteredOperations && filteredOperations.length > 0 ? filteredOperations[0] : null;
+
+    if (!operationId) {
+      throw new Error('Operation Id cannot be determined from definition and swagger');
+    }
+
+    const builtinMcpServerOperationInfo = {
+      connectorId: 'connectionProviders/mcpclient',
+      operationId: 'nativemcpclient',
+      type: 'McpClientTool',
+      kind: 'Builtin',
+    };
+    const builtinMcpServerManifest = await getOperationManifest(builtinMcpServerOperationInfo);
+
+    const operationInfo = { connectorId, operationId, type: operation.type, kind: operation.kind };
+    dispatch(initializeOperationInfo({ id: nodeId, ...operationInfo }));
+
+    const operationForParameters = {
+      inputs: {
+        parameters: {
+          ...(operation as any).inputs.parameters,
+        },
+      },
+    };
+    // Remove mcpServerPath from parameters so it's not treated as a user parameter
+    if (operationForParameters.inputs?.parameters?.mcpServerPath) {
+      delete operationForParameters.inputs.parameters.mcpServerPath;
+    }
+
+    const { inputs: nodeInputs, dependencies: inputDependencies } = getInputParametersFromManifest(
+      nodeId,
+      builtinMcpServerOperationInfo,
+      builtinMcpServerManifest,
+      /* presetParameterValues */ undefined,
+      /* customSwagger */ undefined,
+      operationForParameters
+    );
+
+    const { outputs: nodeOutputs, dependencies: outputDependencies } = getOutputParametersFromManifest(
+      nodeId,
+      builtinMcpServerManifest,
+      /* isTrigger */ false,
+      nodeInputs,
+      builtinMcpServerOperationInfo,
+      dispatch
+    );
+
+    const nodeDependencies = { inputs: inputDependencies, outputs: outputDependencies };
+
+    const settings = getOperationSettings(
+      /* isTrigger */ false,
+      builtinMcpServerOperationInfo,
+      builtinMcpServerManifest,
+      undefined /* swagger */,
+      operation,
+      workflowKind
+    );
+
+    return [
+      {
+        id: nodeId,
+        nodeInputs,
+        nodeOutputs,
+        nodeDependencies,
+        operationMetadata: { brandColor: getBrandColorFromConnector(connector), iconUri: getIconUriFromConnector(connector) },
+        settings,
+        staticResult: operation?.runtimeConfiguration?.staticResult,
+      },
+    ];
+  } catch (error: any) {
+    const errorString = parseErrorMessage(error);
+    const message = `Unable to initialize operation details for managed MCP server operation - ${nodeId}. Error details - ${errorString}`;
+    LoggerService().log({
+      level: LogEntryLevel.Error,
+      area: 'operation deserializer',
+      message,
+      error,
+    });
+
+    dispatch(updateErrorDetails({ id: nodeId, errorInfo: { level: ErrorLevel.Critical, error, message } }));
+    return;
+  }
 };
 
 export const initializeOperationDetailsForManifest = async (

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -57,6 +57,7 @@ import {
   filterRecord,
   excludePathValueFromTarget,
   getRecordEntry,
+  RunAfterType,
 } from '@microsoft/logic-apps-shared';
 import type { ParameterInfo, ValueSegment } from '@microsoft/designer-ui';
 import { TokenType, UIConstants } from '@microsoft/designer-ui';
@@ -286,7 +287,11 @@ export const serializeOperation = async (
   }
 
   let serializedOperation: LogicAppsV2.OperationDefinition;
-  if (OperationManifestService().isSupported(operation.type, operation.kind)) {
+  const isManagedMcpClient = operation.type?.toLowerCase() === 'mcpclienttool' && operation.kind?.toLowerCase() === "managed";
+
+  if (isManagedMcpClient) {
+    serializedOperation = await serializeManagedMcpOperation(rootState, operationId);
+  } else if (OperationManifestService().isSupported(operation.type, operation.kind)) {
     serializedOperation = await serializeManifestBasedOperation(rootState, operationId);
   } else {
     switch (operation.type.toLowerCase()) {
@@ -427,7 +432,7 @@ const serializeManifestBasedOperation = async (rootState: RootState, operationId
   const hostInfo = serializeHost(operationId, manifest, rootState);
   const inputs = hostInfo !== undefined ? mergeHostWithInputs(hostInfo, inputPathValue) : inputPathValue;
   const operationFromWorkflow = getRecordEntry(rootState.workflow.operations, operationId) as LogicAppsV2.OperationDefinition;
-  const runAfter = isRootNode(operationId, rootState.workflow.nodesMetadata)
+  const runAfter = isRootNode(operationId, rootState.workflow.nodesMetadata) || manifest.properties.runAfter?.type === RunAfterType.NotSupported
     ? undefined
     : getRunAfter(operationFromWorkflow, idReplacements);
   const recurrence =
@@ -455,6 +460,47 @@ const serializeManifestBasedOperation = async (rootState: RootState, operationId
     ...optional('runAfter', runAfter),
     ...optional('recurrence', recurrence),
     ...serializeSettings(nodeSettings, nodeStaticResults, isTrigger, operationFromWorkflow),
+  };
+};
+
+const serializeManagedMcpOperation = async (rootState: RootState, nodeId: string): Promise<LogicAppsV2.OperationDefinition> => {
+  const operationInfo = getRecordEntry(rootState.operations.operationInfo, nodeId) as NodeOperation;
+  if (!operationInfo) {
+    throw new AssertionException(AssertionErrorCode.OPERATION_NOT_FOUND, `Operation with id ${nodeId} not found`);
+  }
+  const { type, kind, connectorId, operationId } = operationInfo;
+
+  const inputsToSerialize = getOperationInputsToSerialize(rootState, nodeId);
+
+  const nativeMcpOperationInfo = { connectorId: 'connectionProviders/mcpclient', operationId: 'nativemcpclient' };
+  const manifest = await getOperationManifest(nativeMcpOperationInfo);
+  const inputParameters = serializeParametersFromManifest(inputsToSerialize, manifest);
+   
+  const operationFromWorkflow = getRecordEntry(rootState.workflow.operations, nodeId) as LogicAppsV2.OperationDefinition;
+
+  const { parsedSwagger } = await getConnectorWithSwagger(connectorId);
+  const operation = parsedSwagger.getOperationByOperationId(operationId);
+  if (!operation) {
+    throw new Error('APIM Operation not found');
+  }
+  const { path } = operation;
+  const operationPath = removeConnectionPrefix(path);
+
+  const inputs = {
+    connectionReference: {
+      connectionName: getRecordEntry(rootState.connections.connectionsMapping, nodeId),
+    },
+    parameters: {
+      ...inputParameters.parameters,
+      mcpServerPath: operationPath,
+    },
+  };
+
+  return {
+    type: type,
+    kind: kind,
+    ...optional('description', operationFromWorkflow.description),
+    ...optional('inputs', inputs),
   };
 };
 
@@ -810,6 +856,12 @@ interface AgentConnectionInfo {
   };
 }
 
+interface McpConnectionInfo {
+  connectionReference: {
+    connectionName: string;
+  }
+}
+
 const serializeHost = (
   nodeId: string,
   manifest: OperationManifest,
@@ -820,6 +872,7 @@ const serializeHost = (
   | OpenApiConnectionInfo
   | ServiceProviderConnectionConfigInfo
   | AgentConnectionInfo
+  | McpConnectionInfo
   | HybridTriggerConnectionInfo
   | undefined => {
   if (!manifest.properties.connectionReference) {
@@ -889,6 +942,12 @@ const serializeHost = (
           },
         },
       };
+    case ConnectionReferenceKeyFormat.McpConnection:
+      return {
+        connectionReference: {
+          connectionName: referenceKey
+        }
+      };
     default:
       throw new AssertionException(
         AssertionErrorCode.UNSUPPORTED_MANIFEST_CONNECTION_REFERENCE_FORMAT,
@@ -940,9 +999,36 @@ const serializeNestedOperations = async (
 
   if (subGraphDetails) {
     const subGraphNodes = node.children?.filter((child) => child.type === WORKFLOW_NODE_TYPES.SUBGRAPH_NODE) ?? [];
+    const operationNodes = node.children?.filter((child) => child.type === WORKFLOW_NODE_TYPES.OPERATION_NODE) ?? [];
     for (const subGraphLocation of Object.keys(subGraphDetails)) {
       const subGraphDetail = getRecordEntry(subGraphDetails, subGraphLocation);
       const subGraphs = subGraphNodes.filter((graph) => graph.subGraphLocation === subGraphLocation);
+
+      if (subGraphDetail?.allowOperations) {
+        const operations = operationNodes.filter((graph) => graph.subGraphLocation === subGraphLocation);
+          const nestedOperationsPromises = operations.map((nestedOperation) =>
+            serializeOperation(rootState, nestedOperation.id)
+          ) as Promise<LogicAppsV2.OperationDefinition>[];
+          const nestedOperations = await Promise.all(nestedOperationsPromises);
+          const idReplacements = rootState.workflow.idReplacements;
+
+          const newResult = {};
+          safeSetObjectPropertyValue(
+            newResult,
+            [subGraphLocation],
+            nestedOperations.reduce((actions: LogicAppsV2.Actions, action: LogicAppsV2.OperationDefinition, index: number) => {
+              if (!isNullOrEmpty(action)) {
+                const actionId = operations[index].id;
+                actions[getRecordEntry(idReplacements, actionId) ?? actionId] = action;
+                return actions;
+              }
+
+              return actions;
+            }, {})
+          );
+
+          result = merge(result, newResult);
+      }
 
       if (subGraphDetail?.isAdditive) {
         for (const subGraph of subGraphs) {

--- a/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -742,6 +742,8 @@ export const processScopeActions = (
         nodesMetadata[toolName] = {
           ...nodesMetadata[toolName],
           subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
+          graphId: actionName,
+          parentNodeId: actionName,
         };
 
         if (toolAction.metadata) {

--- a/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/BJSDeserializer.spec.ts
+++ b/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/BJSDeserializer.spec.ts
@@ -1,12 +1,14 @@
 import { Deserialize } from '../BJSDeserializer';
 import { scopedWorkflowDefinitionInput, expectedScopedWorkflowDefinitionOutput } from './scopedWorkflowDefinition';
 import { simpleWorkflowDefinitionInput, expectedSimpleWorkflowDefinitionOutput } from './simpleWorkflowDefinition';
+import { agentMcpWorkflowDefinitionInput, expectedAgentMcpWorkflowDefinitionOutput } from './agentMcpWorkflowDefinition';
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
 import {
   expectedSwitchWorkflowDefinitionOutput,
   expectedSwitchWorkflowDefinitionOutputWithoutAddCase,
   switchWorkflowDefinitionInput,
 } from './switchWorkflowDefinition';
+
 describe('core/parsers/BJSWorkflow/BJSDeserializer', () => {
   it('should deserialize a basic workflow with no scoped nodes', () => {
     const test = Deserialize(simpleWorkflowDefinitionInput, null);
@@ -25,5 +27,10 @@ describe('core/parsers/BJSWorkflow/BJSDeserializer', () => {
   it('should deserialize a workflow with switch nodes and not add nodes for add case', () => {
     const test = Deserialize(switchWorkflowDefinitionInput, null, false);
     expect(test).toEqual(expectedSwitchWorkflowDefinitionOutputWithoutAddCase);
+  });
+
+  it('should be able to deserialize agent workflow with MCP client operations', () => {
+    const test = Deserialize(agentMcpWorkflowDefinitionInput, null);
+    expect(test).toEqual(expectedAgentMcpWorkflowDefinitionOutput);
   });
 });

--- a/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/agentMcpWorkflowDefinition.ts
+++ b/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/agentMcpWorkflowDefinition.ts
@@ -1,0 +1,216 @@
+import type { Operations, NodesMetadata } from '../../../state/workflow/workflowInterfaces';
+import { createWorkflowNode, createWorkflowEdge } from '../../../utils/graph';
+import type { WorkflowNode } from '../../models/workflowNode';
+import { WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
+import type { DeserializedWorkflow } from '../BJSDeserializer';
+
+export const agentMcpWorkflowDefinitionInput = {
+  $schema: 'https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#',
+  contentVersion: '1.0.0.0',
+  parameters: {},
+  triggers: {
+    'manual': {
+      type: 'Request',
+      kind: 'Http',
+      inputs: {
+        schema: {}
+      }
+    }
+  },
+  actions: {
+    'WorkflowAgent': {
+      type: 'Agent',
+      inputs: {
+        parameters: {
+          deploymentId: 'gpt-4o',
+          messages: [
+            {
+              role: 'System',
+              content: 'You are a helpful assistant that can use tools to accomplish tasks.'
+            },
+            {
+              role: 'User',
+              content: 'Help me manage files and data.'
+            }
+          ]
+        }
+      },
+      tools: {
+        'McpFileServer': {
+            type: 'McpClientTool',
+            kind: 'BuiltIn',
+            inputs: {
+                parameters: {
+                    mcpServerPath: '/servers/filesystem',
+                    toolName: 'list_files',
+                }
+            }
+        }
+      },
+      runAfter: {},
+      limit: {
+        timeout: 'PT2H',
+        count: 50
+      }
+    },
+    'ResponseAction': {
+      type: 'Response',
+      inputs: {
+        statusCode: 200,
+        body: '@outputs("WorkflowAgent")'
+      },
+      runAfter: {
+        'WorkflowAgent': ['SUCCEEDED']
+      }
+    }
+  },
+  outputs: {}
+};
+
+export const expectedAgentMcpWorkflowDefinitionOutput = {
+  graph: {
+    id: 'root',
+    type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
+    children: [
+      createWorkflowNode('manual'),
+      {
+        children: [
+          {
+            height: 40,
+            id: 'WorkflowAgent-#scope',
+            type: 'SCOPE_CARD_NODE',
+            width: 200,
+          },
+          {
+            height: 40,
+            id: 'McpFileServer',
+            type: 'OPERATION_NODE',
+            width: 200,
+            subGraphLocation: 'tools',
+          },
+          {
+            children: [
+              {
+                height: 40,
+                id: "WorkflowAgent-addCase-#subgraph",
+                type: "SUBGRAPH_CARD_NODE",
+                width: 200,
+              },
+            ],
+            edges: [],
+            id: "WorkflowAgent-addCase",
+            subGraphLocation: undefined,
+            type: "HIDDEN_NODE",
+        },
+        ],
+        edges: [
+          {
+            id: 'WorkflowAgent-#scope-McpFileServer',
+            source: 'WorkflowAgent-#scope',
+            target: 'McpFileServer',
+            type: 'ONLY_EDGE',
+          },
+          {
+            id: 'WorkflowAgent-#scope-WorkflowAgent-addCase',
+            source: 'WorkflowAgent-#scope',
+            target: 'WorkflowAgent-addCase',
+            type: 'HIDDEN_EDGE',
+          },
+        ],
+        height: 40,
+        id: 'WorkflowAgent',
+        type: 'GRAPH_NODE',
+        width: 200,
+      },
+      createWorkflowNode('ResponseAction'),
+    ],
+    edges: [
+      createWorkflowEdge('manual', 'WorkflowAgent'),
+      createWorkflowEdge('WorkflowAgent', 'ResponseAction'),
+    ],
+  },
+  actionData: {
+    manual: {
+      inputs: {
+        schema: {}
+      },
+      kind: 'Http',
+      type: 'Request',
+    },
+    WorkflowAgent: {
+      inputs: {
+        parameters: {
+          deploymentId: 'gpt-4o',
+          messages: [
+            {
+              role: 'System',
+              content: 'You are a helpful assistant that can use tools to accomplish tasks.'
+            },
+            {
+              role: 'User',
+              content: 'Help me manage files and data.'
+            }
+          ]
+        }
+      },
+      tools: {
+        'McpFileServer': {
+            type: 'McpClientTool',
+            kind: 'BuiltIn',
+            inputs: {
+                parameters: {
+                    mcpServerPath: '/servers/filesystem',
+                    toolName: 'list_files',
+                }
+            }
+        }
+      },
+      limit: {
+        timeout: 'PT2H',
+        count: 50
+      },
+      runAfter: {},
+      type: 'Agent',
+    },
+    ResponseAction: {
+      inputs: {
+        statusCode: 200,
+        body: '@outputs("WorkflowAgent")'
+      },
+      runAfter: {
+        'WorkflowAgent': ['SUCCEEDED']
+      },
+      type: 'Response',
+    },
+    McpFileServer: {
+        type: 'McpClientTool',
+        kind: 'BuiltIn',
+        inputs: {
+            parameters: {
+                mcpServerPath: '/servers/filesystem',
+                toolName: 'list_files',
+            }
+        }
+    },
+  },
+  nodesMetadata: {
+    manual: { graphId: 'root', isRoot: true, isTrigger: true },
+    WorkflowAgent: { 
+      graphId: 'root',
+      actionCount: 1,
+      parentNodeId: undefined,
+    },
+    ResponseAction: { graphId: 'root' },
+    McpFileServer: {
+      graphId: 'WorkflowAgent',
+      parentNodeId: 'WorkflowAgent',
+      subgraphType: "MCP_CLIENT",
+    },
+    'WorkflowAgent-addCase': {
+       actionCount: 0,
+       graphId: 'WorkflowAgent',
+       parentNodeId: 'WorkflowAgent',
+       subgraphType: 'AGENT_ADD_CONDITON',
+    },
+  },
+};

--- a/libs/designer-v2/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer-v2/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -270,3 +270,33 @@ export const addAgentToolToWorkflow = (toolId: string, agentNode: WorkflowNode, 
     nodesMetadata[agentNode.id].actionCount = (nodesMetadata[agentNode.id].actionCount ?? 0) + 1;
   }
 };
+
+export const addMcpServerToWorkflow = (
+  toolId: string,
+  agentNode: WorkflowNode,
+  nodesMetadata: NodesMetadata,
+  state: WorkflowState,
+  operation?: DiscoveryOperation<DiscoveryResultTypes>
+) => {
+  const toolNode = createWorkflowNode(toolId, WORKFLOW_NODE_TYPES.OPERATION_NODE);
+  toolNode.subGraphLocation = 'tools';
+  agentNode.children?.splice(agentNode.children.length - 2, 0, toolNode);
+
+  nodesMetadata[toolId] = {
+    graphId: agentNode.id,
+    parentNodeId: agentNode.id,
+    subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
+  };
+
+  addChildEdge(agentNode, createWorkflowEdge(`${agentNode.id}-#scope`, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
+
+  if (operation) {
+    state.operations[toolId] = { ...state.operations[toolId], type: operation.type };
+    state.newlyAddedOperations[toolId] = toolId;
+    state.isDirty = true;
+  }
+
+  if (nodesMetadata[agentNode.id]) {
+    nodesMetadata[agentNode.id].actionCount = (nodesMetadata[agentNode.id].actionCount ?? 0) + 1;
+  }
+};

--- a/libs/designer-v2/src/lib/core/parsers/deleteNodeFromWorkflow.ts
+++ b/libs/designer-v2/src/lib/core/parsers/deleteNodeFromWorkflow.ts
@@ -101,6 +101,41 @@ export const deleteNodeFromWorkflow = (
   }
 };
 
+export const deleteMcpServerNodeFromWorkflow = (
+  payload: { toolId: string; agentId: string },
+  workflowGraph: WorkflowNode,
+  nodesMetadata: NodesMetadata,
+  state: WorkflowState
+) => {
+  if (!workflowGraph.id) {
+    throw new Error('Workflow graph is missing an id');
+  }
+  const { toolId: nodeId } = payload;
+
+  const node = workflowGraph.children?.find((child: WorkflowNode) => child.id === nodeId);
+  if (!node) {
+    return;
+  }
+
+  // Adjust edges
+  const parentId = (workflowGraph.edges ?? []).find((edge) => edge.target === nodeId)?.source ?? '';
+  removeEdge(state, parentId, nodeId, workflowGraph);
+
+  // Delete Node Data
+  deleteWorkflowNode(nodeId, workflowGraph);
+  delete nodesMetadata[nodeId];
+  delete state.operations[nodeId];
+  delete state.newlyAddedOperations[nodeId];
+  delete state.idReplacements[nodeId];
+  state.isDirty = true;
+
+  // Decrease action count of graph
+  const currentActionCount = getRecordEntry(nodesMetadata, workflowGraph.id)?.actionCount;
+  if (currentActionCount) {
+    nodesMetadata[workflowGraph.id].actionCount = (currentActionCount ?? 1) - 1;
+  }
+};
+
 export const deleteWorkflowNode = (nodeId: string, graph: WorkflowNode): void => {
   graph.children = (graph?.children ?? []).filter((child: WorkflowNode) => child.id !== nodeId);
 };

--- a/libs/designer-v2/src/lib/core/state/__test__/workflowSlice.spec.ts
+++ b/libs/designer-v2/src/lib/core/state/__test__/workflowSlice.spec.ts
@@ -1,11 +1,13 @@
-import { WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
+import { SUBGRAPH_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
 import { describe, expect, it } from 'vitest';
 import { getMockedUndoRedoPartialRootState } from '../../../__test__/mock-root-state';
 import { initialState } from '../../parsers/__test__/mocks/workflowMock';
 import type { AddNodePayload } from '../../parsers/addNodeToWorkflow';
 import { setStateAfterUndoRedo } from '../global';
-import { WorkflowState } from '../workflow/workflowInterfaces';
-import reducer, { addNode } from '../workflow/workflowSlice';
+import { WorkflowState, NodeMetadata } from '../workflow/workflowInterfaces';
+import reducer, { addNode, addMcpServer, deleteMcpServer, setToolRunIndex, updateAgenticMetadata } from '../workflow/workflowSlice';
+import { OperationDefinition } from '../../../../../../logic-apps-shared/src/utils/src/lib/models/logicApps';
+import type { UpdateAgenticGraphPayload } from '../../parsers/updateAgenticGraph';
 
 describe('workflow slice reducers', () => {
   it('should add initial node to the workflow', () => {
@@ -64,5 +66,275 @@ describe('workflow slice reducers', () => {
     );
 
     expect(state).toEqual(workflowState);
+  });
+
+  describe('mcp client actions', () => {
+    const mockAgentId = 'agent-123';
+    const mockToolId = 'mcp-tool-456';
+
+    const createStateWithAgentAndMcpTool = () => {
+      const state = { ...initialState };
+
+      // Set up the main graph with an agent node
+      state.graph = {
+        id: 'root',
+        type: 'GRAPH_NODE',
+        children: [
+          {
+            id: mockAgentId,
+            type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
+            width: 200,
+            height: 40,
+            children: [
+              {
+                id: mockToolId,
+                type: WORKFLOW_NODE_TYPES.OPERATION_NODE,
+                width: 200,
+                height: 40,
+              },
+            ],
+          },
+        ],
+      };
+
+      // Set up nodes metadata
+      state.nodesMetadata = {
+        [mockAgentId]: {
+          graphId: 'root',
+          isRoot: false,
+          isTrigger: false,
+          subgraphType: SUBGRAPH_TYPES.AGENT_SUBGRAPH,
+        } as NodeMetadata,
+        [mockToolId]: {
+          graphId: mockAgentId,
+          isRoot: false,
+          isTrigger: false,
+          subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
+          parentNodeId: mockAgentId,
+        } as NodeMetadata,
+      };
+
+      // Set up operations
+      state.operations = {
+        [mockToolId]: {
+          type: 'mcpclienttool',
+          connector: {
+            id: 'mcp-client',
+            name: 'MCP Client',
+          },
+        } as any,
+      };
+
+      // Initialize other required state properties
+      state.idReplacements = {};
+
+      return state;
+    };
+
+    it('should successfully delete MCP server tool from agent', () => {
+      const state = createStateWithAgentAndMcpTool();
+      const mockPayload = {
+        toolId: mockToolId,
+        agentId: mockAgentId,
+      };
+
+      const newState = reducer(state, deleteMcpServer(mockPayload));
+
+      const agentNode = newState.graph?.children?.find((child: any) => child.id === mockAgentId);
+      expect(agentNode?.children).toEqual([]);
+
+      expect(newState.nodesMetadata[mockToolId]).toBeUndefined();
+      expect(newState.nodesMetadata[mockAgentId]).toBeDefined();
+      expect(newState.operations[mockToolId]).toBeUndefined();
+    });
+
+    it('should preserve other tools when deleting specific MCP server', () => {
+      const state = createStateWithAgentAndMcpTool();
+      const otherToolId = 'other-tool-789';
+
+      // Add another tool to the agent's children
+      const agentNode = state.graph?.children?.find((child) => child.id === mockAgentId);
+      if (agentNode?.children) {
+        agentNode.children.push({
+          id: otherToolId,
+          type: WORKFLOW_NODE_TYPES.OPERATION_NODE,
+          width: 200,
+          height: 40,
+        });
+      }
+
+      // Add metadata for the other tool
+      state.nodesMetadata[otherToolId] = {
+        graphId: mockAgentId,
+        isRoot: false,
+        isTrigger: false,
+        subgraphType: SUBGRAPH_TYPES.UNTIL_SUBGRAPH, // Different type
+        parentNodeId: mockAgentId,
+      } as NodeMetadata;
+
+      // Add operation for the other tool
+      state.operations[otherToolId] = {
+        type: 'tool',
+      } as any;
+
+      const mockPayload = {
+        toolId: mockToolId,
+        agentId: mockAgentId,
+      };
+
+      const newState = reducer(state, deleteMcpServer(mockPayload));
+
+      // Verify the MCP tool is removed
+      expect(newState.nodesMetadata[mockToolId]).toBeUndefined();
+      expect(newState.operations[mockToolId]).toBeUndefined();
+
+      // Verify other nodes are preserved
+      expect(newState.nodesMetadata[mockAgentId]).toBeDefined();
+      expect(newState.nodesMetadata[otherToolId]).toBeDefined();
+      expect(newState.operations[otherToolId]).toBeDefined();
+
+      // Verify the other tool is still in the agent's children
+      const updatedAgentNode = newState.graph?.children?.find((child: any) => child.id === mockAgentId);
+      expect(updatedAgentNode?.children).toHaveLength(1);
+      expect(updatedAgentNode?.children?.[0].id).toBe(otherToolId);
+    });
+
+    const createStateWithAgent = () => {
+      const state = { ...initialState };
+
+      // Set up the main graph with an agent node (without MCP tools)
+      state.graph = {
+        id: 'root',
+        type: 'GRAPH_NODE',
+        children: [
+          {
+            id: mockAgentId,
+            type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
+            width: 200,
+            height: 40,
+            children: [], // Empty children array for agent
+          },
+        ],
+      };
+
+      // Set up agent metadata
+      state.nodesMetadata = {
+        [mockAgentId]: {
+          graphId: 'root',
+          isRoot: false,
+          isTrigger: false,
+          subgraphType: SUBGRAPH_TYPES.AGENT_SUBGRAPH,
+        } as NodeMetadata,
+      };
+
+      // Initialize other required state properties
+      state.operations = {
+        [mockAgentId]: (<unknown>{
+          tools: {},
+        }) as OperationDefinition,
+      };
+      state.idReplacements = {};
+
+      return state;
+    };
+
+    it('should successfully add MCP server to agent', () => {
+      const state = createStateWithAgent();
+      const mockOperation = {
+        id: 'mcp-server-id',
+        name: 'mcp-server-name',
+        properties: {
+          api: {
+            id: 'mcp-client',
+            name: 'MCP Client',
+            type: 'MCP',
+          },
+        } as any,
+        type: 'mcpclienttool' as const,
+      };
+
+      const mockPayload: AddNodePayload = {
+        nodeId: mockToolId,
+        relationshipIds: {
+          graphId: mockAgentId,
+        },
+        operation: mockOperation,
+      };
+
+      const newState = reducer(state, addMcpServer(mockPayload));
+
+      // Verify the MCP tool is added to the agent's children
+      const agentNode = newState.graph?.children?.find((child: any) => child.id === mockAgentId);
+      expect(agentNode?.children).toHaveLength(1);
+      expect(agentNode?.children?.[0].id).toBe(mockToolId);
+      expect(agentNode?.children?.[0].type).toBe(WORKFLOW_NODE_TYPES.OPERATION_NODE);
+
+      // Verify the tool metadata is created
+      expect(newState.nodesMetadata[mockToolId]).toBeDefined();
+      expect(newState.nodesMetadata[mockToolId].subgraphType).toBe(SUBGRAPH_TYPES.MCP_CLIENT);
+      expect(newState.nodesMetadata[mockToolId].graphId).toBe(mockAgentId);
+      expect(newState.nodesMetadata[mockToolId].parentNodeId).toBe(mockAgentId);
+
+      // Verify the agent node is still present
+      expect(newState.nodesMetadata[mockAgentId]).toBeDefined();
+    });
+  });
+
+  it('should set tool run index for existing node', () => {
+    const mockNodeId = 'node-123';
+    const mockPage = 2;
+    const state = { ...initialState };
+    state.nodesMetadata = {
+      [mockNodeId]: {
+        graphId: 'root',
+        subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
+      } as NodeMetadata,
+    };
+
+    const newState = reducer(state, setToolRunIndex({ page: mockPage, nodeId: mockNodeId }));
+
+    expect(newState.nodesMetadata[mockNodeId].toolRunIndex).toBe(mockPage);
+  });
+
+  it('should update MCP client tool run data', () => {
+    const mockAgentId = 'agent-123';
+    const mockMcpToolId = 'mcp-tool-456';
+    const mockRegularToolId = 'regular-tool-789';
+    const state = { ...initialState };
+    state.nodesMetadata = {
+      [mockMcpToolId]: {
+        graphId: mockAgentId,
+        isRoot: false,
+        isTrigger: false,
+        subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
+      } as NodeMetadata,
+      [mockRegularToolId]: {
+        graphId: mockAgentId,
+        isRoot: false,
+        isTrigger: false,
+        subgraphType: SUBGRAPH_TYPES.UNTIL_SUBGRAPH, // Not MCP_CLIENT
+      } as NodeMetadata,
+    };
+
+    const mockPayload: UpdateAgenticGraphPayload = {
+      nodeId: mockAgentId,
+      scopeRepetitionRunData: {
+        tools: {
+          [mockMcpToolId]: {
+            status: 'Succeeded',
+            iterations: 3,
+          },
+        },
+      },
+    };
+
+    const newState = reducer(state, updateAgenticMetadata(mockPayload));
+
+    const mcpToolMetadata = newState.nodesMetadata[mockMcpToolId];
+    expect(mcpToolMetadata.toolRunData).toEqual({
+      status: 'Succeeded',
+      repetitionCount: 3,
+    });
+    expect(mcpToolMetadata.toolRunIndex).toBe(0);
   });
 });

--- a/libs/designer-v2/src/lib/core/state/workflow/__test__/helper.spec.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/__test__/helper.spec.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest';
-import { collapseFlowTree } from '../helper'; // Adjust the import path as needed
+import { collapseFlowTree, isManagedMcpOperation } from '../helper'; // Adjust the import path as needed
 import { WorkflowNode } from '../../../parsers/models/workflowNode';
+import Constants from '../../../../common/constants';
 
 describe('collapseFlowTree', () => {
   test('should return the original tree when no collapsed nodes are provided', () => {
@@ -122,5 +123,45 @@ describe('collapseFlowTree', () => {
     const nodeA = (graph?.children ?? []).find((child) => child.id === 'A');
     expect(nodeA).toBeDefined();
     expect(nodeA?.edges).toBeUndefined();
+  });
+});
+
+describe('isManagedMcpOperation', () => {
+  test('should return true for MCP client operations with managed kind', () => {
+    const operation = {
+      type: Constants.NODE.TYPE.MCP_CLIENT,
+      kind: Constants.NODE.KIND.MANAGED
+    };
+
+    const result = isManagedMcpOperation(operation);
+
+    expect(result).toBe(true);
+  });
+
+  test('should return false for non-MCP operations', () => {
+    const operation = {
+      type: 'Http',
+    };
+
+    const result = isManagedMcpOperation(operation);
+
+    expect(result).toBe(false);
+  });
+
+  test('should return false for MCP operations with non-managed kind', () => {
+    const operation = {
+      type: Constants.NODE.TYPE.MCP_CLIENT,
+      kind: Constants.NODE.KIND.BUILTIN
+    };
+
+    const result = isManagedMcpOperation(operation);
+
+    expect(result).toBe(false);
+  });
+
+  test('should return false for operations with missing type or kind', () => {
+    expect(isManagedMcpOperation({})).toBe(false);
+    expect(isManagedMcpOperation({ type: Constants.NODE.TYPE.MCP_CLIENT })).toBe(false);
+    expect(isManagedMcpOperation({ kind: Constants.NODE.KIND.MANAGED })).toBe(false);
   });
 });

--- a/libs/designer-v2/src/lib/core/state/workflow/helper.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/helper.ts
@@ -1,5 +1,6 @@
 import type { ConsumptionWorkflowMetadata } from '@microsoft/logic-apps-shared';
 import { equals, SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
+import Constants from '../../../common/constants';
 import type { WorkflowNode } from '../../../core/parsers/models/workflowNode';
 import { WorkflowKind, type NodeMetadata, type WorkflowState } from './workflowInterfaces';
 
@@ -130,6 +131,10 @@ export const collapseFlowTree = (
   return { graph: prunedTree, collapsedMapping: collapsedMappingArrays };
 };
 
+export const isManagedMcpOperation = (operation: { type?: string; kind?: string }) => {
+  return equals(operation?.type, Constants.NODE.TYPE.MCP_CLIENT) && equals(operation?.kind, Constants.NODE.KIND.MANAGED);
+};
+
 export const isA2AWorkflow = (state: WorkflowState): boolean => {
   const workflowKind = state.workflowKind;
 
@@ -169,5 +174,8 @@ export const isAgentWorkflow = (kind: string): boolean => {
 };
 
 export const shouldClearNodeRunData = (node: NodeMetadata) => {
-  return node?.runData && (node.graphId !== 'root' || node.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION);
+  return (
+    node?.runData &&
+    (node.graphId !== 'root' || node.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION || node.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT)
+  );
 };

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowInterfaces.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowInterfaces.ts
@@ -16,6 +16,8 @@ export interface NodeMetadata {
   subgraphRunData?: Record<string, { actionResults: LogicAppsV2.WorkflowRunAction[] }>;
   runIndex?: number;
   handoffs?: Record<string, string>;
+  toolRunIndex?: number;
+  toolRunData?: LogicAppsV2.WorkflowRunAction;
 }
 export interface NodesMetadata {
   [nodeId: string]: NodeMetadata;

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
@@ -484,6 +484,9 @@ export const useRetryHistory = (id: string): LogicAppsV2.RetryHistory[] | undefi
 export const useRunData = (id: string): LogicAppsV2.WorkflowRunAction | LogicAppsV2.WorkflowRunTrigger | undefined =>
   useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.runData));
 
+export const useToolRunData = (id: string): LogicAppsV2.WorkflowRunAction | LogicAppsV2.WorkflowRunTrigger | undefined =>
+  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.toolRunData));
+
 export const useSubgraphRunData = (id: string): Record<string, { actionResults: LogicAppsV2.WorkflowRunAction[] }> | undefined =>
   useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.subgraphRunData));
 
@@ -545,6 +548,17 @@ export const useRunIndex = (id: string | undefined): number | undefined => {
         return undefined;
       }
       return getRecordEntry(state.nodesMetadata, id)?.runIndex ?? undefined;
+    })
+  );
+};
+
+export const useToolRunIndex = (id: string | undefined): number | undefined => {
+  return useSelector(
+    createSelector(getWorkflowState, (state: WorkflowState) => {
+      if (!id) {
+        return undefined;
+      }
+      return getRecordEntry(state.nodesMetadata, id)?.toolRunIndex ?? undefined;
     })
   );
 };

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
@@ -2,9 +2,14 @@ import constants from '../../../common/constants';
 import { updateNodeConnection } from '../../actions/bjsworkflow/connections';
 import { initializeGraphState } from '../../parsers/ParseReduxAction';
 import type { AddNodePayload } from '../../parsers/addNodeToWorkflow';
-import { addSwitchCaseToWorkflow, addNodeToWorkflow, addAgentToolToWorkflow } from '../../parsers/addNodeToWorkflow';
+import {
+  addSwitchCaseToWorkflow,
+  addNodeToWorkflow,
+  addAgentToolToWorkflow,
+  addMcpServerToWorkflow,
+} from '../../parsers/addNodeToWorkflow';
 import type { DeleteNodePayload } from '../../parsers/deleteNodeFromWorkflow';
-import { deleteWorkflowNode, deleteNodeFromWorkflow } from '../../parsers/deleteNodeFromWorkflow';
+import { deleteWorkflowNode, deleteNodeFromWorkflow, deleteMcpServerNodeFromWorkflow } from '../../parsers/deleteNodeFromWorkflow';
 import type { WorkflowNode } from '../../parsers/models/workflowNode';
 import { isWorkflowNode } from '../../parsers/models/workflowNode';
 import type { MoveNodePayload } from '../../parsers/moveNodeInWorkflow';
@@ -34,6 +39,7 @@ import {
   WORKFLOW_NODE_TYPES,
   containsIdTag,
   containsCaseTag,
+  SUBGRAPH_TYPES,
 } from '@microsoft/logic-apps-shared';
 import type { MessageLevel } from '@microsoft/designer-ui';
 import { getDurationStringPanelMode } from '@microsoft/designer-ui';
@@ -289,15 +295,29 @@ export const workflowSlice = createSlice({
         if (!nodeMetadata) {
           return;
         }
-        const nodeData = {
-          ...nodeMetadata,
-          runData: {
-            status: tools[toolId].status,
-            repetitionCount: tools[toolId].iterations,
-          },
-          runIndex: 0,
-        };
-        state.nodesMetadata[toolId] = nodeData as NodeMetadata;
+
+        if (nodeMetadata.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT) {
+          // MCP client action does not have a tool, so save the "tool" runData in a dedicated toolRunData.
+          const nodeData = {
+            ...nodeMetadata,
+            toolRunData: {
+              status: tools[toolId].status,
+              repetitionCount: tools[toolId].iterations,
+            },
+            toolRunIndex: 0,
+          };
+          state.nodesMetadata[toolId] = nodeData as NodeMetadata;
+        } else {
+          const nodeData = {
+            ...nodeMetadata,
+            runData: {
+              status: tools[toolId].status,
+              repetitionCount: tools[toolId].iterations,
+            },
+            runIndex: 0,
+          };
+          state.nodesMetadata[toolId] = nodeData as NodeMetadata;
+        }
       });
 
       const nodeMetadata = getRecordEntry(state.nodesMetadata, nodeId);
@@ -339,6 +359,33 @@ export const workflowSlice = createSlice({
     deleteAgentTool: (state: WorkflowState, action: PayloadAction<{ toolId: string; agentId: string }>) => {
       const { toolId, agentId } = action.payload;
       delete (getRecordEntry(state.operations, agentId) as any).tools?.[toolId];
+
+      LoggerService().log({
+        level: LogEntryLevel.Verbose,
+        area: 'Designer:Workflow Slice',
+        message: action.type,
+        args: [action.payload],
+      });
+    },
+    deleteMcpServer: (state: WorkflowState, action: PayloadAction<{ toolId: string; agentId: string }>) => {
+      const { agentId } = action.payload;
+
+      if (!state.graph) {
+        LoggerService().log({
+          level: LogEntryLevel.Error,
+          area: 'Designer:Workflow Slice',
+          message: 'deleteMcpServer: state.graph not set',
+          args: [action.type, action.payload],
+        });
+        return;
+      }
+
+      const graph = getWorkflowNodeFromGraphState(state, agentId);
+      if (!graph) {
+        throw new Error('graph not set');
+      }
+
+      deleteMcpServerNodeFromWorkflow(action.payload, graph, state.nodesMetadata, state);
 
       LoggerService().log({
         level: LogEntryLevel.Verbose,
@@ -475,6 +522,14 @@ export const workflowSlice = createSlice({
       }
       nodeMetadata.runIndex = page;
     },
+    setToolRunIndex: (state: WorkflowState, action: PayloadAction<{ page: number; nodeId: string }>) => {
+      const { page, nodeId } = action.payload;
+      const nodeMetadata = getRecordEntry(state.nodesMetadata, nodeId);
+      if (!nodeMetadata) {
+        return;
+      }
+      nodeMetadata.toolRunIndex = page;
+    },
     setRepetitionRunData: (state: WorkflowState, action: PayloadAction<{ nodeId: string; runData: LogicAppsV2.WorkflowRunAction }>) => {
       const { nodeId, runData } = action.payload;
       const nodeMetadata = getRecordEntry(state.nodesMetadata, nodeId);
@@ -567,6 +622,25 @@ export const workflowSlice = createSlice({
         level: LogEntryLevel.Verbose,
         area: 'Designer:Workflow Slice',
         message: action.type,
+        args: [action.payload],
+      });
+    },
+    addMcpServer: (state: WorkflowState, action: PayloadAction<AddNodePayload>) => {
+      if (!state.graph) {
+        return; // log exception
+      }
+      const { relationshipIds, nodeId, operation } = action.payload;
+      const agentNode = getWorkflowNodeFromGraphState(state, relationshipIds?.graphId);
+      if (!agentNode) {
+        throw new Error('Agent node not found');
+      }
+
+      addMcpServerToWorkflow(nodeId, agentNode, state.nodesMetadata, state, operation);
+
+      LoggerService().log({
+        level: LogEntryLevel.Verbose,
+        area: 'Designer:Workflow Slice',
+        message: 'New Simple Agent Tool Node Added',
         args: [action.payload],
       });
     },
@@ -782,6 +856,7 @@ export const workflowSlice = createSlice({
         addSwitchCase,
         deleteSwitchCase,
         addAgentTool,
+        addMcpServer,
         addImplicitForeachNode,
         pasteScopeNode,
         setNodeDescription,
@@ -814,11 +889,13 @@ export const {
   deleteNode,
   deleteSwitchCase,
   deleteAgentTool,
+  deleteMcpServer,
   updateNodeSizes,
   setNodeDescription,
   toggleCollapsedGraphId,
   addSwitchCase,
   addAgentTool,
+  addMcpServer,
   discardAllChanges,
   updateRunAfter,
   addRunAfter,
@@ -833,6 +910,7 @@ export const {
   collapseGraphsToShowNode,
   replaceId,
   setRunIndex,
+  setToolRunIndex,
   setRepetitionRunData,
   clearAllRepetitionRunData,
   setSubgraphRunData,

--- a/libs/designer-v2/src/lib/core/utils/monitoring/binders/__test__/inputs.test.ts
+++ b/libs/designer-v2/src/lib/core/utils/monitoring/binders/__test__/inputs.test.ts
@@ -86,6 +86,42 @@ describe('InputsBinder', () => {
     expect(result).toEqual([parsedInputs]);
   });
 
+  it('should bind inputs using DefaultInputsBinder when manifest declares so', async () => {
+    const inputs = { key: 'value' };
+    const type = 'JavaScriptCode';
+    const operation = undefined;
+    const manifest = {
+      properties: {
+        iconUri: 'https://logicapps.azureedge.net/icons/javascript.svg',
+        brandColor: '#ba5d00',
+        description: 'Execute JavaScript Code',
+        connection: {
+          type: 'NotSpecified',
+          required: false,
+        },
+        inputs: {},
+        inputsBindingMode: 'untyped',
+      },
+    };
+
+    const mockBind = vi.fn().mockResolvedValue(parsedInputs);
+    vi.spyOn(DefaultInputsBinder.prototype, 'bind').mockImplementation(mockBind);
+
+    const result = await inputsBinder.bind(
+      inputs,
+      type,
+      inputParametersByName,
+      operation,
+      manifest,
+      customSwagger,
+      nodeParameters,
+      operationMetadata
+    );
+
+    expect(mockBind).toHaveBeenCalled();
+    expect(result).toEqual([parsedInputs]);
+  });
+
   it('should bind inputs using DefaultInputsBinder when no special conditions are met', async () => {
     const inputs = { key: 'value' };
     const type = constants.NODE.TYPE.INCREMENT_VARIABLE;
@@ -135,7 +171,7 @@ describe('InputsBinder', () => {
   });
 
   it('should not bind inputs and return an empty array when inptus is an empty array', async () => {
-    const inputs = [];
+    const inputs: any[] = [];
     const type = constants.NODE.TYPE.FOREACH;
     const operation = undefined;
     const manifest = undefined;

--- a/libs/designer-v2/src/lib/core/utils/monitoring/binders/__test__/outputs.test.ts
+++ b/libs/designer-v2/src/lib/core/utils/monitoring/binders/__test__/outputs.test.ts
@@ -57,6 +57,32 @@ describe('OutputsBinder', () => {
     expect(result).toEqual([parsedOutputs]);
   });
 
+  it('should bind outputs using DefaultInputsBinder when manifest declares so', async () => {
+    const outputs = [{ outputs: { key: 'value' } }];
+    const type = 'JavaScriptCode';
+    const manifest = {
+      properties: {
+        iconUri: 'https://logicapps.azureedge.net/icons/javascript.svg',
+        brandColor: '#ba5d00',
+        description: 'Execute JavaScript Code',
+        connection: {
+          type: 'NotSpecified',
+          required: false,
+        },
+        inputs: {},
+        outputsBindingMode: 'untyped',
+      },
+    };
+
+    const mockBind = vi.fn().mockResolvedValue(parsedOutputs);
+    vi.spyOn(DefaultOutputsBinder.prototype, 'bind').mockImplementation(mockBind);
+
+    const result = await outputsBinder.bind(outputs, type, outputParametersByName, manifest, nodeParameters, operationMetadata);
+
+    expect(mockBind).toHaveBeenCalled();
+    expect(result).toEqual([parsedOutputs]);
+  });
+
   it('should bind outputs correctly with DefaultOutputsBinder', async () => {
     const outputs = [{ outputs: { key: 'value' } }];
     const type = constants.NODE.TYPE.IF;
@@ -70,7 +96,7 @@ describe('OutputsBinder', () => {
   });
 
   it('should not bind outputs and return an empty array when outputs is an empty array', async () => {
-    const outputs = [];
+    const outputs: any[] = [];
     const type = constants.NODE.TYPE.FOREACH;
 
     const mockBind = vi.fn().mockResolvedValue(parsedOutputs);

--- a/libs/designer-v2/src/lib/core/utils/monitoring/binders/inputs.ts
+++ b/libs/designer-v2/src/lib/core/utils/monitoring/binders/inputs.ts
@@ -6,7 +6,7 @@ import type {
   ParameterInfo,
   SwaggerParser,
 } from '@microsoft/logic-apps-shared';
-import { equals } from '@microsoft/logic-apps-shared';
+import { equals, BindingMode } from '@microsoft/logic-apps-shared';
 import { ApiConnectionInputsBinder, DefaultInputsBinder, ManifestInputsBinder } from './inputs/index';
 import constants from '../../../../common/constants';
 
@@ -33,6 +33,7 @@ export default class InputsBinder {
     const getBoundParameters = async (input: any): Promise<BoundParameters> => {
       if (
         manifest &&
+        manifest.properties.inputsBindingMode !== BindingMode.Untyped &&
         !equals(type, constants.NODE.TYPE.IF) &&
         !equals(type, constants.NODE.TYPE.FOREACH) &&
         !equals(type, constants.NODE.TYPE.SWITCH) &&

--- a/libs/designer-v2/src/lib/core/utils/monitoring/binders/outputs.ts
+++ b/libs/designer-v2/src/lib/core/utils/monitoring/binders/outputs.ts
@@ -1,5 +1,5 @@
 import type { BoundParameters, OperationManifest, OutputParameter, ParameterInfo } from '@microsoft/logic-apps-shared';
-import { equals } from '@microsoft/logic-apps-shared';
+import { BindingMode, equals } from '@microsoft/logic-apps-shared';
 import constants from '../../../../common/constants';
 import { ManifestOutputsBinder, DefaultOutputsBinder, ApiConnectionOutputsBinder } from './outputs/index';
 
@@ -27,6 +27,7 @@ export default class OutputsBinder {
     const getBoundParameters = async (output: any): Promise<BoundParameters> => {
       if (
         manifest &&
+        manifest.properties.outputsBindingMode !== BindingMode.Untyped &&
         !equals(type, constants.NODE.TYPE.IF) &&
         !equals(type, constants.NODE.TYPE.FOREACH) &&
         !equals(type, constants.NODE.TYPE.SWITCH) &&

--- a/libs/designer-v2/src/lib/ui/CustomNodes/OperationCardNode.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/OperationCardNode.tsx
@@ -1,3 +1,4 @@
+import Constants from '../../common/constants';
 import { useNodeRepetition, type AppDispatch } from '../../core';
 import { copyOperation } from '../../core/actions/bjsworkflow/copypaste';
 import { moveOperation } from '../../core/actions/bjsworkflow/move';
@@ -38,13 +39,16 @@ import {
   useSubgraphRunData,
   useRunIndex,
   useFlowErrorsForNode,
+  useToolRunIndex,
+  useActionMetadata,
 } from '../../core/state/workflow/workflowSelectors';
 import { useIsA2AWorkflow } from '../../core/state/designerView/designerViewSelectors';
 import { setRepetitionRunData } from '../../core/state/workflow/workflowSlice';
 import { getRepetitionName } from '../common/LoopsPager/helper';
+import { LoopsPager } from '../common/LoopsPager/LoopsPager';
 import { DropZone } from '../connections/dropzone';
 import type { LogicAppsV2 } from '@microsoft/logic-apps-shared';
-import { isNullOrUndefined, useNodeIndex } from '@microsoft/logic-apps-shared';
+import { isNullOrUndefined, SUBGRAPH_TYPES, useNodeIndex } from '@microsoft/logic-apps-shared';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDrag } from 'react-dnd';
 import { useIntl } from 'react-intl';
@@ -90,6 +94,7 @@ const DefaultNode = ({ id }: NodeProps) => {
   const selfRunData = useRunData(id);
   const parentSubgraphRunData = useSubgraphRunData(parentNodeId ?? '');
   const toolRunIndex = useRunIndex(graphId);
+  const mcpToolRunIndex = useToolRunIndex(id);
   const isA2AWorkflow = useIsA2AWorkflow();
 
   const { isFetching: isRepetitionFetching, data: repetitionRunData } = useNodeRepetition(
@@ -112,9 +117,16 @@ const DefaultNode = ({ id }: NodeProps) => {
     }
   }, [dispatch, repetitionRunData, id, selfRunData?.correlation?.actionTrackingId]);
 
+  const parentActionMetadata = useActionMetadata(parentNodeId);
+
+  const actualToolRunIndex = useMemo(
+    () => (metadata?.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT ? mcpToolRunIndex : toolRunIndex),
+    [metadata, toolRunIndex, mcpToolRunIndex]
+  );
+
   useEffect(() => {
-    if (isWithinAgenticLoop && !isNullOrUndefined(toolRunIndex)) {
-      const subgraphRunData = parentSubgraphRunData?.[id]?.actionResults?.[toolRunIndex];
+    if (isWithinAgenticLoop && !isNullOrUndefined(actualToolRunIndex)) {
+      const subgraphRunData = parentSubgraphRunData?.[id]?.actionResults?.[actualToolRunIndex];
       if (subgraphRunData) {
         dispatch(
           setRepetitionRunData({
@@ -124,9 +136,24 @@ const DefaultNode = ({ id }: NodeProps) => {
         );
       }
     }
-  }, [isWithinAgenticLoop, id, dispatch, toolRunIndex, parentSubgraphRunData]);
+  }, [isWithinAgenticLoop, id, dispatch, actualToolRunIndex, parentSubgraphRunData]);
+
+  const shouldShowPager = useMemo(() => {
+    const isParentAgent = parentActionMetadata?.type?.toLowerCase() === Constants.NODE.TYPE.AGENT;
+    const isMcpClient = metadata?.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT;
+    return isMonitoringView && isParentAgent && isMcpClient && (metadata?.toolRunData?.repetitionCount ?? 0) > 1;
+  }, [metadata?.toolRunData?.repetitionCount, metadata?.subgraphType, parentActionMetadata?.type, isMonitoringView]);
 
   const { dependencies, loopSources } = useTokenDependencies(id);
+
+  // Check if this is an MCP client node (either by subgraph type or operation type)
+  const isMcpClient = useMemo(() => {
+    return (
+      metadata?.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT ||
+      operationInfo?.type?.toLowerCase() === 'mcpclienttool' ||
+      operationInfo?.operationId === 'nativemcpclient'
+    );
+  }, [metadata?.subgraphType, operationInfo?.type, operationInfo?.operationId]);
 
   const [{ isDragging }, drag, dragPreview] = useDrag(
     () => ({
@@ -154,7 +181,7 @@ const DefaultNode = ({ id }: NodeProps) => {
         loopSources,
         graphId: metadata?.graphId,
       },
-      canDrag: !readOnly && !isTrigger,
+      canDrag: !readOnly && !isTrigger && !isMcpClient,
       collect: (monitor) => ({
         isDragging: monitor.isDragging(),
       }),
@@ -166,7 +193,7 @@ const DefaultNode = ({ id }: NodeProps) => {
   const isLeaf = useIsLeafNode(id);
   const label = useNodeDisplayName(id);
 
-  const showLeafComponents = useMemo(() => !readOnly && isLeaf, [readOnly, isLeaf]);
+  const showLeafComponents = useMemo(() => !readOnly && isLeaf && !isMcpClient, [readOnly, isLeaf, isMcpClient]);
 
   const { iconUri } = useOperationVisuals(id);
 
@@ -326,13 +353,14 @@ const DefaultNode = ({ id }: NodeProps) => {
           subtleBackground={isA2AWorkflow && isTrigger}
         />
         {showCopyCallout ? <CopyTooltip id={id} targetRef={ref} hideTooltip={clearCopyTooltip} /> : null}
-        <EdgeDrawSourceHandle />
+        {!isMcpClient && <EdgeDrawSourceHandle />}
       </div>
       {showLeafComponents ? (
         <div className={'edge-drop-zone-container'}>
           <DropZone graphId={metadata?.graphId ?? ''} parentId={id} isLeaf={isLeaf} tabIndex={nodeIndex} />
         </div>
       ) : null}
+      {shouldShowPager ? <LoopsPager metadata={metadata} scopeId={id} collapsed={false} useToolRun={true} /> : null}
     </>
   );
 };

--- a/libs/designer-v2/src/lib/ui/common/LoopsPager/LoopsPager.tsx
+++ b/libs/designer-v2/src/lib/ui/common/LoopsPager/LoopsPager.tsx
@@ -1,6 +1,6 @@
 import { useScopeFailedRepetitions, type AppDispatch } from '../../../core';
 import { useActionMetadata, useNodeMetadata, useRunInstance } from '../../../core/state/workflow/workflowSelectors';
-import { setRunIndex } from '../../../core/state/workflow/workflowSlice';
+import { setRunIndex, setToolRunIndex } from '../../../core/state/workflow/workflowSlice';
 import { getLoopsCount } from './helper';
 import { FindPreviousAndNextPage, replaceWhiteSpaceWithUnderscore } from '@microsoft/logic-apps-shared';
 import type { PageChangeEventArgs, PageChangeEventHandler } from '@microsoft/designer-ui';
@@ -13,16 +13,20 @@ export interface LoopsPagerProps {
   scopeId: string;
   collapsed: boolean;
   focusElement?: (index: number, nodeId: string) => void;
+  useToolRun?: boolean;
 }
 
-export const LoopsPager = ({ metadata, scopeId, collapsed, focusElement }: LoopsPagerProps) => {
+export const LoopsPager = ({ metadata, scopeId, collapsed, focusElement, useToolRun }: LoopsPagerProps) => {
   const runInstance = useRunInstance();
   const dispatch = useDispatch<AppDispatch>();
   const actionMetadata = useActionMetadata(scopeId);
   const normalizedType = useMemo(() => actionMetadata?.type.toLowerCase(), [actionMetadata]);
   const nodeMetadata = useNodeMetadata(scopeId);
-  const currentPage = useMemo(() => nodeMetadata?.runIndex ?? 0, [nodeMetadata]);
-  const loopsCount = useMemo(() => getLoopsCount(metadata?.runData), [metadata?.runData]);
+  const currentPage = useMemo(() => (useToolRun ? nodeMetadata?.toolRunIndex : nodeMetadata?.runIndex) ?? 0, [nodeMetadata, useToolRun]);
+  const loopsCount = useMemo(
+    () => getLoopsCount(useToolRun ? metadata?.toolRunData : metadata?.runData),
+    [metadata?.runData, metadata?.toolRunData, useToolRun]
+  );
   const { isError, isFetching, data: failedRepetitions } = useScopeFailedRepetitions(normalizedType ?? '', scopeId, runInstance?.id);
 
   const findPreviousAndNextFailed = useCallback(
@@ -33,10 +37,14 @@ export const LoopsPager = ({ metadata, scopeId, collapsed, focusElement }: Loops
   const onPagerChange: PageChangeEventHandler = useCallback(
     (page: PageChangeEventArgs) => {
       const index = page.value - 1;
-      dispatch(setRunIndex({ page: index, nodeId: scopeId }));
+      if (useToolRun) {
+        dispatch(setToolRunIndex({ page: index, nodeId: scopeId }));
+      } else {
+        dispatch(setRunIndex({ page: index, nodeId: scopeId }));
+      }
       focusElement?.(index, scopeId);
     },
-    [dispatch, scopeId, focusElement]
+    [useToolRun, focusElement, scopeId, dispatch]
   );
 
   const onClickNextFailed: PageChangeEventHandler = useCallback(

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/monitoringTab.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/monitoringTab.tsx
@@ -22,6 +22,11 @@ export const MonitoringPanel: React.FC<PanelTabProps> = (props) => {
   const { status: statusRun, error: errorRun, code: codeRun } = runMetaData ?? {};
   const error = getMonitoringTabError(errorRun, statusRun, codeRun);
 
+  // Extract stable identifiers to detect when run data actually changes
+  const actionTrackingId = runMetaData?.correlation?.actionTrackingId;
+  const startTime = runMetaData?.startTime;
+  const endTime = runMetaData?.endTime;
+
   const getActionInputsOutputs = useCallback(() => {
     return RunService().getActionLinks(runMetaData, selectedNodeId);
   }, [selectedNodeId, runMetaData]);
@@ -45,7 +50,7 @@ export const MonitoringPanel: React.FC<PanelTabProps> = (props) => {
     if (!isLoading) {
       dispatch(initializeInputsOutputsBinding({ nodeId: selectedNodeId, inputsOutputs: inputOutputs }));
     }
-  }, [dispatch, inputOutputs, selectedNodeId, isLoading]);
+  }, [dispatch, inputOutputs, selectedNodeId, isLoading, actionTrackingId, startTime, endTime]);
 
   return isNullOrUndefined(runMetaData) ? null : (
     <>

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -150,18 +150,23 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
       return [parametersTabItem];
     }
 
-    return [
-      monitoringTabItem,
-      parametersTabItem,
-      settingsTabItem,
-      channelsTabItem,
-      handoffTabItem,
-      codeViewTabItem,
-      testingTabItem,
-      aboutTabItem,
-      monitorRetryTabItem,
-      scratchTabItem,
-    ]
+    const availableTabs =
+      nodeMetaData?.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT
+        ? [monitoringTabItem, parametersTabItem, codeViewTabItem, aboutTabItem, scratchTabItem, testingTabItem]
+        : [
+            monitoringTabItem,
+            parametersTabItem,
+            settingsTabItem,
+            channelsTabItem,
+            handoffTabItem,
+            codeViewTabItem,
+            testingTabItem,
+            aboutTabItem,
+            monitorRetryTabItem,
+            scratchTabItem,
+          ];
+
+    return availableTabs
       .filter((a) => !panelTabHideKeys.includes(a.id as any))
       .filter((a) => a.visible)
       .sort((a, b) => a.order - b.order);

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -363,7 +363,7 @@ const isIfAction = (action: LogicAppsV2.ActionDefinition): action is LogicAppsV2
 };
 
 const isAgentCondition = (action: LogicAppsV2.AgentCondition | LogicAppsV2.McpClient): action is LogicAppsV2.AgentCondition => {
-  return !action?.type || !equals(action?.type, 'mcpclienttool');
+  return !isMcpClient(action);
 };
 
 const isMcpClient = (action: LogicAppsV2.AgentCondition | LogicAppsV2.McpClient): action is LogicAppsV2.McpClient => {


### PR DESCRIPTION
Port MCP client tool feature to v2 designer

## Commit Type
<!-- Select one -->
- [X] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
This PR ports the v1 MCP client tool feature to v2 designer without the capability for adding an mcp client tool. Since the UX for adding of action has changed between v1 and v2, work is underway to redesign it. This is a purely additive feature that is isolated and should not impact other existing behaviours.

The capabilities that is ported over includes: serialization/deserialization/monitoringview

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
If user added MCP client tools in v1 designer, now they will be able to see them in v2 designer.
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: <!-- environments/scenarios --> local host

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
