### PR TITLE
chore(designer): Remove ParseWithMetadata filter exp flag

### DIFF
--- a/libs/designer-v2/src/lib/ui/panel/recommendation/SearchOpeationsService.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/SearchOpeationsService.tsx
@@ -2,10 +2,7 @@ import type { DiscoveryOpArray, DiscoveryOperation, DiscoveryResultTypes } from 
 import Fuse from 'fuse.js';
 
 export class DefaultSearchOperationsService {
-  constructor(
-    private allOperations: DiscoveryOpArray,
-    private showParseDocWithMetadata: boolean
-  ) {}
+  constructor(private allOperations: DiscoveryOpArray) {}
 
   // Comparison function for sorting Fuse results
   private compareItems(
@@ -59,11 +56,6 @@ export class DefaultSearchOperationsService {
 
     const filterItems = (result: Fuse.FuseResult<DiscoveryOperation<DiscoveryResultTypes>>): boolean => {
       const { item } = result;
-
-      // Skip if document with metadata should not be shown
-      if (!this.showParseDocWithMetadata && item.id === 'parsedocumentwithmetadata') {
-        return false;
-      }
 
       // Apply any additional filter provided
       return additionalFilter ? additionalFilter(item) : true;

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/details/connectorDetailsView.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/details/connectorDetailsView.tsx
@@ -6,7 +6,6 @@ import { isNullOrUndefined, type Connector } from '@microsoft/logic-apps-shared'
 import { useDiscoveryPanelIsAddingTrigger, useIsAddingAgentTool } from '../../../../core/state/panel/panelSelectors';
 import { useIsWithinAgenticLoop } from '../../../../core/state/workflow/workflowSelectors';
 import { useOperationsByConnector } from '../../../../core/queries/browse';
-import { useShouldEnableParseDocumentWithMetadata } from '../hooks';
 import constants from '../../../../common/constants';
 import { useConnectorDetailsViewStyles } from './styles/ConnectorDetailsView.styles';
 import { OperationsAccordion } from './operationsAccordion';
@@ -20,7 +19,6 @@ export const ConnectorDetailsView = ({ connector, onOperationClick }: ConnectorD
   const classes = useConnectorDetailsViewStyles();
   const isTrigger = useDiscoveryPanelIsAddingTrigger();
   const isAgentTool = useIsAddingAgentTool();
-  const shouldEnableParseDocWithMetadata = useShouldEnableParseDocumentWithMetadata();
 
   // Fetch operations for this connector
   const connectorId = connector?.id || '';
@@ -55,13 +53,9 @@ export const ConnectorDetailsView = ({ connector, onOperationClick }: ConnectorD
           }
         }
 
-        if (shouldEnableParseDocWithMetadata === false && data.id === 'parsedocumentwithmetadata') {
-          return false;
-        }
-
         return true;
       },
-    [isAgentTool, isRoot, isWithinAgenticLoop, shouldEnableParseDocWithMetadata]
+    [isAgentTool, isRoot, isWithinAgenticLoop]
   );
 
   const allOperations: OperationActionData[] = useMemo(() => {

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/hooks.ts
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/hooks.ts
@@ -1,23 +1,9 @@
-import { enableParseDocumentWithMetadata, LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
+import { LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
 import { useDiscoveryPanelFavoriteOperations } from '../../../core/state/panel/panelSelectors';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import type { AppDispatch } from '../../../core';
 import { setFavoriteOperations } from '../../../core/state/panel/panelSlice';
-
-export function useShouldEnableParseDocumentWithMetadata(): boolean | null {
-  const [enabled, setEnabled] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    const check = async () => {
-      const result = await enableParseDocumentWithMetadata();
-      setEnabled(result);
-    };
-    check();
-  }, []);
-
-  return enabled;
-}
 
 export const useOnFavoriteClick = () => {
   const favorites = useDiscoveryPanelFavoriteOperations();

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/searchView.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/searchView.tsx
@@ -9,7 +9,6 @@ import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useDiscoveryPanelRelationshipIds, useIsAddingAgentTool } from '../../../core/state/panel/panelSelectors';
 import { useIsA2AWorkflow, useIsAgenticWorkflow } from '../../../core/state/designerView/designerViewSelectors';
-import { useShouldEnableParseDocumentWithMetadata } from './hooks';
 import { DefaultSearchOperationsService } from './SearchOpeationsService';
 import constants from '../../../common/constants';
 import { ALLOWED_A2A_CONNECTOR_NAMES } from './helpers';
@@ -35,7 +34,6 @@ export const SearchView: FC<SearchViewProps> = ({
   displayRuntimeInfo,
 }) => {
   const isAgenticWorkflow = useIsAgenticWorkflow();
-  const shouldEnableParseDocWithMetadata = useShouldEnableParseDocumentWithMetadata();
   const parentGraphId = useDiscoveryPanelRelationshipIds().graphId;
   const isWithinAgenticLoop = useIsWithinAgenticLoop(parentGraphId);
   const isAgentTool = useIsAddingAgentTool();
@@ -128,17 +126,14 @@ export const SearchView: FC<SearchViewProps> = ({
 
   useDebouncedEffect(
     () => {
-      const searchResultsPromise = new DefaultSearchOperationsService(
-        allOperations,
-        shouldEnableParseDocWithMetadata ?? false
-      ).searchOperations(searchTerm, filterAgenticLoops);
+      const searchResultsPromise = new DefaultSearchOperationsService(allOperations).searchOperations(searchTerm, filterAgenticLoops);
 
       searchResultsPromise.then((results) => {
         setSearchResults(results);
         setIsLoadingSearchResults(false);
       });
     },
-    [searchTerm, allOperations, filterAgenticLoops, shouldEnableParseDocWithMetadata],
+    [searchTerm, allOperations, filterAgenticLoops],
     200
   );
 

--- a/libs/designer/src/lib/ui/panel/recommendation/SearchOpeationsService.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/SearchOpeationsService.tsx
@@ -3,10 +3,7 @@ import { isBuiltInConnector, isCustomConnector } from '@microsoft/designer-ui';
 import Fuse from 'fuse.js';
 
 export class DefaultSearchOperationsService {
-  constructor(
-    private allOperations: DiscoveryOpArray,
-    private showParseDocWithMetadata: boolean
-  ) {}
+  constructor(private allOperations: DiscoveryOpArray) {}
 
   // Comparison function for sorting Fuse results
   private compareItems(
@@ -63,11 +60,6 @@ export class DefaultSearchOperationsService {
     const filterItems = (result: Fuse.FuseResult<DiscoveryOperation<DiscoveryResultTypes>>): boolean => {
       const { item } = result;
       const { api } = item.properties;
-
-      // Skip if document with metadata should not be shown
-      if (!this.showParseDocWithMetadata && item.id === 'parsedocumentwithmetadata') {
-        return false;
-      }
 
       // Apply runtime filters
       if (runtimeFilter) {

--- a/libs/designer/src/lib/ui/panel/recommendation/hooks.ts
+++ b/libs/designer/src/lib/ui/panel/recommendation/hooks.ts
@@ -1,23 +1,9 @@
-import { enableParseDocumentWithMetadata, LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
+import { LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
 import { useDiscoveryPanelFavoriteOperations } from '../../../core/state/panel/panelSelectors';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import type { AppDispatch } from '../../../core';
 import { setFavoriteOperations } from '../../../core/state/panel/panelSlice';
-
-export function useShouldEnableParseDocumentWithMetadata(): boolean | null {
-  const [enabled, setEnabled] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    const check = async () => {
-      const result = await enableParseDocumentWithMetadata();
-      setEnabled(result);
-    };
-    check();
-  }, []);
-
-  return enabled;
-}
 
 export const useOnFavoriteClick = () => {
   const favorites = useDiscoveryPanelFavoriteOperations();

--- a/libs/designer/src/lib/ui/panel/recommendation/operationGroupDetailView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/operationGroupDetailView.tsx
@@ -1,13 +1,12 @@
 import type { OperationActionData } from '@microsoft/designer-ui';
 import { OperationActionDataFromOperation, OperationGroupDetailsPage } from '@microsoft/designer-ui';
-import { parsedocumentwithmetadata, type Connector, type DiscoveryOpArray } from '@microsoft/logic-apps-shared';
+import type { Connector, DiscoveryOpArray } from '@microsoft/logic-apps-shared';
 import { useCallback, useMemo } from 'react';
 import { useDiscoveryPanelRelationshipIds, useIsAddingAgentTool } from '../../../core/state/panel/panelSelectors';
 import { useIsWithinAgenticLoop } from '../../../core/state/workflow/workflowSelectors';
 import { useDispatch } from 'react-redux';
 import { addConnectorAsOperation, type AppDispatch } from '../../../core';
 import { selectOperationGroupId } from '../../../core/state/panel/panelSlice';
-import { useShouldEnableParseDocumentWithMetadata } from './hooks';
 import constants from '../../../common/constants';
 
 type OperationGroupDetailViewProps = {
@@ -26,7 +25,6 @@ export const OperationGroupDetailView = (props: OperationGroupDetailViewProps) =
   const isRoot = useMemo(() => graphId === 'root', [graphId]);
   const isWithinAgenticLoop = useIsWithinAgenticLoop(graphId);
   const isAgentTool = useIsAddingAgentTool();
-  const shouldEnableParseDocWithMetadata = useShouldEnableParseDocumentWithMetadata();
 
   const dispatch = useDispatch<AppDispatch>();
 
@@ -53,17 +51,13 @@ export const OperationGroupDetailView = (props: OperationGroupDetailViewProps) =
         }
       }
 
-      if (shouldEnableParseDocWithMetadata === false && data.id === parsedocumentwithmetadata.id) {
-        return false;
-      }
-
       return (
         !filters?.['actionType'] ||
         (filters?.['actionType'] === 'actions' && (!data.isTrigger || ignoreActionsFilter)) ||
         (filters?.['actionType'] === 'triggers' && data.isTrigger)
       );
     },
-    [filters, ignoreActionsFilter, isAgentTool, isRoot, isWithinAgenticLoop, shouldEnableParseDocWithMetadata]
+    [filters, ignoreActionsFilter, isAgentTool, isRoot, isWithinAgenticLoop]
   );
 
   const operationGroupActions: OperationActionData[] = groupOperations

--- a/libs/designer/src/lib/ui/panel/recommendation/searchView.tsx
+++ b/libs/designer/src/lib/ui/panel/recommendation/searchView.tsx
@@ -9,7 +9,6 @@ import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useDiscoveryPanelRelationshipIds, useIsAddingAgentTool } from '../../../core/state/panel/panelSelectors';
 import { useIsA2AWorkflow, useIsAgenticWorkflow } from '../../../core/state/designerView/designerViewSelectors';
-import { useShouldEnableParseDocumentWithMetadata } from './hooks';
 import { DefaultSearchOperationsService } from './SearchOpeationsService';
 import constants from '../../../common/constants';
 import { ALLOWED_A2A_CONNECTOR_NAMES } from './helpers';
@@ -41,7 +40,6 @@ export const SearchView: FC<SearchViewProps> = ({
   isAddingMcpServer,
 }) => {
   const isAgenticWorkflow = useIsAgenticWorkflow();
-  const shouldEnableParseDocWithMetadata = useShouldEnableParseDocumentWithMetadata();
   const parentGraphId = useDiscoveryPanelRelationshipIds().graphId;
   const isWithinAgenticLoop = useIsWithinAgenticLoop(parentGraphId);
   const isAgentTool = useIsAddingAgentTool();
@@ -133,17 +131,19 @@ export const SearchView: FC<SearchViewProps> = ({
 
   useDebouncedEffect(
     () => {
-      const searchResultsPromise = new DefaultSearchOperationsService(
-        allOperations,
-        shouldEnableParseDocWithMetadata ?? false
-      ).searchOperations(searchTerm, filters['actionType'], filters['runtime'], filterAgenticLoops);
+      const searchResultsPromise = new DefaultSearchOperationsService(allOperations).searchOperations(
+        searchTerm,
+        filters['actionType'],
+        filters['runtime'],
+        filterAgenticLoops
+      );
 
       searchResultsPromise.then((results) => {
         setSearchResults(results);
         setIsLoadingSearchResults(false);
       });
     },
-    [searchTerm, allOperations, filters, filterAgenticLoops, shouldEnableParseDocWithMetadata, isAddingMcpServer],
+    [searchTerm, allOperations, filters, filterAgenticLoops, isAddingMcpServer],
     200
   );
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/experimentationFlags.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/experimentationFlags.ts
@@ -1,13 +1,8 @@
 import { ExperimentationService } from './experimentation';
 
 export const EXP_FLAGS = {
-  ENABLE_PARSE_DOCUMENT_WITH_METADATA: 'enable-parse-document-with-metadata',
   ENABLE_APIM_GEN_AI_GATEWAY: 'enable-apim-gen-ai-gateway',
 };
-
-export async function enableParseDocumentWithMetadata(): Promise<boolean> {
-  return ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_PARSE_DOCUMENT_WITH_METADATA);
-}
 
 export async function enableAPIMGatewayConnection(): Promise<boolean> {
   return ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_APIM_GEN_AI_GATEWAY);


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Removing ParseWithMetadata Experiment Flags

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No longer needing an experiment flag for parseWithMetadata
- **Developers**: No no longer a check for enableParseDocumentWithMetadata
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@eric-b-wu

## Screenshots/Videos
<!-- Visual changes only -->
