### PR TITLE
fix(designer): Preserve editor options for dynamic list parameter

### DIFF
--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/initialize.spec.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/initialize.spec.ts
@@ -140,5 +140,68 @@ describe('bjsworkflow initialize', () => {
       expect(inputParameters.inputs.parameterGroups.default.parameters.length).toBe(1);
       expect(inputParameters.inputs.parameterGroups.default.parameters[0].value[0].value).toBe('');
     });
+
+    test('should preserve multiSelect editorOptions for array parameters with dynamic list', () => {
+      const mockMultiSelectManifest: any = {
+        properties: {
+          description: 'Test MCP manifest',
+          summary: 'Test MCP',
+          iconUri: 'test.png',
+          brandColor: '#000000',
+          inputs: {
+            type: 'object',
+            properties: {
+              allowedTools: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+                title: 'Allowed tools',
+                'x-ms-editor': 'combobox',
+                'x-ms-editor-options': {
+                  multiSelect: true,
+                  titleSeparator: ',',
+                  serialization: {
+                    valueType: 'array',
+                  },
+                },
+                'x-ms-dynamic-list': {
+                  dynamicState: {
+                    apiType: 'mcp',
+                    operationId: 'listMcpTools',
+                  },
+                },
+              },
+            },
+          },
+          inputsLocation: ['inputs', 'parameters'],
+        },
+      };
+
+      const stepDefinition = {
+        type: 'McpClientTool',
+        inputs: {
+          parameters: {},
+        },
+      };
+
+      const inputParameters = initialize.getInputParametersFromManifest(
+        'test_node',
+        { type: 'McpClientTool', operationId: 'test', connectorId: 'test' },
+        mockMultiSelectManifest,
+        undefined,
+        undefined,
+        stepDefinition
+      );
+
+      const allowedToolsParam = inputParameters.inputs.parameterGroups.default.parameters.find(
+        (p: ParameterInfo) => p.parameterName === 'allowedTools'
+      );
+
+      expect(allowedToolsParam).toBeDefined();
+      expect(allowedToolsParam?.editor).toBe('combobox');
+      expect(allowedToolsParam?.editorOptions?.multiSelect).toBe(true);
+      expect(allowedToolsParam?.editorOptions?.serialization).toEqual({ valueType: 'array' });
+    });
   });
 });

--- a/libs/designer-v2/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer-v2/src/lib/core/utils/parameters/helper.ts
@@ -1882,12 +1882,14 @@ export const updateParameterAndDependencies = createAsyncThunk(
             });
             continue;
           }
+          // Preserve existing editorOptions (like multiSelect, serialization) when resetting options
+          const existingEditorOptions = dependentParameter.editorOptions ?? {};
           payload.parameters.push({
             groupId,
             parameterId: dependentParameter.id,
             propertiesToUpdate: {
               dynamicData: { status: DynamicLoadStatus.NOTSTARTED },
-              editorOptions: { options: [] },
+              editorOptions: { ...existingEditorOptions, options: [] },
             },
           });
         }
@@ -2476,9 +2478,12 @@ export async function loadDynamicValuesForParameter(
     return;
   }
 
+  // Preserve existing editorOptions (like multiSelect, serialization) when updating options
+  const existingEditorOptions = parameter.editorOptions ?? {};
+
   let propertiesToUpdate: any = {
     dynamicData: { status: DynamicLoadStatus.LOADING },
-    editorOptions: { options: [] },
+    editorOptions: { ...existingEditorOptions, options: [] },
   };
 
   dispatch(
@@ -2500,7 +2505,7 @@ export async function loadDynamicValuesForParameter(
 
     propertiesToUpdate = {
       dynamicData: { status: DynamicLoadStatus.SUCCEEDED },
-      editorOptions: { options: dynamicValues },
+      editorOptions: { ...existingEditorOptions, options: dynamicValues },
     };
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);
@@ -2551,9 +2556,12 @@ export async function fetchDynamicValuesForParameter(
     return;
   }
 
+  // Preserve existing editorOptions (like multiSelect, serialization) when updating options
+  const existingEditorOptions = parameter.editorOptions ?? {};
+
   let propertiesToUpdate: any = {
     dynamicData: { status: DynamicLoadStatus.LOADING },
-    editorOptions: { options: [] },
+    editorOptions: { ...existingEditorOptions, options: [] },
   };
 
   // Send the initial status update to the store
@@ -2576,7 +2584,7 @@ export async function fetchDynamicValuesForParameter(
 
     propertiesToUpdate = {
       dynamicData: { status: DynamicLoadStatus.SUCCEEDED },
-      editorOptions: { options: dynamicValues },
+      editorOptions: { ...existingEditorOptions, options: dynamicValues },
     };
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -1882,12 +1882,14 @@ export const updateParameterAndDependencies = createAsyncThunk(
             });
             continue;
           }
+          // Preserve existing editorOptions (like multiSelect, serialization) when resetting options
+          const existingEditorOptions = dependentParameter.editorOptions ?? {};
           payload.parameters.push({
             groupId,
             parameterId: dependentParameter.id,
             propertiesToUpdate: {
               dynamicData: { status: DynamicLoadStatus.NOTSTARTED },
-              editorOptions: { options: [] },
+              editorOptions: { ...existingEditorOptions, options: [] },
             },
           });
         }
@@ -2476,9 +2478,12 @@ export async function loadDynamicValuesForParameter(
     return;
   }
 
+  // Preserve existing editorOptions (like multiSelect, serialization) when updating options
+  const existingEditorOptions = parameter.editorOptions ?? {};
+
   let propertiesToUpdate: any = {
     dynamicData: { status: DynamicLoadStatus.LOADING },
-    editorOptions: { options: [] },
+    editorOptions: { ...existingEditorOptions, options: [] },
   };
 
   dispatch(
@@ -2500,7 +2505,7 @@ export async function loadDynamicValuesForParameter(
 
     propertiesToUpdate = {
       dynamicData: { status: DynamicLoadStatus.SUCCEEDED },
-      editorOptions: { options: dynamicValues },
+      editorOptions: { ...existingEditorOptions, options: dynamicValues },
     };
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);
@@ -2551,9 +2556,12 @@ export async function fetchDynamicValuesForParameter(
     return;
   }
 
+  // Preserve existing editorOptions (like multiSelect, serialization) when updating options
+  const existingEditorOptions = parameter.editorOptions ?? {};
+
   let propertiesToUpdate: any = {
     dynamicData: { status: DynamicLoadStatus.LOADING },
-    editorOptions: { options: [] },
+    editorOptions: { ...existingEditorOptions, options: [] },
   };
 
   // Send the initial status update to the store
@@ -2576,7 +2584,7 @@ export async function fetchDynamicValuesForParameter(
 
     propertiesToUpdate = {
       dynamicData: { status: DynamicLoadStatus.SUCCEEDED },
-      editorOptions: { options: dynamicValues },
+      editorOptions: { ...existingEditorOptions, options: dynamicValues },
     };
   } catch (error: any) {
     const rootMessage = parseErrorMessage(error);

--- a/libs/logic-apps-shared/src/parsers/lib/common/helpers/utils.ts
+++ b/libs/logic-apps-shared/src/parsers/lib/common/helpers/utils.ts
@@ -227,9 +227,9 @@ export function getEditorOptionsForParameter(
     return editorOptions;
   }
 
-  // Dynamic Values
+  // Dynamic Values - preserve existing editorOptions (like multiSelect, serialization) and just set empty options
   if (dynamicValues) {
-    return { options: [] };
+    return { ...editorOptions, options: [] };
   }
 
   // Static Enum


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
When a parameter is using dynamic list, the editor options are missing when populating dynamic list. This causes the default editor option to be used, thus missing the customizability.  This PR fixed it so customer provided editor options are honored correctly.

Below is an example of editor options provided in manifest. It was missed when dynamic values are loaded, thus options is multiSelect are ignored causing the behavoir.

'x-ms-editor-options': {
            multiSelect: true,
            titleSeparator: ',',
            serialization: {
              valueType: 'array',
            },
},

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
Users will see the intended editor behavior (e.g., multi-select combobox behaves as expected) when parameters use dynamic lists; no change to existing UI except the bugfix restoring expected options.
- **Developers**: <!-- API changes, new patterns, etc. -->
The editor options provided by developers are correctly honored now for parameters that uses dynamic list.
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: <!-- environments/scenarios --> localhost

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->

