### PR TITLE
feat: Add search and replace functionality to CodeMirror editors

### DIFF
--- a/libs/designer-ui/src/lib/editor/codemirror/CodeMirrorEditor.tsx
+++ b/libs/designer-ui/src/lib/editor/codemirror/CodeMirrorEditor.tsx
@@ -5,6 +5,7 @@ import { history, defaultKeymap } from '@codemirror/commands';
 import { bracketMatching, foldGutter, indentOnInput, StreamLanguage } from '@codemirror/language';
 import { autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete';
 import { linter } from '@codemirror/lint';
+import { search, searchKeymap } from '@codemirror/search';
 import { json, jsonParseLinter } from '@codemirror/lang-json';
 import { python } from '@codemirror/lang-python';
 import { javascript } from '@codemirror/lang-javascript';
@@ -208,7 +209,8 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         indentOnInput(),
         highlightActiveLine(),
         highlightActiveLineGutter(),
-        keymap.of([...closeBracketsKeymap, ...completionKeymap, ...defaultKeymap]),
+        keymap.of([...closeBracketsKeymap, ...completionKeymap, ...searchKeymap, ...defaultKeymap]),
+        search(),
         themeCompartment.of(createFluentTheme(isInverted)),
         languageCompartment.of(getLanguageExtension(language)),
         readOnlyCompartment.of(EditorState.readOnly.of(readOnly)),

--- a/libs/designer-ui/src/lib/editor/codemirror/themes/fluent.ts
+++ b/libs/designer-ui/src/lib/editor/codemirror/themes/fluent.ts
@@ -141,6 +141,79 @@ export const createFluentTheme = (isInverted: boolean): Extension[] => {
       '.cm-activeLine': {
         backgroundColor: colors.lineHighlight,
       },
+      // Search panel styling
+      '.cm-panels': {
+        backgroundColor: colors.gutterBackground,
+        color: colors.foreground,
+        borderBottom: `1px solid ${colors.gutterBorder}`,
+      },
+      '.cm-panels.cm-panels-top': {
+        borderBottom: `1px solid ${colors.gutterBorder}`,
+      },
+      '.cm-search': {
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: '4px',
+        padding: '4px 8px',
+        fontSize: '13px',
+      },
+      '.cm-search label': {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '2px',
+        fontSize: '13px',
+        color: colors.foreground,
+      },
+      '.cm-search input[type="text"]': {
+        backgroundColor: isInverted ? '#3c3c3c' : '#ffffff',
+        color: colors.foreground,
+        border: `1px solid ${colors.gutterBorder}`,
+        borderRadius: '2px',
+        padding: '2px 6px',
+        fontSize: '13px',
+        outline: 'none',
+        fontFamily: 'inherit',
+      },
+      '.cm-search input[type="text"]:focus': {
+        borderColor: '#0078d4',
+      },
+      '.cm-search input[type="checkbox"]': {
+        accentColor: '#0078d4',
+      },
+      '.cm-search button': {
+        backgroundColor: isInverted ? '#3c3c3c' : '#e1e1e1',
+        color: colors.foreground,
+        border: `1px solid ${colors.gutterBorder}`,
+        borderRadius: '2px',
+        padding: '2px 8px',
+        fontSize: '13px',
+        cursor: 'pointer',
+      },
+      '.cm-search button:hover': {
+        backgroundColor: isInverted ? '#454545' : '#c8c8c8',
+      },
+      '.cm-search button[name="close"]': {
+        backgroundColor: 'transparent',
+        border: 'none',
+        padding: '2px 6px',
+        fontSize: '16px',
+        lineHeight: '1',
+      },
+      '.cm-search button[name="close"]:hover': {
+        backgroundColor: isInverted ? '#454545' : '#c8c8c8',
+        borderRadius: '2px',
+      },
+      '.cm-searchMatch': {
+        backgroundColor: isInverted ? 'rgba(234, 92, 0, 0.33)' : 'rgba(234, 92, 0, 0.2)',
+        outline: `1px solid ${isInverted ? 'rgba(234, 92, 0, 0.5)' : 'rgba(234, 92, 0, 0.4)'}`,
+      },
+      '.cm-searchMatch.cm-searchMatch-selected': {
+        backgroundColor: isInverted ? 'rgba(81, 92, 106, 0.6)' : 'rgba(164, 206, 255, 0.6)',
+      },
+      '.cm-selectionMatch': {
+        backgroundColor: isInverted ? 'rgba(173, 214, 255, 0.15)' : 'rgba(173, 214, 255, 0.4)',
+      },
     },
     { dark: isInverted }
   );


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Adds search and replace functionality to CodeMirror editors by integrating the built-in `@codemirror/search` extension. This was a missing feature after the Monaco to CodeMirror migration — users could no longer use Ctrl/Cmd+F to find text or Ctrl/Cmd+H to find and replace within code editors.

Closes #8827

# Impact of Change
- **Users**: Search/replace available via Ctrl/Cmd+F (find) and Ctrl/Cmd+H (find & replace) in all CodeMirror editor instances. The search panel supports match highlighting, regex, case-sensitive search, and replace all. No conflicts with existing custom keybindings — the `searchKeymap` is placed before `defaultKeymap` in precedence, and the existing Alt+/ token picker binding operates on a different key combination.
- **Developers**: No API changes. The `@codemirror/search` extension and Fluent-themed search panel styles are added to the shared `CodeMirrorEditor` component, so all consumers automatically get search/replace — no opt-in required.
- **System**: Minimal — adds one extension and its keybindings to the editor, plus theme styles for the search panel. No new dependencies (`@codemirror/search` was already in `package.json`).
- 
## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer (light & dark themes)

## Contributors

## Screenshots/Videos


https://github.com/user-attachments/assets/168d0c68-568f-427a-b39c-f2371995a072


