### PR TITLE
chore(designer): Remove code interpreter experimentation flags (#9055)

### DIFF
--- a/libs/designer-v2/src/lib/core/utils/experimentation.ts
+++ b/libs/designer-v2/src/lib/core/utils/experimentation.ts
@@ -1,4 +1,4 @@
-import { enableAPIMGatewayConnection, enableCodeInterpreterConsumption, enableCodeInterpreterStandard } from '@microsoft/logic-apps-shared';
+import { enableAPIMGatewayConnection } from '@microsoft/logic-apps-shared';
 import { useEffect, useState } from 'react';
 
 export function useShouldEnableAPIMGatewayConnection(): boolean | null {
@@ -7,34 +7,6 @@ export function useShouldEnableAPIMGatewayConnection(): boolean | null {
   useEffect(() => {
     const check = async () => {
       const result = await enableAPIMGatewayConnection();
-      setEnabled(result);
-    };
-    check();
-  }, []);
-
-  return enabled;
-}
-
-export function useShouldEnableCodeInterpreterConsumption(): boolean | null {
-  const [enabled, setEnabled] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    const check = async () => {
-      const result = await enableCodeInterpreterConsumption();
-      setEnabled(result);
-    };
-    check();
-  }, []);
-
-  return enabled;
-}
-
-export function useShouldEnableCodeInterpreterStandard(): boolean | null {
-  const [enabled, setEnabled] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    const check = async () => {
-      const result = await enableCodeInterpreterStandard();
       setEnabled(result);
     };
     check();

--- a/libs/logic-apps-shared/src/designer-client-services/lib/__test__/experimentationFlags.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/__test__/experimentationFlags.spec.ts
@@ -1,11 +1,6 @@
 import { describe, vi, beforeEach, it, expect } from 'vitest';
 import { InitExperimentationServiceService } from '../experimentation';
-import {
-  enableAPIMGatewayConnection,
-  enableCodeInterpreterConsumption,
-  enableCodeInterpreterStandard,
-  EXP_FLAGS,
-} from '../experimentationFlags';
+import { enableAPIMGatewayConnection, EXP_FLAGS } from '../experimentationFlags';
 
 describe('lib/designer-client-services/experimentationFlags', () => {
   let mockIsFeatureEnabled: ReturnType<typeof vi.fn>;
@@ -29,36 +24,6 @@ describe('lib/designer-client-services/experimentationFlags', () => {
     it('should return false when feature flag is disabled', async () => {
       mockIsFeatureEnabled.mockResolvedValue(false);
       const result = await enableAPIMGatewayConnection();
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('enableCodeInterpreterConsumption', () => {
-    it('should return true when feature flag is enabled', async () => {
-      mockIsFeatureEnabled.mockResolvedValue(true);
-      const result = await enableCodeInterpreterConsumption();
-      expect(result).toBe(true);
-      expect(mockIsFeatureEnabled).toHaveBeenCalledWith(EXP_FLAGS.ENABLE_CODE_INTERPRETER_CONSUMPTION);
-    });
-
-    it('should return false when feature flag is disabled', async () => {
-      mockIsFeatureEnabled.mockResolvedValue(false);
-      const result = await enableCodeInterpreterConsumption();
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('enableCodeInterpreterStandard', () => {
-    it('should return true when feature flag is enabled', async () => {
-      mockIsFeatureEnabled.mockResolvedValue(true);
-      const result = await enableCodeInterpreterStandard();
-      expect(result).toBe(true);
-      expect(mockIsFeatureEnabled).toHaveBeenCalledWith(EXP_FLAGS.ENABLE_CODE_INTERPRETER_STANDARD);
-    });
-
-    it('should return false when feature flag is disabled', async () => {
-      mockIsFeatureEnabled.mockResolvedValue(false);
-      const result = await enableCodeInterpreterStandard();
       expect(result).toBe(false);
     });
   });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/__test__/standardOperationManifest.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/__test__/standardOperationManifest.spec.ts
@@ -1,16 +1,14 @@
 import { describe, vi, beforeEach, it, expect } from 'vitest';
 import { InitExperimentationServiceService } from '../experimentation';
 import { StandardOperationManifestService } from '../standard/operationmanifest';
-import { agentType, supportedBaseManifestObjects } from '../base/operationmanifest';
+import { agentType } from '../base/operationmanifest';
 
 describe('StandardOperationManifestService', () => {
-  let mockIsFeatureEnabled: ReturnType<typeof vi.fn>;
   let service: StandardOperationManifestService;
 
   beforeEach(() => {
-    mockIsFeatureEnabled = vi.fn();
     InitExperimentationServiceService({
-      isFeatureEnabled: mockIsFeatureEnabled,
+      isFeatureEnabled: vi.fn(),
       getFeatureValue: vi.fn(),
     });
     service = new StandardOperationManifestService({
@@ -21,39 +19,13 @@ describe('StandardOperationManifestService', () => {
   });
 
   describe('getOperationManifest for agent type', () => {
-    it('should return manifest without builtinTools when code interpreter flag is disabled', async () => {
-      mockIsFeatureEnabled.mockResolvedValue(false);
-
-      const manifest = await service.getOperationManifest('connectorId', agentType);
-
-      const agentChatCompletionSettings = (manifest.properties?.inputs?.properties as any)?.agentModelSettings?.properties
-        ?.agentChatCompletionSettings?.properties;
-
-      expect(agentChatCompletionSettings?.builtinTools).toBeUndefined();
-    });
-
-    it('should return manifest with builtinTools when code interpreter flag is enabled', async () => {
-      mockIsFeatureEnabled.mockResolvedValue(true);
-
+    it('should always return manifest with builtinTools', async () => {
       const manifest = await service.getOperationManifest('connectorId', agentType);
 
       const agentChatCompletionSettings = (manifest.properties?.inputs?.properties as any)?.agentModelSettings?.properties
         ?.agentChatCompletionSettings?.properties;
 
       expect(agentChatCompletionSettings?.builtinTools).toBeDefined();
-    });
-
-    it('should not mutate the original manifest when stripping builtinTools', async () => {
-      mockIsFeatureEnabled.mockResolvedValue(false);
-
-      await service.getOperationManifest('connectorId', agentType);
-
-      // Verify the original manifest in supportedBaseManifestObjects is untouched
-      const originalManifest = supportedBaseManifestObjects.get(agentType);
-      const originalBuiltinTools = (originalManifest?.properties?.inputs?.properties as any)?.agentModelSettings?.properties
-        ?.agentChatCompletionSettings?.properties?.builtinTools;
-
-      expect(originalBuiltinTools).toBeDefined();
     });
   });
 });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/operationmanifest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/operationmanifest.ts
@@ -1,6 +1,5 @@
 import type { Connector, OperationInfo, OperationManifest } from '../../../utils/src';
 import { ArgumentException, startsWith, UnsupportedException } from '../../../utils/src';
-import { enableCodeInterpreterConsumption } from '../experimentationFlags';
 import { BaseOperationManifestService } from '../base';
 import type { BaseOperationManifestServiceOptions } from '../base/operationmanifest';
 import {
@@ -132,15 +131,6 @@ export class ConsumptionOperationManifestService extends BaseOperationManifestSe
     const supportedManifest = supportedConsumptionManifestObjects.get(operationId);
 
     if (supportedManifest) {
-      if (operationId === agentType) {
-        const isCodeInterpreterEnabled = await enableCodeInterpreterConsumption();
-        if (!isCodeInterpreterEnabled) {
-          const manifest: OperationManifest = JSON.parse(JSON.stringify(supportedManifest));
-          delete (manifest.properties?.inputs?.properties as any)?.agentModelSettings?.properties?.agentChatCompletionSettings?.properties
-            ?.builtinTools;
-          return manifest;
-        }
-      }
       return supportedManifest;
     }
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/experimentationFlags.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/experimentationFlags.ts
@@ -2,18 +2,8 @@ import { ExperimentationService } from './experimentation';
 
 export const EXP_FLAGS = {
   ENABLE_APIM_GEN_AI_GATEWAY: 'enable-apim-gen-ai-gateway',
-  ENABLE_CODE_INTERPRETER_CONSUMPTION: 'enable-code-interpreter-consumption',
-  ENABLE_CODE_INTERPRETER_STANDARD: 'enable-code-interpreter-standard',
 };
 
 export async function enableAPIMGatewayConnection(): Promise<boolean> {
   return ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_APIM_GEN_AI_GATEWAY);
-}
-
-export async function enableCodeInterpreterConsumption(): Promise<boolean> {
-  return ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_CODE_INTERPRETER_CONSUMPTION);
-}
-
-export async function enableCodeInterpreterStandard(): Promise<boolean> {
-  return ExperimentationService().isFeatureEnabled(EXP_FLAGS.ENABLE_CODE_INTERPRETER_STANDARD);
 }

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/operationmanifest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/operationmanifest.ts
@@ -1,15 +1,8 @@
 import type { Connector, OperationInfo, OperationManifest } from '../../../utils/src';
 import { ConnectionType, equals } from '../../../utils/src';
-import { enableCodeInterpreterStandard } from '../experimentationFlags';
 import { BaseOperationManifestService } from '../base';
 import type { BaseOperationManifestServiceOptions } from '../base/operationmanifest';
-import {
-  agentType,
-  getBuiltInOperationInfo,
-  isBuiltInOperation,
-  mcpclientConnectorId,
-  supportedBaseManifestObjects,
-} from '../base/operationmanifest';
+import { getBuiltInOperationInfo, isBuiltInOperation, mcpclientConnectorId, supportedBaseManifestObjects } from '../base/operationmanifest';
 import { getHybridAppBaseRelativeUrl, hybridApiVersion, isHybridLogicApp } from './hybrid';
 import { getClientBuiltInConnectors } from '../base/search';
 import { aiOperationsGroup } from './operations/operationgroups';
@@ -161,15 +154,6 @@ export class StandardOperationManifestService extends BaseOperationManifestServi
   override async getOperationManifest(connectorId: string, operationId: string): Promise<OperationManifest> {
     const supportedManifest = supportedBaseManifestObjects.get(operationId);
     if (supportedManifest) {
-      if (operationId === agentType) {
-        const isCodeInterpreterEnabled = await enableCodeInterpreterStandard();
-        if (!isCodeInterpreterEnabled) {
-          const manifest: OperationManifest = JSON.parse(JSON.stringify(supportedManifest));
-          delete (manifest.properties?.inputs?.properties as any)?.agentModelSettings?.properties?.agentChatCompletionSettings?.properties
-            ?.builtinTools;
-          return manifest;
-        }
-      }
       return supportedManifest;
     }
 


### PR DESCRIPTION
## Commit Type
- [x] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Cherry-pick of #9055 to `hotfix/v5.294`.

Remove the code interpreter experimentation flags (`enableCodeInterpreterConsumption`, `enableCodeInterpreterStandard`) and their associated hooks. Code interpreter is now GA and should always be enabled for both consumption and standard workflows, so the feature gating is no longer needed.

## Impact of Change
- **Users**: Code interpreter builtin tools will now always appear in the agent loop manifest for both consumption and standard SKUs, without requiring an experimentation flag.
- **Developers**: `enableCodeInterpreterConsumption`, `enableCodeInterpreterStandard`, `useShouldEnableCodeInterpreterConsumption`, and `useShouldEnableCodeInterpreterStandard` are removed.
- **System**: Removes async experimentation service calls from the `getOperationManifest` path for agent operations, simplifying the flow.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in:
  - Removed corresponding test cases from `experimentationFlags.spec.ts`
  - Existing tests for `enableAPIMGatewayConnection` remain unchanged

## Contributors

## Screenshots/Videos
N/A