### PR TITLE
fix(knowledge-designer): Hiding the knowledge hub parameter from new designer (#9082)

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -906,6 +906,7 @@ const getDesignerServices = (
     notifyCallbackUrlUpdate: (triggerName, newTriggerId) => {
       alert(`Callback URL for ${triggerName} trigger updated to ${newTriggerId}`);
     },
+    isKnowledgeHubEnabled: () => true,
   };
 
   const hostService: IHostService = {

--- a/libs/designer-v2/src/lib/core/utils/parameters/__test__/helper-agentParams.spec.ts
+++ b/libs/designer-v2/src/lib/core/utils/parameters/__test__/helper-agentParams.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { isParameterRequired, createParameterInfo } from '../helper';
-import type { ParameterInfo, ResolvedParameter } from '@microsoft/logic-apps-shared';
+import { isParameterRequired, createParameterInfo, toParameterInfoMap } from '../helper';
+import type { InputParameter, ParameterInfo, ResolvedParameter } from '@microsoft/logic-apps-shared';
 
 describe('Parameter validation logic for Agent operations', () => {
   describe('isParameterRequired', () => {
@@ -314,6 +314,94 @@ describe('Parameter validation logic for Agent operations', () => {
       expect(parameterInfo.required).toBe(true);
       // But when validating, isParameterRequired should return false due to input dependencies
       expect(isParameterRequired(parameterInfo)).toBe(false);
+    });
+  });
+
+  describe('toParameterInfoMap - knowledgebase parameter hiding', () => {
+    it('should exclude parameters with editor: "knowledgebase" from the result', () => {
+      const inputParameters: InputParameter[] = [
+        {
+          name: 'agentKnowledge',
+          key: 'inputs.$.agentKnowledge',
+          type: 'object',
+          title: 'Agent Knowledge',
+          required: false,
+          editor: 'knowledgebase',
+          schema: {
+            type: 'object',
+          },
+        } as any,
+        {
+          name: 'messages',
+          key: 'inputs.$.messages',
+          type: 'array',
+          title: 'Messages',
+          required: true,
+          editor: 'array',
+          schema: {
+            type: 'array',
+          },
+        } as any,
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should only contain 'messages', not 'agentKnowledge'
+      expect(result).toHaveLength(1);
+      expect(result[0].parameterName).toBe('messages');
+    });
+
+    it('should exclude parameters with editor: "knowledgebase" regardless of case', () => {
+      const inputParameters: InputParameter[] = [
+        {
+          name: 'agentKnowledge',
+          key: 'inputs.$.agentKnowledge',
+          type: 'object',
+          title: 'Agent Knowledge',
+          required: false,
+          editor: 'Knowledgebase', // Different casing
+          schema: {
+            type: 'object',
+          },
+        } as any,
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should be empty since knowledgebase parameters are hidden
+      expect(result).toHaveLength(0);
+    });
+
+    it('should include all parameters when none have editor: "knowledgebase"', () => {
+      const inputParameters: InputParameter[] = [
+        {
+          name: 'deploymentId',
+          key: 'inputs.$.deploymentId',
+          type: 'string',
+          title: 'Deployment ID',
+          required: false,
+          editor: 'textbox',
+          schema: {
+            type: 'string',
+          },
+        } as any,
+        {
+          name: 'temperature',
+          key: 'inputs.$.temperature',
+          type: 'number',
+          title: 'Temperature',
+          required: false,
+          editor: 'textbox',
+          schema: {
+            type: 'number',
+          },
+        } as any,
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((p) => p.parameterName)).toEqual(['deploymentId', 'temperature']);
     });
   });
 });

--- a/libs/designer-v2/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer-v2/src/lib/core/utils/parameters/helper.ts
@@ -334,7 +334,7 @@ export function toParameterInfoMap(
   const metadata = stepDefinition && stepDefinition.metadata;
   const result: ParameterInfo[] = [];
   for (const inputParameter of inputParameters) {
-    if (!inputParameter.dynamicSchema) {
+    if (!inputParameter.dynamicSchema && !equals(inputParameter.editor, 'knowledgebase')) {
       const parameter = createParameterInfo(inputParameter, metadata, shouldEncodeBasedOnMetadata);
       result.push(parameter);
     }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.spec.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/initialize.spec.ts
@@ -1,4 +1,4 @@
-import { InitOperationManifestService } from '@microsoft/logic-apps-shared';
+import { InitOperationManifestService, InitWorkflowService } from '@microsoft/logic-apps-shared';
 import * as initialize from '../initialize';
 import {
   mockGetMyOffice365ProfileOpenApiManifest,
@@ -20,7 +20,11 @@ describe('bjsworkflow initialize', () => {
         getOperationManifest: () => Promise.resolve({} as any),
         getOperation: () => Promise.resolve({} as any),
       };
+      const workflowService = {
+        isKnowledgeHubEnabled: () => false,
+      } as any;
       InitOperationManifestService(operationManifestService);
+      InitWorkflowService(workflowService);
     });
 
     test('works for an OpenAPI operation with input parameters and values', () => {

--- a/libs/designer/src/lib/core/templates/utils/__test__/parametershelper.spec.ts
+++ b/libs/designer/src/lib/core/templates/utils/__test__/parametershelper.spec.ts
@@ -1,4 +1,9 @@
-import { ConsumptionOperationManifestService, InitConnectionService, InitOperationManifestService } from '@microsoft/logic-apps-shared';
+import {
+  ConsumptionOperationManifestService,
+  InitConnectionService,
+  InitOperationManifestService,
+  InitWorkflowService,
+} from '@microsoft/logic-apps-shared';
 import { afterEach, describe, expect, test, vitest } from 'vitest';
 import { getReactQueryClient } from '../../../ReactQueryProvider';
 import { testSwagger } from '../../../utils/parameters/__test__/mocks';
@@ -26,10 +31,12 @@ describe('Templates Parameters Helper', () => {
     const connectionService: any = {
       getSwaggerFromConnector: () => Promise.resolve(testSwagger),
     };
+    const workflowService: any = {};
     const templateId = 'templateId';
     test('should initialize operations and template metadata correctly in store when template parameters have dynamic data', async () => {
       InitOperationManifestService(manifestService);
       InitConnectionService(connectionService);
+      InitWorkflowService(workflowService);
 
       const templateParameters = testTemplateManifest.parameters.reduce((result, current) => {
         result[current.name] = current;

--- a/libs/designer/src/lib/core/utils/parameters/__test__/dynamicdata.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/dynamicdata.spec.ts
@@ -1,6 +1,6 @@
 import { DynamicLoadStatus, isBuiltInConnector } from '@microsoft/designer-ui';
 import { getDynamicInputsFromSchema, getDynamicOutputsFromSchema, getDynamicValues } from '../dynamicdata';
-import { InitConnectionService, InitOperationManifestService } from '@microsoft/logic-apps-shared';
+import { InitConnectionService, InitOperationManifestService, InitWorkflowService } from '@microsoft/logic-apps-shared';
 import { expect, describe, test, afterEach, vitest } from 'vitest';
 import * as ConnectorQueries from '../../../queries/connector';
 import { getReactQueryClient } from '../../../ReactQueryProvider';
@@ -304,9 +304,11 @@ describe('DynamicData', () => {
       getConnector: () => Promise.resolve({ id: operationInfo.connectorId }),
       getConnections: () => Promise.resolve([{ id: connectionReference.connection.id }]),
     };
+    const workflowService: any = {};
     test('should make dynamic calls with non referenced default parameters in dynamic operation', async () => {
       InitConnectionService(connectionService);
       InitOperationManifestService({ isBuiltInConnector: () => false } as any);
+      InitWorkflowService(workflowService);
       const spy = vitest.spyOn(ConnectorQueries, 'getLegacyDynamicValues').mockResolvedValueOnce([{ value: 'test', displayName: 'test' }]);
 
       await getDynamicValues(dependencyInfo, nodeInputs, operationInfo, connectionReference, {}, {});

--- a/libs/designer/src/lib/core/utils/parameters/__test__/helper-agentParams.spec.ts
+++ b/libs/designer/src/lib/core/utils/parameters/__test__/helper-agentParams.spec.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect } from 'vitest';
-import { isParameterRequired, createParameterInfo } from '../helper';
-import type { ParameterInfo, ResolvedParameter } from '@microsoft/logic-apps-shared';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isParameterRequired, createParameterInfo, toParameterInfoMap } from '../helper';
+import type { InputParameter, ParameterInfo, ResolvedParameter } from '@microsoft/logic-apps-shared';
+import * as LogicAppsShared from '@microsoft/logic-apps-shared';
+
+// Mock WorkflowService
+vi.mock('@microsoft/logic-apps-shared', async (importOriginal) => {
+  const original = (await importOriginal()) as object;
+  return {
+    ...original,
+    WorkflowService: vi.fn(),
+  };
+});
 describe('Parameter validation logic for Agent operations', () => {
   describe('isParameterRequired', () => {
     it('should return false for hidden parameters', () => {
@@ -313,6 +323,314 @@ describe('Parameter validation logic for Agent operations', () => {
       expect(parameterInfo.required).toBe(true);
       // But when validating, isParameterRequired should return false due to input dependencies
       expect(isParameterRequired(parameterInfo)).toBe(false);
+    });
+  });
+
+  describe('toParameterInfoMap - KnowledgeHub enabled/disabled scenarios', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const createInputParameter = (overrides: Partial<InputParameter> = {}): InputParameter =>
+      ({
+        name: 'testParam',
+        key: 'inputs.$.testParam',
+        type: 'string',
+        title: 'Test Parameter',
+        required: false,
+        editor: 'textbox',
+        schema: { type: 'string' },
+        ...overrides,
+      }) as InputParameter;
+
+    const mockWorkflowService = (isKnowledgeHubEnabled: boolean | undefined) => {
+      if (isKnowledgeHubEnabled === undefined) {
+        (LogicAppsShared.WorkflowService as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+      } else {
+        (LogicAppsShared.WorkflowService as ReturnType<typeof vi.fn>).mockReturnValue({
+          isKnowledgeHubEnabled: () => isKnowledgeHubEnabled,
+          getLogicAppId: () => 'test-logic-app-id',
+          getAppIdentity: () => undefined,
+        });
+      }
+    };
+
+    it('should include knowledgebase parameter when KnowledgeHub is enabled', () => {
+      mockWorkflowService(true);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'agentKnowledge',
+          key: 'inputs.$.agentKnowledge',
+          editor: 'knowledgebase',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].parameterName).toBe('agentKnowledge');
+    });
+
+    it('should exclude knowledgebase parameter when KnowledgeHub is disabled', () => {
+      mockWorkflowService(false);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'agentKnowledge',
+          key: 'inputs.$.agentKnowledge',
+          editor: 'knowledgebase',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should include non-knowledgebase parameters when KnowledgeHub is enabled', () => {
+      mockWorkflowService(true);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'messages',
+          key: 'inputs.$.messages',
+          editor: 'array',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].parameterName).toBe('messages');
+    });
+
+    it('should include non-knowledgebase parameters when KnowledgeHub is disabled', () => {
+      mockWorkflowService(false);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'messages',
+          key: 'inputs.$.messages',
+          editor: 'array',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].parameterName).toBe('messages');
+    });
+
+    it('should default to KnowledgeHub enabled when WorkflowService returns undefined', () => {
+      mockWorkflowService(undefined);
+
+      // Test with non-knowledgebase parameter since knowledgebase requires WorkflowService for other methods
+      // The key behavior being tested is that isKnowledgeHubEnabled defaults to true
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'messages',
+          key: 'inputs.$.messages',
+          editor: 'array',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should include parameter because isKnowledgeHubEnabled defaults to true when service is undefined
+      expect(result).toHaveLength(1);
+      expect(result[0].parameterName).toBe('messages');
+    });
+
+    it('should default to KnowledgeHub enabled when isKnowledgeHubEnabled method is not defined', () => {
+      // WorkflowService exists but doesn't have isKnowledgeHubEnabled method
+      // This should still include knowledgebase parameters (defaults to enabled)
+      (LogicAppsShared.WorkflowService as ReturnType<typeof vi.fn>).mockReturnValue({
+        getLogicAppId: () => 'test-logic-app-id',
+        getAppIdentity: () => undefined,
+      });
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'agentKnowledge',
+          key: 'inputs.$.agentKnowledge',
+          editor: 'knowledgebase',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should include knowledgebase parameter because default is true when method is undefined
+      expect(result).toHaveLength(1);
+      expect(result[0].parameterName).toBe('agentKnowledge');
+    });
+
+    it('should filter mixed parameters correctly when KnowledgeHub is disabled', () => {
+      mockWorkflowService(false);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'agentKnowledge',
+          key: 'inputs.$.agentKnowledge',
+          editor: 'knowledgebase',
+        }),
+        createInputParameter({
+          name: 'messages',
+          key: 'inputs.$.messages',
+          editor: 'array',
+        }),
+        createInputParameter({
+          name: 'temperature',
+          key: 'inputs.$.temperature',
+          editor: 'textbox',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should exclude knowledgebase parameter but include others
+      expect(result).toHaveLength(2);
+      expect(result.map((p) => p.parameterName)).toEqual(['messages', 'temperature']);
+    });
+
+    it('should include all parameters when KnowledgeHub is enabled with mixed editors', () => {
+      mockWorkflowService(true);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'agentKnowledge',
+          key: 'inputs.$.agentKnowledge',
+          editor: 'knowledgebase',
+        }),
+        createInputParameter({
+          name: 'messages',
+          key: 'inputs.$.messages',
+          editor: 'array',
+        }),
+        createInputParameter({
+          name: 'temperature',
+          key: 'inputs.$.temperature',
+          editor: 'textbox',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should include all parameters
+      expect(result).toHaveLength(3);
+      expect(result.map((p) => p.parameterName)).toEqual(['agentKnowledge', 'messages', 'temperature']);
+    });
+
+    it('should always exclude parameters with dynamicSchema regardless of KnowledgeHub state', () => {
+      mockWorkflowService(true);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'dynamicParam',
+          key: 'inputs.$.dynamicParam',
+          editor: 'textbox',
+          dynamicSchema: { type: 'object' },
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should exclude both dynamicSchema and knowledgebase parameters when KnowledgeHub is disabled', () => {
+      mockWorkflowService(false);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'dynamicParam',
+          key: 'inputs.$.dynamicParam',
+          editor: 'textbox',
+          dynamicSchema: { type: 'object' },
+        }),
+        createInputParameter({
+          name: 'agentKnowledge',
+          key: 'inputs.$.agentKnowledge',
+          editor: 'knowledgebase',
+        }),
+        createInputParameter({
+          name: 'normalParam',
+          key: 'inputs.$.normalParam',
+          editor: 'textbox',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should only include normalParam
+      expect(result).toHaveLength(1);
+      expect(result[0].parameterName).toBe('normalParam');
+    });
+
+    it('should handle case-insensitive knowledgebase editor value', () => {
+      mockWorkflowService(false);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'agentKnowledge',
+          key: 'inputs.$.agentKnowledge',
+          editor: 'KnowledgeBase', // Different casing
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should be excluded due to case-insensitive comparison
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle multiple knowledgebase parameters when KnowledgeHub is disabled', () => {
+      mockWorkflowService(false);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'agentKnowledge1',
+          key: 'inputs.$.agentKnowledge1',
+          editor: 'knowledgebase',
+        }),
+        createInputParameter({
+          name: 'agentKnowledge2',
+          key: 'inputs.$.agentKnowledge2',
+          editor: 'knowledgebase',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should exclude all knowledgebase parameters
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle multiple knowledgebase parameters when KnowledgeHub is enabled', () => {
+      mockWorkflowService(true);
+
+      const inputParameters: InputParameter[] = [
+        createInputParameter({
+          name: 'agentKnowledge1',
+          key: 'inputs.$.agentKnowledge1',
+          editor: 'knowledgebase',
+        }),
+        createInputParameter({
+          name: 'agentKnowledge2',
+          key: 'inputs.$.agentKnowledge2',
+          editor: 'knowledgebase',
+        }),
+      ];
+
+      const result = toParameterInfoMap(inputParameters, undefined, true);
+
+      // Should include all knowledgebase parameters
+      expect(result).toHaveLength(2);
+      expect(result.map((p) => p.parameterName)).toEqual(['agentKnowledge1', 'agentKnowledge2']);
     });
   });
 });

--- a/libs/designer/src/lib/core/utils/parameters/helper.ts
+++ b/libs/designer/src/lib/core/utils/parameters/helper.ts
@@ -332,9 +332,10 @@ export function toParameterInfoMap(
   shouldEncodeBasedOnMetadata = true
 ): ParameterInfo[] {
   const metadata = stepDefinition && stepDefinition.metadata;
+  const isKnowledgeHubEnabled = WorkflowService()?.isKnowledgeHubEnabled ? WorkflowService()?.isKnowledgeHubEnabled?.() : true;
   const result: ParameterInfo[] = [];
   for (const inputParameter of inputParameters) {
-    if (!inputParameter.dynamicSchema) {
+    if (!inputParameter.dynamicSchema && !(!isKnowledgeHubEnabled && equals(inputParameter.editor, constants.EDITOR.KNOWLEDGE_BASE))) {
       const parameter = createParameterInfo(inputParameter, metadata, shouldEncodeBasedOnMetadata);
       result.push(parameter);
     }

--- a/libs/designer/src/lib/ui/knowledge/editor/index.tsx
+++ b/libs/designer/src/lib/ui/knowledge/editor/index.tsx
@@ -156,7 +156,7 @@ export const KnowledgeHubEditor = ({ editorOptions, onValueChange, value }: IEdi
         </Text>
         <div>
           <Text size={200}>{INTL_TEXT.description}</Text>
-          <Link href="https://aka.ms/LogicApps/knowledgehubdocs" target="_blank" className={styles.link}>
+          <Link href="https://go.microsoft.com/fwlink/?linkid=2361415" target="_blank" rel="noopener noreferrer" className={styles.link}>
             {INTL_TEXT.learnMore}
             <NavigateIcon style={{ position: 'relative', top: '2px', left: '2px' }} />
           </Link>

--- a/libs/designer/src/lib/ui/knowledge/panel/files/uploadfile.tsx
+++ b/libs/designer/src/lib/ui/knowledge/panel/files/uploadfile.tsx
@@ -302,7 +302,7 @@ export const FileUpload = ({ resourceId, selectedHub, setDetails }: FileUploadPr
         title={INTL_TEXT.groupSectionTitle}
         titleHtmlFor={'groupNameSectionLabel'}
         description={INTL_TEXT.groupSectionDescription}
-        descriptionLink={{ text: INTL_TEXT.learnMore, href: 'https://www.microsoft.com' }}
+        descriptionLink={{ text: INTL_TEXT.learnMore, href: 'https://go.microsoft.com/fwlink/?linkid=2362000' }}
         items={groupSectionItems}
         cssOverrides={{ sectionItem: styles.sectionItem }}
       />
@@ -310,7 +310,7 @@ export const FileUpload = ({ resourceId, selectedHub, setDetails }: FileUploadPr
         title={INTL_TEXT.title}
         titleHtmlFor={'addFilesSectionLabel'}
         description={INTL_TEXT.addFilesSectionDescription}
-        descriptionLink={{ text: INTL_TEXT.learnMore, href: 'https://www.microsoft.com' }}
+        descriptionLink={{ text: INTL_TEXT.learnMore, href: 'https://go.microsoft.com/fwlink/?linkid=2361803' }}
         items={addSectionItems}
       />
       <TemplatesSection

--- a/libs/designer/src/lib/ui/knowledge/wizard/knowledgelist.tsx
+++ b/libs/designer/src/lib/ui/knowledge/wizard/knowledgelist.tsx
@@ -401,11 +401,11 @@ export const KnowledgeList = ({
             ) : null}
             <div className={mergeClasses(styles.nameText, className)}>
               {isHubGroup ? (
-                <FolderOpen20Regular style={{ color: tokens.colorStatusWarningForegroundInverted }} />
+                <FolderOpen20Regular className={styles.nameIcon} style={{ color: tokens.colorStatusWarningForegroundInverted }} />
               ) : (
-                <DocumentText20Regular />
+                <DocumentText20Regular className={styles.nameIcon} />
               )}
-              <Text size={300} title={item.name}>
+              <Text size={300} title={item.name} className={styles.nameLabel}>
                 {item.name}
               </Text>
             </div>
@@ -419,6 +419,8 @@ export const KnowledgeList = ({
       handleExpandCollapse,
       styles.artifactNameCell,
       styles.nameCell,
+      styles.nameIcon,
+      styles.nameLabel,
       styles.nameText,
       styles.rowCell,
     ]
@@ -529,7 +531,9 @@ export const KnowledgeList = ({
               onClick={toggleAllRows}
               onKeyDown={toggleAllKeydown}
             />
-            <TableHeaderCell className={styles.tableCell}>{INTL_TEXT.nameLabel}</TableHeaderCell>
+            <TableHeaderCell className={styles.tableCell} style={{ width: '20%' }}>
+              {INTL_TEXT.nameLabel}
+            </TableHeaderCell>
             <TableHeaderCell className={styles.tableCell} style={{ width: '10%' }}>
               {INTL_TEXT.typeLabel}
             </TableHeaderCell>

--- a/libs/designer/src/lib/ui/knowledge/wizard/styles.ts
+++ b/libs/designer/src/lib/ui/knowledge/wizard/styles.ts
@@ -69,12 +69,24 @@ export const useListStyles = makeStyles({
 
   nameCell: {
     display: 'flex',
+    minWidth: 0,
   },
 
   nameText: {
     display: 'flex',
     gap: '8px',
     marginTop: '6px',
+    minWidth: 0,
+    alignItems: 'flex-start',
+  },
+
+  nameIcon: {
+    flexShrink: 0,
+  },
+
+  nameLabel: {
+    wordBreak: 'break-word',
+    overflowWrap: 'break-word',
   },
 
   hubNameCell: {},

--- a/libs/logic-apps-shared/src/designer-client-services/lib/workflow.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/workflow.ts
@@ -92,6 +92,11 @@ export interface IWorkflowService {
   ): Promise<void>;
 
   /**
+   * Flag to determine if knowledge hub features should be enabled in the workflow designer
+   */
+  isKnowledgeHubEnabled?(): boolean;
+
+  /**
    * Opens an Azure Portal blade
    */
   openBlade?(bladeReference: BladeReference | Promise<BladeReference>, options?: OpenBladeOptions): Promise<boolean>;


### PR DESCRIPTION
* fix(knowledge-designer): Hiding the knowledge hub parameter from new designer

* Updating with correct forward links and adding designer feature flag along with some css updates

* Fixing tests

---------

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Hiding the newly added knowledge hub parameter from agent connector in new designer. This should not impact anything in current GA designer for this new feature to be released.
In the current UI, includes the following changes -
1. Updated the learn more links from 3 places in knowledge hub UI.
2. Added feature flag to hide the knowledge hub UI from designer.
3. Minor CSS update in knowledge list wizard

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users would not be able to configure knowledge hub from preview designer
- **Developers**: Every feature released should be tested from both preview and GA designer for the time being
- **System**: NA

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@divyaswarnkar

## Screenshots/Videos
in V2
Before: 
<img width="525" height="394" alt="image" src="https://github.com/user-attachments/assets/f984e9ef-66ce-4b06-a643-9aad3b781576" />

After: 
<img width="1414" height="935" alt="image" src="https://github.com/user-attachments/assets/fb9401a2-345e-4d31-823d-6f363e5517ec" />

in V1.
Feature flag on -
<img width="880" height="939" alt="image" src="https://github.com/user-attachments/assets/fa376084-67ec-4e69-bc26-56e664435365" />

Feature flag off -
<img width="788" height="893" alt="image" src="https://github.com/user-attachments/assets/efed5ebe-0e62-4de4-a464-6b68edc47211" />

CSS fix for long name
<img width="807" height="811" alt="image" src="https://github.com/user-attachments/assets/8ca90100-6717-4814-823c-cdef610d68d8" />
