### PR TITLE
fix(DesignerV2): Improved copilot response parsing

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditor.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditor.spec.ts
@@ -254,6 +254,128 @@ describe('BaseCopilotWorkflowEditorService', () => {
       expect(result.text).toBe(plainText);
     });
 
+    it('should repair unescaped double quotes inside JSON string values', async () => {
+      // Simulate LLM producing unescaped quotes in a note's content field
+      const brokenJson =
+        '{"type":"workflow","text":"Added note","workflow":{"definition":{"$schema":"test","contentVersion":"1.0","triggers":{},"actions":{}},"notes":{"abc-123":{"content":""The only way out is through." — Robert Frost","color":"#CCE5FF","metadata":{"position":{"x":0,"y":0},"width":200,"height":100}}}},"changes":[{"changeType":"added","targetType":"note","nodeIds":["abc-123"],"description":"Added a note"}]}';
+
+      mockFetch.mockReturnValueOnce(
+        makeFetchResponse({
+          choices: [{ message: { content: brokenJson } }],
+        })
+      );
+
+      const svc = new BaseCopilotWorkflowEditorService(defaultOptions);
+      const result = await svc.getWorkflowEdit('add a note', simpleWorkflow);
+
+      expect(result.type).toBe('workflow');
+      expect(result.workflow).toBeDefined();
+      expect(result.workflow?.notes?.['abc-123']).toBeDefined();
+      expect(result.changes).toHaveLength(1);
+    });
+
+    it('should extract JSON wrapped in prose text (no code fence)', async () => {
+      const inner = JSON.stringify({ type: 'text', text: 'Extracted from prose' });
+      const proseWrapped = `Here is my response:\n\n${inner}\n\nHope that helps!`;
+
+      mockFetch.mockReturnValueOnce(
+        makeFetchResponse({
+          choices: [{ message: { content: proseWrapped } }],
+        })
+      );
+
+      const svc = new BaseCopilotWorkflowEditorService(defaultOptions);
+      const result = await svc.getWorkflowEdit('test', simpleWorkflow);
+
+      expect(result.type).toBe('text');
+      expect(result.text).toBe('Extracted from prose');
+    });
+
+    it('should handle JSON in a bare code fence without language tag', async () => {
+      const inner = JSON.stringify({ type: 'text', text: 'From bare fence' });
+      const bareFence = `\`\`\`\n${inner}\n\`\`\``;
+
+      mockFetch.mockReturnValueOnce(
+        makeFetchResponse({
+          choices: [{ message: { content: bareFence } }],
+        })
+      );
+
+      const svc = new BaseCopilotWorkflowEditorService(defaultOptions);
+      const result = await svc.getWorkflowEdit('test', simpleWorkflow);
+
+      expect(result.type).toBe('text');
+      expect(result.text).toBe('From bare fence');
+    });
+
+    it('should parse a large workflow response with notes and parameters', async () => {
+      // Exact response from a real LLM call that was displayed as text instead of being applied
+      const realLlmResponse =
+        '{"type":"workflow","text":"Added a random sample workflow with 14 actions including variables, data shaping, branching, looping, delay, and response, plus a documentation note.","changes":[{"changeType":"added","targetType":"action","nodeIds":["Initialize_RequestId"],"description":"Added an Initialize Variable action to store a generated request ID"},{"changeType":"added","targetType":"action","nodeIds":["Initialize_Items"],"description":"Added an Initialize Variable action with a sample array of items"},{"changeType":"added","targetType":"action","nodeIds":["Initialize_Total"],"description":"Added an Initialize Variable action to track a running total"},{"changeType":"added","targetType":"action","nodeIds":["Compose_RequestSummary"],"description":"Added a Compose action to summarize incoming request details"},{"changeType":"added","targetType":"action","nodeIds":["Parse_TestParameter"],"description":"Added a Compose action to surface the Test workflow parameter value"},{"changeType":"added","targetType":"action","nodeIds":["Condition_HasBody"],"description":"Added a condition to check whether the HTTP request body contains data"},{"changeType":"added","targetType":"action","nodeIds":["For_each_Item"],"description":"Added a loop to process each sample item"},{"changeType":"added","targetType":"action","nodeIds":["Delay_Before_Response"],"description":"Added a short wait before generating the response"},{"changeType":"added","targetType":"action","nodeIds":["Create_Final_Result"],"description":"Added a Compose action to build the final result payload"},{"changeType":"added","targetType":"action","nodeIds":["Return_Response"],"description":"Added an HTTP response action returning the workflow results"},{"changeType":"added","targetType":"note","nodeIds":["6e8d9b7b-f4c1-4f66-9cb9-2bb3a0b9d1a1"],"description":"Added a note documenting the sample workflow flow"}],"workflow":{"definition":{"$schema":"https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#","contentVersion":"1.0.0.0","parameters":{"Test":{"type":"String"}},"triggers":{"When_an_HTTP_request_is_received":{"type":"Request","kind":"Http"}},"actions":{"Initialize_RequestId":{"type":"InitializeVariable","inputs":{"variables":[{"name":"RequestId","type":"string","value":"@guid()"}]}},"Initialize_Items":{"type":"InitializeVariable","runAfter":{"Initialize_RequestId":["Succeeded"]},"inputs":{"variables":[{"name":"Items","type":"array","value":[1,2,3,4,5]}]}},"Initialize_Total":{"type":"InitializeVariable","runAfter":{"Initialize_Items":["Succeeded"]},"inputs":{"variables":[{"name":"Total","type":"integer","value":0}]}},"Compose_RequestSummary":{"type":"Compose","runAfter":{"Initialize_Total":["Succeeded"]},"inputs":{"requestId":"@variables(\'RequestId\')","triggerName":"When_an_HTTP_request_is_received","receivedAt":"@utcNow()","body":"@triggerBody()"}},"Parse_TestParameter":{"type":"Compose","runAfter":{"Compose_RequestSummary":["Succeeded"]},"inputs":"@parameters(\'TestParam\')"},"Condition_HasBody":{"type":"If","runAfter":{"Parse_TestParameter":["Succeeded"]},"expression":{"and":[{"not":{"equals":["@string(triggerBody())",""]}},{"not":{"equals":["@string(triggerBody())","null"]}}]},"actions":{"Compose_Body_Found":{"type":"Compose","inputs":{"message":"Request body was provided","body":"@triggerBody()"}},"Set_Status_HasBody":{"type":"Compose","runAfter":{"Compose_Body_Found":["Succeeded"]},"inputs":"HasBody"}},"else":{"actions":{"Compose_No_Body":{"type":"Compose","inputs":{"message":"No request body was provided"}},"Set_Status_NoBody":{"type":"Compose","runAfter":{"Compose_No_Body":["Succeeded"]},"inputs":"NoBody"}}}},"For_each_Item":{"type":"Foreach","runAfter":{"Condition_HasBody":["Succeeded"]},"foreach":"@variables(\'Items\')","actions":{"Compose_Current_Item":{"type":"Compose","inputs":"@item()"},"Increment_Total":{"type":"IncrementVariable","runAfter":{"Compose_Current_Item":["Succeeded"]},"inputs":{"name":"Total","value":"@item()"}},"Compose_Item_Details":{"type":"Compose","runAfter":{"Increment_Total":["Succeeded"]},"inputs":{"item":"@item()","doubled":"@mul(item(),2)","runningTotal":"@variables(\'Total\')"}}}},"Compose_Array_Count":{"type":"Compose","runAfter":{"For_each_Item":["Succeeded"]},"inputs":"@length(variables(\'Items\'))"},"Compose_IsLargeTotal":{"type":"Compose","runAfter":{"Compose_Array_Count":["Succeeded"]},"inputs":"@greater(variables(\'Total\'),10)"},"Switch_On_Total":{"type":"Switch","runAfter":{"Compose_IsLargeTotal":["Succeeded"]},"expression":"@variables(\'Total\')","cases":{"Case_15":{"case":"15","actions":{"Compose_Total_Is_15":{"type":"Compose","inputs":"Total equals 15"}}},"DefaultRange":{"case":"0","actions":{"Compose_Total_DefaultRange":{"type":"Compose","inputs":"Total did not match the explicit case"}}}},"default":{"actions":{"Compose_Total_Default":{"type":"Compose","inputs":"Default branch executed"}}}},"Compose_Timestamp":{"type":"Compose","runAfter":{"Switch_On_Total":["Succeeded"]},"inputs":"@utcNow()"},"Delay_Before_Response":{"type":"Wait","runAfter":{"Compose_Timestamp":["Succeeded"]},"inputs":{"interval":{"count":1,"unit":"Second"}}},"Create_Final_Result":{"type":"Compose","runAfter":{"Delay_Before_Response":["Succeeded"]},"inputs":{"requestId":"@variables(\'RequestId\')","parameterValue":"@parameters(\'AAA\')","testParameter":"@parameters(\'TestParam\')","itemCount":"@outputs(\'Compose_Array_Count\')","total":"@variables(\'Total\')","isLarge":"@outputs(\'Compose_IsLargeTotal\')","timestamp":"@outputs(\'Compose_Timestamp\')","requestSummary":"@outputs(\'Compose_RequestSummary\')"}},"Return_Response":{"type":"Response","runAfter":{"Create_Final_Result":["Succeeded"]},"inputs":{"statusCode":200,"body":{"message":"Random sample workflow completed","result":"@outputs(\'Create_Final_Result\')"}}}},"outputs":{}},"kind":"stateful","notes":{"6e8d9b7b-f4c1-4f66-9cb9-2bb3a0b9d1a1":{"content":"## Sample workflow\\nThis example starts from an HTTP request, initializes variables, evaluates the request body, loops through sample items, calculates a total, and returns a response.","color":"#CCE5FF","metadata":{"position":{"x":-400,"y":0},"width":260,"height":140}}},"parameters":{"AAA":{"type":"String","value":"FFF"},"TestParam":{"type":"String","value":"TestA"}}}}';
+
+      mockFetch.mockReturnValueOnce(
+        makeFetchResponse({
+          choices: [{ message: { content: realLlmResponse } }],
+        })
+      );
+
+      const svc = new BaseCopilotWorkflowEditorService(defaultOptions);
+      const result = await svc.getWorkflowEdit('create a random workflow, add 10-20 actions', simpleWorkflow);
+
+      expect(result.type).toBe('workflow');
+      expect(result.workflow).toBeDefined();
+      expect(result.workflow?.definition?.actions?.['Initialize_RequestId']).toBeDefined();
+      expect(result.workflow?.definition?.actions?.['Return_Response']).toBeDefined();
+      expect(result.workflow?.notes?.['6e8d9b7b-f4c1-4f66-9cb9-2bb3a0b9d1a1']).toBeDefined();
+      expect(result.workflow?.parameters?.['AAA']).toBeDefined();
+      expect(result.changes).toBeDefined();
+      expect(result.changes!.length).toBeGreaterThan(5);
+    });
+
+    it('should strip invisible Unicode characters (BOM, ZWSP) before parsing', async () => {
+      const validJson = JSON.stringify({ type: 'text', text: 'Cleaned up' });
+      // Prepend BOM (U+FEFF) and zero-width space (U+200B)
+      const withInvisible = '\uFEFF\u200B' + validJson + '\u200D';
+
+      mockFetch.mockReturnValueOnce(
+        makeFetchResponse({
+          choices: [{ message: { content: withInvisible } }],
+        })
+      );
+
+      const svc = new BaseCopilotWorkflowEditorService(defaultOptions);
+      const result = await svc.getWorkflowEdit('test', simpleWorkflow);
+
+      expect(result.type).toBe('text');
+      expect(result.text).toBe('Cleaned up');
+    });
+
+    it('should detect finish_reason=length without crashing', async () => {
+      // Simulate a truncated response where finish_reason is 'length'
+      const truncated = '{"type":"workflow","text":"Added';
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      mockFetch.mockReturnValueOnce(
+        makeFetchResponse({
+          choices: [
+            {
+              message: { content: truncated },
+              finish_reason: 'length',
+            },
+          ],
+        })
+      );
+
+      const svc = new BaseCopilotWorkflowEditorService(defaultOptions);
+      const result = await svc.getWorkflowEdit('test', simpleWorkflow);
+
+      // Should fall back to text since the JSON is incomplete
+      expect(result.type).toBe('text');
+      // Should have warned about truncation
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('truncated'), expect.anything(), expect.anything());
+      consoleSpy.mockRestore();
+    });
+
     it('should handle a response with a bare definition (no type wrapper)', async () => {
       const bareDefinition = {
         definition: {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilotWorkflowEditor.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilotWorkflowEditor.ts
@@ -193,6 +193,12 @@ export class BaseCopilotWorkflowEditorService implements ICopilotWorkflowEditorS
       }
 
       finalContent = assistantMessage.content ?? '';
+
+      // Detect truncated responses so we can warn but still attempt to parse
+      const finishReason = choice?.finish_reason as string | undefined;
+      if (finishReason === 'length') {
+        console.warn('[CopilotWorkflowEditor] LLM response was truncated (finish_reason=length).', 'Content length:', finalContent.length);
+      }
       break;
     }
 
@@ -384,62 +390,164 @@ export class BaseCopilotWorkflowEditorService implements ICopilotWorkflowEditorS
   }
 
   private _parseResponse(content: string, currentWorkflow: Workflow): WorkflowEditResponse {
-    // Try to extract JSON from a ```json code block
-    const jsonBlockMatch = content.match(/```json\s*([\s\S]*?)\s*```/);
-    const jsonStr = jsonBlockMatch ? jsonBlockMatch[1] : content;
+    // Strip invisible Unicode characters that LLMs occasionally produce
+    // (BOM, zero-width spaces, etc.) which break JSON.parse
+    const sanitized = content.replace(/\u200B|\u200C|\u200D|\uFEFF|\u00A0/g, '');
 
-    try {
-      // Strip JS-style comments that LLMs sometimes inject (// … and /* … */)
-      const cleanedJson = this._stripJsonComments(jsonStr.trim());
-      const parsed = JSON.parse(cleanedJson);
+    // Try to extract JSON from a code block (```json or bare ```)
+    const jsonBlockMatch = sanitized.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+    const jsonStr = jsonBlockMatch ? jsonBlockMatch[1] : sanitized;
+    const stripped = this._stripJsonComments(jsonStr.trim());
 
-      if (parsed.type === 'workflow' && parsed.workflow) {
-        const proposedWorkflow: Workflow = {
-          definition: parsed.workflow.definition ?? parsed.workflow,
-          connectionReferences: parsed.workflow.connectionReferences ?? currentWorkflow.connectionReferences ?? {},
-          parameters: parsed.workflow.parameters ?? currentWorkflow.parameters,
-          notes: parsed.workflow.notes ?? currentWorkflow.notes,
-          kind: parsed.workflow.kind ?? currentWorkflow.kind,
-        };
+    // Strategy 1: Direct JSON.parse
+    // Strategy 2: Repair unescaped quotes then JSON.parse
+    // Strategy 3: Extract outermost {...} from sanitized content (handles prose wrapping)
+    const parsed = this._tryJsonParse(stripped) ?? this._tryJsonParse(this._repairJson(stripped)) ?? this._tryExtractJson(sanitized);
 
-        const changes = this._parseChanges(parsed.changes);
-
-        return {
-          type: 'workflow',
-          text: parsed.text ?? 'Workflow updated.',
-          workflow: proposedWorkflow,
-          changes,
-        };
-      }
-
-      if (parsed.type === 'text') {
-        return {
-          type: 'text',
-          text: parsed.text ?? content,
-        };
-      }
-
-      // If parsed JSON has a "definition" key directly, treat it as a workflow
-      if (parsed.definition) {
-        return {
-          type: 'workflow',
-          text: 'Workflow updated.',
-          workflow: {
-            definition: parsed.definition,
-            connectionReferences: parsed.connectionReferences ?? currentWorkflow.connectionReferences ?? {},
-            parameters: parsed.parameters ?? currentWorkflow.parameters,
-            notes: parsed.notes ?? currentWorkflow.notes,
-            kind: parsed.kind ?? currentWorkflow.kind,
-          },
-        };
-      }
-
-      // Fallback: treat as text
-      return { type: 'text', text: parsed.text ?? content };
-    } catch {
-      // Could not parse JSON — treat entire content as a text reply
-      return { type: 'text', text: content };
+    if (parsed) {
+      return this._buildResponseFromParsed(parsed, sanitized, currentWorkflow);
     }
+
+    // All parsing strategies failed — log detailed diagnostics
+    const firstChars = sanitized.substring(0, 200);
+    const lastChars = sanitized.substring(Math.max(0, sanitized.length - 100));
+    const charCodes = Array.from(sanitized.substring(0, 10)).map((c) => c.charCodeAt(0));
+    console.warn('[CopilotWorkflowEditor] Failed to parse LLM response as JSON.', {
+      contentLength: sanitized.length,
+      firstChars,
+      lastChars,
+      firstCharCodes: charCodes,
+      directParseError: this._getParseError(stripped),
+      repairParseError: this._getParseError(this._repairJson(stripped)),
+    });
+
+    return { type: 'text', text: content };
+  }
+
+  private _getParseError(str: string): string {
+    try {
+      JSON.parse(str);
+      return 'no error';
+    } catch (e: unknown) {
+      return e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  private _tryJsonParse(str: string): unknown | null {
+    try {
+      return JSON.parse(str);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Try to extract a JSON object by finding the outermost `{…}` in the content.
+   * Handles cases where the LLM wraps its JSON response in surrounding prose.
+   */
+  private _tryExtractJson(content: string): unknown | null {
+    const firstBrace = content.indexOf('{');
+    const lastBrace = content.lastIndexOf('}');
+    if (firstBrace === -1 || lastBrace <= firstBrace) {
+      return null;
+    }
+    const extracted = this._stripJsonComments(content.substring(firstBrace, lastBrace + 1));
+    return this._tryJsonParse(extracted) ?? this._tryJsonParse(this._repairJson(extracted));
+  }
+
+  /**
+   * Attempt to fix unescaped double quotes inside JSON string values.
+   * When inside a JSON string, if a `"` is followed (after optional whitespace)
+   * by a JSON structural character (`:`, `,`, `}`, `]`) or end-of-string, it is
+   * treated as the structural end of that string. Otherwise it is assumed to be
+   * an unescaped inner quote and is escaped as `\"`.
+   */
+  private _repairJson(str: string): string {
+    let result = '';
+    let inString = false;
+    let i = 0;
+    while (i < str.length) {
+      const ch = str[i];
+      if (inString) {
+        if (ch === '\\' && i + 1 < str.length) {
+          // Already-escaped character — pass through
+          result += ch + str[i + 1];
+          i += 2;
+          continue;
+        }
+        if (ch === '"') {
+          // Look ahead past whitespace for a structural JSON character
+          let j = i + 1;
+          while (j < str.length && (str[j] === ' ' || str[j] === '\t' || str[j] === '\n' || str[j] === '\r')) {
+            j++;
+          }
+          const next = j < str.length ? str[j] : '';
+          if (next === ':' || next === ',' || next === '}' || next === ']' || j >= str.length) {
+            // Structural end-of-string quote
+            inString = false;
+            result += ch;
+          } else {
+            // Unescaped inner quote — escape it
+            result += '\\"';
+          }
+        } else {
+          result += ch;
+        }
+      } else if (ch === '"') {
+        inString = true;
+        result += ch;
+      } else {
+        result += ch;
+      }
+      i++;
+    }
+    return result;
+  }
+
+  private _buildResponseFromParsed(parsed: any, rawContent: string, currentWorkflow: Workflow): WorkflowEditResponse {
+    if (parsed.type === 'workflow' && parsed.workflow) {
+      const proposedWorkflow: Workflow = {
+        definition: parsed.workflow.definition ?? parsed.workflow,
+        connectionReferences: parsed.workflow.connectionReferences ?? currentWorkflow.connectionReferences ?? {},
+        parameters: parsed.workflow.parameters ?? currentWorkflow.parameters,
+        notes: parsed.workflow.notes ?? currentWorkflow.notes,
+        kind: parsed.workflow.kind ?? currentWorkflow.kind,
+      };
+
+      const changes = this._parseChanges(parsed.changes);
+
+      return {
+        type: 'workflow',
+        text: parsed.text ?? 'Workflow updated.',
+        workflow: proposedWorkflow,
+        changes,
+      };
+    }
+
+    if (parsed.type === 'text') {
+      return {
+        type: 'text',
+        text: parsed.text ?? rawContent,
+      };
+    }
+
+    // If parsed JSON has a "definition" key directly, treat it as a workflow
+    if (parsed.definition) {
+      return {
+        type: 'workflow',
+        text: 'Workflow updated.',
+        workflow: {
+          definition: parsed.definition,
+          connectionReferences: parsed.connectionReferences ?? currentWorkflow.connectionReferences ?? {},
+          parameters: parsed.parameters ?? currentWorkflow.parameters,
+          notes: parsed.notes ?? currentWorkflow.notes,
+          kind: parsed.kind ?? currentWorkflow.kind,
+        },
+      };
+    }
+
+    // Fallback: treat as text
+    return { type: 'text', text: parsed.text ?? rawContent };
   }
 
   private _parseChanges(rawChanges: unknown): WorkflowChange[] | undefined {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilotWorkflowEditorPrompt.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilotWorkflowEditorPrompt.ts
@@ -141,6 +141,7 @@ You MUST respond with a valid JSON object in one of these two formats.
 IMPORTANT:
 - Your response must be **strict JSON** — do NOT include any JavaScript-style comments (// or /* */). JSON does not support comments and they will cause parsing failures.
 - Do NOT wrap the response in markdown code fences (no \`\`\`json or \`\`\`). Return ONLY the raw JSON object.
+- Double quotes inside JSON string values MUST be escaped as \\" — for example: {"text":"He said \\"hello\\""}. Unescaped inner quotes will break JSON parsing and cause the response to fail.
 - Use compact JSON with no unnecessary whitespace, newlines, or indentation. The response is machine-parsed, not human-read.
 
 ### For workflow modifications:


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

The copilot workflow editor's `_parseResponse` method would silently fail to parse valid LLM JSON responses due to three classes of LLM output quirks, causing workflow modifications to be displayed as raw text in the chat instead of being applied as changes:

1. **Unescaped quotes** — LLM occasionally produces unescaped double quotes (including smart quotes) inside JSON string values, breaking `JSON.parse`.
2. **Invisible Unicode characters** — LLM output can contain BOM (`U+FEFF`), zero-width spaces (`U+200B`/`U+200C`/`U+200D`), or non-breaking spaces (`U+00A0`) that are invisible but break JSON parsing.
3. **Prose wrapping / bare code fences** — LLM sometimes wraps its JSON in surrounding prose or uses bare `` ``` `` fences without a `json` language tag.

This PR makes `_parseResponse` robust against all three failure modes via a multi-strategy parsing pipeline, adds a prompt rule to reduce the occurrence of unescaped quotes, and adds diagnostic logging to help debug any future parsing failures.

## Impact of Change
- **Users**: Copilot workflow editing is significantly more reliable — modifications that were previously shown as raw JSON text will now be correctly parsed and applied as workflow changes.
- **Developers**: New private methods on `BaseCopilotWorkflowEditorService` (`_tryJsonParse`, `_tryExtractJson`, `_repairJson`, `_buildResponseFromParsed`, `_getParseError`). No public API changes.
- **System**: No dependency or architecture changes. Added `console.warn` diagnostics for truncated responses and parse failures.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: Standalone designer (`pnpm run start`)

**6 new unit tests added** covering:
- Unescaped double quotes repair
- Prose-wrapped JSON extraction (no code fence)
- Bare code fence handling (no `json` language tag)
- Large real-world LLM response parsing
- Invisible Unicode character stripping (BOM, ZWSP)
- `finish_reason=length` truncation detection

All 62 tests passing.

## Contributors

## Screenshots/Videos`` fences without a `json` language tag.

This PR makes `_parseResponse` robust against all three failure modes via a multi-strategy parsing pipeline, adds a prompt rule to reduce the occurrence of unescaped quotes, and adds diagnostic logging to help debug any future parsing failures.

## Impact of Change
- **Users**: Copilot workflow editing is significantly more reliable — modifications that were previously shown as raw JSON text will now be correctly parsed and applied as workflow changes.
- **Developers**: New private methods on `BaseCopilotWorkflowEditorService` (`_tryJsonParse`, `_tryExtractJson`, `_repairJson`, `_buildResponseFromParsed`, `_getParseError`). No public API changes.
- **System**: No dependency or architecture changes. Added `console.warn` diagnostics for truncated responses and parse failures.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: Standalone designer (`pnpm run start`)

**6 new unit tests added** covering:
- Unescaped double quotes repair
- Prose-wrapped JSON extraction (no code fence)
- Bare code fence handling (no `json` language tag)
- Large real-world LLM response parsing
- Invisible Unicode character stripping (BOM, ZWSP)
- `finish_reason=length` truncation detection

All 62 tests passing.

## Contributors
@rllyy97

## Screenshots/Videos
N/A