### PR TITLE
fix(designer): Change Agent Title and Remove Handoff Agent in Recommendation Panel

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/operations/agent.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/operations/agent.ts
@@ -15,7 +15,7 @@ export const agentOperation = {
       displayName: 'Agent',
       iconUri,
     },
-    summary: 'Agent',
+    summary: 'Agent Loop',
     description:
       'Loop in which the AI agent decides at each step which tools to use and how, and which text to generate to respond to the user.',
     visibility: 'Important',

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/search.ts
@@ -455,7 +455,6 @@ export function getClientBuiltInOperations(
     ClientOperationsData.untilOperation,
     ClientOperationsData.switchOperation,
     ClientOperationsData.agentOperation,
-    ClientOperationsData.handoffOperation,
     ClientOperationsData.recurrenceOperation,
     ClientOperationsData.delayOperation,
     ClientOperationsData.delayUntilOperation,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Slight title change
Also handoff agents were being enabled for non-"agent" workflows and they wouldn't work adding from the recommendation panel regardless as `Add an action` is disabled below an agent action where handoff agents can actually be used.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fix a bug where users can add an errored `Handoff Agent`. Small text change.
- **Developers**: No dev changes
- **System**: No system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@eric-b-wu

## Screenshots/Videos
<!-- Visual changes only -->
