### PR TITLE
fix: disable public blob access on e2e test storage account

### DIFF
--- a/e2e/testSetup/BlankLogicApp/logicAppStandard.bicep
+++ b/e2e/testSetup/BlankLogicApp/logicAppStandard.bicep
@@ -40,6 +40,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
     defaultToOAuthAuthentication: true
+    allowBlobPublicAccess: false
   }
 }
 


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
The real-e2e workflow (`real-e2e.yml`) has been failing on all runs due to an Azure Policy violation. The Bicep template for e2e test infrastructure was creating a storage account without explicitly disabling public blob access, which violates the subscription's security policy: "Storage account public access should be disallowed".

This fix adds `allowBlobPublicAccess: false` to the storage account properties in the Bicep template.

## Impact of Change
- **Users**: None - this is CI infrastructure only
- **Developers**: E2E tests using real Azure APIs will now pass the deployment step
- **System**: Storage account created for e2e tests will have public blob access disabled (security best practice)

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Verified the Bicep template change is valid; deployment will be validated when the workflow runs

## Contributors

## Screenshots/Videos
N/A - Infrastructure fix only