### PR TITLE
fix(designer): multi-select combobox selection not updated when options/keys change

### DIFF
--- a/libs/designer-ui/src/lib/combobox/__test__/combobox.spec.tsx
+++ b/libs/designer-ui/src/lib/combobox/__test__/combobox.spec.tsx
@@ -429,4 +429,53 @@ describe('lib/combobox', () => {
       expect(optionTexts.slice(0, -1)).toEqual(sortedTexts);
     });
   });
+
+  it('updates selectedKeys when options change in multiSelect mode', async () => {
+    const initialOptions = [
+      { key: '1', value: 'one', displayName: 'Option One' },
+      { key: '2', value: 'two', displayName: 'Option Two' },
+    ];
+
+    const updatedOptions = [
+      { key: '1', value: 'one', displayName: 'Updated Option One' },
+      { key: '2', value: 'two', displayName: 'Updated Option Two' },
+      { key: '3', value: 'three', displayName: 'Option Three' },
+    ];
+
+    const initialValue = [createLiteralValueSegment(JSON.stringify(['one', 'two']))];
+
+    const tree = renderer.create(
+      <TestWrapper>
+        <Combobox
+          {...defaultProps}
+          options={initialOptions}
+          initialValue={initialValue}
+          multiSelect={true}
+          serialization={{ valueType: 'array' }}
+        />
+      </TestWrapper>
+    );
+
+    let comboboxInput = tree.root.findByProps({ role: 'combobox' });
+    expect(comboboxInput.props.value).toContain('Option One');
+    expect(comboboxInput.props.value).toContain('Option Two');
+
+    await act(async () => {
+      tree.update(
+        <TestWrapper>
+          <Combobox
+            {...defaultProps}
+            options={updatedOptions}
+            initialValue={initialValue}
+            multiSelect={true}
+            serialization={{ valueType: 'array' }}
+          />
+        </TestWrapper>
+      );
+    });
+
+    comboboxInput = tree.root.findByProps({ role: 'combobox' });
+    expect(comboboxInput.props.value).toContain('Updated Option One');
+    expect(comboboxInput.props.value).toContain('Updated Option Two');
+  });
 });

--- a/libs/designer-ui/src/lib/combobox/index.tsx
+++ b/libs/designer-ui/src/lib/combobox/index.tsx
@@ -89,9 +89,10 @@ export const Combobox = ({
       const updatedOptionkey = getSelectedKey(options, initialValue, isLoading, isCaseSensitive);
       const updatedOptionKeys = getSelectedKeys(options, initialValue, serialization, isCaseSensitive);
       setSelectedKey(updatedOptionkey);
+      setSelectedKeys(multiSelect ? updatedOptionKeys : undefined);
       setMode(getMode(updatedOptionkey, updatedOptionKeys, initialValue, isLoading));
     }
-  }, [errorDetails, initialValue, isCaseSensitive, isLoading, options, serialization]);
+  }, [errorDetails, initialValue, isCaseSensitive, isLoading, multiSelect, options, serialization]);
 
   // Debounce search value to prevent excessive filtering
   useEffect(() => {


### PR DESCRIPTION

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
When parameter got changed for multi-select combo box, the selected keys are not updated in UI. The combo box selected key is updated when option changes for single selection, however we doesn't have the code to handle multi-selection combo box. This PR added the missing logic to handle multi-select scenario.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
Now user see the new value shown correctly in UI.
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: <!-- environments/scenarios --> local

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
