### PR TITLE
chore(Automation): Auto-close daily status reports

### DIFF
--- a/.github/workflows/ISSUE_MANAGEMENT.yml
+++ b/.github/workflows/ISSUE_MANAGEMENT.yml
@@ -21,3 +21,12 @@ jobs:
           close-issue-message: "This issue has been closed because the information requested wasn't provided within 7 days."
           operations-per-run: 200
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/stale@v4
+        with:
+          only-labels: 'daily-status'
+          days-before-issue-stale: 0
+          days-before-issue-close: 1
+          stale-issue-label: 'stale'
+          close-issue-message: "Auto-closing daily status report after 1 day."
+          operations-per-run: 100
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Our automated daily status report issues are flooding our open issue logs.
This will auto-close any that are over a day old since there will be a new one to take it's place.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: N/A
- **Developers**: Our open issues will not be flooded with daily status reports
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

** GH issue automation, testing not needed **

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A
