### PR TITLE
fix(designers): Improving action name validation

### DIFF
--- a/libs/designer-v2/src/lib/core/utils/__test__/graph.spec.ts
+++ b/libs/designer-v2/src/lib/core/utils/__test__/graph.spec.ts
@@ -1,6 +1,15 @@
-import { createWorkflowEdge, createWorkflowNode, isRootNode, getAllNodesInsideNode, getUpstreamNodeIds, isTriggerNode } from '../graph';
+import {
+  createWorkflowEdge,
+  createWorkflowNode,
+  isRootNode,
+  getAllNodesInsideNode,
+  getUpstreamNodeIds,
+  isTriggerNode,
+  isOperationNameValid,
+} from '../graph';
 import { WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
+import { getTestIntl } from '../../../__test__/intl-test-helper';
 describe('Graph Utilities', () => {
   const graph = {
     id: 'root',
@@ -124,6 +133,20 @@ describe('Graph Utilities', () => {
       expect(isTriggerNode('Compose_2', nodesMetadata)).toBeFalsy();
       expect(isTriggerNode('Compose_10', nodesMetadata)).toBeFalsy();
       expect(isTriggerNode('Compose_3', nodesMetadata)).toBeFalsy();
+    });
+  });
+
+  describe('isOperationNameValid', () => {
+    it('should return true as there is no node with that name', () => {
+      expect(isOperationNameValid('Compose', 'Compose_12', 'Compose_', false, nodesMetadata, {}, getTestIntl()).isValid).toBeTruthy();
+    });
+
+    it('should return true as there is no other node with that name, even if the selected node previous and new name are equal', () => {
+      expect(isOperationNameValid('Compose', 'Compose_13', 'Compose_13', false, nodesMetadata, {}, getTestIntl()).isValid).toBeTruthy();
+    });
+
+    it('should return false as there is already a node with that name', () => {
+      expect(isOperationNameValid('Compose', 'Compose_5', 'Compose_', false, nodesMetadata, {}, getTestIntl()).isValid).toBeFalsy();
     });
   });
 

--- a/libs/designer-v2/src/lib/core/utils/graph.ts
+++ b/libs/designer-v2/src/lib/core/utils/graph.ts
@@ -217,12 +217,14 @@ export const getFirstParentOfType = (
 export const isOperationNameValid = (
   nodeId: string,
   newName: string,
+  oldName: string,
   isTrigger: boolean,
   nodesMetadata: NodesMetadata,
   idReplacements: Record<string, string>,
   intl: IntlShape
 ): { isValid: boolean; message: string } => {
   const name = transformOperationTitle(newName);
+  const previousName = transformOperationTitle(oldName);
   const subgraphType = getRecordEntry(nodesMetadata, nodeId)?.subgraphType;
 
   const messages = {
@@ -255,12 +257,17 @@ export const isOperationNameValid = (
     }
   }
 
-  // Check for name uniqueness.
-  const existingNames = Object.keys(nodesMetadata).map((id) => getRecordEntry(idReplacements, id) ?? id);
-  const isDuplicateName = existingNames.some((nodeName) => equals(nodeName, name));
-  if (isDuplicateName) {
-    return { isValid: false, message: messages.DEFAULT };
+  // Check for name uniqueness only when previous and new names of the selected node are not equal
+  const previousAndNewNamesNotSame = !equals(previousName, name);
+
+  if (previousAndNewNamesNotSame) {
+    const existingNames = Object.keys(nodesMetadata).map((id) => getRecordEntry(idReplacements, id) ?? id);
+    const isDuplicateName = existingNames.some((nodeName) => equals(nodeName, name));
+    if (isDuplicateName) {
+      return { isValid: false, message: messages.DEFAULT };
+    }
   }
+
   return { isValid: true, message: '' };
 };
 

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -154,7 +154,15 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
   );
 
   const onTitleChange = (originalId: string, newId: string): { valid: boolean; oldValue?: string; message: string } => {
-    const validation = isOperationNameValid(originalId, newId, isTrigger, nodesMetadata, idReplacements, intl);
+    const validation = isOperationNameValid(
+      originalId,
+      newId,
+      selectedNodeData!.displayName,
+      isTrigger,
+      nodesMetadata,
+      idReplacements,
+      intl
+    );
     return { valid: validation.isValid, oldValue: validation.isValid ? newId : originalId, message: validation.message };
   };
 
@@ -284,5 +292,5 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
 };
 
 // TODO: 12798935 Analytics (event logging)
-// eslint-disable-next-line @typescript-eslint/no-empty-function
+
 const handleTrackEvent = (_data: PageActionTelemetryData): void => {};

--- a/libs/designer/src/lib/core/utils/__test__/graph.spec.ts
+++ b/libs/designer/src/lib/core/utils/__test__/graph.spec.ts
@@ -1,6 +1,15 @@
-import { createWorkflowEdge, createWorkflowNode, isRootNode, getAllNodesInsideNode, getUpstreamNodeIds, isTriggerNode } from '../graph';
+import {
+  createWorkflowEdge,
+  createWorkflowNode,
+  isRootNode,
+  getAllNodesInsideNode,
+  getUpstreamNodeIds,
+  isTriggerNode,
+  isOperationNameValid,
+} from '../graph';
 import { WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
+import { getTestIntl } from '../../../__test__/intl-test-helper';
 describe('Graph Utilities', () => {
   const graph = {
     id: 'root',
@@ -124,6 +133,20 @@ describe('Graph Utilities', () => {
       expect(isTriggerNode('Compose_2', nodesMetadata)).toBeFalsy();
       expect(isTriggerNode('Compose_10', nodesMetadata)).toBeFalsy();
       expect(isTriggerNode('Compose_3', nodesMetadata)).toBeFalsy();
+    });
+  });
+
+  describe('isOperationNameValid', () => {
+    it('should return true as there is no node with that name', () => {
+      expect(isOperationNameValid('Compose', 'Compose_12', 'Compose_', false, nodesMetadata, {}, getTestIntl()).isValid).toBeTruthy();
+    });
+
+    it('should return true as there is no other node with that name, even if the selected node previous and new name are equal', () => {
+      expect(isOperationNameValid('Compose', 'Compose_13', 'Compose_13', false, nodesMetadata, {}, getTestIntl()).isValid).toBeTruthy();
+    });
+
+    it('should return false as there is already a node with that name', () => {
+      expect(isOperationNameValid('Compose', 'Compose_5', 'Compose_', false, nodesMetadata, {}, getTestIntl()).isValid).toBeFalsy();
     });
   });
 

--- a/libs/designer/src/lib/core/utils/graph.ts
+++ b/libs/designer/src/lib/core/utils/graph.ts
@@ -210,12 +210,14 @@ export const getFirstParentOfType = (
 export const isOperationNameValid = (
   nodeId: string,
   newName: string,
+  oldName: string,
   isTrigger: boolean,
   nodesMetadata: NodesMetadata,
   idReplacements: Record<string, string>,
   intl: IntlShape
 ): { isValid: boolean; message: string } => {
   const name = transformOperationTitle(newName);
+  const previousName = transformOperationTitle(oldName);
   const subgraphType = getRecordEntry(nodesMetadata, nodeId)?.subgraphType;
 
   const messages = {
@@ -248,12 +250,17 @@ export const isOperationNameValid = (
     }
   }
 
-  // Check for name uniqueness.
-  const existingNames = Object.keys(nodesMetadata).map((id) => getRecordEntry(idReplacements, id) ?? id);
-  const isDuplicateName = existingNames.some((nodeName) => equals(nodeName, name));
-  if (isDuplicateName) {
-    return { isValid: false, message: messages.DEFAULT };
+  // Check for name uniqueness only when previous and new names of the selected node are not equal
+  const previousAndNewNamesNotSame = !equals(previousName, name);
+
+  if (previousAndNewNamesNotSame) {
+    const existingNames = Object.keys(nodesMetadata).map((id) => getRecordEntry(idReplacements, id) ?? id);
+    const isDuplicateName = existingNames.some((nodeName) => equals(nodeName, name));
+    if (isDuplicateName) {
+      return { isValid: false, message: messages.DEFAULT };
+    }
   }
+
   return { isValid: true, message: '' };
 };
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/nodeDetailsPanel.tsx
@@ -153,7 +153,15 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
   );
 
   const onTitleChange = (originalId: string, newId: string): { valid: boolean; oldValue?: string; message: string } => {
-    const validation = isOperationNameValid(originalId, newId, isTrigger, nodesMetadata, idReplacements, intl);
+    const validation = isOperationNameValid(
+      originalId,
+      newId,
+      selectedNodeData!.displayName,
+      isTrigger,
+      nodesMetadata,
+      idReplacements,
+      intl
+    );
     return { valid: validation.isValid, oldValue: validation.isValid ? newId : originalId, message: validation.message };
   };
 
@@ -283,5 +291,5 @@ export const NodeDetailsPanel = (props: CommonPanelProps): JSX.Element => {
 };
 
 // TODO: 12798935 Analytics (event logging)
-// eslint-disable-next-line @typescript-eslint/no-empty-function
+
 const handleTrackEvent = (_data: PageActionTelemetryData): void => {};


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
When you select an action or node to change its name in the details panel, you type a name and then realize that you added an extra space at the end. When you try to remove it (without hitting Enter), it says "The name already exists..." (even though there are no other actions with that name). Finally, your given name gets removed.

Root cause: The selected node's previous name is being included in the name uniqueness validation. The validation should only check against the names of other nodes.

This improves the user experience, as it's common to rename actions, mistype or add extra spaces, and want to correct them mid-edit — especially when copying names from elsewhere.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: better user experience
- **Developers**: 
- **System**: 

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer 

## Contributors
@Santiagosala2


## Screenshots/Videos
