### PR TITLE
fix(designer): show delete button for MCP client tools and generate connection data when missing

### DIFF
--- a/libs/designer-v2/src/lib/ui/common/DesignerContextualMenu/DesignerContextualMenu.tsx
+++ b/libs/designer-v2/src/lib/ui/common/DesignerContextualMenu/DesignerContextualMenu.tsx
@@ -218,7 +218,9 @@ export const DesignerContextualMenu = () => {
 
   const subgraphMenuItems: JSX.Element[] = useMemo(
     () => [
-      ...(metadata?.subgraphType === SUBGRAPH_TYPES.SWITCH_CASE || metadata?.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION
+      ...(metadata?.subgraphType === SUBGRAPH_TYPES.SWITCH_CASE ||
+      metadata?.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION ||
+      metadata?.subgraphType === SUBGRAPH_TYPES.MCP_CLIENT
         ? [<DeleteMenuItem key={'delete'} onClick={deleteClick} showKey />]
         : []),
     ],
@@ -250,13 +252,13 @@ export const DesignerContextualMenu = () => {
       items.push(...(metadata?.subgraphType ? subgraphMenuItems : actionContextMenuItems));
     }
 
-    if (metadata?.subgraphType || isScopeNode) {
-      // For subgraphs and scope nodes, we show graph context menu items
+    if ((metadata?.subgraphType && metadata?.subgraphType !== SUBGRAPH_TYPES.MCP_CLIENT) || isScopeNode) {
+      // For subgraphs (except MCP_CLIENT) and scope nodes, we show graph context menu items
       items.push(...graphMenuItems);
     }
 
     return items;
-  }, [metadata?.subgraphType, isScopeNode, actionContextMenuItems, subgraphMenuItems, graphMenuItems]);
+  }, [nodeId, canvasMenuItems, metadata?.subgraphType, isScopeNode, actionContextMenuItems, subgraphMenuItems, graphMenuItems]);
 
   return (
     <>

--- a/libs/designer-v2/src/lib/ui/common/DesignerContextualMenu/__test__/DesignerContextualMenu.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/common/DesignerContextualMenu/__test__/DesignerContextualMenu.spec.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { describe, vi, beforeEach, it, expect } from 'vitest';
+import { DesignerContextualMenu } from '../DesignerContextualMenu';
+import { SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
+import * as designerViewSelectors from '../../../../core/state/designerView/designerViewSelectors';
+import * as panelSelectors from '../../../../core/state/panel/panelSelectors';
+import * as workflowSelectors from '../../../../core/state/workflow/workflowSelectors';
+import * as designerOptionsSelectors from '../../../../core/state/designerOptions/designerOptionsSelectors';
+import * as operationInfoHook from '../../../../core/state/selectors/actionMetadataSelector';
+
+// Mock react-redux
+vi.mock('react-redux', () => ({
+  useDispatch: () => vi.fn(),
+  useSelector: (selector: any) => selector({ workflow: { operations: {} } }),
+}));
+
+// Mock @xyflow/react
+vi.mock('@xyflow/react', () => ({
+  useReactFlow: () => ({
+    screenToFlowPosition: vi.fn(() => ({ x: 0, y: 0 })),
+  }),
+}));
+
+// Mock react-intl
+vi.mock('react-intl', async () => {
+  const actualIntl = await vi.importActual('react-intl');
+  return {
+    ...actualIntl,
+    useIntl: () => ({
+      formatMessage: vi.fn(({ defaultMessage }) => defaultMessage),
+    }),
+  };
+});
+
+// Mock @microsoft/designer-ui
+vi.mock('@microsoft/designer-ui', async () => {
+  const actual = await vi.importActual('@microsoft/designer-ui');
+  return {
+    ...actual,
+    CardContextMenu: ({ menuItems, title }: { menuItems: JSX.Element[]; title: string }) => (
+      <div data-testid="card-context-menu" data-title={title}>
+        {menuItems}
+      </div>
+    ),
+  };
+});
+
+// Mock logic-apps-shared
+vi.mock('@microsoft/logic-apps-shared', async () => {
+  const actual = await vi.importActual('@microsoft/logic-apps-shared');
+  return {
+    ...actual,
+    getRecordEntry: vi.fn(() => ({})),
+    isScopeOperation: vi.fn(() => false),
+    isUiInteractionsServiceEnabled: vi.fn(() => false),
+    WorkflowService: vi.fn(() => ({})),
+  };
+});
+
+// Mock menu items
+vi.mock('../../../../ui/menuItems', () => ({
+  DeleteMenuItem: ({ onClick, showKey }: { onClick: () => void; showKey?: boolean }) => (
+    <div data-testid="delete-menu-item" data-show-key={showKey} onClick={onClick}>
+      Delete
+    </div>
+  ),
+  CopyMenuItem: () => <div data-testid="copy-menu-item">Copy</div>,
+  ResubmitMenuItem: () => <div data-testid="resubmit-menu-item">Resubmit</div>,
+  ExpandCollapseMenuItem: ({ nodeId }: { nodeId: string }) => (
+    <div data-testid="expand-collapse-menu-item" data-node-id={nodeId}>
+      Expand/Collapse
+    </div>
+  ),
+  CollapseMenuItem: () => <div data-testid="collapse-menu-item">Collapse</div>,
+}));
+
+vi.mock('../../../../ui/menuItems/pinMenuItem', () => ({
+  PinMenuItem: () => <div data-testid="pin-menu-item">Pin</div>,
+}));
+
+vi.mock('../../../../ui/menuItems/runAfterMenuItem', () => ({
+  RunAfterMenuItem: () => <div data-testid="run-after-menu-item">Run After</div>,
+}));
+
+vi.mock('../../../../ui/menuItems/addNoteMenuItem', () => ({
+  AddNoteMenuItem: () => <div data-testid="add-note-menu-item">Add Note</div>,
+}));
+
+describe('DesignerContextualMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mocks
+    vi.spyOn(designerViewSelectors, 'useNodeContextMenuData').mockReturnValue({
+      nodeId: 'test-node',
+      location: { x: 100, y: 100 },
+    });
+    vi.spyOn(workflowSelectors, 'useIsActionCollapsed').mockReturnValue(false);
+    vi.spyOn(workflowSelectors, 'useNodeDisplayName').mockReturnValue('Test Node');
+    vi.spyOn(workflowSelectors, 'useNodeMetadata').mockReturnValue({});
+    vi.spyOn(workflowSelectors, 'useRunData').mockReturnValue({});
+    vi.spyOn(workflowSelectors, 'useRunInstance').mockReturnValue(undefined);
+    vi.spyOn(workflowSelectors, 'useRunMode').mockReturnValue('Draft');
+    vi.spyOn(workflowSelectors, 'useIsAgentLoop').mockReturnValue(false);
+    vi.spyOn(panelSelectors, 'useOperationAlternateSelectedNodeId').mockReturnValue('');
+    vi.spyOn(designerOptionsSelectors, 'useSuppressDefaultNodeSelectFunctionality').mockReturnValue(false);
+    vi.spyOn(designerOptionsSelectors, 'useNodeSelectAdditionalCallback').mockReturnValue(undefined);
+    vi.spyOn(operationInfoHook, 'useOperationInfo').mockReturnValue({ type: 'action' } as any);
+  });
+
+  it('should show delete menu item for MCP_CLIENT subgraph type', () => {
+    vi.spyOn(workflowSelectors, 'useNodeMetadata').mockReturnValue({
+      subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
+    } as any);
+
+    const tree = renderer.create(<DesignerContextualMenu />);
+    const testInstance = tree.root;
+
+    const deleteItem = testInstance.findByProps({ 'data-testid': 'delete-menu-item' });
+    expect(deleteItem).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixed below bugs:
- Show delete button for MCP client tools.
- Dynamic list failed when connection data is not found.
  When we found connection data is not found, instead of throw null reference exception. We now generate the connection data so we can successfully make list mcp tools call correctly. This does not impact existing runtime behavior but a bug fix for mcp server which is under development.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
Dynamic list will succeed now even if workflow is not saved. User will be able to delete the mcp client tool now.
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: <!-- environments/scenarios --> local

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
