### PR TITLE
fix(iframe-app): fix auth popup not auto-refreshing after login

### DIFF
--- a/apps/iframe-app/src/lib/__tests__/authHandler.test.ts
+++ b/apps/iframe-app/src/lib/__tests__/authHandler.test.ts
@@ -367,6 +367,202 @@ describe('authHandler', () => {
 
       vi.useRealTimers();
     });
+
+    it('should keep polling when popup is still open and user is not yet authenticated', async () => {
+      vi.useFakeTimers();
+
+      const mockPopup = { closed: false, close: vi.fn() } as Record<string, unknown>;
+      Object.defineProperty(mockPopup, 'location', {
+        get: () => {
+          throw new DOMException('cross-origin');
+        },
+        configurable: true,
+      });
+      mockWindowOpen.mockReturnValueOnce(mockPopup);
+
+      // Initially return 401 (not authenticated, error: null)
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        type: 'basic',
+      });
+
+      const onSuccess = vi.fn();
+      const onFailed = vi.fn();
+
+      openLoginPopup({
+        baseUrl: 'https://example.com',
+        signInEndpoint: '/.auth/login/aad',
+        onSuccess,
+        onFailed,
+      });
+
+      // Advance several polling ticks while popup is still open
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(500);
+
+      // Should NOT have called onFailed or onSuccess — popup is still open
+      expect(onFailed).not.toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+
+      // Now simulate popup closing and auth succeeding
+      mockPopup.closed = true;
+      const mockToken = createMockJwt({ name: 'Test User', sub: 'user123' });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ provider_name: 'aad', access_token: mockToken }]),
+      });
+
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.runAllTimersAsync();
+
+      expect(onSuccess).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('should call onFailed when popup is closed and user is not authenticated', async () => {
+      vi.useFakeTimers();
+
+      const mockPopup = { closed: false, close: vi.fn() } as Record<string, unknown>;
+      Object.defineProperty(mockPopup, 'location', {
+        get: () => {
+          throw new DOMException('cross-origin');
+        },
+        configurable: true,
+      });
+      mockWindowOpen.mockReturnValueOnce(mockPopup);
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        type: 'basic',
+      });
+
+      const onFailed = vi.fn();
+
+      openLoginPopup({
+        baseUrl: 'https://example.com',
+        signInEndpoint: '/.auth/login/aad',
+        onFailed,
+      });
+
+      // First tick triggers cross-origin detection (wasOnDifferentOrigin = true)
+      await vi.advanceTimersByTimeAsync(500);
+
+      // Close the popup
+      mockPopup.closed = true;
+
+      // Next tick detects popup closed + not authenticated
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.runAllTimersAsync();
+
+      expect(onFailed).toHaveBeenCalled();
+      const errorArg = onFailed.mock.calls[0][0];
+      expect(errorArg).toBeInstanceOf(Error);
+      expect(errorArg.message).toBe('Login cancelled or failed');
+
+      vi.useRealTimers();
+    });
+
+    it('should not crash when checkAuthStatus returns null error', async () => {
+      vi.useFakeTimers();
+
+      const mockPopup = { closed: true, close: vi.fn() } as Record<string, unknown>;
+      Object.defineProperty(mockPopup, 'location', {
+        get: () => {
+          throw new DOMException('cross-origin');
+        },
+        configurable: true,
+      });
+      mockWindowOpen.mockReturnValueOnce(mockPopup);
+
+      // 401 returns { isAuthenticated: false, error: null }
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        type: 'basic',
+      });
+
+      const onFailed = vi.fn();
+
+      openLoginPopup({
+        baseUrl: 'https://example.com',
+        signInEndpoint: '/.auth/login/aad',
+        onFailed,
+      });
+
+      // Advance timers — should not throw TypeError
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.runAllTimersAsync();
+
+      expect(onFailed).toHaveBeenCalled();
+      const errorArg = onFailed.mock.calls[0][0];
+      expect(errorArg).toBeInstanceOf(Error);
+
+      vi.useRealTimers();
+    });
+
+    it('should call onSuccess after cross-origin navigation when authentication succeeds', async () => {
+      vi.useFakeTimers();
+
+      const mockPopup = { closed: false, close: vi.fn() } as Record<string, unknown>;
+      Object.defineProperty(mockPopup, 'location', {
+        get: () => {
+          throw new DOMException('cross-origin');
+        },
+        configurable: true,
+      });
+      mockWindowOpen.mockReturnValueOnce(mockPopup);
+
+      // First few ticks: 401 (not authenticated)
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        type: 'basic',
+      });
+
+      const onSuccess = vi.fn();
+      const onFailed = vi.fn();
+
+      openLoginPopup({
+        baseUrl: 'https://example.com',
+        signInEndpoint: '/.auth/login/aad',
+        onSuccess,
+        onFailed,
+      });
+
+      // First tick: cross-origin error sets wasOnDifferentOrigin
+      await vi.advanceTimersByTimeAsync(500);
+      // Second tick: polls auth, gets 401, popup still open — keeps polling
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(onFailed).not.toHaveBeenCalled();
+
+      // Now auth succeeds (user completed login in popup)
+      const mockToken = createMockJwt({ name: 'Authenticated User', sub: 'user456' });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ provider_name: 'aad', access_token: mockToken }]),
+      });
+
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.runAllTimersAsync();
+
+      expect(onSuccess).toHaveBeenCalled();
+      expect(onFailed).not.toHaveBeenCalled();
+
+      const authInfo = onSuccess.mock.calls[0][0];
+      expect(authInfo.isAuthenticated).toBe(true);
+      expect(authInfo.username).toBe('Authenticated User');
+
+      vi.useRealTimers();
+    });
   });
 
   describe('createUnauthorizedHandler', () => {

--- a/apps/iframe-app/src/lib/authHandler.ts
+++ b/apps/iframe-app/src/lib/authHandler.ts
@@ -297,7 +297,7 @@ export function openLoginPopup(options: LoginPopupOptions): void {
       return;
     }
 
-    // Single path for auth checking - prevents duplicate success calls
+    // Re-check: another tick may have completed during the async block above
     if (completed) {
       return;
     }
@@ -320,12 +320,9 @@ export function openLoginPopup(options: LoginPopupOptions): void {
 
       if (authInfo.isAuthenticated) {
         handleSuccess(authInfo);
-      } else if (!authInfo.isAuthenticated) {
-        // Only fail if popup is closed AND not authenticated
-        handleFailure(authInfo.error as Error);
-      } else if (popupIsClosed && !completed) {
-        // Only fail if popup is closed AND not authenticated
-        handleFailure(new Error('Login cancelled or failed'));
+      } else if (popupIsClosed) {
+        // Only fail when popup is closed AND user is not authenticated
+        handleFailure(authInfo.error ?? new Error('Login cancelled or failed'));
       }
       // If not authenticated but popup still open, keep polling
     } catch (error) {
@@ -334,7 +331,7 @@ export function openLoginPopup(options: LoginPopupOptions): void {
         handleFailure(err);
       }
     }
-  }, 500); // Poll every 500ms
+  }, 500);
 
   // Timeout handler
   const timeoutId = setTimeout(() => {
@@ -342,7 +339,6 @@ export function openLoginPopup(options: LoginPopupOptions): void {
       return;
     }
     console.log('[Auth] Login timed out');
-    cleanup();
     if (!popup.closed) {
       popup.close();
     }


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
The iframe chat app login popup flow was broken: after the user clicked an identity provider (e.g., "Microsoft account") and completed authentication in the popup, the iframe page stayed stuck on the login prompt instead of transitioning to the chat UI.

**Root cause:** In `openLoginPopup` (authHandler.ts), the polling logic had three interrelated bugs:

1. **Premature failure** — Once the popup navigated to Azure AD (cross-origin), every 500ms poll tick called `handleFailure` without checking if the popup was still open. The user was still logging in, but the polling already gave up.
2. **Null error → silent crash** — `checkAuthStatus` returns `error: null` for 401/403. Passing `null` to `onFailed` caused a TypeError on `error.message`, silently crashing the interval and permanently stopping the polling.
3. **Dead code** — The third `else if` branch was unreachable (first two conditions covered all boolean values).

**Fix:** Replace the broken 3-way condition with a correct 2-way that only fails when `popupIsClosed` is true, and uses nullish coalescing (`??`) for a fallback error message.

## Impact of Change
- **Users**: Iframe chat users who need to authenticate via identity providers (e.g., Microsoft account) will now see the chat UI automatically after completing login, instead of being stuck on the login screen.
- **Developers**: No API changes.
- **System**: No performance or architectural impact. Surgical fix to polling condition logic.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: Unit test suite (36/36 authHandler tests pass, 266/266 full iframe-app tests pass)

### New test cases added:
1. **Keeps polling when popup open** — verifies no premature `onFailed` while user is still on Azure AD
2. **Fails properly when popup closed + unauthenticated** — confirms `onFailed` called with meaningful Error
3. **No crash on null error** — ensures `??` fallback prevents TypeError
4. **Full OAuth flow succeeds** — validates cross-origin → auth check → success with username

## Contributors
@Copilot

## Screenshots/Videos
N/A — logic fix, no visual changes.