### PR TITLE
fix(mcp): Error handling when server is not enabled in MCP Apis (#8757)

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/WorkflowAndArtifacts.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/WorkflowAndArtifacts.tsx
@@ -848,7 +848,7 @@ export const updateMcpServers = async (
     let updatedHostConfig: any;
     const queryClient = getReactQueryClient();
 
-    if (!areAllServersDeleted && !hostConfig?.extensions?.workflow?.McpServerEndpoints?.enabled) {
+    if (!areAllServersDeleted && !hostConfig?.properties.extensions?.workflow?.McpServerEndpoints?.enable) {
       updatedHostConfig = {
         ...(hostConfig.properties ?? {}),
         extensions: {
@@ -857,12 +857,12 @@ export const updateMcpServers = async (
             ...(hostConfig.properties.extensions?.workflow ?? {}),
             McpServerEndpoints: {
               ...(hostConfig.properties.extensions?.workflow?.McpServerEndpoints ?? {}),
-              enabled: true,
+              enable: true,
             },
           },
         },
       };
-    } else if (areAllServersDeleted && hostConfig?.extensions?.workflow?.McpServerEndpoints?.enabled === true) {
+    } else if (areAllServersDeleted && hostConfig?.properties.extensions?.workflow?.McpServerEndpoints?.enable === true) {
       updatedHostConfig = {
         ...(hostConfig.properties ?? {}),
         extensions: {
@@ -871,7 +871,7 @@ export const updateMcpServers = async (
             ...(hostConfig.properties.extensions?.workflow ?? {}),
             McpServerEndpoints: {
               ...(hostConfig.properties.extensions?.workflow?.McpServerEndpoints ?? {}),
-              enabled: false,
+              enable: false,
             },
           },
         },

--- a/apps/Standalone/src/mcp/app/McpServer.tsx
+++ b/apps/Standalone/src/mcp/app/McpServer.tsx
@@ -17,14 +17,14 @@ export const McpServer = () => {
     theme: state.workflowLoader.theme,
   }));
 
-  const appId = '/subscriptions/f34b22a3-2202-4fb1-b040-1332bd928c84/resourceGroups/TestACSRG/providers/Microsoft.Web/sites/prititemplates';
+  const appId = '/subscriptions/f34b22a3-2202-4fb1-b040-1332bd928c84/resourceGroups/TestACSRG/providers/Microsoft.Web/sites/pritimcpserver';
   const resourceDetails = useMemo(() => {
     const parser = new ArmParser(appId);
     return {
       subscriptionId: parser.subscriptionId || '',
       resourceGroup: parser.resourceGroup || '',
       logicAppName: parser.resourceName || '',
-      location: 'westus3',
+      location: 'westus',
     };
   }, []);
 

--- a/libs/designer/src/lib/core/mcp/utils/__test__/queries.spec.tsx
+++ b/libs/designer/src/lib/core/mcp/utils/__test__/queries.spec.tsx
@@ -1,0 +1,223 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useAllMcpServers } from '../queries';
+import type { McpServer } from '@microsoft/logic-apps-shared';
+
+// Mock external dependencies
+vi.mock('@microsoft/logic-apps-shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@microsoft/logic-apps-shared')>();
+  return {
+    ...actual,
+    ResourceService: vi.fn(),
+    LoggerService: vi.fn(() => ({
+      log: vi.fn(),
+    })),
+  };
+});
+
+describe('useAllMcpServers', () => {
+  let mockResourceService: any;
+  let mockExecuteResourceAction: any;
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+
+  beforeEach(async () => {
+    // Create a new QueryClient for each test to avoid cache issues
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    // Import mocked functions dynamically
+    const shared = await import('@microsoft/logic-apps-shared');
+    mockResourceService = shared.ResourceService as any;
+
+    mockExecuteResourceAction = vi.fn();
+    mockResourceService.mockReturnValue({
+      executeResourceAction: mockExecuteResourceAction,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+  });
+
+  describe('successful responses', () => {
+    it('should return MCP servers sorted by name', async () => {
+      const mockServers: McpServer[] = [
+        { name: 'zebra-server', description: 'Zebra', enabled: true, tools: [] },
+        { name: 'alpha-server', description: 'Alpha', enabled: true, tools: [] },
+        { name: 'middle-server', description: 'Middle', enabled: false, tools: [] },
+      ];
+
+      mockExecuteResourceAction.mockResolvedValue({ value: mockServers });
+
+      const { result } = renderHook(() => useAllMcpServers('/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/myApp'), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toHaveLength(3);
+      expect(result.current.data?.[0].name).toBe('alpha-server');
+      expect(result.current.data?.[1].name).toBe('middle-server');
+      expect(result.current.data?.[2].name).toBe('zebra-server');
+    });
+
+    it('should default enabled to true when undefined', async () => {
+      const mockServers = [
+        { name: 'server1', description: 'Server 1' },
+        { name: 'server2', description: 'Server 2', enabled: false },
+        { name: 'server3', description: 'Server 3', enabled: true },
+      ];
+
+      mockExecuteResourceAction.mockResolvedValue({ value: mockServers });
+
+      const { result } = renderHook(() => useAllMcpServers('/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/myApp'), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      const server1 = result.current.data?.find((s) => s.name === 'server1');
+      const server2 = result.current.data?.find((s) => s.name === 'server2');
+      const server3 = result.current.data?.find((s) => s.name === 'server3');
+
+      expect(server1?.enabled).toBe(true);
+      expect(server2?.enabled).toBe(false);
+      expect(server3?.enabled).toBe(true);
+    });
+
+    it('should return empty array when response value is null', async () => {
+      mockExecuteResourceAction.mockResolvedValue({ value: null });
+
+      const { result } = renderHook(() => useAllMcpServers('/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/myApp'), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toEqual([]);
+    });
+
+    it('should return empty array when response value is undefined', async () => {
+      mockExecuteResourceAction.mockResolvedValue({});
+
+      const { result } = renderHook(() => useAllMcpServers('/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/myApp'), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toEqual([]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should return empty array when McpServerNotEnabled error occurs', async () => {
+      mockExecuteResourceAction.mockRejectedValue({
+        error: { code: 'McpServerNotEnabled' },
+      });
+
+      const { result } = renderHook(() => useAllMcpServers('/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/myApp'), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toEqual([]);
+    });
+
+    it('should return empty array and log error for other errors', async () => {
+      const shared = await import('@microsoft/logic-apps-shared');
+      const mockLog = vi.fn();
+      (shared.LoggerService as any).mockReturnValue({ log: mockLog });
+
+      mockExecuteResourceAction.mockRejectedValue({
+        error: { code: 'SomeOtherError', message: 'Something went wrong' },
+      });
+
+      const { result } = renderHook(() => useAllMcpServers('/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/myApp'), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toEqual([]);
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: shared.LogEntryLevel.Error,
+          area: 'McpServer.listServers',
+        })
+      );
+    });
+  });
+
+  describe('query configuration', () => {
+    it('should not execute query when siteResourceId is empty', async () => {
+      const { result } = renderHook(() => useAllMcpServers(''), {
+        wrapper: createWrapper(),
+      });
+
+      // Query should not be loading or fetching when disabled
+      expect(result.current.isFetching).toBe(false);
+      expect(mockExecuteResourceAction).not.toHaveBeenCalled();
+    });
+
+    it('should use lowercase siteResourceId in query key', async () => {
+      mockExecuteResourceAction.mockResolvedValue({ value: [] });
+
+      const { result: result1 } = renderHook(
+        () => useAllMcpServers('/subscriptions/SUB1/resourceGroups/RG1/providers/Microsoft.Web/sites/MYAPP'),
+        {
+          wrapper: createWrapper(),
+        }
+      );
+
+      await waitFor(() => expect(result1.current.isSuccess).toBe(true));
+
+      // The second call with different casing should use cached result
+      const { result: result2 } = renderHook(
+        () => useAllMcpServers('/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp'),
+        {
+          wrapper: createWrapper(),
+        }
+      );
+
+      await waitFor(() => expect(result2.current.isSuccess).toBe(true));
+
+      // Should only be called once due to cache hit with normalized key
+      expect(mockExecuteResourceAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call executeResourceAction with correct parameters', async () => {
+      mockExecuteResourceAction.mockResolvedValue({ value: [] });
+
+      const siteResourceId = '/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/myApp';
+
+      const { result } = renderHook(() => useAllMcpServers(siteResourceId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(mockExecuteResourceAction).toHaveBeenCalledWith(
+        `${siteResourceId}/hostruntime/runtime/webhooks/workflow/api/management/listMcpServers`,
+        'POST',
+        { 'api-version': '2024-11-01' }
+      );
+    });
+  });
+});

--- a/libs/designer/src/lib/ui/mcp/servers/styles.ts
+++ b/libs/designer/src/lib/ui/mcp/servers/styles.ts
@@ -81,7 +81,7 @@ export const useMcpServerStyles = makeStyles({
   serverHeaderActions: { display: 'flex', alignItems: 'center', gap: '6px' },
   serverHeaderButtons: { minWidth: '50px', padding: '0 4px' },
   serverHeaderDivider: { padding: '0 8px' },
-  serverDescription: { paddingLeft: '28px', maxWidth: '778px', paddingTop: '8px' },
+  serverDescription: { paddingLeft: '28px', maxWidth: '778px', paddingTop: '8px', display: 'block' },
   serverField: { paddingTop: '10px', paddingLeft: '28px' },
   serverContent: { paddingTop: '16px', paddingLeft: '16px' },
 });

--- a/libs/designer/src/lib/ui/mcp/wizard/styles.ts
+++ b/libs/designer/src/lib/ui/mcp/wizard/styles.ts
@@ -157,7 +157,7 @@ export const useMcpServerWizardStyles = makeStyles({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingTop: '30%',
+    paddingTop: '10%',
   },
 
   loadingText: {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Error handling in listing mcp servers make sure UX is not frozen when API throws and users can continue editing.
Styling updates based on designs.
Added logging for unexpected error and gracefully handling it in UI.
Updated the property name to enable mcp servers in hostconfig correctly which was causing issues in new app.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: End-users will no longer see indefinite loading when MCP servers are disabled (good).
- **Developers**:  hostConfig property rename (enabled -> enable) is the bug fix which was causing test page to not load first created servers in new app correctly. This was only a test page issue and not a breaking change.
- **System**: The new logging call will capture any errors being thrown while loading blade but will continue to load UX components so users can continue editing.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@kewear 

## Screenshots/Videos
<!-- Visual changes only -->
