### PR TITLE
chore(test): Remove obsolete getAgentBaseUrl tests from config-parser.spec.ts

### DIFF
--- a/apps/iframe-app/src/lib/utils/__tests__/config-parser.spec.ts
+++ b/apps/iframe-app/src/lib/utils/__tests__/config-parser.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { parseIframeConfig, getAgentBaseUrl, parseIdentityProviders } from '../config-parser';
+import { parseIframeConfig, parseIdentityProviders } from '../config-parser';
 
 describe('config-parser', () => {
   const originalLocation = window.location;
@@ -177,32 +177,6 @@ describe('config-parser', () => {
       const config = parseIframeConfig();
 
       expect(config.mode).toBe('dark');
-    });
-  });
-
-  describe('getAgentBaseUrl', () => {
-    it('should remove .well-known/agent-card.json from URL', () => {
-      const result = getAgentBaseUrl('https://example.com/api/agents/myAgent/.well-known/agent-card.json');
-
-      expect(result).toBe('https://example.com/api/agents/myAgent');
-    });
-
-    it('should preserve query params when removing agent-card.json', () => {
-      const result = getAgentBaseUrl('https://example.com/api/agents/myAgent/.well-known/agent-card.json?param=value');
-
-      expect(result).toBe('https://example.com/api/agents/myAgent?param=value');
-    });
-
-    it('should return empty string for undefined input', () => {
-      const result = getAgentBaseUrl(undefined);
-
-      expect(result).toBe('');
-    });
-
-    it('should return URL unchanged if no agent-card.json pattern', () => {
-      const result = getAgentBaseUrl('https://example.com/api/agents/myAgent');
-
-      expect(result).toBe('https://example.com/api/agents/myAgent');
     });
   });
 


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [x] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Removes the `getAgentBaseUrl` test suite from `config-parser.spec.ts` and its corresponding import. The `getAgentBaseUrl` function is no longer exported from `config-parser.ts`, making these tests obsolete and causing test compilation/import errors.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No user-facing changes
- **Developers**: Removes 4 obsolete unit tests and cleans up import statement
- **System**: Fixes test suite by removing references to non-existent function

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- Tested in: Local development environment - verified test suite passes after removal

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@ccastrotrejo

## Screenshots/Videos
<!-- Visual changes only -->
N/A - No visual changes
