### PR TITLE
debug(designer): Add console logs to trace static result schema flow

### DIFF
--- a/libs/designer-ui/src/lib/staticResult/index.tsx
+++ b/libs/designer-ui/src/lib/staticResult/index.tsx
@@ -172,7 +172,14 @@ export const StaticResultContainer = ({
     additionalProperties: additionalPropertiesSchema,
     required,
   } = useMemo(() => {
-    return parseStaticResultSchema(staticResultSchema);
+    const parsed = parseStaticResultSchema(staticResultSchema);
+    console.log('[DEBUG StaticResult] StaticResultContainer - parseStaticResultSchema', {
+      inputSchema: JSON.stringify(staticResultSchema, null, 2),
+      parsedPropertiesKeys: parsed.properties ? Object.keys(parsed.properties) : 'none',
+      parsedRequired: parsed.required,
+      outputsInParsed: parsed.properties?.outputs ? JSON.stringify(parsed.properties.outputs, null, 2) : 'none',
+    });
+    return parsed;
   }, [staticResultSchema]);
 
   return (

--- a/libs/designer-ui/src/lib/staticResult/staticResultProperties.tsx
+++ b/libs/designer-ui/src/lib/staticResult/staticResultProperties.tsx
@@ -4,7 +4,7 @@ import { StaticResultProperty } from './staticResultProperty';
 import { formatShownProperties, getOptions, initializeShownProperties } from './util';
 import type { OpenAPIV2 } from '@microsoft/logic-apps-shared';
 import type { Dispatch, SetStateAction } from 'react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 
 interface StaticResultPropertiesProps {
@@ -27,6 +27,18 @@ export const StaticResultProperties = ({
   const [shownProperties, setShownProperties] = useState<Record<string, boolean>>(
     initializeShownProperties(required, propertiesSchema, propertyValues)
   );
+
+  // Debug logging for StaticResultProperties
+  useEffect(() => {
+    console.log('[DEBUG StaticResult] StaticResultProperties rendered', {
+      isRoot,
+      propertiesSchemaKeys: propertiesSchema ? Object.keys(propertiesSchema) : 'none',
+      required,
+      shownProperties,
+      propertyValues,
+      dropdownOptions: getOptions(propertiesSchema, required),
+    });
+  }, [isRoot, propertiesSchema, required, shownProperties, propertyValues]);
 
   const updateShownProperties = (optionValue: string, _optionText: string) => {
     const optionKey = optionValue;

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -369,10 +369,24 @@ export const initializeOperationDetailsForManifest = async (
 
     const { connectorId, operationId } = nodeOperationInfo;
     const parsedManifest = new ManifestParser(manifest, OperationManifestService().isAliasingSupported(operation.type, operation.kind));
+    console.log('[DEBUG StaticResult] operationdeserializer - fetching schema', {
+      nodeId,
+      connectorId,
+      operationId,
+      manifestOutputs: JSON.stringify(manifest.properties.outputs, null, 2),
+    });
     const schema = staticResultService.getOperationResultSchema(connectorId, operationId, parsedManifest);
     schema.then((schema) => {
       if (schema) {
+        console.log('[DEBUG StaticResult] operationdeserializer - dispatching schema to Redux', {
+          schemaId: `${connectorId}-${operationId}`,
+          schemaProperties: schema.properties ? Object.keys(schema.properties) : 'none',
+          outputsProperties: schema.properties?.outputs?.properties ? Object.keys(schema.properties.outputs.properties) : 'none',
+          fullSchema: JSON.stringify(schema, null, 2),
+        });
         dispatch(addResultSchema({ id: `${connectorId}-${operationId}`, schema }));
+      } else {
+        console.log('[DEBUG StaticResult] operationdeserializer - no schema returned for', { connectorId, operationId });
       }
     });
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/testingTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/testingTab/index.tsx
@@ -13,7 +13,7 @@ import {
 import type { PanelTabFn, PanelTabProps } from '@microsoft/designer-ui';
 import { StaticResultContainer } from '@microsoft/designer-ui';
 import { isNullOrUndefined, type OpenAPIV2 } from '@microsoft/logic-apps-shared';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 export const TestingPanel: React.FC<PanelTabProps> = (props) => {
@@ -26,6 +26,25 @@ export const TestingPanel: React.FC<PanelTabProps> = (props) => {
   const name = selectedNode + 0;
   const staticResultOptions = parameterStaticResult?.staticResultOptions;
   const properties = useStaticResultProperties(name);
+
+  // Debug logging for Testing tab
+  useEffect(() => {
+    console.log('[DEBUG StaticResult] TestingPanel rendered', {
+      selectedNode,
+      connectorId,
+      operationId,
+      schemaId: `${connectorId}-${operationId}`,
+      hasSchema: !!staticResultSchema,
+      schemaProperties: staticResultSchema?.properties ? Object.keys(staticResultSchema.properties) : 'none',
+      outputsProperties: staticResultSchema?.properties?.outputs?.properties
+        ? Object.keys(staticResultSchema.properties.outputs.properties)
+        : 'none',
+      bodySchema: staticResultSchema?.properties?.outputs?.properties?.body
+        ? JSON.stringify(staticResultSchema.properties.outputs.properties.body, null, 2)
+        : 'none',
+      currentProperties: properties,
+    });
+  }, [selectedNode, connectorId, operationId, staticResultSchema, properties]);
 
   const selectPanelTabFn = isPanelPinned ? setPinnedPanelActiveTab : setSelectedPanelActiveTab;
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/staticresultschema/schemas/apiConnector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/staticresultschema/schemas/apiConnector.ts
@@ -15,6 +15,11 @@ export const getStaticResultSchemaForAPIConnector = (
   parser: SwaggerParser | ManifestParser
 ): Promise<StaticResultRootSchemaType | undefined> => {
   const outputSchema = parser.getOutputSchema(operationId);
+  console.log('[DEBUG StaticResult] getStaticResultSchemaForAPIConnector called', {
+    operationId,
+    parserType: parser.constructor.name,
+    outputSchema: JSON.stringify(outputSchema, null, 2),
+  });
   return wrapOutputsSchemaToOperationSchema(outputSchema);
 };
 
@@ -28,9 +33,20 @@ const wrapOutputsSchemaToOperationSchema = (outputSchema: OpenApiSchema): Promis
   if (outputSchema) {
     const newSchema = cleanDynamicSchemaParameters(clone(outputSchema));
     schema.properties.outputs.properties.body = newSchema;
+    console.log('[DEBUG StaticResult] wrapOutputsSchemaToOperationSchema', {
+      originalOutputSchema: JSON.stringify(outputSchema, null, 2),
+      cleanedSchema: JSON.stringify(newSchema, null, 2),
+      finalBodySchema: JSON.stringify(schema.properties.outputs.properties.body, null, 2),
+    });
   } else {
     schema.properties.outputs.properties.body = {};
+    console.log('[DEBUG StaticResult] wrapOutputsSchemaToOperationSchema - no outputSchema, using empty body');
   }
+
+  console.log('[DEBUG StaticResult] Final wrapped schema', {
+    schemaKeys: Object.keys(schema.properties),
+    outputsKeys: Object.keys(schema.properties.outputs.properties),
+  });
 
   return Promise.resolve(schema);
 };
@@ -47,6 +63,9 @@ const cleanDynamicSchemaParameters = (schema: OpenAPIV2.SchemaObject): OpenAPIV2
 
   const currSchema = schema;
   if (currSchema[ExtensionProperties.DynamicSchema]) {
+    console.log('[DEBUG StaticResult] cleanDynamicSchemaParameters - found dynamic schema, stripping to title only', {
+      title: currSchema.title,
+    });
     return { title: currSchema.title };
   }
 


### PR DESCRIPTION
## Summary
- Add debug logging throughout the static result schema pipeline to help diagnose issues where Testing tab fields don't match actual action outputs

## Debug Points Added
Logs added at key points in the schema flow:
1. **Schema generation** (`apiConnector.ts`) - Logs when schema is fetched from parser
2. **Schema dispatch to Redux** (`operationdeserializer.ts`) - Logs the full schema being stored
3. **TestingPanel component** (`testingTab/index.tsx`) - Logs what schema the Testing tab receives
4. **StaticResultContainer** (`staticResult/index.tsx`) - Logs parsed schema structure
5. **StaticResultProperties** (`staticResultProperties.tsx`) - Logs dropdown options and shown fields

## How to Use
1. Start the standalone app: `pnpm run start`
2. Open browser DevTools Console
3. Filter by `[DEBUG StaticResult]`
4. Load a workflow with an action
5. Click on the action and go to the Testing tab
6. Watch the console for the schema flow

## Test plan
- [ ] Load a workflow with API connector actions (e.g., SharePoint "Get lists")
- [ ] Verify debug logs appear in console when clicking Testing tab
- [ ] Logs should show the schema at each step of the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)