### PR TITLE
fix(designer): Normalize 204 No Content responses in run service getContent

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/run.ts
@@ -66,7 +66,8 @@ export class ConsumptionRunService implements IRunService {
         noAuth: true,
         headers: { 'Access-Control-Allow-Origin': '*' },
       });
-      return response;
+      // API may return 204 No Content (empty response) — normalize to empty object
+      return response || {};
     } catch (e: any) {
       throw new Error(e.message);
     }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
@@ -62,7 +62,8 @@ export class StandardRunService implements IRunService {
         noAuth: true,
         headers: { 'Access-Control-Allow-Origin': '*' },
       });
-      return response;
+      // API may return 204 No Content (empty response) — normalize to empty object
+      return response || {};
     } catch (e: any) {
       throw new Error(e.message);
     }


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
When the API returns a 204 No Content for action inputs/outputs (e.g., a Compose action with no data), axios returns an empty string for `response.data`. This falsy value propagates through `getContent()` in both `StandardRunService` and `ConsumptionRunService`, causing the monitoring view UI to display empty boxes instead of a clean `{}` representation.

This PR adds a simple `|| {}` fallback in `getContent()` for both run services to normalize any falsy response (empty string, null, undefined from a 204) into an empty object `{}`.

## Impact of Change
- **Users**: Monitoring view now consistently renders `{}` for empty action inputs/outputs instead of showing blank/broken content boxes.
- **Developers**: No API changes. The `getContent()` method in both run services now guarantees a truthy return value when the HTTP call succeeds.
- **System**: No performance or architecture impact. Minimal 1-line change per service.

## Changes
- `libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts` — Added `|| {}` fallback to normalize empty `getContent()` responses
- `libs/logic-apps-shared/src/designer-client-services/lib/consumption/run.ts` — Same `|| {}` fallback applied for consistency
- `libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/run.spec.ts` — Added `getContent` test suite covering 204/null/undefined/valid/oversized content scenarios
- `libs/logic-apps-shared/src/designer-client-services/lib/consumption/__tests__/run.spec.ts` — Added matching `getContent` test suite for consumption service

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer with workflow actions returning 204 No Content

## Contributors
@ccastrotrejo

## Screenshots/Videos
<!-- N/A — no visual component changes -->
