### PR TITLE
fix(vscode): Remove error message when no custom code projects found

### DIFF
--- a/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
+++ b/apps/vs-code-designer/src/app/commands/buildCustomCodeFunctionsProject.ts
@@ -15,21 +15,17 @@ import * as vscode from 'vscode';
 import { isNullOrUndefined } from '@microsoft/logic-apps-shared';
 
 /**
- * Builds a custom code functions project.
+ * Builds a custom code functions project if exists.
  * @param {IActionContext} context - The action context.
  * @param {vscode.Uri} node - The URI of the project to build or the corresponding logic app project.
- * @returns {Promise<void>} - A promise that resolves when the build process is complete.
+ * @returns {Promise<boolean>} - A promise that resolves to true if a custom code functions project was built, otherwise false.
  */
-export async function buildCustomCodeFunctionsProject(context: IActionContext, node: vscode.Uri): Promise<void> {
+export async function tryBuildCustomCodeFunctionsProject(context: IActionContext, node: vscode.Uri): Promise<boolean> {
   const workspaceFolderPath = await getWorkspaceRoot(context);
 
   const nodePath = node?.fsPath || workspaceFolderPath;
   if (isNullOrUndefined(nodePath)) {
-    const errorMessage = 'No project path found to build custom code functions project.';
-    context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.errorMessage = errorMessage;
-    ext.outputChannel.appendLog(localize('noProjectPathBuildCustomCode', errorMessage));
-    return;
+    return false;
   }
 
   context.telemetry.properties.lastStep = 'isCustomCodeFunctionsProject';
@@ -37,31 +33,33 @@ export async function buildCustomCodeFunctionsProject(context: IActionContext, n
     try {
       context.telemetry.properties.lastStep = 'buildCustomCodeProject';
       await buildCustomCodeProject(nodePath);
-      context.telemetry.properties.result = 'Succeeded';
     } catch (error) {
-      context.telemetry.properties.result = 'Failed';
       context.telemetry.properties.errorMessage = error.message ?? error;
+      return false;
     }
-    return;
+    return true;
   }
 
   context.telemetry.properties.lastStep = 'tryGetLogicAppCustomCodeFunctionsProjects';
   const customCodeProjectPaths = await tryGetLogicAppCustomCodeFunctionsProjects(nodePath);
   if (!customCodeProjectPaths || customCodeProjectPaths.length === 0) {
-    const errorMessage = 'No custom code functions projects found for the logic app folder "{0}".';
-    context.telemetry.properties.result = 'Failed';
-    context.telemetry.properties.errorMessage = errorMessage.replace('{0}', nodePath);
-    ext.outputChannel.appendLog(localize('azureLogicAppsStandard.noCustomCodeFunctionsProjectsFound', errorMessage, nodePath));
-    return;
+    return false;
   }
 
   try {
     context.telemetry.properties.lastStep = 'buildLogicAppCustomCodeProjects';
     await Promise.all(customCodeProjectPaths.map((functionsProjectPath) => buildCustomCodeProject(functionsProjectPath)));
-    context.telemetry.properties.result = 'Succeeded';
+    return true;
   } catch (error) {
-    context.telemetry.properties.result = 'Failed';
     context.telemetry.properties.errorMessage = error.message ?? error;
+    ext.outputChannel.appendLog(
+      localize(
+        'azureLogicAppsStandard.buildCustomCodeFunctionsProjectError',
+        'Error building custom code functions projects: {0}',
+        error.message ?? error
+      )
+    );
+    return false;
   }
 }
 

--- a/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
@@ -57,7 +57,7 @@ import { deployHybridLogicApp, zipDeployHybridLogicApp } from './hybridLogicApp'
 import { createContainerClient } from '../../utils/azureClients';
 import { uploadAppSettings } from '../appSettings/uploadAppSettings';
 import { isNullOrUndefined, resolveConnectionsReferences } from '@microsoft/logic-apps-shared';
-import { buildCustomCodeFunctionsProject } from '../buildCustomCodeFunctionsProject';
+import { tryBuildCustomCodeFunctionsProject } from '../buildCustomCodeFunctionsProject';
 
 export async function deployProductionSlot(
   context: IActionContext,
@@ -92,7 +92,7 @@ async function deploy(
   if (!isNullOrUndefined(workspaceFolder)) {
     const logicAppNode = workspaceFolder.uri;
     if (!(await fse.pathExists(path.join(logicAppNode.fsPath, libDirectory, 'custom')))) {
-      await buildCustomCodeFunctionsProject(actionContext, logicAppNode);
+      await tryBuildCustomCodeFunctionsProject(actionContext, logicAppNode);
     }
   }
 

--- a/apps/vs-code-designer/src/app/commands/pickFuncProcess.ts
+++ b/apps/vs-code-designer/src/app/commands/pickFuncProcess.ts
@@ -31,7 +31,7 @@ import { Platform, ProjectLanguage, type IProcessInfo } from '@microsoft/vscode-
 import unixPsTree from 'ps-tree';
 import * as vscode from 'vscode';
 import parser from 'yargs-parser';
-import { buildCustomCodeFunctionsProject } from './buildCustomCodeFunctionsProject';
+import { tryBuildCustomCodeFunctionsProject } from './buildCustomCodeFunctionsProject';
 import { getProjFiles } from '../utils/dotnet/dotnet';
 import { delay } from '../utils/delay';
 
@@ -86,7 +86,7 @@ export async function pickFuncProcessInternal(
     throw new UserCancelledError('preDebugValidate');
   }
 
-  await buildCustomCodeFunctionsProject(context, workspaceFolder.uri);
+  await tryBuildCustomCodeFunctionsProject(context, workspaceFolder.uri);
 
   await waitForPrevFuncTaskToStop(workspaceFolder);
   const projectFiles = await getProjFiles(context, ProjectLanguage.CSharp, projectPath);

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -14,7 +14,7 @@ import { uploadAppSettings } from './appSettings/uploadAppSettings';
 import { disableValidateAndInstallBinaries, resetValidateAndInstallBinaries } from './binaries/resetValidateAndInstallBinaries';
 import { validateAndInstallBinaries } from './binaries/validateAndInstallBinaries';
 import { browseWebsite } from './browseWebsite';
-import { buildCustomCodeFunctionsProject } from './buildCustomCodeFunctionsProject';
+import { tryBuildCustomCodeFunctionsProject } from './buildCustomCodeFunctionsProject';
 import { configureDeploymentSource } from './configureDeploymentSource';
 import { createChildNode } from './createChildNode';
 import { createLogicApp, createLogicAppAdvanced } from './createLogicApp/createLogicApp';
@@ -162,7 +162,7 @@ export function registerCommands(): void {
   registerCommand(extensionCommand.createNewDataMap, (context: IActionContext) => createNewDataMapCmd(context));
   registerCommand(extensionCommand.loadDataMapFile, (context: IActionContext, uri: Uri) => loadDataMapFileCmd(context, uri));
   // Custom code commands
-  registerCommandWithTreeNodeUnwrapping(extensionCommand.buildCustomCodeFunctionsProject, buildCustomCodeFunctionsProject);
+  registerCommandWithTreeNodeUnwrapping(extensionCommand.buildCustomCodeFunctionsProject, tryBuildCustomCodeFunctionsProject);
   registerCommand(extensionCommand.createCustomCodeFunction, createCustomCodeFunction);
   registerCommand(extensionCommand.debugLogicApp, debugLogicApp);
   registerCommand(extensionCommand.switchToDataMapperV2, switchToDataMapperV2);

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesigner.ts
@@ -9,7 +9,7 @@ import type { IAzureConnectorsContext } from '../azureConnectorWizard';
 import { OpenDesignerForAzureResource } from './openDesignerForAzureResource';
 import OpenDesignerForLocalProject from './openDesignerForLocalProject';
 import { Uri } from 'vscode';
-import { buildCustomCodeFunctionsProject } from '../../buildCustomCodeFunctionsProject';
+import { tryBuildCustomCodeFunctionsProject } from '../../buildCustomCodeFunctionsProject';
 import { customCodeArtifactsExist } from '../../../utils/customCodeUtils';
 
 export async function openDesigner(context: IAzureConnectorsContext, node: Uri | RemoteWorkflowTreeItem | undefined): Promise<void> {
@@ -21,7 +21,7 @@ export async function openDesigner(context: IAzureConnectorsContext, node: Uri |
     const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
     // Only build custom code projects on open designer if custom code binaries don't already exist in the logic app folder
     if (!(await customCodeArtifactsExist(logicAppNode.fsPath))) {
-      await buildCustomCodeFunctionsProject(context, logicAppNode);
+      await tryBuildCustomCodeFunctionsProject(context, logicAppNode);
     }
 
     openDesignerObj = new OpenDesignerForLocalProject(context, workflowNode);


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Remove error message logging/telemetry when no custom code projects found during pre-startup/deploy build. The tryBuildCustomCodeFunctionsProject is always called, including for non-custom code projects, so it doesn't make sense to log an error here.

## Impact of Change
- **Users**: Removes unnecessary custom code console logs for non-custom code projects
- **Developers**: Removes invalid errors from telemetry
- **System**: N/A

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge 

