### PR TITLE
(feat:designer) Support dynamic list for MCP client tool actions

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -141,19 +141,39 @@ const DesignerEditor = () => {
     addOrUpdateAppSettings(connectionAndSetting.settings, settingsData?.properties ?? {});
   };
 
-  const getConnectionConfiguration = async (connectionId: string): Promise<any> => {
+  const getConnectionConfiguration = async (connectionId: string, _manifest: any, useMcpConnections?: boolean): Promise<any> => {
     if (!connectionId) {
       return Promise.resolve();
     }
 
     const connectionName = connectionId.split('/').splice(-1)[0];
-    const connectionInfo =
-      connectionsData?.serviceProviderConnections?.[connectionName] ?? connectionsData?.apiManagementConnections?.[connectionName];
+    let connectionInfo: any;
+    let isAgentMcpConnection = false;
+
+    if (useMcpConnections) {
+      connectionInfo = connectionsData?.agentMcpConnections?.[connectionName];
+
+      if (connectionInfo) {
+        isAgentMcpConnection = true;
+      }
+
+      connectionInfo = connectionInfo ?? connectionsData?.managedApiConnections?.[connectionName];
+    } else {
+      connectionInfo =
+        connectionsData?.serviceProviderConnections?.[connectionName] ?? connectionsData?.apiManagementConnections?.[connectionName];
+    }
 
     if (connectionInfo) {
       // TODO(psamband): Add new settings in this blade so that we do not resolve all the appsettings in the connectionInfo.
       const resolvedConnectionInfo = resolveConnectionsReferences(JSON.stringify(connectionInfo), {}, settingsData?.properties);
       delete resolvedConnectionInfo.displayName;
+
+      if (useMcpConnections) {
+        return {
+          isAgentMcpConnection,
+          connection: resolvedConnectionInfo,
+        };
+      }
 
       return {
         connection: resolvedConnectionInfo,
@@ -627,6 +647,7 @@ const getDesignerServices = (
   });
   const connectorService = new StandardConnectorService({
     ...defaultServiceParams,
+    workflowName,
     clientSupportedOperations: [
       ['connectionProviders/localWorkflowOperation', 'invokeWorkflow'],
       ['connectionProviders/xmlOperations', 'xmlValidation'],

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
@@ -156,19 +156,39 @@ const DesignerEditor = () => {
     setIsDraftMode(draftMode);
   }, []);
 
-  const getConnectionConfiguration = async (connectionId: string): Promise<any> => {
+  const getConnectionConfiguration = async (connectionId: string, _manifest: any, useMcpConnections?: boolean): Promise<any> => {
     if (!connectionId) {
       return Promise.resolve();
     }
 
     const connectionName = connectionId.split('/').splice(-1)[0];
-    const connectionInfo =
-      connectionsData?.serviceProviderConnections?.[connectionName] ?? connectionsData?.apiManagementConnections?.[connectionName];
+    let connectionInfo: any;
+    let isAgentMcpConnection = false;
+
+    if (useMcpConnections) {
+      connectionInfo = connectionsData?.agentMcpConnections?.[connectionName];
+
+      if (connectionInfo) {
+        isAgentMcpConnection = true;
+      }
+
+      connectionInfo = connectionInfo ?? connectionsData?.managedApiConnections?.[connectionName];
+    } else {
+      connectionInfo =
+        connectionsData?.serviceProviderConnections?.[connectionName] ?? connectionsData?.apiManagementConnections?.[connectionName];
+    }
 
     if (connectionInfo) {
       // TODO(psamband): Add new settings in this blade so that we do not resolve all the appsettings in the connectionInfo.
       const resolvedConnectionInfo = resolveConnectionsReferences(JSON.stringify(connectionInfo), {}, settingsData?.properties);
       delete resolvedConnectionInfo.displayName;
+
+      if (useMcpConnections) {
+        return {
+          isAgentMcpConnection,
+          connection: resolvedConnectionInfo,
+        };
+      }
 
       return {
         connection: resolvedConnectionInfo,
@@ -771,6 +791,7 @@ const getDesignerServices = (
   });
   const connectorService = new StandardConnectorService({
     ...defaultServiceParams,
+    workflowName,
     clientSupportedOperations: [
       ['connectionProviders/localWorkflowOperation', 'invokeWorkflow'],
       ['connectionProviders/xmlOperations', 'xmlValidation'],

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/operationdeserializer.spec.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/operationdeserializer.spec.ts
@@ -249,6 +249,7 @@ describe('operationdeserializer', () => {
             operationId: 'test-operation',
             type: 'McpClientTool',
             kind: 'Managed',
+            operationPath: '/servers/filesystem',
           }),
         })
       );

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -273,7 +273,7 @@ export const initializeOperationDetailsForManagedMcpServer = async (
     };
     const builtinMcpServerManifest = await getOperationManifest(builtinMcpServerOperationInfo);
 
-    const operationInfo = { connectorId, operationId, type: operation.type, kind: operation.kind };
+    const operationInfo = { connectorId, operationId, type: operation.type, kind: operation.kind, operationPath: mcpServerPath };
     dispatch(initializeOperationInfo({ id: nodeId, ...operationInfo }));
 
     const operationForParameters = {

--- a/libs/designer-v2/src/lib/core/queries/connector.ts
+++ b/libs/designer-v2/src/lib/core/queries/connector.ts
@@ -105,7 +105,8 @@ export const getListDynamicValues = async (
   connectorId: string,
   operationId: string,
   parameters: Record<string, any>,
-  dynamicState: any
+  dynamicState: any,
+  operationPath?: string
 ): Promise<ListDynamicValue[]> => {
   const queryClient = getReactQueryClient();
   const service = ConnectorService();
@@ -119,7 +120,7 @@ export const getListDynamicValues = async (
       dynamicState.operationId?.toLowerCase(),
       getParametersKey({ ...dynamicState.parameters, ...parameters }),
     ],
-    () => service.getListDynamicValues(connectionId, connectorId, operationId, parameters, dynamicState)
+    () => service.getListDynamicValues(connectionId, connectorId, operationId, parameters, dynamicState, undefined, operationPath)
   );
 };
 

--- a/libs/designer-v2/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -262,8 +262,8 @@ export const operationMetadataSlice = createSlice({
       state.loadStatus.nodesInitialized = true;
     },
     initializeOperationInfo: (state, action: PayloadAction<AddNodeOperationPayload>) => {
-      const { id, connectorId, operationId, type, kind } = action.payload;
-      state.operationInfo[id] = { connectorId, operationId, type, kind };
+      const { id, connectorId, operationId, type, kind, operationPath } = action.payload;
+      state.operationInfo[id] = { connectorId, operationId, type, kind, operationPath };
     },
     initializeNodes: (state, action: PayloadAction<InitializeNodesPayload>) => {
       const { nodes, clearExisting = false } = action.payload;

--- a/libs/designer-v2/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer-v2/src/lib/core/utils/parameters/dynamicdata.ts
@@ -118,7 +118,8 @@ export async function getDynamicValues(
       operationInfo.connectorId,
       operationInfo.operationId,
       operationParameters,
-      dynamicState
+      dynamicState,
+      operationInfo.operationPath
     );
   }
   if (isLegacyDynamicValuesExtension(definition)) {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -273,7 +273,7 @@ export const initializeOperationDetailsForManagedMcpServer = async (
     };
     const builtinMcpServerManifest = await getOperationManifest(builtinMcpServerOperationInfo);
 
-    const operationInfo = { connectorId, operationId, type: operation.type, kind: operation.kind };
+    const operationInfo = { connectorId, operationId, type: operation.type, kind: operation.kind, operationPath: mcpServerPath };
     dispatch(initializeOperationInfo({ id: nodeId, ...operationInfo }));
 
     //const parsedManifest = new ManifestParser(manifest, OperationManifestService().isAliasingSupported(operation.type, operation.kind));

--- a/libs/designer/src/lib/core/queries/connector.ts
+++ b/libs/designer/src/lib/core/queries/connector.ts
@@ -105,7 +105,8 @@ export const getListDynamicValues = async (
   connectorId: string,
   operationId: string,
   parameters: Record<string, any>,
-  dynamicState: any
+  dynamicState: any,
+  operationPath?: string
 ): Promise<ListDynamicValue[]> => {
   const queryClient = getReactQueryClient();
   const service = ConnectorService();
@@ -119,7 +120,7 @@ export const getListDynamicValues = async (
       dynamicState.operationId?.toLowerCase(),
       getParametersKey({ ...dynamicState.parameters, ...parameters }),
     ],
-    () => service.getListDynamicValues(connectionId, connectorId, operationId, parameters, dynamicState)
+    () => service.getListDynamicValues(connectionId, connectorId, operationId, parameters, dynamicState, undefined, operationPath)
   );
 };
 

--- a/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
+++ b/libs/designer/src/lib/core/state/operation/operationMetadataSlice.ts
@@ -262,8 +262,8 @@ export const operationMetadataSlice = createSlice({
       state.loadStatus.nodesInitialized = true;
     },
     initializeOperationInfo: (state, action: PayloadAction<AddNodeOperationPayload>) => {
-      const { id, connectorId, operationId, type, kind } = action.payload;
-      state.operationInfo[id] = { connectorId, operationId, type, kind };
+      const { id, connectorId, operationId, type, kind, operationPath } = action.payload;
+      state.operationInfo[id] = { connectorId, operationId, type, kind, operationPath };
     },
     initializeNodes: (state, action: PayloadAction<InitializeNodesPayload>) => {
       const { nodes, clearExisting = false } = action.payload;

--- a/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
+++ b/libs/designer/src/lib/core/utils/parameters/dynamicdata.ts
@@ -118,7 +118,8 @@ export async function getDynamicValues(
       operationInfo.connectorId,
       operationInfo.operationId,
       operationParameters,
-      dynamicState
+      dynamicState,
+      operationInfo.operationPath
     );
   }
   if (isLegacyDynamicValuesExtension(definition)) {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/connector.ts
@@ -67,7 +67,8 @@ export interface IConnectorService {
     operationId: string,
     parameters: Record<string, any>,
     dynamicState: any,
-    isManagedIdentityConnection?: boolean
+    isManagedIdentityConnection?: boolean,
+    operationPath?: string
   ): Promise<ListDynamicValue[]>;
 
   /**

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connector.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connector.spec.ts
@@ -1,0 +1,292 @@
+import { describe, vi, beforeEach, it, expect } from 'vitest';
+import { StandardConnectorService, type StandardConnectorServiceOptions } from '../connector';
+import type { IHttpClient } from '../../httpClient';
+
+describe('StandardConnectorService', () => {
+  let mockHttpClient: IHttpClient;
+  let mockGetConfiguration: ReturnType<typeof vi.fn>;
+  let connectorService: StandardConnectorService;
+
+  const createMockOptions = (): StandardConnectorServiceOptions => ({
+    apiVersion: '2024-01-01',
+    baseUrl:
+      'https://test.azure.com/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Web/sites/test-app/hostruntime/runtime/webhooks/workflow/api/management',
+    httpClient: {} as IHttpClient,
+    workflowName: 'testWorkflow',
+    getConfiguration: vi.fn(),
+    clientSupportedOperations: [],
+    schemaClient: {},
+    valuesClient: {},
+  });
+
+  // Helper to create mock API response in the expected format
+  const createMockApiResponse = (body: unknown) => ({
+    response: {
+      statusCode: 'OK',
+      body,
+      headers: {},
+    },
+  });
+
+  let mockOptions: StandardConnectorServiceOptions;
+
+  beforeEach(() => {
+    mockHttpClient = {
+      dispose: vi.fn(),
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    };
+    mockGetConfiguration = vi.fn();
+    mockOptions = createMockOptions();
+    mockOptions.httpClient = mockHttpClient;
+    mockOptions.getConfiguration = mockGetConfiguration;
+    connectorService = new StandardConnectorService(mockOptions);
+  });
+
+  describe('MCP Connection - _listDynamicValues', () => {
+    const mcpDynamicState = {
+      operationId: 'listMcpTools',
+      apiType: 'mcp',
+    };
+
+    const mockMcpToolsResponse = [
+      { name: 'tool1', description: 'First tool description' },
+      { name: 'tool2', description: 'Second tool description' },
+      { name: 'tool3', description: 'Third tool description' },
+    ];
+
+    it('should call listMcpTools endpoint for MCP connections', async () => {
+      const connectionId = '/connections/mcp-connection-1';
+      const connectorId = '/connectionProviders/mcpclient';
+      const operationId = 'nativemcpclient';
+      const operationPath = '/mcp/server/path';
+
+      mockGetConfiguration.mockResolvedValue({
+        connection: { connectionId: 'mcp-connection-1' },
+      });
+
+      vi.mocked(mockHttpClient.post).mockResolvedValue(createMockApiResponse(mockMcpToolsResponse));
+
+      const result = await connectorService.getListDynamicValues(
+        connectionId,
+        connectorId,
+        operationId,
+        {},
+        mcpDynamicState,
+        false,
+        operationPath
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith({
+        uri: `${mockOptions.baseUrl}/workflows/${mockOptions.workflowName}/listMcpTools`,
+        queryParameters: { 'api-version': mockOptions.apiVersion },
+        content: {
+          managedConnection: { connectionId: 'mcp-connection-1' },
+          mcpServerPath: operationPath,
+        },
+      });
+
+      expect(result).toEqual([
+        { value: 'tool1', displayName: 'tool1', description: 'First tool description' },
+        { value: 'tool2', displayName: 'tool2', description: 'Second tool description' },
+        { value: 'tool3', displayName: 'tool3', description: 'Third tool description' },
+      ]);
+    });
+
+    it('should handle agent MCP connections differently', async () => {
+      const connectionId = '/connections/agent-mcp-connection';
+      const connectorId = '/connectionProviders/mcpclient';
+      const operationId = 'nativemcpclient';
+
+      mockGetConfiguration.mockResolvedValue({
+        isAgentMcpConnection: true,
+        connection: { connectionId: 'agent-mcp-connection', type: 'agent' },
+      });
+
+      vi.mocked(mockHttpClient.post).mockResolvedValue(createMockApiResponse(mockMcpToolsResponse));
+
+      const result = await connectorService.getListDynamicValues(connectionId, connectorId, operationId, {}, mcpDynamicState, false);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith({
+        uri: `${mockOptions.baseUrl}/workflows/${mockOptions.workflowName}/listMcpTools`,
+        queryParameters: { 'api-version': mockOptions.apiVersion },
+        content: {
+          connection: { connectionId: 'agent-mcp-connection', type: 'agent' },
+        },
+      });
+
+      expect(result).toHaveLength(3);
+    });
+
+    it('should remove connectionRuntimeUrl from connectionProperties for managed MCP connections', async () => {
+      const connectionId = '/connections/mcp-connection-1';
+      const connectorId = '/connectionProviders/mcpclient';
+      const operationId = 'nativemcpclient';
+      const operationPath = '/mcp/server/path';
+
+      mockGetConfiguration.mockResolvedValue({
+        connection: {
+          connectionId: 'mcp-connection-1',
+          connectionProperties: {
+            connectionRuntimeUrl: 'https://runtime.url',
+            otherProperty: 'value',
+          },
+        },
+      });
+
+      vi.mocked(mockHttpClient.post).mockResolvedValue(createMockApiResponse(mockMcpToolsResponse));
+
+      await connectorService.getListDynamicValues(connectionId, connectorId, operationId, {}, mcpDynamicState, false, operationPath);
+
+      const postCallArgs = vi.mocked(mockHttpClient.post).mock.calls[0][0];
+      const managedConnection = (postCallArgs.content as any)?.managedConnection;
+
+      // Verify connectionRuntimeUrl was removed from connectionProperties
+      expect(managedConnection.connectionProperties).not.toHaveProperty('connectionRuntimeUrl');
+      expect(managedConnection.connectionProperties.otherProperty).toBe('value');
+    });
+
+    it('should throw error when workflowName is not provided for MCP connections', async () => {
+      const optionsWithoutWorkflowName = createMockOptions();
+      optionsWithoutWorkflowName.httpClient = mockHttpClient;
+      optionsWithoutWorkflowName.getConfiguration = mockGetConfiguration;
+      (optionsWithoutWorkflowName as any).workflowName = undefined;
+
+      const serviceWithoutWorkflowName = new StandardConnectorService(optionsWithoutWorkflowName);
+
+      mockGetConfiguration.mockResolvedValue({
+        connection: { connectionId: 'mcp-connection-1' },
+      });
+
+      await expect(
+        serviceWithoutWorkflowName.getListDynamicValues(
+          '/connections/mcp-connection-1',
+          '/connectionProviders/mcpclient',
+          'nativemcpclient',
+          {},
+          mcpDynamicState,
+          false
+        )
+      ).rejects.toThrow('workflowName is required for MCP connections.');
+    });
+
+    it('should return empty array when MCP tools response is null or undefined', async () => {
+      const connectionId = '/connections/mcp-connection-1';
+      const connectorId = '/connectionProviders/mcpclient';
+      const operationId = 'nativemcpclient';
+
+      mockGetConfiguration.mockResolvedValue({
+        connection: { connectionId: 'mcp-connection-1' },
+      });
+
+      vi.mocked(mockHttpClient.post).mockResolvedValue(createMockApiResponse(null));
+
+      const result = await connectorService.getListDynamicValues(connectionId, connectorId, operationId, {}, mcpDynamicState, false);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle MCP tools with missing description', async () => {
+      const connectionId = '/connections/mcp-connection-1';
+      const connectorId = '/connectionProviders/mcpclient';
+      const operationId = 'nativemcpclient';
+
+      mockGetConfiguration.mockResolvedValue({
+        connection: { connectionId: 'mcp-connection-1' },
+      });
+
+      const toolsWithMissingDescription = [{ name: 'tool1' }, { name: 'tool2', description: 'Has description' }];
+
+      vi.mocked(mockHttpClient.post).mockResolvedValue(createMockApiResponse(toolsWithMissingDescription));
+
+      const result = await connectorService.getListDynamicValues(connectionId, connectorId, operationId, {}, mcpDynamicState, false);
+
+      expect(result).toEqual([
+        { value: 'tool1', displayName: 'tool1', description: undefined },
+        { value: 'tool2', displayName: 'tool2', description: 'Has description' },
+      ]);
+    });
+  });
+
+  describe('Non-MCP Dynamic Values', () => {
+    it('should call standard dynamicInvoke endpoint for non-MCP operations', async () => {
+      const connectionId = '/connections/standard-connection';
+      const connectorId = '/connectionProviders/office365';
+      const operationId = 'getEmails';
+      const dynamicState = {
+        operationId: 'getDynamicValues',
+        parameters: {},
+      };
+
+      mockGetConfiguration.mockResolvedValue({
+        connection: { connectionId: 'standard-connection' },
+      });
+
+      vi.mocked(mockHttpClient.post).mockResolvedValue(createMockApiResponse([{ value: 'option1', displayName: 'Option 1' }]));
+
+      await connectorService.getListDynamicValues(connectionId, connectorId, operationId, {}, dynamicState, false);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uri: expect.stringContaining('/operationGroups/office365/operations/getDynamicValues/dynamicInvoke'),
+        })
+      );
+    });
+  });
+
+  describe('getConfiguration integration', () => {
+    it('should pass useManagedConnections flag as true for MCP connections', async () => {
+      const connectionId = '/connections/mcp-connection-1';
+      const mcpDynamicState = {
+        operationId: 'listMcpTools',
+        apiType: 'mcp',
+      };
+
+      mockGetConfiguration.mockResolvedValue({
+        connection: { connectionId: 'mcp-connection-1' },
+      });
+
+      vi.mocked(mockHttpClient.post).mockResolvedValue(createMockApiResponse([]));
+
+      await connectorService.getListDynamicValues(
+        connectionId,
+        '/connectionProviders/mcpclient',
+        'nativemcpclient',
+        {},
+        mcpDynamicState,
+        false
+      );
+
+      // Verify getConfiguration was called with useManagedConnections=true for MCP
+      expect(mockGetConfiguration).toHaveBeenCalledWith(connectionId, undefined, true);
+    });
+
+    it('should not pass useManagedConnections flag for non-MCP connections', async () => {
+      const connectionId = '/connections/standard-connection';
+      const nonMcpDynamicState = {
+        operationId: 'getDynamicValues',
+      };
+
+      mockGetConfiguration.mockResolvedValue({
+        connection: { connectionId: 'standard-connection' },
+      });
+
+      vi.mocked(mockHttpClient.post).mockResolvedValue(createMockApiResponse([]));
+
+      await connectorService.getListDynamicValues(
+        connectionId,
+        '/connectionProviders/office365',
+        'getEmails',
+        {},
+        nonMcpDynamicState,
+        false
+      );
+
+      // Verify getConfiguration was called without useManagedConnections flag
+      expect(mockGetConfiguration).toHaveBeenCalledWith(connectionId, undefined, false);
+    });
+  });
+});

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/builtinmcpclient.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/builtinmcpclient.ts
@@ -26,21 +26,20 @@ export default {
             type: 'string',
           },
           title: 'Allowed tools',
-          // 'x-ms-editor-options': {
-          //   multiSelect: true,
-          //   titleSeparator: ',',
-          //   serialization: {
-          //     valueType: 'array'
-          //   }
-          // },
-          // 'x-ms-dynamic-list': {
-          //   dynamicState: {
-          //     operationId: 'gettools',
-          //   },
-          //   parameters: {},
-          //   itemPath: '',
-          //   itemValuePath: 'Name',
-          // },
+          'x-ms-editor': 'combobox',
+          'x-ms-editor-options': {
+            multiSelect: true,
+            titleSeparator: ',',
+            serialization: {
+              valueType: 'array',
+            },
+          },
+          'x-ms-dynamic-list': {
+            dynamicState: {
+              apiType: 'mcp',
+              operationId: 'listMcpTools',
+            },
+          },
         },
       },
     },

--- a/libs/logic-apps-shared/src/utils/src/lib/models/operationmanifest.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/operationmanifest.ts
@@ -16,6 +16,7 @@ export interface DownloadChunkMetadata {
 export interface OperationInfo {
   connectorId: string;
   operationId: string;
+  operationPath?: string;
 }
 
 export interface SecureDataOptions {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Adding support for dynamic list in mcp tools so user can choose the tools they want, rather than having to manually type in the tools which is difficult for them. This PR adds the capability. The capability is purely additive and doesn't impact existing features.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
User will be able to choose the tools now instead of manually type them in.
- **Developers**: <!-- API changes, new patterns, etc. -->
if dynamic list on MCP client tool feature is needed, workflowName needs to be passed to connector service, and getConfiguration callback needs to support new optional parameters. If this feature is not needed, no change is needed.
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: <!-- environments/scenarios --> local host

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
