### PR TITLE
feat(Designer-v2): Add chat history summarization

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/agentloop.ts
@@ -186,7 +186,7 @@ export default {
                   type: 'integer',
                   title: 'Threshold message count',
                   description:
-                    'The number of messages beyond the Target message count that must be present in order to trigger reduction in the agent history',
+                    'The number of messages beyond the target message count that must be present in order to trigger reduction in the agent history',
                   'x-ms-input-dependencies': {
                     type: 'visibility',
                     parameters: [

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -363,7 +363,7 @@ export default {
                   type: 'integer',
                   title: 'Threshold message count',
                   description:
-                    'The number of messages beyond the Target message count that must be present in order to trigger reduction in the agent history',
+                    'The number of messages beyond the target message count that must be present in order to trigger reduction in the agent history',
                   'x-ms-input-dependencies': {
                     type: 'visibility',
                     parameters: [


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [X] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [X] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Adding chat history summarization to the agent loop

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users can now find and add chat history as an advanced paramter option
- **Developers**: Adds two manifest fields (targetMessageCount, thresholdMessageCount) and a new option value summarizationReduction in agent history reduction settings. No breaking API changes expected, but manifests consumers should handle the new values.
- **System**: none

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [X] Manual testing completed
- [X] Tested in: Local standalone

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->

https://github.com/user-attachments/assets/7b2cca2f-b179-4485-88e8-ec11df41503b

