### PR TITLE
feat(Designer): Direct standalone initialization

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureConsumptionLogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureConsumptionLogicAppSelector.tsx
@@ -69,6 +69,22 @@ export const AzureConsumptionLogicAppSelector = () => {
     }
   }, [reloadRunIds, runId, runInstances?.value]);
 
+  // If url query has preset values, set them on load
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const resourceId = urlParams.get('id');
+    if (resourceId) {
+      dispatch(setAppid(resourceId));
+      dispatch(setResourcePath(resourceId));
+      const workflowName = resourceId.split('/').at(-1) ?? '';
+      dispatch(setWorkflowName(workflowName));
+    }
+    const runId = urlParams.get('runId');
+    if (runId) {
+      dispatch(changeRunId(runId));
+    }
+  }, [dispatch]);
+
   const runOptions =
     runInstances?.value
       ?.map<IDropdownOption>((runInstance) => ({

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector.tsx
@@ -128,6 +128,28 @@ export const AzureStandardLogicAppSelector = ({
       })
       .sort((a, b) => a.text.localeCompare(b.text)) ?? [];
 
+  // If url query has preset values, set them on load
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const resourceId = urlParams.get('id');
+    if (resourceId) {
+      const appId = resourceId.substring(0, resourceId.lastIndexOf('/workflows'));
+      dispatch(setAppid(appId));
+      onLogicAppSelected?.();
+      const workflowName = resourceId.split('/').at(-1) ?? '';
+      dispatch(setWorkflowName(workflowName));
+      dispatch(
+        setResourcePath(
+          hostingPlan === 'hybrid' ? `${HybridAppUtility.getHybridAppBaseRelativeUrl(appId ?? '')}/workflows/${workflowName}` : resourceId
+        )
+      );
+    }
+    const runId = urlParams.get('runId');
+    if (runId) {
+      dispatch(changeRunId(runId));
+    }
+  }, [dispatch]);
+
   return (
     <Stack {...columnProps}>
       <div style={{ position: 'relative' }}>

--- a/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
@@ -3,7 +3,7 @@ import { useResourcePath, useIsMonitoringView, useRunFiles } from '../../../stat
 import { setResourcePath, loadWorkflow, loadRun } from '../../../state/workflowLoadingSlice';
 import type { IDropdownOption } from '@fluentui/react';
 import { Dropdown, DropdownMenuItemType } from '@fluentui/react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
 const fileOptions = [
@@ -98,14 +98,32 @@ export const LocalLogicAppSelector: React.FC = () => {
   );
 
   const runOptions = useMemo(() => {
-    return runFiles.map((runFile) => {
-      return {
-        key: runFile.path,
-        text: runFile.path.split('/').pop().replace('.json', ''),
-        module: runFile.module,
-      };
-    });
+    return runFiles.map((runFile) => ({
+      key: runFile.path,
+      text: runFile.path.split('/').pop().replace('.json', ''),
+      module: runFile.module,
+    }));
   }, [runFiles]);
+
+  // If url query has preset values, set them on load
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const resourceId = urlParams.get('localId');
+    const resourceOption = fileOptions.find((opt) => opt.key === resourceId);
+    if (resourceId && resourceOption) {
+      dispatch(setResourcePath(resourceId));
+      dispatch(loadWorkflow(resourceOption));
+    }
+  }, [dispatch]);
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const runId = urlParams.get('localRunId');
+    const runFile = runOptions.find((run) => run.text === runId)?.module;
+    if (runFile) {
+      dispatch(loadRun({ runFile }));
+    }
+  }, [dispatch, runOptions]);
 
   return (
     <div>

--- a/apps/Standalone/src/designer/app/SettingsSections/sourceSettings.tsx
+++ b/apps/Standalone/src/designer/app/SettingsSections/sourceSettings.tsx
@@ -2,7 +2,13 @@ import { environment } from '../../../environments/environment';
 import { getStateHistory } from '../../state/historyHelpers';
 import type { AppDispatch } from '../../state/store';
 import { useIsLocal, useHostingPlan, useResourcePath } from '../../state/workflowLoadingSelectors';
-import { type HostingPlanTypes, loadLastWorkflow, setHostingPlan, setIsLocalSelected } from '../../state/workflowLoadingSlice';
+import {
+  type HostingPlanTypes,
+  loadLastWorkflow,
+  setHostingPlan,
+  setIsLocalSelected,
+  setMonitoringView,
+} from '../../state/workflowLoadingSlice';
 import { ChoiceGroup, IconButton } from '@fluentui/react';
 import { useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
@@ -32,6 +38,23 @@ const SourceSettings = ({
   if (showHybridPlan) {
     planOptions.push({ key: 'hybrid', text: 'Hybrid' });
   }
+
+  // If a plan is specified in the URL params, set it on load
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const plan = urlParams.get('plan');
+    if (plan) {
+      dispatch(setHostingPlan(plan as HostingPlanTypes));
+    }
+    const localId = urlParams.get('localId');
+    if (localId) {
+      dispatch(setIsLocalSelected(true));
+    }
+    const runId = urlParams.get('localRunId') || urlParams.get('runId');
+    if (runId) {
+      dispatch(setMonitoringView(true));
+    }
+  }, [dispatch]);
 
   return (
     <div style={{ display: 'flex', gap: '24px' }}>

--- a/apps/Standalone/src/designer/components/settings_box.tsx
+++ b/apps/Standalone/src/designer/components/settings_box.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { AzureConsumptionLogicAppSelector } from '../app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureConsumptionLogicAppSelector';
 import { AzureStandardLogicAppSelector } from '../app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector';
 import { LocalLogicAppSelector } from '../app/LocalDesigner/LogicAppSelector/LogicAppSelector';
@@ -11,12 +12,25 @@ import { ThemeProvider } from '@fluentui/react';
 import { useBoolean } from '@fluentui/react-hooks';
 import { css } from '@fluentui/utilities';
 
+const isLoadingDirect = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get('id') !== null || urlParams.get('localId') !== null;
+};
+
 export const SettingsBox = () => {
-  const [active, toggleActive] = useBoolean(true);
+  const [active, toggleActive] = useBoolean(isLoadingDirect());
   const isDark = useIsDarkMode();
   const isLocal = useIsLocal();
   const isConsumption = useHostingPlan() === 'consumption';
   const cs = css(styles.toybox, active && styles.active, isDark && styles.dark);
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    // If there is no 'id' param, we are in local mode
+    if (urlParams.get('id') !== null || urlParams.get('localId') !== null) {
+      toggleActive.setFalse();
+    }
+  }, [toggleActive]);
 
   const SettingsSection = (props: any) => {
     const { title, children, startExpanded = true } = props;

--- a/apps/Standalone/src/designer/components/settings_box.tsx
+++ b/apps/Standalone/src/designer/components/settings_box.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { AzureConsumptionLogicAppSelector } from '../app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureConsumptionLogicAppSelector';
 import { AzureStandardLogicAppSelector } from '../app/AzureLogicAppsDesigner/LogicAppSelectionSetting/AzureStandardLogicAppSelector';
 import { LocalLogicAppSelector } from '../app/LocalDesigner/LogicAppSelector/LogicAppSelector';
@@ -23,14 +22,6 @@ export const SettingsBox = () => {
   const isLocal = useIsLocal();
   const isConsumption = useHostingPlan() === 'consumption';
   const cs = css(styles.toybox, active && styles.active, isDark && styles.dark);
-
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    // If there is no 'id' param, we are in local mode
-    if (urlParams.get('id') !== null || urlParams.get('localId') !== null) {
-      toggleActive.setFalse();
-    }
-  }, [toggleActive]);
 
   const SettingsSection = (props: any) => {
     const { title, children, startExpanded = true } = props;

--- a/e2e/designer/TokenPicker.spec.ts
+++ b/e2e/designer/TokenPicker.spec.ts
@@ -1,5 +1,5 @@
 import test, { expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'Token Picker Tests',
@@ -8,9 +8,7 @@ test.describe(
   },
   async () => {
     test('Token picker search should have robust name matching', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       await page.getByLabel('Parse JSON operation, Data').click();
       await page.getByLabel('Content').click();
@@ -28,9 +26,7 @@ test.describe(
     });
 
     test('Expression Editor works with dynamic content', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       await page.getByLabel('Parse JSON operation, Data').click();
       await page.getByLabel('Content').click();
       await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-expression"]').click();

--- a/e2e/designer/app.spec.ts
+++ b/e2e/designer/app.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test(
   'Sanity Check',
@@ -7,9 +7,7 @@ test(
     tag: '@mock',
   },
   async ({ page }) => {
-    await page.goto('/');
-
-    await GoToMockWorkflow(page, 'Simple Big Workflow');
+    await LoadMockDirect(page, 'simpleBigworkflow.json');
 
     await page.getByTestId('card-increment_variable').getByRole('button').click();
     await page.getByLabel('Value').getByRole('paragraph').click();

--- a/e2e/designer/collapseActions.spec.ts
+++ b/e2e/designer/collapseActions.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'Collapse actions tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   () => {
     test('Should collapse actions', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       // Collapse action
       await page.getByText('HTTP', { exact: true }).click({ button: 'right' });
@@ -21,8 +20,7 @@ test.describe(
     });
 
     test('Should collapse actions and expand', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       // Collapse last action
       await page.getByText('Filter array', { exact: true }).click({ button: 'right' });
@@ -52,8 +50,7 @@ test.describe(
     });
 
     test('Should collapse actions within scope', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Scope');
+      await LoadMockDirect(page, 'Scope.json');
 
       // Collapse nested scope
       await page.getByText('Scope nested', { exact: true }).click({ button: 'right' });

--- a/e2e/designer/collapseActions.spec.ts
+++ b/e2e/designer/collapseActions.spec.ts
@@ -50,7 +50,7 @@ test.describe(
     });
 
     test('Should collapse actions within scope', async ({ page }) => {
-      await LoadMockDirect(page, 'Scope.json');
+      await LoadMockDirect(page, 'simpleScoped.json');
 
       // Collapse nested scope
       await page.getByText('Scope nested', { exact: true }).click({ button: 'right' });

--- a/e2e/designer/contextMenus.spec.ts
+++ b/e2e/designer/contextMenus.spec.ts
@@ -8,7 +8,7 @@ test.describe(
   },
   () => {
     test('Should open node context menus', async ({ page }) => {
-      await LoadMockDirect(page, 'Scope.json');
+      await LoadMockDirect(page, 'simpleScoped.json');
 
       // Open trigger context menu
       await page.getByText('manual', { exact: true }).click({ button: 'right' });
@@ -25,7 +25,7 @@ test.describe(
     });
 
     test('Should open edge context menus', async ({ page }) => {
-      await LoadMockDirect(page, 'Scope.json');
+      await LoadMockDirect(page, 'simpleScoped.json');
 
       // Click first edge button
       await page.getByLabel('Insert a new step between manual and Initialize variable').click();

--- a/e2e/designer/contextMenus.spec.ts
+++ b/e2e/designer/contextMenus.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'ContextMenu Tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   () => {
     test('Should open node context menus', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Scope');
+      await LoadMockDirect(page, 'Scope.json');
 
       // Open trigger context menu
       await page.getByText('manual', { exact: true }).click({ button: 'right' });
@@ -26,8 +25,7 @@ test.describe(
     });
 
     test('Should open edge context menus', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Scope');
+      await LoadMockDirect(page, 'Scope.json');
 
       // Click first edge button
       await page.getByLabel('Insert a new step between manual and Initialize variable').click();

--- a/e2e/designer/dragAndDrop.spec.ts
+++ b/e2e/designer/dragAndDrop.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test(
   'Should be able to drag and drop operations',
@@ -7,9 +7,7 @@ test(
     tag: '@mock',
   },
   async ({ page }) => {
-    await page.goto('/');
-
-    await GoToMockWorkflow(page, 'Panel');
+    await LoadMockDirect(page, 'Panel.json');
     await page.getByTestId('card-http').dragTo(page.getByTestId('msla-plus-button-manual-initialize_arrayvariable'));
   }
 );

--- a/e2e/designer/editors/condition.spec.ts
+++ b/e2e/designer/editors/condition.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+import { LoadMockDirect } from '../utils/GoToWorkflow';
 
 test(
   'condition editor',
@@ -7,9 +7,7 @@ test(
     tag: '@mock',
   },
   async ({ page }) => {
-    await page.goto('/');
-
-    await GoToMockWorkflow(page, 'Conditionals');
+    await LoadMockDirect(page, 'Conditionals.json');
     await expect(page.getByLabel('Condition operation')).toBeVisible();
 
     await page.getByLabel('Condition operation').click();

--- a/e2e/designer/editors/dictionary.spec.ts
+++ b/e2e/designer/editors/dictionary.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+import { LoadMockDirect } from '../utils/GoToWorkflow';
 
 test.describe(
   'dictionary editor',
@@ -8,9 +8,7 @@ test.describe(
   },
   async () => {
     test('Should handle dictionary serialization', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       await page.getByLabel('Insert a new step between Initialize ArrayVariable and Parse JSON').click();
       await page.getByText('Add an action').click();
       await page.getByLabel('HTTP', { exact: true }).first().click();
@@ -46,9 +44,7 @@ test.describe(
     });
 
     test('Should not do value string interpolation if is of type `any` and has a token', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       await page.getByLabel('Insert a new step between Initialize ArrayVariable and Parse JSON').click();
       await page.getByText('Add an action').click();
       await page.getByPlaceholder('Search for an action or').fill('select');

--- a/e2e/designer/editors/password.spec.ts
+++ b/e2e/designer/editors/password.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+import { LoadMockDirect } from '../utils/GoToWorkflow';
 
 test(
   'password mask',
@@ -7,9 +7,7 @@ test(
     tag: '@mock',
   },
   async ({ page }) => {
-    await page.goto('/');
-
-    await GoToMockWorkflow(page, 'Panel');
+    await LoadMockDirect(page, 'Panel.json');
 
     await page.getByTestId('card-http').click();
     await page.getByPlaceholder('Showing 0 of').click();

--- a/e2e/designer/errorsPanel.spec.ts
+++ b/e2e/designer/errorsPanel.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'ErrorsPanel Tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   () => {
     test('Should show operation errors in errors panel', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       await page.getByRole('button', { name: 'zoom out' }).click();
 
@@ -35,8 +34,7 @@ test.describe(
     });
 
     test('Should show workflow parameters errors in errors panel', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       // Open workflow parameters panel
       await page.getByText('Workflow Parameters', { exact: true }).click();

--- a/e2e/designer/fixtures/real-api.ts
+++ b/e2e/designer/fixtures/real-api.ts
@@ -15,14 +15,7 @@ export class RealDataApi {
     this.siteId = `/subscriptions/${process.env.AZURE_SUBSCRIPTION_ID}/resourceGroups/${process.env.AZURE_RESOURCE_GROUP}/providers/Microsoft.Web/sites/${this.siteName}`;
   }
   async goToWorkflow(workflowName?: string) {
-    await this.page.getByPlaceholder('Select an App').click();
-    await this.page.getByPlaceholder('Select an App').fill(this.siteName);
-    await this.page.getByPlaceholder('Select an App').press('Enter');
-    await this.page.getByText('Select a Workflow').click();
-    await this.page.getByRole('option', { name: workflowName ?? this.workflowName, exact: true }).click();
-    await this.page.getByRole('button', { name: 'Toolbox' }).click();
-    await this.page.waitForTimeout(2000);
-    await this.page.getByLabel('Zoom view to fit').click({ force: true });
+    await this.page.goto(`/?id=${workflowName ?? this.workflowName}&plan=standard`);
   }
   async saveWorkflow() {
     const responsePromise = this.page.waitForResponse(

--- a/e2e/designer/graphCollapse.spec.ts
+++ b/e2e/designer/graphCollapse.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'Graph Collapse Tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   () => {
     test('Should collapse graphs', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
+      await LoadMockDirect(page, 'AllScopeNodes.json');
 
       // Collapse and reopen the foreach condition node, confirming the child node visibility
       await expect(page.getByLabel('ForEach operation')).toBeVisible();

--- a/e2e/designer/mock-copypastescope.spec.ts
+++ b/e2e/designer/mock-copypastescope.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { getSerializedWorkflowFromState } from './utils/designerFunctions';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test(
   'Mock: Expect Copy and Paste of Scopes to work on single workflow',
@@ -8,8 +8,7 @@ test(
     tag: '@mock',
   },
   async ({ page }) => {
-    await page.goto('/');
-    await GoToMockWorkflow(page, 'Conditionals');
+    await LoadMockDirect(page, 'Conditionals.json');
     await page.getByTestId('card-condition').click({
       button: 'right',
     });

--- a/e2e/designer/monitoringView/loopsPager.spec.ts
+++ b/e2e/designer/monitoringView/loopsPager.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow, LoadRunFile } from '../utils/GoToWorkflow';
+import { LoadDirect } from '../utils/GoToWorkflow';
 
 test.describe(
   'Loops pager in monitoring view tests',
@@ -8,10 +8,7 @@ test.describe(
   },
   () => {
     test('Success run check', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Loops pager');
-      await LoadRunFile(page, 'SuccessRun');
+      await LoadDirect(page, 'LoopsPager.json', 'SuccessRun', 'standard', true);
 
       // Verify status for success in previous action
       await expect(page.getByTestId('msla-pill-initialize_variable_status')).toBeVisible();

--- a/e2e/designer/monitoringView/loopsPager.spec.ts
+++ b/e2e/designer/monitoringView/loopsPager.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { LoadDirect } from '../utils/GoToWorkflow';
+import { LoadMockDirect } from '../utils/GoToWorkflow';
 
 test.describe(
   'Loops pager in monitoring view tests',
@@ -8,7 +8,7 @@ test.describe(
   },
   () => {
     test('Success run check', async ({ page }) => {
-      await LoadDirect(page, 'LoopsPager.json', 'SuccessRun', 'standard', true);
+      await LoadMockDirect(page, 'LoopsPager.json', 'SuccessRun', 'standard');
 
       // Verify status for success in previous action
       await expect(page.getByTestId('msla-pill-initialize_variable_status')).toBeVisible();

--- a/e2e/designer/monitoringView/monitoringView.spec.ts
+++ b/e2e/designer/monitoringView/monitoringView.spec.ts
@@ -1,6 +1,6 @@
 import test from '@playwright/test';
 import { expect } from '../fixtures/opacityFixture';
-import { GoToMockWorkflow, LoadRunFile } from '../utils/GoToWorkflow';
+import { LoadMockDirect } from '../utils/GoToWorkflow';
 
 test.describe(
   'Monitoring view tests sanity check',
@@ -9,9 +9,7 @@ test.describe(
   },
   () => {
     test('Sanity check', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Monitoring view conditional');
-      await LoadRunFile(page, 'normalState');
+      await LoadMockDirect(page, 'MonitoringViewConditional.json', 'normalState');
 
       // Verify status for success action
       await expect(page.getByTestId('msla-pill-condition_2_status')).toBeVisible();
@@ -31,9 +29,7 @@ test.describe(
     });
 
     test('Sanity check for loading state', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Monitoring view conditional');
-      await LoadRunFile(page, 'loadingState');
+      await LoadMockDirect(page, 'MonitoringViewConditional.json', 'loadingState');
 
       // Verify trigger status
       await expect(page.getByTestId('msla-pill-when_a_http_request_is_received_status')).toBeVisible();

--- a/e2e/designer/nodeSearchPanel.spec.ts
+++ b/e2e/designer/nodeSearchPanel.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'NodeSearchPanel Tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   () => {
     test('Selecting action from node panel should open action panel', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Conditionals (Complex)');
+      await LoadMockDirect(page, 'MoreComplex.json');
 
       // Ensure conditional and action inside is visible
       expect(await page.getByText('Verify property changes', { exact: true }).isVisible()).toBeTruthy();

--- a/e2e/designer/operationPanel.spec.ts
+++ b/e2e/designer/operationPanel.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'OperationPanel Tests',
@@ -19,8 +19,7 @@ test.describe(
         await expect(page.locator('.msla-panel-container-nested')).not.toBeVisible();
       };
 
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       // Left-click on 'Initialize ArrayVariable' node.
       await page.getByTestId('card-initialize_arrayvariable').click();
@@ -45,8 +44,7 @@ test.describe(
         await expect(page.locator('.msla-panel-container-nested')).not.toBeVisible();
       };
 
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       // Left-click on 'Initialize ArrayVariable' node.
       await page.getByTestId('card-initialize_arrayvariable').click({ button: 'right' });
@@ -81,8 +79,7 @@ test.describe(
         await expect(page.locator('.msla-panel-container-nested')).not.toBeVisible();
       };
 
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       // Left-click on 'Parse JSON' node.
       await page.getByTestId('card-parse_json').click();
@@ -100,8 +97,7 @@ test.describe(
     });
 
     test('Can switch between different tabs independently in selected/pinned panels', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       // Left-click on 'Parse JSON' node.
       await page.getByTestId('card-parse_json').click();
@@ -120,8 +116,7 @@ test.describe(
     });
 
     test('Should only show the panel info message when trigger type is request', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       // Left-click on 'manual' trigger.
       await page.getByTestId('card-manual').click();
@@ -138,8 +133,7 @@ test.describe(
     });
 
     test('Should show proper operation panel tabs', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       // Left-click on 'manual' trigger.
       await page.getByTestId('card-manual').click();
       await expect(page.getByRole('tab', { name: 'Parameters' })).toBeVisible();

--- a/e2e/designer/queryCache.spec.ts
+++ b/e2e/designer/queryCache.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'QueryCache Tests',
@@ -15,7 +15,7 @@ test.describe(
         localStorage.setItem('control-expand-collapse-button', 'true');
       });
 
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       expect(await page.getByText('manual', { exact: true }).isVisible()).toBeTruthy();
 
       // There should be no cache in local storage
@@ -32,7 +32,7 @@ test.describe(
       await page.getByRole('heading', { name: '▼ Context Settings' }).click();
       await page.locator('label').filter({ hasText: 'Query Cache Persist' }).locator('i').click();
 
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       expect(await page.getByText('manual', { exact: true }).isVisible()).toBeTruthy();
 
       await page.waitForFunction(() => localStorage.getItem('REACT_QUERY_OFFLINE_CACHE') !== null);

--- a/e2e/designer/real-api/SanityTest/sanity-test.spec.ts
+++ b/e2e/designer/real-api/SanityTest/sanity-test.spec.ts
@@ -11,7 +11,6 @@ test.describe(
       await realDataApi.deployWorkflow(workflow);
     });
     test('Sanity Check', async ({ page, realDataApi }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow();
       await page.getByTestId('card-when_a_http_request_is_received').click();
       await page.getByRole('combobox', { name: 'Method' }).click();

--- a/e2e/designer/real-api/StatelessVariables/statelessvariables.spec.ts
+++ b/e2e/designer/real-api/StatelessVariables/statelessvariables.spec.ts
@@ -11,7 +11,6 @@ test.describe(
       await realDataApi.deployWorkflow(workflow);
     });
     test('Variable Functionality works', async ({ page, realDataApi, browserName }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow();
 
       await page.getByTestId('msla-plus-button-when_a_http_request_is_received-response').click();

--- a/e2e/designer/real-api/agentic/agentConnections.spec.ts
+++ b/e2e/designer/real-api/agentic/agentConnections.spec.ts
@@ -35,7 +35,6 @@ test.describe(
     };
 
     test('Can create a valid connection', async ({ page, realDataApi }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow();
 
       // Click on the agent action
@@ -57,7 +56,6 @@ test.describe(
       await realDataApi.saveWorkflow();
 
       // Reload the page and verify the connection is still there
-      await page.reload();
       await realDataApi.goToWorkflow();
       // Click on the agent action
       await expect(page.getByLabel('Default Agent operation')).toBeVisible();
@@ -70,7 +68,6 @@ test.describe(
     });
 
     test('Show MSI warnings', async ({ page, realDataApi }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow();
 
       // Click on the agent action

--- a/e2e/designer/real-api/connections/connectionAuth.spec.ts
+++ b/e2e/designer/real-api/connections/connectionAuth.spec.ts
@@ -7,7 +7,6 @@ test.describe(
   },
   () => {
     test('OAuth check', async ({ page, realDataApi }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow('OperationParameters');
 
       await page.getByLabel('Insert a new step after').click();
@@ -23,7 +22,6 @@ test.describe(
       await expect(page.getByLabel('Sign in to connector')).toBeVisible();
     });
     test('Legacy service principal + client cert check', async ({ page, realDataApi }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow('OperationParameters');
       await page.getByLabel('Insert a new step after').click();
       await page.getByText('Add an action').click();

--- a/e2e/designer/real-api/custom-code/custom-code.spec.ts
+++ b/e2e/designer/real-api/custom-code/custom-code.spec.ts
@@ -11,7 +11,6 @@ test.describe(
     });
 
     test('Inline Javascript', async ({ page, browserName, realDataApi }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow();
       await page.getByTestId('msla-plus-button-when_a_http_request_is_received-response').click();
       await page.getByTestId('msla-add-button-when_a_http_request_is_received-response').click({ force: true });

--- a/e2e/designer/real-api/editors/htmleditor.spec.ts
+++ b/e2e/designer/real-api/editors/htmleditor.spec.ts
@@ -14,7 +14,6 @@ test.describe(
     });
 
     test('HTML Editor', async ({ page, realDataApi }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow();
       await page.getByTestId('msla-plus-button-when_a_http_request_is_received-response').click();
       await page.getByTestId('msla-add-button-when_a_http_request_is_received-response').click({ force: true });

--- a/e2e/designer/real-api/monitoring/NestedLoops/nestedLoops.spec.ts
+++ b/e2e/designer/real-api/monitoring/NestedLoops/nestedLoops.spec.ts
@@ -13,7 +13,6 @@ test.describe(
   },
   () => {
     test('Sanity check', async ({ page, realDataApi }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow('NestedLoops');
 
       // Check workfow loads correctly

--- a/e2e/designer/real-api/operationPanel/operationParameters.spec.ts
+++ b/e2e/designer/real-api/operationPanel/operationParameters.spec.ts
@@ -7,7 +7,6 @@ test.describe(
   },
   () => {
     test('Parameters sanity check', async ({ page, realDataApi }) => {
-      await page.goto('/');
       await realDataApi.goToWorkflow('OperationParameters');
 
       // Checks parameters are rendering correctly

--- a/e2e/designer/real-api/operationPanel/triggerUpdateName.spec.ts
+++ b/e2e/designer/real-api/operationPanel/triggerUpdateName.spec.ts
@@ -6,7 +6,6 @@ test.describe(
   },
   () => {
     test('Sanity check', async ({ page, realDataApi }) => {
-      await page.goto('/');
       const initialName = 'manual';
       const updatedName = 'manualUpdated';
 

--- a/e2e/designer/recurrence.spec.ts
+++ b/e2e/designer/recurrence.spec.ts
@@ -1,5 +1,5 @@
 import test, { expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'Recurrence Tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   async () => {
     test.skip('Recurrence should load preview text properly', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Recurrence');
+      await LoadMockDirect(page, 'Recurrence.json');
       await page.getByTestId('card-recurrence').click();
 
       // interval

--- a/e2e/designer/runAfter.spec.ts
+++ b/e2e/designer/runAfter.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'RunAfter Tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   async () => {
     test('RunAfter visible for all operations (except trigger and action immediately after the trigger', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       await page.getByLabel('Parse JSON operation, Data').click({
         button: 'right',
@@ -36,8 +35,7 @@ test.describe(
       await expect(page.getByRole('menuitem', { name: 'Run After' })).not.toBeVisible();
     });
     test('RunAfter visible for all scope operations (except trigger and action immediately after the trigger', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       await page.getByLabel('Insert a new step after HTTP').click();
       await page.getByText('Add an action').click();

--- a/e2e/designer/scopeActions.spec.ts
+++ b/e2e/designer/scopeActions.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'Scope actions tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   () => {
     test('Should collapse condition actions', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
+      await LoadMockDirect(page, 'AllScopeNodes.json');
 
       // Check items inside conditions exist in true side are visible
       await expect(page.getByTestId('card-terminate').getByRole('button', { name: 'Terminate' })).toBeVisible();
@@ -48,8 +47,7 @@ test.describe(
     });
 
     test('Should collapse for each actions', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
+      await LoadMockDirect(page, 'AllScopeNodes.json');
 
       // Collapse empty foreach
       await page.getByTestId('ForEach_empty-collapse-toggle').click();
@@ -85,8 +83,7 @@ test.describe(
     });
 
     test('Should collapse do until actions', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
+      await LoadMockDirect(page, 'AllScopeNodes.json');
 
       // Check items inside do until actions are visible
       await expect(page.getByTestId('card-until_action_1').getByRole('button', { name: 'Until Action' })).toBeVisible();
@@ -114,8 +111,7 @@ test.describe(
     });
 
     test('Should collapse switch actions', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
+      await LoadMockDirect(page, 'AllScopeNodes.json');
 
       // Check items inside conditions exist in true side are visible
       await expect(page.getByTestId('card-terminate').getByRole('button', { name: 'Terminate' })).toBeVisible();

--- a/e2e/designer/serialization.spec.ts
+++ b/e2e/designer/serialization.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 import { getSerializedWorkflowFromState } from './utils/designerFunctions';
 import panelData from '../../__mocks__/workflows/Panel.json' assert { type: 'json' };
 import switchData from '../../__mocks__/workflows/Switch.json' assert { type: 'json' };
@@ -12,9 +12,7 @@ test.describe(
   },
   () => {
     test('Should serialize the workflow after deserializing it and match', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       const serialized: any = await getSerializedWorkflowFromState(page);
 
@@ -26,8 +24,7 @@ test.describe(
     });
 
     test('Should serialize the workflow after deserializing it and match with a switch statement', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Switch');
+      await LoadMockDirect(page, 'Switch.json');
 
       const serialized: any = await getSerializedWorkflowFromState(page);
 
@@ -37,9 +34,7 @@ test.describe(
     test('Should serialize the workflow after deserializing it and match with some strings and keys containing unicode characters', async ({
       page,
     }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Unicode Keys');
+      await LoadMockDirect(page, 'UnicodeKeys.json');
 
       const serialized: any = await getSerializedWorkflowFromState(page);
 

--- a/e2e/designer/tabFocus.spec.ts
+++ b/e2e/designer/tabFocus.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'TabFocus Tests',
@@ -11,8 +11,7 @@ test.describe(
       test.skip(browserName === 'firefox', 'Still working on it');
       const tab = async () => page.locator('*:focus').press('Tab');
 
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
+      await LoadMockDirect(page, 'AllScopeNodes.json');
 
       // Find element with text 'Recurrence'
       await page.getByText('Recurrence', { exact: true }).click();
@@ -52,8 +51,7 @@ test.describe(
       const tab = async () => page.locator('*:focus').press('Tab');
       const backTab = async () => page.locator('*:focus').press('Shift+Tab');
 
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
 
       // Find element with text 'manual'
       await page.getByText('manual', { exact: true }).click();

--- a/e2e/designer/tokens/escapeExpressionTokens.spec.ts
+++ b/e2e/designer/tokens/escapeExpressionTokens.spec.ts
@@ -1,5 +1,5 @@
 import test, { expect } from '@playwright/test';
-import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+import { LoadMockDirect } from '../utils/GoToWorkflow';
 
 test.describe(
   'Escape Expression Tokens Tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   async () => {
     test('Expressions should be able to use escape characters and serialize', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       await page.getByLabel('HTTP operation, HTTP connector').click();
       await page.getByTitle('Enter request content').getByRole('paragraph').click();
       await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-expression"]').click();
@@ -26,8 +25,7 @@ test.describe(
     });
 
     test('Expressions should be able to use escaped escape characters and serialize as the same', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       await page.getByLabel('HTTP operation, HTTP connector').click();
       await page.getByTitle('Enter request content').getByRole('paragraph').click();
       await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-expression"]').click();
@@ -44,8 +42,7 @@ test.describe(
     });
 
     test('Expressions should maintain behavior of escaped characters in all instances the user views at', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       await page.getByLabel('HTTP operation, HTTP connector').click();
       await page.getByTitle('Enter request content').getByRole('paragraph').click();
       await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-expression"]').click();

--- a/e2e/designer/tokens/tokenRemoval.spec.ts
+++ b/e2e/designer/tokens/tokenRemoval.spec.ts
@@ -1,5 +1,5 @@
 import test, { expect } from '@playwright/test';
-import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+import { LoadMockDirect } from '../utils/GoToWorkflow';
 import { getSerializedWorkflowFromState } from '../utils/designerFunctions';
 
 test.describe(
@@ -9,8 +9,7 @@ test.describe(
   },
   async () => {
     test('Tokens should be removed from parameters when operation is deleted', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect(serializedOld.definition.actions.Filter_array.inputs.from).toEqual("@{body('Parse_JSON')}test");
       await page.getByLabel('Parse JSON operation, Data').click({
@@ -24,9 +23,7 @@ test.describe(
       expect(JSON.stringify(serializedNew)).not.toContain("@{body('Parse_JSON')}");
     });
     test('Tokens should be removed from parameters when variable is deleted', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect(serializedOld.definition.actions.Parse_JSON.inputs.content).toEqual(
         "@{triggerBody()?['string']}@{variables('ArrayVariable')}@{parameters('EILCO Admin Nominations-OCSA List (cr773_EILCOAdminNominations_OCSA_L2)')}"
@@ -47,9 +44,7 @@ test.describe(
     });
 
     test('Tokens should be removed from parameters when trigger is deleted', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect
         .soft(serializedOld.definition.actions.Parse_JSON.inputs.content)
@@ -70,9 +65,7 @@ test.describe(
     });
 
     test('Tokens should be removed from parameters when workflow parameter is deleted', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect(serializedOld.definition.actions.Parse_JSON.inputs.content).toEqual(
         "@{triggerBody()?['string']}@{variables('ArrayVariable')}@{parameters('EILCO Admin Nominations-OCSA List (cr773_EILCOAdminNominations_OCSA_L2)')}"
@@ -96,9 +89,7 @@ test.describe(
       );
     });
     test('Output should be correct when multiple tokens get removed by removing source', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
+      await LoadMockDirect(page, 'Panel.json');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect(serializedOld.definition.actions.Parse_JSON.inputs.content).toEqual(
         "@{triggerBody()?['string']}@{variables('ArrayVariable')}@{parameters('EILCO Admin Nominations-OCSA List (cr773_EILCOAdminNominations_OCSA_L2)')}"

--- a/e2e/designer/unicodeCharacters.spec.ts
+++ b/e2e/designer/unicodeCharacters.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'UnicodeCharacter Tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   async () => {
     test('Actions with unicode character names are rendered properly', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Unicode Keys');
+      await LoadMockDirect(page, 'UnicodeKeys.json');
 
       const actionNames = ['Http', 'Groß-/Kleinbuchstaben', '🐞🍋🐠', '早上好', 'トで読み込み中'];
       for (const actionName of actionNames) {

--- a/e2e/designer/utils/GoToWorkflow.ts
+++ b/e2e/designer/utils/GoToWorkflow.ts
@@ -12,6 +12,7 @@ export const GoToRealWorkflow = async (page: Page, appName: string, workflowName
 };
 
 export const GoToMockWorkflow = async (page: Page, workflowName: string) => {
+  await page.goto('/');
   await page.getByText('Local', { exact: true }).click();
   await page.getByText('Select an option').click();
   await page.getByRole('option', { name: workflowName, exact: true }).click();
@@ -27,4 +28,12 @@ export const LoadRunFile = async (page: Page, runName: string) => {
   await page.getByText('Select a run file to load').click();
   await page.getByRole('option', { name: runName, exact: true }).click();
   await page.getByRole('button', { name: 'Toolbox' }).click();
+};
+
+export const LoadDirect = async (page: Page, workflowName: string, runName?: string, plan = 'standard', isLocal = false) => {
+  if (isLocal) {
+    await page.goto(`/?localId=${workflowName}&localRunId=${runName}&plan=${plan}`);
+  } else {
+    await page.goto(`/?id=${workflowName}&runId=${runName}&plan=${plan}`);
+  }
 };

--- a/e2e/designer/utils/GoToWorkflow.ts
+++ b/e2e/designer/utils/GoToWorkflow.ts
@@ -31,9 +31,9 @@ export const LoadRunFile = async (page: Page, runName: string) => {
 };
 
 export const LoadMockDirect = async (page: Page, workflowName: string, runName?: string, plan = 'standard') => {
-  await page.goto(`/?localId=${workflowName}&localRunId=${runName}&plan=${plan}`);
+  await page.goto(`/?localId=${workflowName}${runName ? `&localRunId=${runName}` : ''}&plan=${plan}`);
 };
 
 export const LoadDirect = async (page: Page, workflowName: string, runName?: string, plan = 'standard') => {
-  await page.goto(`/?id=${workflowName}&runId=${runName}&plan=${plan}`);
+  await page.goto(`/?id=${workflowName}${runName ? `&runId=${runName}` : ''}&plan=${plan}`);
 };

--- a/e2e/designer/utils/GoToWorkflow.ts
+++ b/e2e/designer/utils/GoToWorkflow.ts
@@ -30,10 +30,10 @@ export const LoadRunFile = async (page: Page, runName: string) => {
   await page.getByRole('button', { name: 'Toolbox' }).click();
 };
 
-export const LoadDirect = async (page: Page, workflowName: string, runName?: string, plan = 'standard', isLocal = false) => {
-  if (isLocal) {
-    await page.goto(`/?localId=${workflowName}&localRunId=${runName}&plan=${plan}`);
-  } else {
-    await page.goto(`/?id=${workflowName}&runId=${runName}&plan=${plan}`);
-  }
+export const LoadMockDirect = async (page: Page, workflowName: string, runName?: string, plan = 'standard') => {
+  await page.goto(`/?localId=${workflowName}&localRunId=${runName}&plan=${plan}`);
+};
+
+export const LoadDirect = async (page: Page, workflowName: string, runName?: string, plan = 'standard') => {
+  await page.goto(`/?id=${workflowName}&runId=${runName}&plan=${plan}`);
 };

--- a/e2e/designer/variables/ensureInitializeVariable.spec.ts
+++ b/e2e/designer/variables/ensureInitializeVariable.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+import { LoadMockDirect } from '../utils/GoToWorkflow';
 import { getSerializedWorkflowFromState } from '../utils/designerFunctions';
 
 test(
@@ -8,8 +8,7 @@ test(
     tag: '@mock',
   },
   async ({ page }) => {
-    await page.goto('/');
-    await GoToMockWorkflow(page, 'Recurrence');
+    await LoadMockDirect(page, 'Recurrence.json');
     await page.getByLabel('Insert a new step after').click();
     await page.getByText('Add an action').click();
     await page.getByPlaceholder('Search for an action or').fill('initialize variable');

--- a/e2e/designer/workflowParametersPanel.spec.ts
+++ b/e2e/designer/workflowParametersPanel.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { LoadMockDirect } from './utils/GoToWorkflow';
 
 test.describe(
   'WorkflowParametersPanel Tests',
@@ -8,8 +8,7 @@ test.describe(
   },
   () => {
     test('Should open workflow parameters panel and add / edit / delete parameter', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Standard Workflow Parameters');
+      await LoadMockDirect(page, 'StandardWorkflowParameters.json');
 
       // Open workflow parameters panel
       await page.getByText('Workflow Parameters', { exact: true }).click();


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Can now load standalone designer from url search params.
- `plan` - Standard / Consumption
- `id` - Remote workflow id
- `runId` - Remote workflow run id
- `localId` - Local workflow id
- `localRunId` - Local workflow run id

The intention of this is to speed up workflow initialization during our automated testing to avoid waiting on all LA / workflow resources to load before the proper workflow can be selected.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: N/A
- **Developers**: Faster PR integration due to decreased E2E test durations
- **System**: Decreased E2E test suite durations

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A