### PR TITLE
chore(designer): rename 'Foundry Agent Service' to 'Foundry project' in display strings

### DIFF
--- a/e2e/designer/real-api/agentic/agentConnections.spec.ts
+++ b/e2e/designer/real-api/agentic/agentConnections.spec.ts
@@ -77,9 +77,9 @@ test.describe(
       await expect(page.getByLabel('Default Agent operation')).toBeVisible();
       await page.getByLabel('Default Agent operation').click();
 
-      // Change the model type to Foundry Agent Service
+      // Change the model type to Foundry project
       await page.getByTestId('msla-setting-token-editor-dropdowneditor-agent_model_type').click();
-      await page.getByText('Foundry Agent Service').click();
+      await page.getByText('Foundry project').click();
 
       await startConnectionCreation(page);
 

--- a/libs/designer-v2/src/lib/common/utilities/Utils.ts
+++ b/libs/designer-v2/src/lib/common/utilities/Utils.ts
@@ -30,7 +30,7 @@ export const isDynamicConnection = (feature?: string): boolean => {
 export class AgentUtils {
   public static ModelType = {
     AzureOpenAI: 'Azure OpenAI',
-    FoundryService: 'Foundry Agent Service',
+    FoundryService: 'Foundry project',
     APIM: 'APIM Gen AI Gateway',
     V1ChatCompletionsService: 'V1 Chat Completions Service',
   };

--- a/libs/designer-v2/src/lib/common/utilities/__test__/Utils.test.ts
+++ b/libs/designer-v2/src/lib/common/utilities/__test__/Utils.test.ts
@@ -5,7 +5,7 @@ describe('AgentUtils', () => {
   describe('ModelType constants', () => {
     it('should have correct model type values', () => {
       expect(AgentUtils.ModelType.AzureOpenAI).toBe('Azure OpenAI');
-      expect(AgentUtils.ModelType.FoundryService).toBe('Foundry Agent Service');
+      expect(AgentUtils.ModelType.FoundryService).toBe('Foundry project');
       expect(AgentUtils.ModelType.APIM).toBe('APIM Gen AI Gateway');
       expect(AgentUtils.ModelType.V1ChatCompletionsService).toBe('V1 Chat Completions Service');
     });

--- a/libs/designer/src/lib/common/utilities/Utils.ts
+++ b/libs/designer/src/lib/common/utilities/Utils.ts
@@ -30,7 +30,7 @@ export const isDynamicConnection = (feature?: string): boolean => {
 export class AgentUtils {
   public static ModelType = {
     AzureOpenAI: 'Azure OpenAI',
-    FoundryService: 'Foundry Agent Service',
+    FoundryService: 'Foundry project',
     APIM: 'APIM Gen AI Gateway',
     V1ChatCompletionsService: 'V1 Chat Completions Service',
   };

--- a/libs/designer/src/lib/common/utilities/__test__/Utils.test.ts
+++ b/libs/designer/src/lib/common/utilities/__test__/Utils.test.ts
@@ -5,7 +5,7 @@ describe('AgentUtils', () => {
   describe('ModelType constants', () => {
     it('should have correct model type values', () => {
       expect(AgentUtils.ModelType.AzureOpenAI).toBe('Azure OpenAI');
-      expect(AgentUtils.ModelType.FoundryService).toBe('Foundry Agent Service');
+      expect(AgentUtils.ModelType.FoundryService).toBe('Foundry project');
       expect(AgentUtils.ModelType.APIM).toBe('APIM Gen AI Gateway');
       expect(AgentUtils.ModelType.V1ChatCompletionsService).toBe('V1 Chat Completions Service');
     });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -56,7 +56,7 @@ export default {
               },
               {
                 value: 'FoundryAgentService',
-                displayName: 'Foundry Agent Service (Preview)',
+                displayName: 'Foundry project (Preview)',
                 unSupportedWorkflowKind: ['agent'],
               },
               {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Renames the display string "Foundry Agent Service" to "Foundry project" across the codebase to align with updated product naming conventions.

## Impact of Change
- **Users**: Users will see "Foundry project" instead of "Foundry Agent Service" in the model type dropdown when configuring agent operations
- **Developers**: None - no API changes, only display string updates
- **System**: None

## Test Plan
- [x] Unit tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing completed
- Tested in: Unit tests verify the updated constant values

### Files Changed
- `libs/designer/src/lib/common/utilities/Utils.ts` - Updated `AgentUtils.ModelType.FoundryService` display value
- `libs/designer-v2/src/lib/common/utilities/Utils.ts` - Updated `AgentUtils.ModelType.FoundryService` display value
- `libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts` - Updated manifest display name for FoundryAgentService option
- `libs/designer/src/lib/common/utilities/__test__/Utils.test.ts` - Updated unit test expectations
- `libs/designer-v2/src/lib/common/utilities/__test__/Utils.test.ts` - Updated unit test expectations
- `e2e/designer/real-api/agentic/agentConnections.spec.ts` - Updated E2E test to select new display name

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
### Before
<img width="1236" height="466" alt="CleanShot 2026-02-05 at 11 46 48@2x" src="https://github.com/user-attachments/assets/12c1aad2-1f90-4ddc-bece-857f1d17d37e" />


### After
<img width="1230" height="442" alt="CleanShot 2026-02-05 at 11 45 25@2x" src="https://github.com/user-attachments/assets/c8a4434e-3e5d-4e1f-9499-fa409fec8964" />
