### PR TITLE
feat(v2designer): add feature flags for MCP client tools feature

### DIFF
--- a/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
+++ b/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import { getStateHistory, setStateHistory } from './historyHelpers';
 import type { RootState } from './store';
 import type { ConnectionReferences, WorkflowParameter } from '@microsoft/logic-apps-designer';

--- a/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -52,6 +52,8 @@ export interface DesignerOptionsState {
     collapseGraphsByDefault?: boolean; // collapse scope by default
     enableMultiVariable?: boolean; // prevent creating multiple variables in one action
     enableNestedAgentLoops?: boolean; // allow agent loops to be added inside regular loops (requires bundle version >= 1.115.0)
+    disableMcpClientTools?: boolean; // hide MCP client tools from browse panel
+    disableNativeMcpClientTools?: boolean; // hide native (built-in) MCP client tools tab from browse panel
   };
   nodeSelectAdditionalCallback?: (nodeId: string) => any;
   panelTabHideKeys?: PANEL_TAB_NAMES[];

--- a/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSelectors.ts
@@ -62,6 +62,14 @@ export const useEnableNestedAgentLoops = () => {
   return useSelector((state: RootState) => state.designerOptions.hostOptions?.enableNestedAgentLoops ?? false);
 };
 
+export const useDisableMcpClientTools = () => {
+  return useSelector((state: RootState) => state.designerOptions.hostOptions?.disableMcpClientTools ?? false);
+};
+
+export const useDisableNativeMcpClientTools = () => {
+  return useSelector((state: RootState) => state.designerOptions.hostOptions?.disableNativeMcpClientTools ?? false);
+};
+
 export const useAreDesignerOptionsInitialized = () => {
   return useSelector((state: RootState) => state.designerOptions?.designerOptionsInitialized ?? false);
 };

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/browseView.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/browseView.spec.tsx
@@ -131,6 +131,7 @@ const createTestStore = () =>
       panel: () => ({}),
       operations: () => ({}),
       workflow: () => ({}),
+      designerOptions: () => ({ hostOptions: {} }),
     },
   });
 
@@ -316,7 +317,7 @@ describe('BrowseView', () => {
       render(<BrowseView isTrigger={false} onOperationClick={mockOnOperationClick} />, { wrapper: createWrapper() });
 
       // getActionCategories should be called with allowAgents=true
-      expect(mockGetActionCategories).toHaveBeenCalledWith(true, false);
+      expect(mockGetActionCategories).toHaveBeenCalledWith(true, false, false);
     });
 
     test('should pass allowAgents as false when graphId is not root', () => {
@@ -329,7 +330,7 @@ describe('BrowseView', () => {
       render(<BrowseView isTrigger={false} onOperationClick={mockOnOperationClick} />, { wrapper: createWrapper() });
 
       // getActionCategories should be called with allowAgents=false
-      expect(mockGetActionCategories).toHaveBeenCalledWith(false, false);
+      expect(mockGetActionCategories).toHaveBeenCalledWith(false, false, false);
     });
 
     test('should pass isAddingAgentTool to getActionCategories', () => {
@@ -337,7 +338,7 @@ describe('BrowseView', () => {
 
       render(<BrowseView isTrigger={false} onOperationClick={mockOnOperationClick} />, { wrapper: createWrapper() });
 
-      expect(mockGetActionCategories).toHaveBeenCalledWith(true, true);
+      expect(mockGetActionCategories).toHaveBeenCalledWith(true, true, false);
     });
   });
 });

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/helper.spec.ts
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/helper.spec.ts
@@ -105,6 +105,20 @@ describe('browse helper', () => {
       expect(mcpServers?.visible).toBeUndefined();
     });
 
+    test('should set mcpServers visible to false when disableMcpClientTools is true even if isAddingAgentTool is true', () => {
+      const categories = getActionCategories(false, true, true);
+      const mcpServers = categories.find((c) => c.key === 'mcpServers');
+
+      expect(mcpServers?.visible).toBe(false);
+    });
+
+    test('should set mcpServers visible to true when isAddingAgentTool is true and disableMcpClientTools is false', () => {
+      const categories = getActionCategories(false, true, false);
+      const mcpServers = categories.find((c) => c.key === 'mcpServers');
+
+      expect(mcpServers?.visible).toBe(true);
+    });
+
     test('should include aiAgent category', () => {
       const categories = getActionCategories();
       const aiAgent = categories.find((c) => c.key === 'aiAgent');

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/mcpServersBrowse.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/mcpServersBrowse.spec.tsx
@@ -52,6 +52,7 @@ const createTestStore = () =>
   configureStore({
     reducer: {
       panel: () => ({}),
+      designerOptions: () => ({ hostOptions: {} }),
     },
   });
 

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/browseView.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/browseView.tsx
@@ -17,6 +17,7 @@ import type { AppDispatch } from '../../../../core';
 import { equals, type DiscoveryOperation, type DiscoveryResultTypes } from '@microsoft/logic-apps-shared';
 import { getNodeId } from '../helpers';
 import { getTriggerCategories, getActionCategories, BrowseCategoryType } from './helper';
+import { useDisableMcpClientTools } from '../../../../core/state/designerOptions/designerOptionsSelectors';
 
 interface BrowseViewProps {
   isTrigger?: boolean;
@@ -33,8 +34,9 @@ export const BrowseView = ({ isTrigger = false, onOperationClick }: BrowseViewPr
 
   const allowAgents = equals(relationshipIds.graphId, 'root');
   const isAddingAgentTool = useIsAddingAgentTool();
+  const disableMcpClientTools = useDisableMcpClientTools();
 
-  const categories = isTrigger ? getTriggerCategories() : getActionCategories(allowAgents, isAddingAgentTool);
+  const categories = isTrigger ? getTriggerCategories() : getActionCategories(allowAgents, isAddingAgentTool, disableMcpClientTools);
 
   const addTriggerOperation = useCallback(
     (operation: DiscoveryOperation<DiscoveryResultTypes>) => {

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/helper.ts
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/helper.ts
@@ -185,7 +185,11 @@ export const getTriggerCategories = (): BrowseCategoryConfig[] => {
   ];
 };
 
-export const getActionCategories = (allowAgents?: boolean, isAddingAgentTool?: boolean): BrowseCategoryConfig[] => {
+export const getActionCategories = (
+  allowAgents?: boolean,
+  isAddingAgentTool?: boolean,
+  disableMcpClientTools?: boolean
+): BrowseCategoryConfig[] => {
   const intl = getIntl();
 
   return [
@@ -206,7 +210,7 @@ export const getActionCategories = (allowAgents?: boolean, isAddingAgentTool?: b
     },
     {
       key: 'mcpServers',
-      visible: isAddingAgentTool,
+      visible: isAddingAgentTool && !(disableMcpClientTools ?? false),
       text: intl.formatMessage({
         defaultMessage: 'MCP servers',
         id: 'pVNvTG',

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpServersBrowse.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpServersBrowse.tsx
@@ -10,6 +10,7 @@ import { useMcpServersBrowseStyles } from './styles/McpServersBrowse.styles';
 import type { DiscoveryOperation, DiscoveryResultTypes } from '@microsoft/logic-apps-shared';
 import { openMcpToolWizard } from '../../../../core/state/panel/panelSlice';
 import { builtinMcpServerOperation, connectionToOperation, getOperationCardDataFromOperation, MCP_CLIENT_CONNECTOR_ID } from '../helpers';
+import { useDisableNativeMcpClientTools } from '../../../../core/state/designerOptions/designerOptionsSelectors';
 
 type McpServerTab = 'all' | 'microsoft' | 'custom' | 'others';
 
@@ -24,6 +25,7 @@ export const McpServersBrowse = ({ onOperationClick: _onOperationClick }: McpSer
 
   const [selectedTab, setSelectedTab] = useState<McpServerTab>('all');
   const [sortOrder, setSortOrder] = useState<'a-to-z' | 'z-to-a'>('a-to-z');
+  const disableNativeMcpClientTools = useDisableNativeMcpClientTools();
 
   const { data: mcpServersData, isLoading: isServersLoading } = useMcpServersQuery();
 
@@ -127,7 +129,7 @@ export const McpServersBrowse = ({ onOperationClick: _onOperationClick }: McpSer
   }, []);
 
   const filteredAndSortedServers = useMemo(() => {
-    const connectionOperations = (mcpConnections ?? []).map(connectionToOperation);
+    const connectionOperations = disableNativeMcpClientTools ? [] : (mcpConnections ?? []).map(connectionToOperation);
 
     let filtered: DiscoveryOperation<DiscoveryResultTypes>[] = [];
 
@@ -147,14 +149,14 @@ export const McpServersBrowse = ({ onOperationClick: _onOperationClick }: McpSer
       return sortOrder === 'a-to-z' ? aName.localeCompare(bName) : bName.localeCompare(aName);
     });
 
-    if (selectedTab === 'all') {
+    if (selectedTab === 'all' && !disableNativeMcpClientTools) {
       return [builtinMcpServerOperation, ...filtered];
     }
     if (selectedTab === 'others') {
-      return [builtinMcpServerOperation, ...filtered];
+      return disableNativeMcpClientTools ? filtered : [builtinMcpServerOperation, ...filtered];
     }
     return filtered;
-  }, [mcpServers, mcpConnections, selectedTab, sortOrder, isMicrosoftServer]);
+  }, [mcpServers, mcpConnections, selectedTab, sortOrder, isMicrosoftServer, disableNativeMcpClientTools]);
 
   const displayingItemsText = intl.formatMessage(
     {
@@ -189,7 +191,7 @@ export const McpServersBrowse = ({ onOperationClick: _onOperationClick }: McpSer
           <Tab value="all">{allTabText}</Tab>
           <Tab value="microsoft">{microsoftTabText}</Tab>
           <Tab value="custom">{customTabText}</Tab>
-          <Tab value="others">{othersTabText}</Tab>
+          {!disableNativeMcpClientTools && <Tab value="others">{othersTabText}</Tab>}
         </TabList>
       </div>
 


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Add disableMcpClientTools and disableNativeMcpClientTools feature flags. If not set, default will be false. These flags allow partners to hide the MCP servers category and the native built-in MCP client tools tab in the Browse panel.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
feature could be hidden
- **Developers**: <!-- API changes, new patterns, etc. -->
Partners will use this flag to hide two features for their customers
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: <!-- environments/scenarios --> local

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
