### PR TITLE
feat(DesignerV2): Added global change count selector, isDraft designer option

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
@@ -578,6 +578,7 @@ const DesignerEditor = () => {
           isDarkMode,
           readOnly: isReadOnly || isMonitoringView || !isDraftMode,
           isMonitoringView,
+          isDraft: isDraftMode,
           isUnitTest,
           suppressDefaultNodeSelectFunctionality: suppressDefaultNodeSelect,
           hostOptions: {

--- a/libs/designer-v2/src/lib/core/index.ts
+++ b/libs/designer-v2/src/lib/core/index.ts
@@ -33,7 +33,7 @@ export {
   useIsWorkflowParametersDirty,
   useWorkflowParameterValidationErrors,
 } from './state/workflowparameters/workflowparametersselector';
-export { useIsDesignerDirty, resetDesignerDirtyState, resetTemplatesState } from './state/global';
+export { useIsDesignerDirty, useChangeCount, resetDesignerDirtyState, resetTemplatesState } from './state/global';
 export { useAllSettingsValidationErrors } from './state/setting/settingSelector';
 export { useAllConnectionErrors } from './state/operation/operationSelector';
 export {

--- a/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -32,6 +32,7 @@ type PANEL_TAB_NAMES = keyof typeof CONSTANTS.PANEL_TAB_NAMES;
 export interface DesignerOptionsState {
   readOnly?: boolean;
   isMonitoringView?: boolean;
+  isDraft?: boolean;
   isDarkMode?: boolean;
   isUnitTest?: boolean;
   isVSCode?: boolean;

--- a/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
@@ -15,6 +15,10 @@ export const useMonitoringView = () => {
   return useSelector((state: RootState) => state.designerOptions.isMonitoringView);
 };
 
+export const useIsDraft = () => {
+  return useSelector((state: RootState) => state.designerOptions.isDraft);
+};
+
 export const useUnitTest = () => {
   return useSelector((state: RootState) => state.designerOptions.isUnitTest);
 };

--- a/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -33,6 +33,7 @@ import CONSTANTS from '../../../common/constants';
 export const initialDesignerOptionsState: DesignerOptionsState = {
   readOnly: false,
   isMonitoringView: false,
+  isDraft: false,
   isUnitTest: false,
   isDarkMode: false,
   isVSCode: false,
@@ -158,6 +159,7 @@ export const designerOptionsSlice = createSlice({
     initDesignerOptions: (state: DesignerOptionsState, action: PayloadAction<Omit<DesignerOptionsState, 'servicesInitialized'>>) => {
       state.readOnly = action.payload.readOnly;
       state.isMonitoringView = action.payload.isMonitoringView;
+      state.isDraft = action.payload.isDraft;
       state.isUnitTest = action.payload.isUnitTest;
       state.isDarkMode = action.payload.isDarkMode;
       state.useLegacyWorkflowParameters = action.payload.useLegacyWorkflowParameters;

--- a/libs/designer-v2/src/lib/core/state/global.ts
+++ b/libs/designer-v2/src/lib/core/state/global.ts
@@ -1,11 +1,11 @@
 import { resetCustomCode } from './customcode/customcodeSlice';
-import { useIsWorkflowDirty } from './workflow/workflowSelectors';
+import { useIsWorkflowDirty, useWorkflowChangeCount } from './workflow/workflowSelectors';
 import { setIsWorkflowDirty } from './workflow/workflowSlice';
 import { setIsWorkflowParametersDirty } from './workflowparameters/workflowparametersSlice';
-import { useIsWorkflowParametersDirty } from './workflowparameters/workflowparametersselector';
+import { useIsWorkflowParametersDirty, useWorkflowParametersChangeCount } from './workflowparameters/workflowparametersselector';
 import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
 import type { UndoRedoPartialRootState } from './undoRedo/undoRedoTypes';
-import { useIsNotesDirty } from './notes/notesSelectors';
+import { useIsNotesDirty, useNotesChangeCount } from './notes/notesSelectors';
 import { resetNoteDirty } from './notes/notesSlice';
 
 export const resetWorkflowState = createAction('resetWorkflowState');
@@ -28,3 +28,10 @@ export const resetDesignerDirtyState = createAsyncThunk('resetDesignerDirtyState
   dispatch(resetCustomCode());
   dispatch(resetNoteDirty(false));
 });
+
+export const useChangeCount = () => {
+  const workflowChangeCount = useWorkflowChangeCount();
+  const workflowParametersChangeCount = useWorkflowParametersChangeCount();
+  const notesChangeCount = useNotesChangeCount();
+  return workflowChangeCount + workflowParametersChangeCount + notesChangeCount;
+};

--- a/libs/designer-v2/src/lib/core/state/notes/notesSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/notes/notesSelectors.ts
@@ -10,3 +10,5 @@ export const useNotes = () => useSelector(createSelector(getNotesState, (state: 
 export const useNote = (id: string) => useSelector(createSelector(getNotesState, (state: NotesState) => state.notes[id]));
 
 export const useIsNotesDirty = () => useSelector(createSelector(getNotesState, (state: NotesState) => state.isDirty));
+
+export const useNotesChangeCount = () => useSelector(createSelector(getNotesState, (state: NotesState) => state.changeCount));

--- a/libs/designer-v2/src/lib/core/state/notes/notesSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/notes/notesSlice.ts
@@ -10,11 +10,13 @@ import type { Note } from '../../../common/models/workflow';
 export interface NotesState {
   notes: Record<string, Note>;
   isDirty: boolean;
+  changeCount: number;
 }
 
 const initialState: NotesState = {
   notes: {},
   isDirty: false,
+  changeCount: 0,
 };
 
 const notesSlice = createSlice({
@@ -71,6 +73,7 @@ const notesSlice = createSlice({
     builder.addCase(setStateAfterUndoRedo, (_, action: PayloadAction<UndoRedoPartialRootState>) => action.payload.notes);
     builder.addMatcher(isAnyOf(addNote, updateNote, deleteNote), (state) => {
       state.isDirty = true;
+      state.changeCount += 1;
     });
   },
 });

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowInterfaces.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowInterfaces.ts
@@ -52,6 +52,7 @@ export interface WorkflowState {
   newlyAddedOperations: Record<string, string>;
   runInstance: LogicAppsV2.RunInstanceDefinition | null;
   isDirty: boolean;
+  changeCount: number;
   workflowKind: WorkflowKind;
   originalDefinition: LogicAppsV2.WorkflowDefinition;
   hostData: {

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
@@ -48,6 +48,8 @@ export const useFocusElement = () => useSelector(createSelector(getWorkflowState
 
 export const useIsWorkflowDirty = () => useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.isDirty));
 
+export const useWorkflowChangeCount = () => useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.changeCount));
+
 export const useTimelineRepetitionIndex = () =>
   useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.timelineRepetitionIndex));
 

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
@@ -64,6 +64,7 @@ export const initialWorkflowState: WorkflowState = {
   idReplacements: {},
   newlyAddedOperations: {},
   isDirty: false,
+  changeCount: 0,
   originalDefinition: {
     $schema: constants.SCHEMA.GA_20160601.URL,
     contentVersion: '1.0.0.0',
@@ -725,6 +726,9 @@ export const workflowSlice = createSlice({
     },
     setIsWorkflowDirty: (state: WorkflowState, action: PayloadAction<boolean>) => {
       state.isDirty = action.payload;
+      if (action.payload) {
+        state.changeCount += 1;
+      }
     },
     setHostErrorMessages: (state, action: PayloadAction<{ level: MessageLevel; errorMessages: ErrorMessage[] | undefined }>) => {
       if (!action.payload.errorMessages) {
@@ -747,7 +751,10 @@ export const workflowSlice = createSlice({
       state.nodesMetadata = deserializedWorkflow.nodesMetadata;
     });
     builder.addCase(updateNodeParameters, (state, action) => {
-      state.isDirty = state.isDirty || action.payload.isUserAction || false;
+      if (action.payload.isUserAction) {
+        state.isDirty = true;
+        state.changeCount += 1;
+      }
     });
     builder.addCase(resetWorkflowState, () => initialWorkflowState);
     builder.addCase(initializeInputsOutputsBinding.fulfilled, (state, action) => {
@@ -768,6 +775,7 @@ export const workflowSlice = createSlice({
       const { ignoreDirty = false } = action.payload;
       if (!ignoreDirty) {
         state.isDirty = true;
+        state.changeCount += 1;
       }
     });
     builder.addMatcher(
@@ -791,6 +799,7 @@ export const workflowSlice = createSlice({
       ),
       (state) => {
         state.isDirty = true;
+        state.changeCount += 1;
       }
     );
   },

--- a/libs/designer-v2/src/lib/core/state/workflowparameters/workflowparametersSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/workflowparameters/workflowparametersSlice.ts
@@ -17,12 +17,14 @@ export interface WorkflowParametersState {
   definitions: Record<string, WorkflowParameterDefinition>;
   validationErrors: Record<string, Record<string, string | undefined>>;
   isDirty: boolean;
+  changeCount: number;
 }
 
 export const initialState: WorkflowParametersState = {
   definitions: {},
   validationErrors: {},
   isDirty: false,
+  changeCount: 0,
 };
 
 export const validateParameter = (
@@ -96,12 +98,14 @@ export const workflowParametersSlice = createSlice({
         name: '',
       };
       state.isDirty = true;
+      state.changeCount += 1;
     },
     deleteParameter: (state, action: PayloadAction<string>) => {
       const parameterId = action.payload;
       delete state.validationErrors[parameterId];
       delete state.definitions[parameterId];
       state.isDirty = true;
+      state.changeCount += 1;
     },
     updateParameter: (state, action: PayloadAction<WorkflowParameterUpdateEvent>) => {
       const {
@@ -145,9 +149,13 @@ export const workflowParametersSlice = createSlice({
         state.validationErrors[id] = newErrorObj;
       }
       state.isDirty = true;
+      state.changeCount += 1;
     },
     setIsWorkflowParametersDirty: (state, action: PayloadAction<boolean>) => {
       state.isDirty = action.payload;
+      if (action.payload) {
+        state.changeCount += 1;
+      }
     },
   },
   extraReducers: (builder) => {

--- a/libs/designer-v2/src/lib/core/state/workflowparameters/workflowparametersselector.ts
+++ b/libs/designer-v2/src/lib/core/state/workflowparameters/workflowparametersselector.ts
@@ -13,3 +13,6 @@ export const useWorkflowParameterValidationErrors = () =>
 
 export const useIsWorkflowParametersDirty = () =>
   useSelector(createSelector(getWorkflowParametersState, (state: WorkflowParametersState) => state.isDirty));
+
+export const useWorkflowParametersChangeCount = () =>
+  useSelector(createSelector(getWorkflowParametersState, (state: WorkflowParametersState) => state.changeCount));


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Added global change count selector, this is incremented each time the dirty flag would be set.
Added `isDraft` designer option.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: N/A
- **Developers**: Adds a change count selector for use with autosaving
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97 

## Screenshots/Videos
<!-- Visual changes only -->
N/A