### PR TITLE
feat(designer): Add new chunk text encoding models

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/chunktext.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/chunktext.ts
@@ -52,7 +52,7 @@ export const chunkTextManifest = {
               },
               {
                 value: 'cl200k_base',
-                displayName: 'cl200k_base (gpt-4.1, gpt-4o, gpt-5, gpt-5-mini, gpt-5-pro, gpt-5-thinking, etc.)',
+                displayName: 'cl200k_base (gpt-4.1, gpt-4o, gpt-5, gpt-5-mini, gpt-5-pro, gpt-5-thinking, gpt-5-)',
               },
               {
                 value: 'o200k_harmony',


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [X] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [X] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Add new text encoding models and update the default encoding to cl200k_base. This aligns our default with the newer encoder used by gpt-4.1/gpt-4o and ensures better tokenization coverage for chunking. Also add o200k_harmony as an available option for OSS/harmony models.

## Impact of Change
<!-- Who/what is affected? -->
- Users: e.g. "No visible UI changes. Default chunking encoding changed to cl200k_base which may change token counts used for chunking; users should not notice functional changes but chunk sizes/metadata may change slightly."
- Developers: e.g. "Default encoding updated to cl200k_base. Ensure services that depend on token counts for chunking/pagination are aware; add a note in the API usage docs if consumers rely on the previous tokenization behavior. Added o200k_harmony as an option for OSS/harmony models."
- System: e.g. "No expected performance impact; tokenization behavior changed, so batch sizes or storage for chunks may need review in edge cases."

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
