### PR TITLE
feat(Designer): Info bubble for code interpreter (#9043)

### DIFF
--- a/libs/designer-ui/src/lib/builtintools/__test__/__snapshots__/builtintools.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/builtintools/__test__/__snapshots__/builtintools.spec.tsx.snap
@@ -16,14 +16,18 @@ exports[`lib/builtintools > should render with basic props 1`] = `
       className="___1hxfasu_0000000 f22iagw f1vx9l62 fz7g6wx fe7p41z"
     >
       <span
-        className="___bbz8wo0_0000000 fl43uef fy9rknc f19n0e5"
+        className="___1ej4kmx_0000000 f22iagw f122n59 fkln5zr"
       >
-        Code Interpreter
+        <span
+          className="___bbz8wo0_0000000 fl43uef fy9rknc f19n0e5"
+        >
+          Code Interpreter
+        </span>
       </span>
       <span
         className="___l0twgo0_0000000 fy9rknc fkfq4zb"
       >
-        Enable the agent to write and execute JavaScript code for calculations, data analysis, and file processing.
+        Enable the agent to write and execute JavaScript code for calculations, and data analysis.
       </span>
     </div>
     <div

--- a/libs/designer-ui/src/lib/builtintools/__test__/__snapshots__/builtintools.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/builtintools/__test__/__snapshots__/builtintools.spec.tsx.snap
@@ -27,7 +27,7 @@ exports[`lib/builtintools > should render with basic props 1`] = `
       <span
         className="___l0twgo0_0000000 fy9rknc fkfq4zb"
       >
-        Enable the agent to write and execute JavaScript code for calculations, and data analysis.
+        Enable the agent to write and execute JavaScript code for calculations and data analysis.
       </span>
     </div>
     <div

--- a/libs/designer-ui/src/lib/builtintools/__test__/builtintools.spec.tsx
+++ b/libs/designer-ui/src/lib/builtintools/__test__/builtintools.spec.tsx
@@ -17,7 +17,7 @@ describe('lib/builtintools', () => {
     {
       value: 'code_interpreter',
       displayName: 'Code Interpreter',
-      description: 'Enable the agent to write and execute JavaScript code for calculations, data analysis, and file processing.',
+      description: 'Enable the agent to write and execute JavaScript code for calculations, and data analysis.',
     },
   ];
 
@@ -60,9 +60,7 @@ describe('lib/builtintools', () => {
     );
 
     expect(getByText('Code Interpreter')).toBeTruthy();
-    expect(
-      getByText('Enable the agent to write and execute JavaScript code for calculations, data analysis, and file processing.')
-    ).toBeTruthy();
+    expect(getByText('Enable the agent to write and execute JavaScript code for calculations, and data analysis.')).toBeTruthy();
   });
 
   it('should render switch as unchecked when initialValue is empty', () => {

--- a/libs/designer-ui/src/lib/builtintools/__test__/builtintools.spec.tsx
+++ b/libs/designer-ui/src/lib/builtintools/__test__/builtintools.spec.tsx
@@ -17,7 +17,7 @@ describe('lib/builtintools', () => {
     {
       value: 'code_interpreter',
       displayName: 'Code Interpreter',
-      description: 'Enable the agent to write and execute JavaScript code for calculations, and data analysis.',
+      description: 'Enable the agent to write and execute JavaScript code for calculations and data analysis.',
     },
   ];
 
@@ -60,7 +60,7 @@ describe('lib/builtintools', () => {
     );
 
     expect(getByText('Code Interpreter')).toBeTruthy();
-    expect(getByText('Enable the agent to write and execute JavaScript code for calculations, and data analysis.')).toBeTruthy();
+    expect(getByText('Enable the agent to write and execute JavaScript code for calculations and data analysis.')).toBeTruthy();
   });
 
   it('should render switch as unchecked when initialValue is empty', () => {

--- a/libs/designer-ui/src/lib/builtintools/index.tsx
+++ b/libs/designer-ui/src/lib/builtintools/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
-import { Switch } from '@fluentui/react-components';
+import { Link, Switch, Tooltip } from '@fluentui/react-components';
+import { Info16Regular } from '@fluentui/react-icons';
 import type { ValueSegment } from '../editor';
 import type { ChangeHandler } from '../editor/base';
 import { createLiteralValueSegment } from '../editor/base/utils/helper';
@@ -10,6 +11,9 @@ export interface BuiltinToolOption {
   value: string;
   displayName: string;
   description: string;
+  infoMessage?: string;
+  infoLinkText?: string;
+  infoLinkUrl?: string;
 }
 
 export interface BuiltinToolsEditorProps {
@@ -61,7 +65,26 @@ export const BuiltinToolsEditor = ({ initialValue, options = [], readonly, onCha
       {options.map((option) => (
         <div key={option.value} className={styles.toolRow}>
           <div className={styles.toolInfo}>
-            <span className={styles.toolName}>{option.displayName}</span>
+            <span className={styles.toolNameRow}>
+              <span className={styles.toolName}>{option.displayName}</span>
+              {option.infoMessage && (
+                <Tooltip
+                  relationship="description"
+                  content={
+                    <span>
+                      {option.infoMessage}{' '}
+                      {option.infoLinkUrl && (
+                        <Link href={option.infoLinkUrl} target="_blank" rel="noopener noreferrer" inline>
+                          {option.infoLinkText ?? option.infoLinkUrl}
+                        </Link>
+                      )}
+                    </span>
+                  }
+                >
+                  <Info16Regular className={styles.infoIcon} tabIndex={0} aria-label={option.infoMessage} />
+                </Tooltip>
+              )}
+            </span>
             <span className={styles.toolDescription}>{option.description}</span>
           </div>
           <Switch

--- a/libs/designer-ui/src/lib/builtintools/styles.ts
+++ b/libs/designer-ui/src/lib/builtintools/styles.ts
@@ -26,10 +26,20 @@ export const useBuiltinToolsStyles = makeStyles({
     flex: 1,
     gap: tokens.spacingVerticalXXS,
   },
+  toolNameRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalXS,
+  },
   toolName: {
     fontWeight: tokens.fontWeightSemibold,
     fontSize: tokens.fontSizeBase200,
     color: tokens.colorNeutralForeground1,
+  },
+  infoIcon: {
+    fontSize: tokens.fontSizeBase300,
+    color: tokens.colorNeutralForeground3,
+    cursor: 'pointer',
   },
   toolDescription: {
     fontSize: tokens.fontSizeBase200,

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/agentloop.ts
@@ -212,8 +212,11 @@ export default {
                       {
                         value: 'code_interpreter',
                         displayName: 'Code Interpreter',
-                        description:
-                          'Enable the agent to write and execute JavaScript code for calculations, data analysis, and file processing.',
+                        description: 'Enable the agent to write and execute JavaScript code for calculations, and data analysis.',
+                        infoMessage: 'Integration account is required to enable code interpreter.',
+                        infoLinkText: 'Read more',
+                        infoLinkUrl:
+                          'https://learn.microsoft.com/en-us/azure/logic-apps/enterprise-integration/create-integration-account?tabs=azure-portal%2Cconsumption#create-integration-account',
                       },
                     ],
                   },

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/agentloop.ts
@@ -212,7 +212,7 @@ export default {
                       {
                         value: 'code_interpreter',
                         displayName: 'Code Interpreter',
-                        description: 'Enable the agent to write and execute JavaScript code for calculations, and data analysis.',
+                        description: 'Enable the agent to write and execute JavaScript code for calculations and data analysis.',
                         infoMessage: 'Integration account is required to enable code interpreter.',
                         infoLinkText: 'Read more',
                         infoLinkUrl:

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -331,8 +331,7 @@ export default {
                       {
                         value: 'code_interpreter',
                         displayName: 'Code Interpreter',
-                        description:
-                          'Enable the agent to write and execute JavaScript code for calculations, data analysis, and file processing.',
+                        description: 'Enable the agent to write and execute JavaScript code for calculations, and data analysis.',
                       },
                     ],
                   },

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -331,7 +331,7 @@ export default {
                       {
                         value: 'code_interpreter',
                         displayName: 'Code Interpreter',
-                        description: 'Enable the agent to write and execute JavaScript code for calculations, and data analysis.',
+                        description: 'Enable the agent to write and execute JavaScript code for calculations and data analysis.',
                       },
                     ],
                   },


### PR DESCRIPTION
## Commit Type
- [x] feature - New functionality

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Cherry-picks PR #9043 from `main` into the `hotfix/v5.294` release branch.

Adds an info tooltip next to the **Code Interpreter** display name in the built-in tools editor for consumption agent loop workflows. The tooltip informs users that an integration account is required to enable code interpreter, with a "Read more" link to the relevant Microsoft Learn documentation.

This is consumption-only — the `infoMessage`, `infoLinkText`, and `infoLinkUrl` fields are added to the consumption agent loop manifest's `code_interpreter` option, and the `BuiltinToolOption` interface supports them optionally.

## Impact of Change
- **Users**: Consumption workflow users see an info icon next to Code Interpreter with guidance about the integration account requirement
- **Developers**: `BuiltinToolOption` interface gains three optional fields (`infoMessage`, `infoLinkText`, `infoLinkUrl`) for adding info tooltips to any built-in tool option
- **System**: No performance or architecture impact; additive change only

## Test Plan
- [x] Unit tests added/updated (updated `builtintools.spec.tsx` + snapshot in original PR)
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Verified in original PR (#9043)

## Contributors
@Elaina-Lee