### PR TITLE
fix(Designer): Fixed action IO regression

### DIFF
--- a/libs/designer-v2/src/lib/core/state/__test__/workflowSlice.spec.ts
+++ b/libs/designer-v2/src/lib/core/state/__test__/workflowSlice.spec.ts
@@ -584,5 +584,35 @@ describe('workflow slice reducers', () => {
       expect((newState.nodesMetadata.test_node.runData as any)?.inputs).toEqual(newInputs);
       expect((newState.nodesMetadata.test_node.runData as any)?.outputs).toEqual(newOutputs);
     });
+
+    it('should write empty inputs/outputs when no existing data exists (regular actions like Response)', () => {
+      const state = { ...initialState };
+
+      state.nodesMetadata = {
+        Response: {
+          graphId: 'root',
+          isRoot: false,
+          isTrigger: false,
+          runData: {
+            status: 'Succeeded',
+          },
+        } as NodeMetadata,
+      };
+
+      const action = {
+        type: initializeInputsOutputsBinding.fulfilled.type,
+        payload: {
+          nodeId: 'Response',
+          inputs: {},
+          outputs: {},
+        },
+      };
+
+      const newState = reducer(state, action);
+
+      // Empty {} should be written (not left as undefined) so the UI shows "No outputs" instead of a download link
+      expect((newState.nodesMetadata.Response.runData as any)?.inputs).toEqual({});
+      expect((newState.nodesMetadata.Response.runData as any)?.outputs).toEqual({});
+    });
   });
 });

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
@@ -842,15 +842,18 @@ export const workflowSlice = createSlice({
       const existingInputs = nodeMetadata.runData?.inputs;
       const existingOutputs = nodeMetadata.runData?.outputs;
 
-      // Don't overwrite existing inputs/outputs with empty values
-      // (e.g., for built-in tools that already have their data from fetchBuiltInToolRunData)
+      // Only preserve existing inputs/outputs when they have content
+      // (e.g., for built-in tools that already have their data from fetchBuiltInToolRunData).
+      // For regular actions, empty {} is a valid result and should be written.
       const hasNewInputs = inputs && Object.keys(inputs).length > 0;
       const hasNewOutputs = outputs && Object.keys(outputs).length > 0;
+      const hasExistingInputs = existingInputs && Object.keys(existingInputs).length > 0;
+      const hasExistingOutputs = existingOutputs && Object.keys(existingOutputs).length > 0;
 
       const nodeRunData = {
         ...nodeMetadata.runData,
-        inputs: hasNewInputs ? inputs : existingInputs,
-        outputs: hasNewOutputs ? outputs : existingOutputs,
+        inputs: hasNewInputs || !hasExistingInputs ? inputs : existingInputs,
+        outputs: hasNewOutputs || !hasExistingOutputs ? outputs : existingOutputs,
       };
       nodeMetadata.runData = nodeRunData as LogicAppsV2.WorkflowRunAction;
     });

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -831,15 +831,18 @@ export const workflowSlice = createSlice({
       const existingInputs = nodeMetadata.runData?.inputs;
       const existingOutputs = nodeMetadata.runData?.outputs;
 
-      // Don't overwrite existing inputs/outputs with empty values
-      // (e.g., for built-in tools that already have their data from fetchBuiltInToolRunData)
+      // Only preserve existing inputs/outputs when they have content
+      // (e.g., for built-in tools that already have their data from fetchBuiltInToolRunData).
+      // For regular actions, empty {} is a valid result and should be written.
       const hasNewInputs = inputs && Object.keys(inputs).length > 0;
       const hasNewOutputs = outputs && Object.keys(outputs).length > 0;
+      const hasExistingInputs = existingInputs && Object.keys(existingInputs).length > 0;
+      const hasExistingOutputs = existingOutputs && Object.keys(existingOutputs).length > 0;
 
       const nodeRunData = {
         ...nodeMetadata.runData,
-        inputs: hasNewInputs ? inputs : existingInputs,
-        outputs: hasNewOutputs ? outputs : existingOutputs,
+        inputs: hasNewInputs || !hasExistingInputs ? inputs : existingInputs,
+        outputs: hasNewOutputs || !hasExistingOutputs ? outputs : existingOutputs,
       };
       nodeMetadata.runData = nodeRunData as LogicAppsV2.WorkflowRunAction;
     });


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->

Fix regression from #8875 (v5.277.0) where the [initializeInputsOutputsBinding.fulfilled](vscode-file://vscode-app/c:/Users/rileyevans/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) reducer discarded empty {} inputs/outputs for regular actions (like Response), causing the monitoring view to show a download link instead of "No outputs" with a "Show raw outputs" button.

The original change preserved existing inputs/outputs over empty new values to protect built-in tool data from [fetchBuiltInToolRunData](vscode-file://vscode-app/c:/Users/rileyevans/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html). However, it also prevented regular actions that legitimately return empty {} from [getActionLinks](vscode-file://vscode-app/c:/Users/rileyevans/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from being written, leaving them as undefined.

Only preserve existing inputs/outputs over empty new values when the existing data actually has content, so regular actions like Response correctly receive {} instead of undefined.

Fixes https://github.com/Azure/LogicAppsUX/issues/9001

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Monitoring view for actions like Response will correctly show "No outputs" with a "Show raw outputs" button instead of a download link.
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone

## Contributors
N/A

## Screenshots/Videos
N/A
