### PR TITLE
fix(designer): resolve built-in MCP save/serialization validation issues in consumption

### DIFF
--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -161,6 +161,11 @@ export const serializeWorkflow = async (rootState: RootState, options?: Serializ
       return references;
     }
 
+    const operation = getRecordEntry(rootState.operations.operationInfo, nodeId);
+    if (operation && isBuiltInMcpOperation(operation)) {
+      return references;
+    }
+
     references[referenceKey] = referencesObject[referenceKey];
     return references;
   }, {});

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -161,6 +161,11 @@ export const serializeWorkflow = async (rootState: RootState, options?: Serializ
       return references;
     }
 
+    const operation = getRecordEntry(rootState.operations.operationInfo, nodeId);
+    if (operation && isBuiltInMcpOperation(operation)) {
+      return references;
+    }
+
     references[referenceKey] = referencesObject[referenceKey];
     return references;
   }, {});


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
This PR fixes built-in MCP behavior for consumption workflows where:
1. Code view/save payloads could serialize MCP connections in a shape that caused backend validation errors.
2. Built-in MCP references were incorrectly included in `$connections`, producing invalid `connectionId` validation failures.
3. MCP dynamic tool listing payload shape did not match backend expectations for `listMcpTools`.

The goal is to keep built-in MCP connection data inlined in operation inputs, while avoiding invalid connection reference serialization for save.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Built-in MCP tool flows can be saved more reliably; code view now reflects expected MCP connection input structure.
- **Developers**: Added guardrails in serialization logic for MCP operation handling and connection reference filtering.
- **System**: Reduced save-time validation failures from malformed/invalid MCP connection payloads.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: local standalone + portal test environment

Manual scenarios covered:
- Add built-in MCP server/tool from agent flow.
- Verify code view shows MCP connection under `inputs.Connection`.
- Save workflow and validate no `connectionId` format error for MCP built-in paths.
- Validate MCP tool list call shape for `listMcpTools`.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
- @bhavya

## Screenshots/Videos
<!-- Visual changes only -->
- N/A (behavioral/serialization fix)