### PR TITLE
fix(vscode): Fixing Syntax Issue Causing Local Build Error

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/foundryAgentService.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/foundryAgentService.ts
@@ -273,7 +273,7 @@ function extractVersionsData(response: unknown): FoundryAgentVersion[] {
 
   // Wrapped shape: { result: { data: [...] } }
   const result = resp['result'] as Record<string, unknown> | undefined;
-  if (Array.isArray(result?.['data'])) {
+  if (result && Array.isArray(result['data'])) {
     return result['data'] as FoundryAgentVersion[];
   }
 


### PR DESCRIPTION

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
This fixes an issue with building the vscode extension locally. The syntax is currently not allowed as is.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
N/A
- **Developers**: <!-- API changes, new patterns, etc. -->
N/A
- **System**: <!-- Performance, architecture, dependencies -->
System can build as expected now

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
