### PR TITLE
fix(designer): Pass sorting as an optional parameter to Combobox

### DIFF
--- a/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
+++ b/libs/designer-ui/src/lib/settings/settingsection/settingTokenField.tsx
@@ -322,6 +322,7 @@ export const TokenField = ({
           onMenuOpen={onComboboxMenuOpen}
           multiSelect={getPropertyValue(editorOptions, 'multiSelect')}
           serialization={editorOptions?.serialization}
+          shouldSort={editorOptions?.shouldSort}
           dataAutomationId={`msla-setting-token-editor-combobox-${labelForAutomationId}`}
           tokenMapping={tokenMapping}
           loadParameterValueFromString={loadParameterValueFromString}


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
We had this combobox option to prevent sorting, but never passed it back so the backend couldn't actually prevent sorting.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Combobox options can now be prevented from sorting
- **Developers**: small change to allow/prevent sorting on the combobox editor
- **System**: no system changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@eric-b-wu

## Screenshots/Videos
<!-- Visual changes only -->
