### PR TITLE
fix(deps): pin axios to exact version 1.13.5

### DIFF
--- a/apps/Standalone/package.json
+++ b/apps/Standalone/package.json
@@ -31,7 +31,7 @@
     "@tanstack/react-query": "4.36.1",
     "@tanstack/react-query-devtools": "4.36.1",
     "@tanstack/react-query-persist-client": "4.36.1",
-    "axios": "^1.13.5",
+    "axios": "1.13.5",
     "axios-retry": "^3.5.0",
     "core-js": "3.24.1",
     "jwt-decode": "^3.1.2",

--- a/apps/vs-code-designer/package.json
+++ b/apps/vs-code-designer/package.json
@@ -32,7 +32,7 @@
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.1.1",
     "adm-zip": "^0.5.10",
-    "axios": "^1.13.5",
+    "axios": "1.13.5",
     "azure-storage": "^2.10.3",
     "chai": "^4.3.7",
     "fs-extra": "^11.2.0",

--- a/libs/logic-apps-shared/package.json
+++ b/libs/logic-apps-shared/package.json
@@ -5,7 +5,7 @@
     "@formatjs/intl": "^2.10.1",
     "@xyflow/react": "^12.3.5",
     "@xyflow/system": "^0.0.37",
-    "axios": "^1.13.5",
+    "axios": "1.13.5",
     "react-intl": "6.3.0"
   },
   "devDependencies": {

--- a/libs/vscode-extension/package.json
+++ b/libs/vscode-extension/package.json
@@ -7,7 +7,7 @@
     "@microsoft/vscode-azext-azureappservice": "^3.6.6",
     "@microsoft/vscode-azext-utils": "^3.5.0",
     "@xyflow/react": "^12.3.5",
-    "axios": "^1.13.5",
+    "axios": "1.13.5",
     "react-intl": "6.3.0",
     "tslib": "2.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,7 +348,7 @@ importers:
         specifier: 4.36.1
         version: 4.36.1(@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       axios:
-        specifier: ^1.13.5
+        specifier: 1.13.5
         version: 1.13.5(debug@4.4.3)
       axios-retry:
         specifier: ^3.5.0
@@ -615,7 +615,7 @@ importers:
         specifier: ^0.5.10
         version: 0.5.12
       axios:
-        specifier: ^1.13.5
+        specifier: 1.13.5
         version: 1.13.5(debug@4.4.3)
       azure-storage:
         specifier: ^2.10.3
@@ -1649,7 +1649,7 @@ importers:
         specifier: ^0.0.37
         version: 0.0.37
       axios:
-        specifier: ^1.13.5
+        specifier: 1.13.5
         version: 1.13.5(debug@4.4.3)
       react:
         specifier: 18.3.1
@@ -1695,7 +1695,7 @@ importers:
         specifier: ^12.3.5
         version: 12.3.5(@types/react@18.3.0)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axios:
-        specifier: ^1.13.5
+        specifier: 1.13.5
         version: 1.13.5(debug@4.4.3)
       react:
         specifier: 18.3.1
@@ -9267,10 +9267,6 @@ packages:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
     engines: {node: '>= 0.4'}
 
-  es-define-property@1.0.0:
-    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
-    engines: {node: '>= 0.4'}
-
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -10159,10 +10155,6 @@ packages:
 
   has-proto@1.2.0:
     resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
-    engines: {node: '>= 0.4'}
-
-  has-symbols@1.0.3:
-    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
 
   has-symbols@1.1.0:
@@ -25192,7 +25184,7 @@ snapshots:
 
   call-bind@1.0.7:
     dependencies:
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
       es-errors: 1.3.0
       function-bind: 1.1.2
       get-intrinsic: 1.3.0
@@ -26458,7 +26450,7 @@ snapshots:
       data-view-buffer: 1.0.1
       data-view-byte-length: 1.0.1
       data-view-byte-offset: 1.0.0
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       es-set-tostringtag: 2.1.0
@@ -26554,10 +26546,6 @@ snapshots:
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
       which-typed-array: 1.1.19
-
-  es-define-property@1.0.0:
-    dependencies:
-      get-intrinsic: 1.3.0
 
   es-define-property@1.0.1: {}
 
@@ -27768,13 +27756,11 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
 
-  has-symbols@1.0.3: {}
-
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
     dependencies:
-      has-symbols: 1.0.3
+      has-symbols: 1.1.0
 
   has-yarn@3.0.0: {}
 


### PR DESCRIPTION
## Commit Type
- [x] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Pins the axios dependency to exact version `1.13.5` (removes caret `^` range specifier) across all four packages that reference it:
- `apps/Standalone`
- `apps/vs-code-designer`
- `libs/vscode-extension`
- `libs/logic-apps-shared`

This ensures deterministic builds by preventing automatic minor/patch upgrades of axios.

## Impact of Change
- **Users**: None — same version resolved
- **Developers**: Axios upgrades must now be done explicitly
- **System**: More predictable dependency resolution

## Test Plan
- [x] `pnpm install` completed successfully with updated lockfile
- [ ] CI pipeline validates build

## Contributors

## Screenshots/Videos
N/A