### PR TITLE
fix(designer): Agent connection MicrosoftFoundry fixes (#9012, #9028)

### DIFF
--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/connections.ts
@@ -48,6 +48,7 @@ import {
   LoggerService,
   LogEntryLevel,
   foundryServiceConnectionRegex,
+  microsoftFoundryModelsRegex,
 } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
@@ -125,26 +126,26 @@ const updateAgentParametersForConnection = (
   // Map display name to manifest parameter value
   let agentModelTypeValue = AgentUtils.DisplayNameToManifest[rawModelType] ?? '';
 
-  // Fallback: detect Foundry connections by cognitiveServiceAccountId resource pattern
+  // Fallback: detect connection type by cognitiveServiceAccountId resource pattern
   if (!agentModelTypeValue) {
     const cognitiveServiceId = connection.properties.connectionParameters?.cognitiveServiceAccountId?.metadata?.value ?? '';
     if (foundryServiceConnectionRegex.test(cognitiveServiceId)) {
-      agentModelTypeValue = 'FoundryAgentService';
+      agentModelTypeValue = 'FoundryAgentServiceV2';
+    } else if (microsoftFoundryModelsRegex.test(cognitiveServiceId)) {
+      agentModelTypeValue = 'MicrosoftFoundry';
     } else {
+      // Default to AzureOpenAI, but preserve other existing valid values
+      // (e.g., 'FoundryAgentServiceV2', 'APIMGenAIGateway') that the regex couldn't detect
       agentModelTypeValue = 'AzureOpenAI';
-    }
-  }
+      const paramGroups = state.operations.inputParameters[nodeId]?.parameterGroups;
+      const defaultGrp = paramGroups?.[ParameterGroupKeys.DEFAULT];
+      const existingParam = defaultGrp?.parameters?.find((p) => p.parameterKey === 'inputs.$.agentModelType');
+      const currentValue = existingParam?.value?.[0]?.value;
 
-  // If fallback detection yields the default 'AzureOpenAI', preserve existing valid value
-  // from the workflow definition (e.g., 'MicrosoftFoundry' that shares the same connection pattern)
-  if (agentModelTypeValue === 'AzureOpenAI') {
-    const paramGroups = state.operations.inputParameters[nodeId]?.parameterGroups;
-    const defaultGrp = paramGroups?.[ParameterGroupKeys.DEFAULT];
-    const existingParam = defaultGrp?.parameters?.find((p) => p.parameterKey === 'inputs.$.agentModelType');
-    const currentValue = existingParam?.value?.[0]?.value;
-    const validManifestValues = Object.values(AgentUtils.DisplayNameToManifest);
-    if (currentValue && validManifestValues.includes(currentValue) && currentValue !== 'AzureOpenAI') {
-      agentModelTypeValue = currentValue;
+      const validManifestValues = Object.values(AgentUtils.DisplayNameToManifest);
+      if (currentValue && validManifestValues.includes(currentValue) && currentValue !== 'AzureOpenAI') {
+        agentModelTypeValue = currentValue;
+      }
     }
   }
 
@@ -180,29 +181,42 @@ const updateAgentParametersForConnection = (
     },
   });
 
-  // Update visibility and clear values based on model type
-  const isV1 = agentModelTypeValue === 'V1ChatCompletionsService';
+  // Always clear deploymentId and modelId when switching connections
+  parametersToUpdate.push({
+    groupId: ParameterGroupKeys.DEFAULT,
+    parameterId: deploymentIdParam.id,
+    propertiesToUpdate: {
+      value: [createLiteralValueSegment('')],
+      preservedValue: undefined,
+    },
+  });
+  parametersToUpdate.push({
+    groupId: ParameterGroupKeys.DEFAULT,
+    parameterId: modelIdParam.id,
+    propertiesToUpdate: {
+      value: [createLiteralValueSegment('')],
+      preservedValue: undefined,
+    },
+  });
 
-  if (isV1) {
-    // V1 Chat Completions: show modelId, hide deploymentId
-    parametersToUpdate.push({
-      groupId: ParameterGroupKeys.DEFAULT,
-      parameterId: deploymentIdParam.id,
-      propertiesToUpdate: {
-        value: [createLiteralValueSegment('')],
-        preservedValue: undefined,
-      },
-    });
-  } else {
-    // AzureOpenAI/Foundry/APIM: show deploymentId, hide modelId
-    parametersToUpdate.push({
-      groupId: ParameterGroupKeys.DEFAULT,
-      parameterId: modelIdParam.id,
-      propertiesToUpdate: {
-        value: [createLiteralValueSegment('')],
-        preservedValue: undefined,
-      },
-    });
+  // Clear deploymentModelProperties (name, format, version) when switching connections
+  const deploymentModelPropertiesKeys = [
+    'inputs.$.agentModelSettings.deploymentModelProperties.name',
+    'inputs.$.agentModelSettings.deploymentModelProperties.format',
+    'inputs.$.agentModelSettings.deploymentModelProperties.version',
+  ];
+  for (const key of deploymentModelPropertiesKeys) {
+    const param = defaultGroup.parameters?.find((p) => p.parameterKey === key);
+    if (param) {
+      parametersToUpdate.push({
+        groupId: ParameterGroupKeys.DEFAULT,
+        parameterId: param.id,
+        propertiesToUpdate: {
+          value: [createLiteralValueSegment('')],
+          preservedValue: undefined,
+        },
+      });
+    }
   }
 
   dispatch(

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/useCognitiveService.ts
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/useCognitiveService.ts
@@ -92,7 +92,8 @@ const getServiceAccountId = (resourceId: string | undefined, isFoundryServiceCon
     return parts.length >= 2 ? parts.slice(0, -2).join('/') : resourceId;
   }
 
-  return resourceId;
+  // Strip /models suffix for MicrosoftFoundry connections
+  return resourceId.replace(/\/models$/, '');
 };
 
 export const getCognitiveServiceAccountDeploymentsForConnection = async (connection: Connection) => {

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.tsx
@@ -23,6 +23,7 @@ import {
   equals,
   foundryServiceConnectionRegex,
   apimanagementRegex,
+  microsoftFoundryModelsRegex,
   getIconUriFromConnector,
   parseErrorMessage,
   type Connection,
@@ -64,7 +65,7 @@ export const SelectConnectionWrapper = () => {
     if (AgentUtils.isConnector(connector?.id)) {
       return connectionData.filter((c) => {
         const connectionReference = connectionReferencesForConnector.find((ref) => equals(ref.connection.id, c?.id, true));
-        let modelType = AgentUtils.ModelType.AzureOpenAI;
+        let modelType = AgentUtils.ModelType.AzureOpenAI; // default (legacy)
         const cognitiveResourceId =
           connectionReference?.resourceId ?? c.properties?.connectionParameters?.cognitiveServiceAccountId?.metadata?.value;
 
@@ -73,6 +74,8 @@ export const SelectConnectionWrapper = () => {
             modelType = AgentUtils.ModelType.FoundryService;
           } else if (apimanagementRegex.test(cognitiveResourceId)) {
             modelType = AgentUtils.ModelType.APIM;
+          } else if (microsoftFoundryModelsRegex.test(cognitiveResourceId)) {
+            modelType = AgentUtils.ModelType.MicrosoftFoundry;
           }
         } else if (!c.properties?.connectionParameters?.cognitiveServiceAccountId?.metadata?.value) {
           // No cognitive serviceAccountId means this is a V1ChatCompletionsService connection (BYO)
@@ -87,8 +90,12 @@ export const SelectConnectionWrapper = () => {
           },
         };
 
-        // For A2A, hide the foundry connection from the list
-        return isA2A ? modelType === AgentUtils.ModelType.AzureOpenAI || modelType === AgentUtils.ModelType.V1ChatCompletionsService : true;
+        // For A2A, show AzureOpenAI, MicrosoftFoundry, and V1 connections only
+        return isA2A
+          ? modelType === AgentUtils.ModelType.AzureOpenAI ||
+              modelType === AgentUtils.ModelType.MicrosoftFoundry ||
+              modelType === AgentUtils.ModelType.V1ChatCompletionsService
+          : true;
       });
     }
 

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/custom/deploymentModelResource.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/custom/deploymentModelResource.tsx
@@ -62,7 +62,7 @@ export const CustomDeploymentModelResource = (props: IEditorProps) => {
   );
 
   const onSubmit = useCallback(async () => {
-    const resourceId = metadata?.cognitiveServiceAccountId;
+    const resourceId = metadata?.cognitiveServiceAccountId?.replace(/\/models$/, '');
     if (!resourceId) {
       console.error('OpenAI account ID is not provided in metadata.');
       return;

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -1026,6 +1026,32 @@ export const ParameterSection = ({
         if (!isNullOrUndefined(newValue) && !isNullOrUndefined(oldValue) && newValue !== oldValue && !isNullOrUndefined(connector)) {
           dispatch(dynamicallyLoadAgentConnection({ nodeId, connector, modelType: newValue }));
         }
+
+        // Clear deploymentModelProperties when switching away from MicrosoftFoundry.
+        // For AzureOpenAI the backend derives model info from the deployment itself.
+        if (newValue !== 'MicrosoftFoundry') {
+          updatedDependencies.inputs ??= {};
+          for (const key of [
+            'inputs.$.agentModelSettings.deploymentModelProperties.name',
+            'inputs.$.agentModelSettings.deploymentModelProperties.format',
+            'inputs.$.agentModelSettings.deploymentModelProperties.version',
+          ]) {
+            const targetParam = parameterGroup.parameters.find((param) => equals(key, param.parameterKey, true));
+            if (targetParam) {
+              updatedDependencies.inputs[key] = {
+                definition: targetParam.schema,
+                dependencyType: 'AgentSchema' as const,
+                dependentParameters: { [id]: { isValid: true } },
+                parameter: {
+                  key,
+                  name: targetParam.parameterName ?? '',
+                  type: targetParam.type ?? '',
+                  value: [createLiteralValueSegment('')],
+                },
+              };
+            }
+          }
+        }
       }
 
       const isAgentDeployment = isAgentConnectorAndDeploymentId(operationInfo.connectorId ?? '', parameter?.parameterName ?? '');
@@ -1052,48 +1078,38 @@ export const ParameterSection = ({
 
       if (isAgentDeployment) {
         const selectedModelId = value?.length ? value[0]?.value : undefined;
+        const currentModelType = findFoundryParam(nodeInputs.parameterGroups, group.id, agentModelTypeParameterKey)?.value?.[0]?.value;
 
-        // Look up the deployment from the API response (deployment.name = deploymentId, deployment.properties.model.name = modelId)
-        const deploymentInfo = selectedModelId
-          ? deploymentsForCognitiveServiceAccount?.find((deployment: any) => deployment.name === selectedModelId)
-          : undefined;
+        // Only populate deploymentModelProperties for MicrosoftFoundry.
+        // For AzureOpenAI the backend derives model info from the deployment itself.
+        if (currentModelType === 'MicrosoftFoundry' && selectedModelId) {
+          const config = AGENT_MODEL_CONFIG[selectedModelId];
+          const modelName = selectedModelId;
+          const modelFormat = config?.format ?? 'OpenAI';
+          const modelVersion = config?.version;
 
-        const modelName = deploymentInfo?.properties?.model?.name;
-        let modelFormat = deploymentInfo?.properties?.model?.format;
-        let modelVersion = deploymentInfo?.properties?.model?.version;
+          updatedDependencies.inputs ??= {};
 
-        // For MicrosoftFoundry, format and version are not in the ARM response — fill from AGENT_MODEL_CONFIG
-        if (!modelFormat || !modelVersion) {
-          const config = modelName ? AGENT_MODEL_CONFIG[modelName] : undefined;
-          if (!modelFormat) {
-            modelFormat = config?.format ?? 'OpenAI';
-          }
-          if (!modelVersion) {
-            modelVersion = config?.version;
-          }
-        }
+          const agentDeploymentKeys = [
+            {
+              key: 'inputs.$.agentModelSettings.deploymentModelProperties.name',
+              default: modelName,
+            },
+            {
+              key: 'inputs.$.agentModelSettings.deploymentModelProperties.format',
+              default: modelFormat,
+            },
+            {
+              key: 'inputs.$.agentModelSettings.deploymentModelProperties.version',
+              default: modelVersion,
+            },
+          ];
 
-        updatedDependencies.inputs ??= {};
-
-        const agentDeploymentKeys = [
-          {
-            key: 'inputs.$.agentModelSettings.deploymentModelProperties.name',
-            default: modelName,
-          },
-          {
-            key: 'inputs.$.agentModelSettings.deploymentModelProperties.format',
-            default: modelFormat,
-          },
-          {
-            key: 'inputs.$.agentModelSettings.deploymentModelProperties.version',
-            default: modelVersion,
-          },
-        ];
-
-        for (const { key, default: defaultValue } of agentDeploymentKeys) {
-          const dependency = buildDependentParam(key, defaultValue);
-          if (dependency) {
-            updatedDependencies.inputs[key] = dependency;
+          for (const { key, default: defaultValue } of agentDeploymentKeys) {
+            const dependency = buildDependentParam(key, defaultValue);
+            if (dependency) {
+              updatedDependencies.inputs[key] = dependency;
+            }
           }
         }
       }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -47,6 +47,7 @@ import {
   LoggerService,
   LogEntryLevel,
   foundryServiceConnectionRegex,
+  microsoftFoundryModelsRegex,
 } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
@@ -125,26 +126,26 @@ const updateAgentParametersForConnection = (
   // Map display name to manifest parameter value
   let agentModelTypeValue = AgentUtils.DisplayNameToManifest[rawModelType] ?? '';
 
-  // Fallback: detect Foundry connections by cognitiveServiceAccountId resource pattern
+  // Fallback: detect connection type by cognitiveServiceAccountId resource pattern
   if (!agentModelTypeValue) {
     const cognitiveServiceId = connection.properties.connectionParameters?.cognitiveServiceAccountId?.metadata?.value ?? '';
     if (foundryServiceConnectionRegex.test(cognitiveServiceId)) {
-      agentModelTypeValue = 'FoundryAgentService';
+      agentModelTypeValue = 'FoundryAgentServiceV2';
+    } else if (microsoftFoundryModelsRegex.test(cognitiveServiceId)) {
+      agentModelTypeValue = 'MicrosoftFoundry';
     } else {
+      // Default to AzureOpenAI, but preserve other existing valid values
+      // (e.g., 'FoundryAgentServiceV2', 'APIMGenAIGateway') that the regex couldn't detect
       agentModelTypeValue = 'AzureOpenAI';
-    }
-  }
+      const paramGroups = state.operations.inputParameters[nodeId]?.parameterGroups;
+      const defaultGrp = paramGroups?.[ParameterGroupKeys.DEFAULT];
+      const existingParam = defaultGrp?.parameters?.find((p) => p.parameterKey === 'inputs.$.agentModelType');
+      const currentValue = existingParam?.value?.[0]?.value;
 
-  // If fallback detection yields the default 'AzureOpenAI', preserve existing valid value
-  // from the workflow definition (e.g., 'MicrosoftFoundry' that shares the same connection pattern)
-  if (agentModelTypeValue === 'AzureOpenAI') {
-    const paramGroups = state.operations.inputParameters[nodeId]?.parameterGroups;
-    const defaultGrp = paramGroups?.[ParameterGroupKeys.DEFAULT];
-    const existingParam = defaultGrp?.parameters?.find((p) => p.parameterKey === 'inputs.$.agentModelType');
-    const currentValue = existingParam?.value?.[0]?.value;
-    const validManifestValues = Object.values(AgentUtils.DisplayNameToManifest);
-    if (currentValue && validManifestValues.includes(currentValue) && currentValue !== 'AzureOpenAI') {
-      agentModelTypeValue = currentValue;
+      const validManifestValues = Object.values(AgentUtils.DisplayNameToManifest);
+      if (currentValue && validManifestValues.includes(currentValue) && currentValue !== 'AzureOpenAI') {
+        agentModelTypeValue = currentValue;
+      }
     }
   }
 
@@ -180,29 +181,42 @@ const updateAgentParametersForConnection = (
     },
   });
 
-  // Update visibility and clear values based on model type
-  const isV1 = agentModelTypeValue === 'V1ChatCompletionsService';
+  // Always clear deploymentId and modelId when switching connections
+  parametersToUpdate.push({
+    groupId: ParameterGroupKeys.DEFAULT,
+    parameterId: deploymentIdParam.id,
+    propertiesToUpdate: {
+      value: [createLiteralValueSegment('')],
+      preservedValue: undefined,
+    },
+  });
+  parametersToUpdate.push({
+    groupId: ParameterGroupKeys.DEFAULT,
+    parameterId: modelIdParam.id,
+    propertiesToUpdate: {
+      value: [createLiteralValueSegment('')],
+      preservedValue: undefined,
+    },
+  });
 
-  if (isV1) {
-    // V1 Chat Completions: show modelId, hide deploymentId
-    parametersToUpdate.push({
-      groupId: ParameterGroupKeys.DEFAULT,
-      parameterId: deploymentIdParam.id,
-      propertiesToUpdate: {
-        value: [createLiteralValueSegment('')],
-        preservedValue: undefined,
-      },
-    });
-  } else {
-    // AzureOpenAI/Foundry/APIM: show deploymentId, hide modelId
-    parametersToUpdate.push({
-      groupId: ParameterGroupKeys.DEFAULT,
-      parameterId: modelIdParam.id,
-      propertiesToUpdate: {
-        value: [createLiteralValueSegment('')],
-        preservedValue: undefined,
-      },
-    });
+  // Clear deploymentModelProperties (name, format, version) when switching connections
+  const deploymentModelPropertiesKeys = [
+    'inputs.$.agentModelSettings.deploymentModelProperties.name',
+    'inputs.$.agentModelSettings.deploymentModelProperties.format',
+    'inputs.$.agentModelSettings.deploymentModelProperties.version',
+  ];
+  for (const key of deploymentModelPropertiesKeys) {
+    const param = defaultGroup.parameters?.find((p) => p.parameterKey === key);
+    if (param) {
+      parametersToUpdate.push({
+        groupId: ParameterGroupKeys.DEFAULT,
+        parameterId: param.id,
+        propertiesToUpdate: {
+          value: [createLiteralValueSegment('')],
+          preservedValue: undefined,
+        },
+      });
+    }
   }
 
   dispatch(

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/useCognitiveService.ts
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/useCognitiveService.ts
@@ -93,7 +93,8 @@ const getServiceAccountId = (resourceId: string | undefined, isFoundryServiceCon
     return parts.length >= 2 ? parts.slice(0, -2).join('/') : resourceId;
   }
 
-  return resourceId;
+  // Strip /models suffix for MicrosoftFoundry connections
+  return resourceId.replace(/\/models$/, '');
 };
 
 export const getCognitiveServiceAccountDeploymentsForConnection = async (connection: Connection) => {

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.tsx
@@ -23,6 +23,7 @@ import {
   equals,
   foundryServiceConnectionRegex,
   apimanagementRegex,
+  microsoftFoundryModelsRegex,
   getIconUriFromConnector,
   parseErrorMessage,
   type Connection,
@@ -64,7 +65,7 @@ export const SelectConnectionWrapper = () => {
     if (AgentUtils.isConnector(connector?.id)) {
       return connectionData.filter((c) => {
         const connectionReference = connectionReferencesForConnector.find((ref) => equals(ref.connection.id, c?.id, true));
-        let modelType = AgentUtils.ModelType.AzureOpenAI;
+        let modelType = AgentUtils.ModelType.AzureOpenAI; // default (legacy)
         const cognitiveResourceId =
           connectionReference?.resourceId ?? c.properties?.connectionParameters?.cognitiveServiceAccountId?.metadata?.value;
 
@@ -73,6 +74,8 @@ export const SelectConnectionWrapper = () => {
             modelType = AgentUtils.ModelType.FoundryService;
           } else if (apimanagementRegex.test(cognitiveResourceId)) {
             modelType = AgentUtils.ModelType.APIM;
+          } else if (microsoftFoundryModelsRegex.test(cognitiveResourceId)) {
+            modelType = AgentUtils.ModelType.MicrosoftFoundry;
           }
         } else if (!c.properties?.connectionParameters?.cognitiveServiceAccountId?.metadata?.value) {
           // No cognitive serviceAccountId means this is a V1ChatCompletionsService connection (BYO)
@@ -87,8 +90,12 @@ export const SelectConnectionWrapper = () => {
           },
         };
 
-        // For A2A, hide the foundry connection from the list
-        return isA2A ? modelType === AgentUtils.ModelType.AzureOpenAI || modelType === AgentUtils.ModelType.V1ChatCompletionsService : true;
+        // For A2A, show AzureOpenAI, MicrosoftFoundry, and V1 connections only
+        return isA2A
+          ? modelType === AgentUtils.ModelType.AzureOpenAI ||
+              modelType === AgentUtils.ModelType.MicrosoftFoundry ||
+              modelType === AgentUtils.ModelType.V1ChatCompletionsService
+          : true;
       });
     }
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/custom/deploymentModelResource.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/custom/deploymentModelResource.tsx
@@ -62,7 +62,7 @@ export const CustomDeploymentModelResource = (props: IEditorProps) => {
   );
 
   const onSubmit = useCallback(async () => {
-    const resourceId = metadata?.cognitiveServiceAccountId;
+    const resourceId = metadata?.cognitiveServiceAccountId?.replace(/\/models$/, '');
     if (!resourceId) {
       console.error('OpenAI account ID is not provided in metadata.');
       return;

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -1031,54 +1031,70 @@ export const ParameterSection = ({
             })
           );
         }
+
+        // Clear deploymentModelProperties when switching away from MicrosoftFoundry.
+        // For AzureOpenAI the backend derives model info from the deployment itself.
+        if (newValue !== 'MicrosoftFoundry') {
+          updatedDependencies.inputs ??= {};
+          for (const key of [
+            'inputs.$.agentModelSettings.deploymentModelProperties.name',
+            'inputs.$.agentModelSettings.deploymentModelProperties.format',
+            'inputs.$.agentModelSettings.deploymentModelProperties.version',
+          ]) {
+            const targetParam = parameterGroup.parameters.find((param) => equals(key, param.parameterKey, true));
+            if (targetParam) {
+              updatedDependencies.inputs[key] = {
+                definition: targetParam.schema,
+                dependencyType: 'AgentSchema' as const,
+                dependentParameters: { [id]: { isValid: true } },
+                parameter: {
+                  key,
+                  name: targetParam.parameterName ?? '',
+                  type: targetParam.type ?? '',
+                  value: [createLiteralValueSegment('')],
+                },
+              };
+            }
+          }
+        }
       }
 
       const isAgentDeployment = isAgentConnectorAndDeploymentId(operationInfo.connectorId ?? '', parameter?.parameterName ?? '');
 
       if (isAgentDeployment) {
         const selectedModelId = value?.length ? value[0]?.value : undefined;
+        const currentModelType = findFoundryParam(nodeInputs.parameterGroups, group.id, agentModelTypeParameterKey)?.value?.[0]?.value;
 
-        // Look up the deployment from the API response (deployment.name = deploymentId, deployment.properties.model.name = modelId)
-        const deploymentInfo = selectedModelId
-          ? deploymentsForCognitiveServiceAccount?.find((deployment: any) => deployment.name === selectedModelId)
-          : undefined;
+        // Only populate deploymentModelProperties for MicrosoftFoundry.
+        // For AzureOpenAI the backend derives model info from the deployment itself.
+        if (currentModelType === 'MicrosoftFoundry' && selectedModelId) {
+          const config = AGENT_MODEL_CONFIG[selectedModelId];
+          const modelName = selectedModelId;
+          const modelFormat = config?.format ?? 'OpenAI';
+          const modelVersion = config?.version;
 
-        const modelName = deploymentInfo?.properties?.model?.name;
-        let modelFormat = deploymentInfo?.properties?.model?.format;
-        let modelVersion = deploymentInfo?.properties?.model?.version;
+          updatedDependencies.inputs ??= {};
 
-        // For MicrosoftFoundry, format and version are not in the ARM response — fill from AGENT_MODEL_CONFIG
-        if (!modelFormat || !modelVersion) {
-          const config = modelName ? AGENT_MODEL_CONFIG[modelName] : undefined;
-          if (!modelFormat) {
-            modelFormat = config?.format ?? 'OpenAI';
-          }
-          if (!modelVersion) {
-            modelVersion = config?.version;
-          }
-        }
+          const agentDeploymentKeys = [
+            {
+              key: 'inputs.$.agentModelSettings.deploymentModelProperties.name',
+              default: modelName,
+            },
+            {
+              key: 'inputs.$.agentModelSettings.deploymentModelProperties.format',
+              default: modelFormat,
+            },
+            {
+              key: 'inputs.$.agentModelSettings.deploymentModelProperties.version',
+              default: modelVersion,
+            },
+          ];
 
-        updatedDependencies.inputs ??= {};
-
-        const agentDeploymentKeys = [
-          {
-            key: 'inputs.$.agentModelSettings.deploymentModelProperties.name',
-            default: modelName,
-          },
-          {
-            key: 'inputs.$.agentModelSettings.deploymentModelProperties.format',
-            default: modelFormat,
-          },
-          {
-            key: 'inputs.$.agentModelSettings.deploymentModelProperties.version',
-            default: modelVersion,
-          },
-        ];
-
-        for (const { key, default: defaultValue } of agentDeploymentKeys) {
-          const dependency = buildDependentParam(id, key, defaultValue);
-          if (dependency) {
-            updatedDependencies.inputs[key] = dependency;
+          for (const { key, default: defaultValue } of agentDeploymentKeys) {
+            const dependency = buildDependentParam(id, key, defaultValue);
+            if (dependency) {
+              updatedDependencies.inputs[key] = dependency;
+            }
           }
         }
       }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connection.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connection.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { StandardConnectionService } from '../connection';
+import { StandardConnectionService, microsoftFoundryModelsRegex, foundryServiceConnectionRegex, apimanagementRegex } from '../connection';
 import type { StandardConnectionServiceOptions, ConnectionsData } from '../connection';
-import { mcpclientConnectorId } from '../../base/operationmanifest';
+import { agentConnectorId, mcpclientConnectorId } from '../../base/operationmanifest';
 import { ConnectionType } from '../../../../utils/src';
 import { InitLoggerService } from '../../logger';
 
@@ -201,6 +201,202 @@ describe('StandardConnectionService', () => {
       expect(auth.type).toBe('ManagedServiceIdentity');
       expect(auth.identity).toBeUndefined();
       expect(auth.audience).toBe('api://my-app');
+    });
+  });
+
+  describe('createConnection - Agent with /models suffix', () => {
+    const mockLoggerService = {
+      log: vi.fn(),
+      startTrace: vi.fn().mockReturnValue('mock-trace-id'),
+      endTrace: vi.fn(),
+      logErrorWithFormatting: vi.fn(),
+    };
+
+    const agentConnector = {
+      id: agentConnectorId,
+      type: agentConnectorId,
+      name: 'agent',
+      properties: {
+        displayName: 'Agent',
+        iconUri: '',
+        brandColor: '#000000',
+        capabilities: ['actions'],
+        description: 'Agent',
+      },
+    };
+
+    it('should append /models to resourceId for standard Cognitive Services connections', async () => {
+      InitLoggerService([mockLoggerService]);
+      let capturedConnectionData: any;
+      const writeConnection = vi.fn().mockImplementation((data: any) => {
+        capturedConnectionData = data;
+        return Promise.resolve();
+      });
+
+      const options = createMockOptions({});
+      (options as any).writeConnection = writeConnection;
+      const service = new StandardConnectionService(options);
+
+      const connectionInfo = {
+        displayName: 'test-agent-foundry',
+        connectionParametersSet: {
+          name: 'ManagedServiceIdentity',
+          values: {
+            cognitiveServiceAccountId: {
+              value: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount',
+            },
+          },
+        },
+      };
+
+      const parametersMetadata = {
+        connectionMetadata: { type: ConnectionType.Agent },
+      };
+
+      await service.createConnection('test-agent', agentConnector as any, connectionInfo, parametersMetadata as any);
+
+      expect(writeConnection).toHaveBeenCalledOnce();
+      expect(capturedConnectionData.connectionData.resourceId).toBe(
+        '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models'
+      );
+      expect(capturedConnectionData.connectionData.type).toBe('model');
+    });
+
+    it('should NOT append /models for FoundryAgentServiceV2 connections', async () => {
+      InitLoggerService([mockLoggerService]);
+      let capturedConnectionData: any;
+      const writeConnection = vi.fn().mockImplementation((data: any) => {
+        capturedConnectionData = data;
+        return Promise.resolve();
+      });
+
+      const options = createMockOptions({});
+      (options as any).writeConnection = writeConnection;
+      const service = new StandardConnectionService(options);
+
+      const foundryResourceId =
+        '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/projects/myproject';
+      const connectionInfo = {
+        displayName: 'test-agent-foundry-service',
+        connectionParametersSet: {
+          name: 'ManagedServiceIdentity',
+          values: {
+            cognitiveServiceAccountId: { value: foundryResourceId },
+          },
+        },
+      };
+
+      const parametersMetadata = {
+        connectionMetadata: { type: ConnectionType.Agent },
+      };
+
+      await service.createConnection('test-agent', agentConnector as any, connectionInfo, parametersMetadata as any);
+
+      expect(writeConnection).toHaveBeenCalledOnce();
+      expect(capturedConnectionData.connectionData.resourceId).toBe(foundryResourceId);
+      expect(capturedConnectionData.connectionData.type).toBe('FoundryAgentServiceV2');
+    });
+
+    it('should NOT append /models for APIM connections', async () => {
+      InitLoggerService([mockLoggerService]);
+      let capturedConnectionData: any;
+      const writeConnection = vi.fn().mockImplementation((data: any) => {
+        capturedConnectionData = data;
+        return Promise.resolve();
+      });
+
+      const options = createMockOptions({});
+      (options as any).writeConnection = writeConnection;
+      const service = new StandardConnectionService(options);
+
+      const apimResourceId = '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ApiManagement/service/myservice/apis/myapi';
+      const connectionInfo = {
+        displayName: 'test-agent-apim',
+        connectionParametersSet: {
+          name: 'ManagedServiceIdentity',
+          values: {
+            cognitiveServiceAccountId: { value: apimResourceId },
+          },
+        },
+      };
+
+      const parametersMetadata = {
+        connectionMetadata: { type: ConnectionType.Agent },
+      };
+
+      await service.createConnection('test-agent', agentConnector as any, connectionInfo, parametersMetadata as any);
+
+      expect(writeConnection).toHaveBeenCalledOnce();
+      expect(capturedConnectionData.connectionData.resourceId).toBe(apimResourceId);
+      expect(capturedConnectionData.connectionData.type).toBe('APIMGenAIGateway');
+    });
+  });
+});
+
+describe('Connection regex patterns', () => {
+  describe('microsoftFoundryModelsRegex', () => {
+    it('should match resourceIds ending with /models', () => {
+      expect(
+        microsoftFoundryModelsRegex.test(
+          '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models'
+        )
+      ).toBe(true);
+    });
+
+    it('should not match resourceIds without /models suffix', () => {
+      expect(
+        microsoftFoundryModelsRegex.test('/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount')
+      ).toBe(false);
+    });
+
+    it('should not match /models in the middle of a path', () => {
+      expect(microsoftFoundryModelsRegex.test('/some/path/models/deployments')).toBe(false);
+    });
+
+    it('should not match FoundryAgentServiceV2 resourceIds', () => {
+      expect(
+        microsoftFoundryModelsRegex.test(
+          '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/projects/myproject'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('foundryServiceConnectionRegex', () => {
+    it('should match FoundryAgentServiceV2 resourceIds with /accounts/x/projects/y', () => {
+      expect(
+        foundryServiceConnectionRegex.test(
+          '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/projects/myproject'
+        )
+      ).toBe(true);
+    });
+
+    it('should not match standard Cognitive Services resourceIds', () => {
+      expect(
+        foundryServiceConnectionRegex.test('/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount')
+      ).toBe(false);
+    });
+
+    it('should not match resourceIds with /models suffix', () => {
+      expect(
+        foundryServiceConnectionRegex.test(
+          '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('apimanagementRegex', () => {
+    it('should match APIM resourceIds', () => {
+      expect(
+        apimanagementRegex.test('/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ApiManagement/service/myservice/apis/myapi')
+      ).toBe(true);
+    });
+
+    it('should not match Cognitive Services resourceIds', () => {
+      expect(apimanagementRegex.test('/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount')).toBe(
+        false
+      );
     });
   });
 });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
@@ -156,6 +156,7 @@ const knowledgeHubLocation = 'knowledgeHubConnections';
 const mcpLocation = 'agentMcpConnections';
 export const foundryServiceConnectionRegex = /\/Microsoft\.CognitiveServices\/accounts\/[^/]+\/projects\/[^/]+/;
 export const apimanagementRegex = /\/Microsoft\.ApiManagement\/service\/[^/]+\/apis\/[^/]+/;
+export const microsoftFoundryModelsRegex = /\/models$/;
 
 export interface StandardConnectionServiceOptions {
   apiVersion: string;
@@ -946,8 +947,12 @@ function convertToAgentConnectionsData(
       },
       endpoint: isBringYourOwnKeyAuth || isClientCertificateAuth ? parameterValues?.['endpoint'] : parameterValues?.['openAIEndpoint'],
       // Only include resourceId if it has a value
-      ...(cognitiveServiceAccountId && { resourceId: cognitiveServiceAccountId }),
-      type: isFoundryAgentServiceConnection ? 'FoundryAgentService' : isAPIMManagementConnection ? 'APIMGenAIGateway' : 'model',
+      // Append /models for standard Cognitive Services connections (MicrosoftFoundry) to distinguish from legacy AzureOpenAI
+      ...(cognitiveServiceAccountId && {
+        resourceId:
+          isFoundryAgentServiceConnection || isAPIMManagementConnection ? cognitiveServiceAccountId : `${cognitiveServiceAccountId}/models`,
+      }),
+      type: isFoundryAgentServiceConnection ? 'FoundryAgentServiceV2' : isAPIMManagementConnection ? 'APIMGenAIGateway' : 'model',
     },
     settings,
     pathLocation: [agentLocation],

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/index.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/index.ts
@@ -6,6 +6,7 @@ export {
   escapeSpecialChars,
   foundryServiceConnectionRegex,
   apimanagementRegex,
+  microsoftFoundryModelsRegex,
 } from './connection';
 export { StandardConnectorService, type StandardConnectorServiceOptions } from './connector';
 export { StandardOperationManifestService, isServiceProviderOperation } from './operationmanifest';

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
@@ -7,58 +7,29 @@ const agentModelTypeOptions = inputs.agentModelType['x-ms-editor-options'].optio
   displayName: string;
 }[];
 
-describe('agentloop – Foundry V2 regression', () => {
+describe('agentloop – MicrosoftFoundry regression', () => {
   describe('agentModelType dropdown values', () => {
     const dropdownValues = agentModelTypeOptions.map((o) => o.value);
 
-    it('should include FoundryAgentServiceV2 (not FoundryAgentService)', () => {
-      expect(dropdownValues).toContain('FoundryAgentServiceV2');
-      expect(dropdownValues).not.toContain('FoundryAgentService');
+    it('should include MicrosoftFoundry', () => {
+      expect(dropdownValues).toContain('MicrosoftFoundry');
     });
 
     it('should contain the full expected set of dropdown values', () => {
-      expect(dropdownValues).toEqual(['MicrosoftFoundry', 'FoundryAgentServiceV2', 'APIMGenAIGateway', 'V1ChatCompletionsService']);
+      expect(dropdownValues).toEqual(['MicrosoftFoundry', 'FoundryAgentService', 'APIMGenAIGateway', 'V1ChatCompletionsService']);
     });
 
     it('should NOT include AzureOpenAI (removed from new connection creation)', () => {
       expect(dropdownValues).not.toContain('AzureOpenAI');
     });
 
-    it('should label the V2 option as "Foundry project (Preview)"', () => {
-      const v2Option = agentModelTypeOptions.find((o) => o.value === 'FoundryAgentServiceV2');
-      expect(v2Option?.displayName).toBe('Foundry project (Preview)');
+    it('should default to MicrosoftFoundry', () => {
+      expect(inputs.agentModelType.default).toBe('MicrosoftFoundry');
     });
   });
 
-  describe('V2-required fields', () => {
-    it('foundryAgentName is defined with visibility dependency on FoundryAgentServiceV2', () => {
-      const field = inputs.foundryAgentName;
-      expect(field).toBeDefined();
-      const visValues = field['x-ms-input-dependencies'].parameters[0].values;
-      expect(visValues).toEqual(['FoundryAgentServiceV2']);
-    });
-
-    it('foundryVersionName is defined with visibility dependency on FoundryAgentServiceV2 and no default', () => {
-      const field = inputs.foundryVersionName;
-      expect(field).toBeDefined();
-      expect(field.default).toBeUndefined();
-      const visValues = field['x-ms-input-dependencies'].parameters[0].values;
-      expect(visValues).toEqual(['FoundryAgentServiceV2']);
-    });
-  });
-
-  describe('V1-only fields are NOT present', () => {
-    it.each(['foundryAgentId', 'foundryAgentVersion', 'foundryAgentVersionNumber'])('%s should not exist in inputs', (fieldName) => {
-      expect(inputs[fieldName]).toBeUndefined();
-    });
-  });
-
-  describe('deploymentId does NOT include V2', () => {
+  describe('deploymentId visibility', () => {
     const deploymentVisValues = inputs.deploymentId['x-ms-input-dependencies'].parameters[0].values as string[];
-
-    it('should NOT include FoundryAgentServiceV2', () => {
-      expect(deploymentVisValues).not.toContain('FoundryAgentServiceV2');
-    });
 
     it('should include AzureOpenAI, MicrosoftFoundry, and APIMGenAIGateway', () => {
       expect(deploymentVisValues).toContain('AzureOpenAI');
@@ -67,53 +38,11 @@ describe('agentloop – Foundry V2 regression', () => {
     });
   });
 
-  describe('no leftover V1 references in visibility conditions', () => {
-    it('no input parameter should reference bare "FoundryAgentService" (without V2 suffix)', () => {
-      for (const [key, field] of Object.entries(inputs)) {
-        const deps = (field as any)?.['x-ms-input-dependencies'];
-        if (!deps?.parameters) {
-          continue;
-        }
-        for (const param of deps.parameters) {
-          if (!param.values) {
-            continue;
-          }
-          for (const v of param.values) {
-            if (v === 'FoundryAgentService') {
-              throw new Error(`Input "${key}" still references bare "FoundryAgentService" — expected "FoundryAgentServiceV2"`);
-            }
-          }
-        }
+  describe('no leftover AzureOpenAI in dropdown options', () => {
+    it('no dropdown option should have AzureOpenAI as a value', () => {
+      for (const option of agentModelTypeOptions) {
+        expect(option.value).not.toBe('AzureOpenAI');
       }
-    });
-  });
-
-  describe('knowledgeBaseName excludes V2', () => {
-    const kbVisValues = inputs.knowledgeBaseName['x-ms-input-dependencies'].parameters[0].values as string[];
-
-    it('should NOT include FoundryAgentServiceV2', () => {
-      expect(kbVisValues).not.toContain('FoundryAgentServiceV2');
-    });
-
-    it('should include AzureOpenAI and other non-V2 model types', () => {
-      expect(kbVisValues).toContain('AzureOpenAI');
-      expect(kbVisValues).toContain('MicrosoftFoundry');
-    });
-  });
-
-  describe('foundryVersionName contract', () => {
-    const field = inputs.foundryVersionName;
-
-    it('should have internal visibility (hidden from UI)', () => {
-      expect(field['x-ms-visibility']).toBe('internal');
-    });
-
-    it('should have no default value (set dynamically from API)', () => {
-      expect(field.default).toBeUndefined();
-    });
-
-    it('should be a string type field', () => {
-      expect(field.type).toBe('string');
     });
   });
 });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import agentloop from '../agentloop';
+
+const inputs = agentloop.properties.inputs?.properties as Record<string, any>;
+const agentModelTypeOptions = inputs.agentModelType['x-ms-editor-options'].options as {
+  value: string;
+  displayName: string;
+}[];
+
+describe('agentloop – Foundry V2 regression', () => {
+  describe('agentModelType dropdown values', () => {
+    const dropdownValues = agentModelTypeOptions.map((o) => o.value);
+
+    it('should include FoundryAgentServiceV2 (not FoundryAgentService)', () => {
+      expect(dropdownValues).toContain('FoundryAgentServiceV2');
+      expect(dropdownValues).not.toContain('FoundryAgentService');
+    });
+
+    it('should contain the full expected set of dropdown values', () => {
+      expect(dropdownValues).toEqual(['MicrosoftFoundry', 'FoundryAgentServiceV2', 'APIMGenAIGateway', 'V1ChatCompletionsService']);
+    });
+
+    it('should NOT include AzureOpenAI (removed from new connection creation)', () => {
+      expect(dropdownValues).not.toContain('AzureOpenAI');
+    });
+
+    it('should label the V2 option as "Foundry project (Preview)"', () => {
+      const v2Option = agentModelTypeOptions.find((o) => o.value === 'FoundryAgentServiceV2');
+      expect(v2Option?.displayName).toBe('Foundry project (Preview)');
+    });
+  });
+
+  describe('V2-required fields', () => {
+    it('foundryAgentName is defined with visibility dependency on FoundryAgentServiceV2', () => {
+      const field = inputs.foundryAgentName;
+      expect(field).toBeDefined();
+      const visValues = field['x-ms-input-dependencies'].parameters[0].values;
+      expect(visValues).toEqual(['FoundryAgentServiceV2']);
+    });
+
+    it('foundryVersionName is defined with visibility dependency on FoundryAgentServiceV2 and no default', () => {
+      const field = inputs.foundryVersionName;
+      expect(field).toBeDefined();
+      expect(field.default).toBeUndefined();
+      const visValues = field['x-ms-input-dependencies'].parameters[0].values;
+      expect(visValues).toEqual(['FoundryAgentServiceV2']);
+    });
+  });
+
+  describe('V1-only fields are NOT present', () => {
+    it.each(['foundryAgentId', 'foundryAgentVersion', 'foundryAgentVersionNumber'])('%s should not exist in inputs', (fieldName) => {
+      expect(inputs[fieldName]).toBeUndefined();
+    });
+  });
+
+  describe('deploymentId does NOT include V2', () => {
+    const deploymentVisValues = inputs.deploymentId['x-ms-input-dependencies'].parameters[0].values as string[];
+
+    it('should NOT include FoundryAgentServiceV2', () => {
+      expect(deploymentVisValues).not.toContain('FoundryAgentServiceV2');
+    });
+
+    it('should include AzureOpenAI, MicrosoftFoundry, and APIMGenAIGateway', () => {
+      expect(deploymentVisValues).toContain('AzureOpenAI');
+      expect(deploymentVisValues).toContain('MicrosoftFoundry');
+      expect(deploymentVisValues).toContain('APIMGenAIGateway');
+    });
+  });
+
+  describe('no leftover V1 references in visibility conditions', () => {
+    it('no input parameter should reference bare "FoundryAgentService" (without V2 suffix)', () => {
+      for (const [key, field] of Object.entries(inputs)) {
+        const deps = (field as any)?.['x-ms-input-dependencies'];
+        if (!deps?.parameters) {
+          continue;
+        }
+        for (const param of deps.parameters) {
+          if (!param.values) {
+            continue;
+          }
+          for (const v of param.values) {
+            if (v === 'FoundryAgentService') {
+              throw new Error(`Input "${key}" still references bare "FoundryAgentService" — expected "FoundryAgentServiceV2"`);
+            }
+          }
+        }
+      }
+    });
+  });
+
+  describe('knowledgeBaseName excludes V2', () => {
+    const kbVisValues = inputs.knowledgeBaseName['x-ms-input-dependencies'].parameters[0].values as string[];
+
+    it('should NOT include FoundryAgentServiceV2', () => {
+      expect(kbVisValues).not.toContain('FoundryAgentServiceV2');
+    });
+
+    it('should include AzureOpenAI and other non-V2 model types', () => {
+      expect(kbVisValues).toContain('AzureOpenAI');
+      expect(kbVisValues).toContain('MicrosoftFoundry');
+    });
+  });
+
+  describe('foundryVersionName contract', () => {
+    const field = inputs.foundryVersionName;
+
+    it('should have internal visibility (hidden from UI)', () => {
+      expect(field['x-ms-visibility']).toBe('internal');
+    });
+
+    it('should have no default value (set dynamically from API)', () => {
+      expect(field.default).toBeUndefined();
+    });
+
+    it('should be a string type field', () => {
+      expect(field.type).toBe('string');
+    });
+  });
+});

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -498,13 +498,12 @@ export default {
                   title: 'Model name',
                   description: 'Name of the model which you want to use for the agent',
                   type: 'string',
-                  default: 'gpt-4.1',
                   'x-ms-input-dependencies': {
                     type: 'visibility',
                     parameters: [
                       {
                         name: 'agentModelType',
-                        values: ['AzureOpenAI', 'MicrosoftFoundry'],
+                        values: ['MicrosoftFoundry'],
                       },
                     ],
                   },
@@ -513,13 +512,12 @@ export default {
                   title: 'Model format',
                   description: 'Format of the model you are using',
                   type: 'string',
-                  default: 'OpenAI',
                   'x-ms-input-dependencies': {
                     type: 'visibility',
                     parameters: [
                       {
                         name: 'agentModelType',
-                        values: ['AzureOpenAI', 'MicrosoftFoundry'],
+                        values: ['MicrosoftFoundry'],
                       },
                     ],
                   },
@@ -528,13 +526,12 @@ export default {
                   title: 'Model version',
                   description: 'Version of the model you are using',
                   type: 'string',
-                  default: '2025-06-10',
                   'x-ms-input-dependencies': {
                     type: 'visibility',
                     parameters: [
                       {
                         name: 'agentModelType',
-                        values: ['AzureOpenAI', 'MicrosoftFoundry'],
+                        values: ['MicrosoftFoundry'],
                       },
                     ],
                   },

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -51,10 +51,6 @@ export default {
             readOnly: true,
             options: [
               {
-                value: 'AzureOpenAI',
-                displayName: 'Azure OpenAI',
-              },
-              {
                 value: 'MicrosoftFoundry',
                 displayName: 'Foundry Models (Preview)',
               },
@@ -74,7 +70,7 @@ export default {
             ],
           },
           type: 'string',
-          default: 'AzureOpenAI',
+          default: 'MicrosoftFoundry',
         },
         foundryAgentId: {
           type: 'string',


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Cherry-picks two related PRs from `main` into the `hotfix/v5.294` release branch:

### PR #9012 — Only populate deploymentModelProperties for MicrosoftFoundry
- Removes hardcoded defaults from the agent manifest (`gpt-4.1`, `OpenAI`, `2025-06-10`)
- Changes visibility of `deploymentModelProperties` to `MicrosoftFoundry` only
- Clears `deploymentModelProperties` when switching away from `MicrosoftFoundry`
- Only populates `deploymentModelProperties` when a Foundry model is selected

### PR #9028 — Default agent connection type to MicrosoftFoundry
- Differentiates MicrosoftFoundry from AzureOpenAI using `/models` resourceId suffix
- New `microsoftFoundryModelsRegex` for connection classification
- Display name reverted to `Foundry Models`
- A2A filter updated to show both AzureOpenAI and MicrosoftFoundry connections
- Resets deployment params (`deploymentId`, `modelId`, `deploymentModelProperties`) on connection switch
- Strips `/models` suffix before ARM calls

### Backward compatibility
Existing connections without `/models` are classified as `AzureOpenAI` — no migration needed.

## Impact of Change
- **Users**: Foundry model properties now correctly reflect the selected model. New agent connections are classified as `MicrosoftFoundry` with `Foundry Models` label. Legacy connections without `/models` remain `AzureOpenAI`. Deployment fields (`deploymentId`, `modelId`, `deploymentModelProperties`) are cleared on connection switch to prevent stale values.
- **Developers**: `microsoftFoundryModelsRegex` exported from `@microsoft/logic-apps-shared`. `deploymentModelProperties` scoped to `MicrosoftFoundry` visibility only. Note: `connection.resourceId` for new MicrosoftFoundry connections now includes a `/models` suffix (e.g., `.../accounts/<name>/models`), and `connection.type` may be `FoundryAgentServiceV2` instead of legacy `FoundryAgentService`. Downstream consumers or integrations that parse `resourceId` or `type` values should be updated accordingly.
- **System**: No performance or architectural changes. There is a format change for `connection.resourceId` — newly created MicrosoftFoundry connections will have `/models` appended to the resourceId. Scripts, tooling, or backing-store consumers that parse this field should account for the new suffix. ARM API callers in the designer already strip `/models` before making deployment calls.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Verified in original PRs (#9012, #9028)

### Test files added/updated:
- `libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connection.spec.ts` — unit tests for `microsoftFoundryModelsRegex`, `foundryServiceConnectionRegex`, `apimanagementRegex` patterns, and `convertToAgentConnectionsData` verifying `/models` suffix behavior
- `libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts` — manifest tests for `FoundryAgentServiceV2` values, `MicrosoftFoundry` dropdown options, and visibility dependencies

## Contributors
@Elaina-Lee