### PR TITLE
fix(designer): Adding support for dynamic invoke calls for invokeWorkflow action

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -86,7 +86,6 @@ const httpClient = new HttpClient();
 
 const DesignerEditor = () => {
   const { id: workflowId } = useSelector((state: RootState) => ({
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     id: state.workflowLoader.resourcePath!,
   }));
 
@@ -651,7 +650,6 @@ const getDesignerServices = (
     ...defaultServiceParams,
     workflowName,
     clientSupportedOperations: [
-      ['connectionProviders/localWorkflowOperation', 'invokeWorkflow'],
       ['connectionProviders/xmlOperations', 'xmlValidation'],
       ['connectionProviders/xmlOperations', 'xmlTransform'],
       ['connectionProviders/liquidOperations', 'liquidJsonToJson'],
@@ -1041,7 +1039,6 @@ const getConnectionsToUpdate = (
   if (hasNewServiceProviderKeys) {
     for (const serviceProviderConnectionName of Object.keys(connectionsJson.serviceProviderConnections ?? {})) {
       if (originalConnectionsJson.serviceProviderConnections?.[serviceProviderConnectionName]) {
-        // eslint-disable-next-line no-param-reassign
         (connectionsJson.serviceProviderConnections as any)[serviceProviderConnectionName] =
           originalConnectionsJson.serviceProviderConnections[serviceProviderConnectionName];
       }
@@ -1051,7 +1048,6 @@ const getConnectionsToUpdate = (
   if (hasNewAgentKeys) {
     for (const agentConnectionName of Object.keys(connectionsJson.agentConnections ?? {})) {
       if (originalConnectionsJson.agentConnections?.[agentConnectionName]) {
-        // eslint-disable-next-line no-param-reassign
         (connectionsJson.agentConnections as any)[agentConnectionName] = originalConnectionsJson.agentConnections[agentConnectionName];
       }
     }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/connector.ts
@@ -92,16 +92,20 @@ export abstract class BaseConnectorService implements IConnectorService {
     );
   }
 
-  protected _getInvokeParameters(parameters: Record<string, any>, dynamicState: any): Record<string, any> {
+  protected _getInvokeParameters(parameters: Record<string, any>, dynamicState: any, workflowName?: string): Record<string, any> {
     const invokeParameters = { ...parameters };
     const additionalParameters = dynamicState.parameters;
 
     if (additionalParameters) {
       for (const parameterName of Object.keys(additionalParameters)) {
-        const { value } = additionalParameters[parameterName];
+        const { value, workflowReference } = additionalParameters[parameterName];
 
         if (value !== undefined) {
           invokeParameters[parameterName] = value;
+        }
+
+        if (workflowReference === true && workflowName) {
+          invokeParameters[parameterName] = workflowName;
         }
       }
     }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connector.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connector.ts
@@ -104,9 +104,9 @@ export class StandardConnectorService extends BaseConnectorService {
     connectionId: string | undefined,
     operationPath?: string
   ): Promise<ListDynamicValue[]> {
-    const { baseUrl, apiVersion, httpClient, getConfiguration } = this.options;
+    const { baseUrl, apiVersion, httpClient, getConfiguration, workflowName } = this.options;
     const { operationId: dynamicOperation, apiType } = dynamicState;
-    const invokeParameters = this._getInvokeParameters(parameters, dynamicState);
+    const invokeParameters = this._getInvokeParameters(parameters, dynamicState, workflowName);
     const isMcpConnection = apiType === 'mcp' && dynamicOperation === 'listMcpTools';
 
     if (this._isClientSupportedOperation(connectorId, operationId)) {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Using backend dynamic invoke api to list childworkflows. Also added new parameter type support while sending the operation parameters in dynamic invoke api.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users will see quick loading of workflows in their built in action dropdown since using backend API instead of client one.
- **Developers**: removed hard coding of special handling for child workflow actions.
- **System**: Fast loading of designer since multiple api call is not happening from client side.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors

## Screenshots/Videos
<!-- Visual changes only -->
