### PR TITLE
fix(mcp): Add back the logic for detecting mcp client tool

### DIFF
--- a/libs/designer/src/lib/common/hooks/__test__/agent.spec.tsx
+++ b/libs/designer/src/lib/common/hooks/__test__/agent.spec.tsx
@@ -60,15 +60,9 @@ describe('useIsAgentSubGraph', () => {
   test('should return true for a mcp client node', () => {
     const nodesMetadata: NodesMetadata = {
       'mcp-tool-1': {
-        graphId: 'agent-tool-1',
-        parentNodeId: 'agent-tool-1',
-        subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
-        actionCount: 0,
-      },
-      'agent-tool-1': {
         graphId: 'agent1',
         parentNodeId: 'agent1',
-        subgraphType: SUBGRAPH_TYPES.AGENT_CONDITION,
+        subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
         actionCount: 0,
       },
       'agent1': {

--- a/libs/designer/src/lib/common/hooks/agent.ts
+++ b/libs/designer/src/lib/common/hooks/agent.ts
@@ -23,7 +23,14 @@ export function isAgentSubgraphFromMetadata(nodeId?: string, nodesMetadata?: Nod
     return false;
   }
 
-  let nodeGraphId = getRecordEntry(nodesMetadata, nodeId)?.graphId;
+  const metadata = getRecordEntry(nodesMetadata, nodeId);
+  // Check if the node itself is an MCP client tool since there's no parent AGENT_CONDITION node for them
+  const isMcpClientTool = metadata?.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT;
+  if (isMcpClientTool) {
+    return true;
+  }
+
+  let nodeGraphId = metadata?.graphId;
   while (nodeId && nodeGraphId) {
     const nodeMetadata = getRecordEntry(nodesMetadata, nodeGraphId);
     if (!nodeMetadata) {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
The logic for detecting mcp client tool was removed by mistake. This PR adds back that logic

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
User will be able to create OBO connections correctly now.
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: <!-- environments/scenarios --> local env

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
