### PR TITLE
fix(vscode): getConfiguration handles object input for Service Provider connections with MSI

### DIFF
--- a/apps/vs-code-react/src/app/designer/servicesHelper.ts
+++ b/apps/vs-code-react/src/app/designer/servicesHelper.ts
@@ -180,6 +180,13 @@ export const getDesignerServices = (
     getConfiguration: async (connectionId: string, manifest: OperationManifest | undefined): Promise<any> => {
       try {
         const configuration: Record<string, any> = {};
+        // WORKAROUND: If connectionId is already a configuration object (not a string),
+        // it means something is calling getConfiguration with the result of a previous call.
+        // In this case, just return the object as-is.
+        const connectionIdAsAny = connectionId as any;
+        if (typeof connectionIdAsAny === 'object' && connectionIdAsAny !== null) {
+          return connectionIdAsAny as Record<string, any>;
+        }
 
         if (shouldIncludeWorkflowAppLocation(isLocal, manifest)) {
           configuration.workflowAppLocation = appSettings.ProjectDirectoryPath;


### PR DESCRIPTION
## Commit Type

- [x] **fix** - Bug fix

## Risk Level

- [x] **Low** - Minor changes, limited scope

---

## Summary

When using Service Provider connections with Managed Identity authentication in VS Code local development, dynamic dropdowns (e.g., Queue name for Service Bus) fail with a network error.

## Root Cause

The `getConfiguration` function was being called twice in the call chain:

1. **First call:** `connectionId` = string (e.g., `"/serviceProviders/serviceBus/connections/serviceBus-6"`) ✅
2. **Second call:** `connectionId` = the configuration object returned from the first call ❌

On the second call, the function tried to parse an object as a string, which caused `extractConnectionName()` to fail, resulting in an empty configuration being sent to the backend.

## Fix

Added a type check at the start of `getConfiguration` to detect when an object is passed instead of a string. If an object is passed, return it directly since it's already a valid configuration.

## Impact of Change

| Area | Impact |
|------|--------|
| **Users** | Service Provider connections with Managed Identity now work correctly in VS Code local development. Dynamic dropdowns populate as expected. |
| **Developers** | No API changes. This is a defensive workaround that makes `getConfiguration` resilient to incorrect input types. |
| **System** | No performance or architectural impact. The type check adds negligible overhead. |

---

## Test Plan

- [x] Manual testing completed
- [x] Tested in: VS Code local development with Service Bus MSI connection

### Manual Test Steps

1. Create Logic App Standard project in VS Code
2. Add Service Bus connection with Managed Identity authentication
3. Add "Send message" action
4. Click **Queue name** dropdown
5. **Expected:** Dropdown populates with queues from Service Bus namespace
6. **Actual (before fix):** Network error, empty response
7. **Actual (after fix):** Dropdown works correctly ✅

---

## Notes

> This is a workaround fix. The root cause is upstream in the call chain where something calls `getConfiguration` twice, passing the result of the first call as input to the second. A future cleanup could investigate and fix the upstream caller.
```