### PR TITLE
fix(designer): Use actual model name for deploymentModelProperties (#9054)

### DIFF
--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/__test__/helpers.spec.ts
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/__test__/helpers.spec.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../connectionsPanel/createConnection/custom/useCognitiveService', () => ({
+  getCognitiveServiceAccountDeploymentsForConnection: vi.fn(),
+}));
+
 import {
   isAgentConnectorAndAgentServiceModel,
   isAgentConnectorAndDeploymentId,
@@ -7,16 +12,22 @@ import {
   agentModelTypeParameterKey,
   getConnectionToAssign,
   categorizeConnections,
+  getFirstDeploymentInfo,
+  getFirstDeploymentModelName,
 } from '../helpers';
+import { getCognitiveServiceAccountDeploymentsForConnection } from '../../../../connectionsPanel/createConnection/custom/useCognitiveService';
 import type { ParameterGroup } from '../../../../../../core/state/operation/operationMetadataSlice';
 import type { ParameterInfo } from '@microsoft/designer-ui';
 import type { Connection } from '@microsoft/logic-apps-shared';
+
+const mockGetDeployments = vi.mocked(getCognitiveServiceAccountDeploymentsForConnection);
 
 function makeParameterGroups(groupId: string, parameters: Partial<ParameterInfo>[]): Record<string, ParameterGroup> {
   return {
     [groupId]: {
       id: groupId,
       description: '',
+      rawInputs: [],
       parameters: parameters.map((p, i) => ({
         id: `param-${i}`,
         label: '',
@@ -216,5 +227,128 @@ describe('categorizeConnections', () => {
     const result = categorizeConnections([]);
     expect(result.azureOpenAI).toHaveLength(0);
     expect(result.foundry).toHaveLength(0);
+  });
+});
+
+describe('getFirstDeploymentInfo', () => {
+  const dummyConnection = { id: 'conn-1', name: 'conn-1', properties: {} } as unknown as Connection;
+
+  beforeEach(() => {
+    mockGetDeployments.mockReset();
+  });
+
+  it('should return undefined when connection has no deployments', async () => {
+    mockGetDeployments.mockResolvedValue([]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return correct deployment info when deployment has full model properties', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'my-deployment',
+        properties: {
+          model: {
+            name: 'gpt-4o',
+            format: 'OpenAI',
+            version: '2024-11-20',
+          },
+        },
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result).toEqual({
+      deploymentName: 'my-deployment',
+      modelName: 'gpt-4o',
+      modelFormat: 'OpenAI',
+      modelVersion: '2024-11-20',
+    });
+  });
+
+  it('should return first deployment when multiple deployments exist', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'deploy-1',
+        properties: { model: { name: 'gpt-4o', format: 'OpenAI', version: '2024-11-20' } },
+      },
+      {
+        name: 'deploy-2',
+        properties: { model: { name: 'gpt-4', format: 'OpenAI', version: 'turbo-2024-04-09' } },
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result?.deploymentName).toBe('deploy-1');
+    expect(result?.modelName).toBe('gpt-4o');
+  });
+
+  it('should handle deployment with missing model properties gracefully', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'deploy-no-model',
+        properties: {},
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result).toEqual({
+      deploymentName: 'deploy-no-model',
+      modelName: '',
+      modelFormat: undefined,
+      modelVersion: undefined,
+    });
+  });
+
+  it('should handle deployment with partial model properties', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'deploy-partial',
+        properties: {
+          model: {
+            name: 'gpt-4o',
+          },
+        },
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result).toEqual({
+      deploymentName: 'deploy-partial',
+      modelName: 'gpt-4o',
+      modelFormat: undefined,
+      modelVersion: undefined,
+    });
+  });
+
+  it('should default deploymentName to empty string when name is undefined', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        properties: { model: { name: 'gpt-4o', format: 'OpenAI', version: '2024-11-20' } },
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result?.deploymentName).toBe('');
+  });
+});
+
+describe('getFirstDeploymentModelName', () => {
+  const dummyConnection = { id: 'conn-1', name: 'conn-1', properties: {} } as unknown as Connection;
+
+  beforeEach(() => {
+    mockGetDeployments.mockReset();
+  });
+
+  it('should return deployment name when deployments exist', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'my-deployment',
+        properties: { model: { name: 'gpt-4o', format: 'OpenAI', version: '2024-11-20' } },
+      },
+    ]);
+    const result = await getFirstDeploymentModelName(dummyConnection);
+    expect(result).toBe('my-deployment');
+  });
+
+  it('should return empty string when no deployments exist', async () => {
+    mockGetDeployments.mockResolvedValue([]);
+    const result = await getFirstDeploymentModelName(dummyConnection);
+    expect(result).toBe('');
   });
 });

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/helpers.ts
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/helpers.ts
@@ -53,9 +53,30 @@ export const categorizeConnections = (connections: Connection[]): CategorizedCon
   );
 };
 
-export const getFirstDeploymentModelName = async (connection: Connection): Promise<string> => {
+export interface FirstDeploymentInfo {
+  deploymentName: string;
+  modelName: string;
+  modelFormat?: string;
+  modelVersion?: string;
+}
+
+export const getFirstDeploymentInfo = async (connection: Connection): Promise<FirstDeploymentInfo | undefined> => {
   const deploymentModels = await getCognitiveServiceAccountDeploymentsForConnection(connection);
-  return deploymentModels.length > 0 ? deploymentModels[0].name : '';
+  if (deploymentModels.length === 0) {
+    return undefined;
+  }
+  const first = deploymentModels[0];
+  return {
+    deploymentName: first.name ?? '',
+    modelName: first.properties?.model?.name ?? '',
+    modelFormat: first.properties?.model?.format,
+    modelVersion: first.properties?.model?.version,
+  };
+};
+
+export const getFirstDeploymentModelName = async (connection: Connection): Promise<string> => {
+  const info = await getFirstDeploymentInfo(connection);
+  return info?.deploymentName ?? '';
 };
 
 export const getDeploymentIdParameter = (state: RootState, nodeId: string): ParameterInfo | undefined => {

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -130,7 +130,7 @@ import {
   getConnectionToAssign,
   getDeploymentIdParameter,
   agentModelTypeParameterKey,
-  getFirstDeploymentModelName,
+  getFirstDeploymentInfo,
   isAgentConnectorAndAgentModel,
   isAgentConnectorAndAgentServiceModel,
   isAgentConnectorAndDeploymentId,
@@ -315,7 +315,9 @@ const updateConnectionAndDeployment = async (
   nodeId: string,
   connector: Connector,
   connection: Connection,
-  deploymentIdParamId: string
+  deploymentIdParamId: string,
+  state?: RootState,
+  modelType?: string
 ): Promise<void> => {
   try {
     // Update connection
@@ -329,24 +331,65 @@ const updateConnectionAndDeployment = async (
 
     ConnectionService().setupConnectionIfNeeded(connection);
 
-    // Get deployment model name
-    const deploymentModelName = await getFirstDeploymentModelName(connection);
+    // Get deployment info (name + model properties)
+    const deploymentInfo = await getFirstDeploymentInfo(connection);
+    const deploymentModelName = deploymentInfo?.deploymentName ?? '';
 
     // Update deployment model parameter
-    dispatch(
-      updateNodeParameters({
-        nodeId,
-        parameters: [
-          {
-            groupId: ParameterGroupKeys.DEFAULT,
-            parameterId: deploymentIdParamId,
-            propertiesToUpdate: {
-              value: [createLiteralValueSegment(deploymentModelName)],
-            },
-          },
-        ],
-      })
-    );
+    const parametersToUpdate: Array<{
+      groupId: string;
+      parameterId: string;
+      propertiesToUpdate: { value: any[] };
+    }> = [
+      {
+        groupId: ParameterGroupKeys.DEFAULT,
+        parameterId: deploymentIdParamId,
+        propertiesToUpdate: {
+          value: [createLiteralValueSegment(deploymentModelName)],
+        },
+      },
+    ];
+
+    // Also populate deploymentModelProperties for MicrosoftFoundry
+    if (modelType === 'MicrosoftFoundry' && state && deploymentInfo) {
+      const parameterGroups = state.operations.inputParameters[nodeId]?.parameterGroups;
+      const defaultGroup = parameterGroups?.[ParameterGroupKeys.DEFAULT];
+      if (defaultGroup) {
+        const modelName = deploymentInfo.modelName;
+        let modelFormat = deploymentInfo.modelFormat;
+        let modelVersion = deploymentInfo.modelVersion;
+        if (!modelFormat || !modelVersion) {
+          const config = modelName ? AGENT_MODEL_CONFIG[modelName] : undefined;
+          if (!modelFormat) {
+            modelFormat = config?.format ?? 'OpenAI';
+          }
+          if (!modelVersion) {
+            modelVersion = config?.version;
+          }
+        }
+
+        const deploymentModelPropertiesMap: Record<string, string | undefined> = {
+          'inputs.$.agentModelSettings.deploymentModelProperties.name': modelName,
+          'inputs.$.agentModelSettings.deploymentModelProperties.format': modelFormat,
+          'inputs.$.agentModelSettings.deploymentModelProperties.version': modelVersion,
+        };
+
+        for (const [key, val] of Object.entries(deploymentModelPropertiesMap)) {
+          const param = defaultGroup.parameters.find((p) => p.parameterKey === key);
+          if (param && val) {
+            parametersToUpdate.push({
+              groupId: ParameterGroupKeys.DEFAULT,
+              parameterId: param.id,
+              propertiesToUpdate: {
+                value: [createLiteralValueSegment(val)],
+              },
+            });
+          }
+        }
+      }
+    }
+
+    dispatch(updateNodeParameters({ nodeId, parameters: parametersToUpdate }));
   } catch {
     clearConnectionAndDeploymentModel(dispatch, nodeId, deploymentIdParamId);
   }
@@ -377,7 +420,15 @@ export const dynamicallyLoadAgentConnection = createAsyncThunk(
     }
 
     // Update connection and deployment model
-    await updateConnectionAndDeployment(dispatch, nodeId, connector, connectionToAssign, deploymentIdParam.id);
+    await updateConnectionAndDeployment(
+      dispatch,
+      nodeId,
+      connector,
+      connectionToAssign,
+      deploymentIdParam.id,
+      getState() as RootState,
+      modelType
+    );
   }
 );
 
@@ -1083,10 +1134,19 @@ export const ParameterSection = ({
         // Only populate deploymentModelProperties for MicrosoftFoundry.
         // For AzureOpenAI the backend derives model info from the deployment itself.
         if (currentModelType === 'MicrosoftFoundry' && selectedModelId) {
-          const config = AGENT_MODEL_CONFIG[selectedModelId];
-          const modelName = selectedModelId;
-          const modelFormat = config?.format ?? 'OpenAI';
-          const modelVersion = config?.version;
+          const deploymentInfo = deploymentsForCognitiveServiceAccount?.find((deployment: any) => deployment.name === selectedModelId);
+          const modelName = deploymentInfo?.properties?.model?.name;
+          let modelFormat = deploymentInfo?.properties?.model?.format;
+          let modelVersion = deploymentInfo?.properties?.model?.version;
+          if (!modelFormat || !modelVersion) {
+            const config = modelName ? AGENT_MODEL_CONFIG[modelName] : undefined;
+            if (!modelFormat) {
+              modelFormat = config?.format ?? 'OpenAI';
+            }
+            if (!modelVersion) {
+              modelVersion = config?.version;
+            }
+          }
 
           updatedDependencies.inputs ??= {};
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/__test__/helpers.spec.ts
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/__test__/helpers.spec.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../connectionsPanel/createConnection/custom/useCognitiveService', () => ({
+  getCognitiveServiceAccountDeploymentsForConnection: vi.fn(),
+}));
+
 import {
   isAgentConnectorAndAgentServiceModel,
   isAgentConnectorAndDeploymentId,
@@ -8,16 +13,22 @@ import {
   agentModelTypeParameterKey,
   getConnectionToAssign,
   categorizeConnections,
+  getFirstDeploymentInfo,
+  getFirstDeploymentModelName,
 } from '../helpers';
+import { getCognitiveServiceAccountDeploymentsForConnection } from '../../../../connectionsPanel/createConnection/custom/useCognitiveService';
 import type { ParameterGroup } from '../../../../../../core/state/operation/operationMetadataSlice';
 import type { ParameterInfo } from '@microsoft/designer-ui';
 import type { Connection } from '@microsoft/logic-apps-shared';
+
+const mockGetDeployments = vi.mocked(getCognitiveServiceAccountDeploymentsForConnection);
 
 function makeParameterGroups(groupId: string, parameters: Partial<ParameterInfo>[]): Record<string, ParameterGroup> {
   return {
     [groupId]: {
       id: groupId,
       description: '',
+      rawInputs: [],
       parameters: parameters.map((p, i) => ({
         id: `param-${i}`,
         label: '',
@@ -248,5 +259,128 @@ describe('categorizeConnections', () => {
     const result = categorizeConnections([]);
     expect(result.azureOpenAI).toHaveLength(0);
     expect(result.foundry).toHaveLength(0);
+  });
+});
+
+describe('getFirstDeploymentInfo', () => {
+  const dummyConnection = { id: 'conn-1', name: 'conn-1', properties: {} } as unknown as Connection;
+
+  beforeEach(() => {
+    mockGetDeployments.mockReset();
+  });
+
+  it('should return undefined when connection has no deployments', async () => {
+    mockGetDeployments.mockResolvedValue([]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return correct deployment info when deployment has full model properties', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'my-deployment',
+        properties: {
+          model: {
+            name: 'gpt-4o',
+            format: 'OpenAI',
+            version: '2024-11-20',
+          },
+        },
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result).toEqual({
+      deploymentName: 'my-deployment',
+      modelName: 'gpt-4o',
+      modelFormat: 'OpenAI',
+      modelVersion: '2024-11-20',
+    });
+  });
+
+  it('should return first deployment when multiple deployments exist', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'deploy-1',
+        properties: { model: { name: 'gpt-4o', format: 'OpenAI', version: '2024-11-20' } },
+      },
+      {
+        name: 'deploy-2',
+        properties: { model: { name: 'gpt-4', format: 'OpenAI', version: 'turbo-2024-04-09' } },
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result?.deploymentName).toBe('deploy-1');
+    expect(result?.modelName).toBe('gpt-4o');
+  });
+
+  it('should handle deployment with missing model properties gracefully', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'deploy-no-model',
+        properties: {},
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result).toEqual({
+      deploymentName: 'deploy-no-model',
+      modelName: '',
+      modelFormat: undefined,
+      modelVersion: undefined,
+    });
+  });
+
+  it('should handle deployment with partial model properties', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'deploy-partial',
+        properties: {
+          model: {
+            name: 'gpt-4o',
+          },
+        },
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result).toEqual({
+      deploymentName: 'deploy-partial',
+      modelName: 'gpt-4o',
+      modelFormat: undefined,
+      modelVersion: undefined,
+    });
+  });
+
+  it('should default deploymentName to empty string when name is undefined', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        properties: { model: { name: 'gpt-4o', format: 'OpenAI', version: '2024-11-20' } },
+      },
+    ]);
+    const result = await getFirstDeploymentInfo(dummyConnection);
+    expect(result?.deploymentName).toBe('');
+  });
+});
+
+describe('getFirstDeploymentModelName', () => {
+  const dummyConnection = { id: 'conn-1', name: 'conn-1', properties: {} } as unknown as Connection;
+
+  beforeEach(() => {
+    mockGetDeployments.mockReset();
+  });
+
+  it('should return deployment name when deployments exist', async () => {
+    mockGetDeployments.mockResolvedValue([
+      {
+        name: 'my-deployment',
+        properties: { model: { name: 'gpt-4o', format: 'OpenAI', version: '2024-11-20' } },
+      },
+    ]);
+    const result = await getFirstDeploymentModelName(dummyConnection);
+    expect(result).toBe('my-deployment');
+  });
+
+  it('should return empty string when no deployments exist', async () => {
+    mockGetDeployments.mockResolvedValue([]);
+    const result = await getFirstDeploymentModelName(dummyConnection);
+    expect(result).toBe('');
   });
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/helpers.ts
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/helpers.ts
@@ -57,9 +57,30 @@ export const categorizeConnections = (connections: Connection[]): CategorizedCon
   );
 };
 
-export const getFirstDeploymentModelName = async (connection: Connection): Promise<string> => {
+export interface FirstDeploymentInfo {
+  deploymentName: string;
+  modelName: string;
+  modelFormat?: string;
+  modelVersion?: string;
+}
+
+export const getFirstDeploymentInfo = async (connection: Connection): Promise<FirstDeploymentInfo | undefined> => {
   const deploymentModels = await getCognitiveServiceAccountDeploymentsForConnection(connection);
-  return deploymentModels.length > 0 ? deploymentModels[0].name : '';
+  if (deploymentModels.length === 0) {
+    return undefined;
+  }
+  const first = deploymentModels[0];
+  return {
+    deploymentName: first.name ?? '',
+    modelName: first.properties?.model?.name ?? '',
+    modelFormat: first.properties?.model?.format,
+    modelVersion: first.properties?.model?.version,
+  };
+};
+
+export const getFirstDeploymentModelName = async (connection: Connection): Promise<string> => {
+  const info = await getFirstDeploymentInfo(connection);
+  return info?.deploymentName ?? '';
 };
 
 export const getDeploymentIdParameter = (state: RootState, nodeId: string): ParameterInfo | undefined => {

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -129,7 +129,7 @@ import {
   categorizeConnections,
   getConnectionToAssign,
   getDeploymentIdParameter,
-  getFirstDeploymentModelName,
+  getFirstDeploymentInfo,
   isAgentConnectorAndAgentModel,
   isAgentConnectorAndAgentServiceModel,
   agentModelTypeParameterKey,
@@ -314,7 +314,9 @@ const updateConnectionAndDeployment = async (
   nodeId: string,
   connector: Connector,
   connection: Connection,
-  deploymentIdParamId: string
+  deploymentIdParamId: string,
+  state?: RootState,
+  modelType?: string
 ): Promise<void> => {
   try {
     // Update connection
@@ -328,24 +330,65 @@ const updateConnectionAndDeployment = async (
 
     ConnectionService().setupConnectionIfNeeded(connection);
 
-    // Get deployment model name
-    const deploymentModelName = await getFirstDeploymentModelName(connection);
+    // Get deployment info (name + model properties)
+    const deploymentInfo = await getFirstDeploymentInfo(connection);
+    const deploymentModelName = deploymentInfo?.deploymentName ?? '';
 
     // Update deployment model parameter
-    dispatch(
-      updateNodeParameters({
-        nodeId,
-        parameters: [
-          {
-            groupId: ParameterGroupKeys.DEFAULT,
-            parameterId: deploymentIdParamId,
-            propertiesToUpdate: {
-              value: [createLiteralValueSegment(deploymentModelName)],
-            },
-          },
-        ],
-      })
-    );
+    const parametersToUpdate: Array<{
+      groupId: string;
+      parameterId: string;
+      propertiesToUpdate: { value: any[] };
+    }> = [
+      {
+        groupId: ParameterGroupKeys.DEFAULT,
+        parameterId: deploymentIdParamId,
+        propertiesToUpdate: {
+          value: [createLiteralValueSegment(deploymentModelName)],
+        },
+      },
+    ];
+
+    // Also populate deploymentModelProperties for MicrosoftFoundry
+    if (modelType === 'MicrosoftFoundry' && state && deploymentInfo) {
+      const parameterGroups = state.operations.inputParameters[nodeId]?.parameterGroups;
+      const defaultGroup = parameterGroups?.[ParameterGroupKeys.DEFAULT];
+      if (defaultGroup) {
+        const modelName = deploymentInfo.modelName;
+        let modelFormat = deploymentInfo.modelFormat;
+        let modelVersion = deploymentInfo.modelVersion;
+        if (!modelFormat || !modelVersion) {
+          const config = modelName ? AGENT_MODEL_CONFIG[modelName] : undefined;
+          if (!modelFormat) {
+            modelFormat = config?.format ?? 'OpenAI';
+          }
+          if (!modelVersion) {
+            modelVersion = config?.version;
+          }
+        }
+
+        const deploymentModelPropertiesMap: Record<string, string | undefined> = {
+          'inputs.$.agentModelSettings.deploymentModelProperties.name': modelName,
+          'inputs.$.agentModelSettings.deploymentModelProperties.format': modelFormat,
+          'inputs.$.agentModelSettings.deploymentModelProperties.version': modelVersion,
+        };
+
+        for (const [key, val] of Object.entries(deploymentModelPropertiesMap)) {
+          const param = defaultGroup.parameters.find((p) => p.parameterKey === key);
+          if (param && val) {
+            parametersToUpdate.push({
+              groupId: ParameterGroupKeys.DEFAULT,
+              parameterId: param.id,
+              propertiesToUpdate: {
+                value: [createLiteralValueSegment(val)],
+              },
+            });
+          }
+        }
+      }
+    }
+
+    dispatch(updateNodeParameters({ nodeId, parameters: parametersToUpdate }));
   } catch {
     clearConnectionAndDeploymentModel(dispatch, nodeId, deploymentIdParamId);
   }
@@ -376,7 +419,15 @@ export const dynamicallyLoadAgentConnection = createAsyncThunk(
     }
 
     // Update connection and deployment model
-    await updateConnectionAndDeployment(dispatch, nodeId, connector, connectionToAssign, deploymentIdParam.id);
+    await updateConnectionAndDeployment(
+      dispatch,
+      nodeId,
+      connector,
+      connectionToAssign,
+      deploymentIdParam.id,
+      getState() as RootState,
+      modelType
+    );
   }
 );
 
@@ -1068,10 +1119,19 @@ export const ParameterSection = ({
         // Only populate deploymentModelProperties for MicrosoftFoundry.
         // For AzureOpenAI the backend derives model info from the deployment itself.
         if (currentModelType === 'MicrosoftFoundry' && selectedModelId) {
-          const config = AGENT_MODEL_CONFIG[selectedModelId];
-          const modelName = selectedModelId;
-          const modelFormat = config?.format ?? 'OpenAI';
-          const modelVersion = config?.version;
+          const deploymentInfo = deploymentsForCognitiveServiceAccount?.find((deployment: any) => deployment.name === selectedModelId);
+          const modelName = deploymentInfo?.properties?.model?.name;
+          let modelFormat = deploymentInfo?.properties?.model?.format;
+          let modelVersion = deploymentInfo?.properties?.model?.version;
+          if (!modelFormat || !modelVersion) {
+            const config = modelName ? AGENT_MODEL_CONFIG[modelName] : undefined;
+            if (!modelFormat) {
+              modelFormat = config?.format ?? 'OpenAI';
+            }
+            if (!modelVersion) {
+              modelVersion = config?.version;
+            }
+          }
 
           updatedDependencies.inputs ??= {};
 


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Medium - Moderate changes, some user impact

## What & Why
Cherry-pick of #9054 to `hotfix/v5.294`.

PRs #9012 and #9028 regressed #8965 in two ways:

1. **`onValueChange` handler**: Used the deployment ID (`selectedModelId`) directly as `deploymentModelProperties.name` and as the key for `AGENT_MODEL_CONFIG` lookup. Since `AGENT_MODEL_CONFIG` is keyed by model names (e.g., `"gpt-4.1"`), not deployment names (e.g., `"my-gpt4-deployment"`), the lookup fails and incorrect values are written.

2. **Auto-connection flow**: `updateConnectionAndDeployment` (called by `dynamicallyLoadAgentConnection` when model type switches) only set `deploymentId` but never populated `deploymentModelProperties`. Since `onValueChange` only fires on manual dropdown changes, the model properties were missing when the deployment was auto-populated.

**Fixes:**
- Restore PR #8965's approach in `onValueChange`: look up the deployment object from `deploymentsForCognitiveServiceAccount` to extract the actual model name, format, and version from `deployment.properties.model`, falling back to `AGENT_MODEL_CONFIG[modelName]` only when the deployment doesn't provide format/version.
- Add `getFirstDeploymentInfo` helper that returns full deployment info (name, model name, format, version).
- Update `updateConnectionAndDeployment` to also populate `deploymentModelProperties` for MicrosoftFoundry during auto-connection setup.

Applied to both designer v1 and v2.

## Impact of Change
- **Users**: MicrosoftFoundry agent deployments now correctly populate `deploymentModelProperties.name` with the actual model name instead of the deployment ID, in both manual dropdown changes and auto-connection setup flows
- **Developers**: No API changes.
- **System**: No performance or architecture impact

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in:
  - [ ] Select MicrosoftFoundry model type, verify `deploymentModelProperties` is auto-populated with correct model name/format/version
  - [ ] Manually change deployment dropdown, verify `deploymentModelProperties.name` is the actual model name (e.g., `"gpt-4.1"`), NOT the deployment ID
  - [ ] Verify AzureOpenAI model type still works
  - [ ] Test in both designer v1 and v2

## Contributors

## Screenshots/Videos
N/A