### PR TITLE
refactor(assistant): Replace hardcoded color with Fluent UI token for protected message

### DIFF
--- a/libs/chatbot/src/lib/ui/styles.ts
+++ b/libs/chatbot/src/lib/ui/styles.ts
@@ -146,7 +146,7 @@ export const useChatbotStyles = makeStyles({
     fontSize: '10.5px',
     display: 'flex',
     fontWeight: tokens.fontWeightBold,
-    color: '#489d42', // Keep original green
+    color: tokens.colorPaletteGreenBorderActive,
     lineHeight: '12px',
   },
 


### PR DESCRIPTION
## Commit Type

- [ ] feature - New functionality
- [ ] fix - Bug fix
- [x] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level

- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

Replaces a hardcoded green color value (`#489d42`) with the Fluent UI design token `tokens.colorPaletteGreenBorderActive` in the chatbot protected message styles.

**Why this change:**
- Ensures consistency with the Fluent UI design system
- Improves theme compatibility (light/dark mode support)
- Follows best practices for design token usage instead of magic values

## Impact of Change

- **Users**: Protected message text color will now properly adapt to theme changes
- **Developers**: No API changes; follows established pattern of using Fluent UI tokens
- **System**: None - styling change only

## Test Plan

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: Standalone designer with light/dark themes

## Contributors

@ccastrotrejo

## Screenshots/Videos

### Before
<img width="700" height="346" alt="CleanShot 2026-01-21 at 15 54 26@2x" src="https://github.com/user-attachments/assets/f92253c2-52bf-4ac1-b61c-dbf3c9232a93" />

### After

<img width="486" height="194" alt="CleanShot 2026-01-21 at 15 53 36@2x" src="https://github.com/user-attachments/assets/a303e992-e1c5-4a8a-9ca6-1059ee835eee" />
<img width="484" height="222" alt="CleanShot 2026-01-21 at 15 54 01@2x" src="https://github.com/user-attachments/assets/350fc1ab-c79e-4b60-bd6e-9717fbcbd8db" />
<img width="686" height="354" alt="CleanShot 2026-01-21 at 15 54 20@2x" src="https://github.com/user-attachments/assets/e53b3930-4300-433f-bb6b-db923cc06d9a" />

