### PR TITLE
fix(designer): Foundry project connection type should be "model" in connection.json

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connection.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connection.spec.ts
@@ -294,7 +294,7 @@ describe('StandardConnectionService', () => {
 
       expect(writeConnection).toHaveBeenCalledOnce();
       expect(capturedConnectionData.connectionData.resourceId).toBe(foundryResourceId);
-      expect(capturedConnectionData.connectionData.type).toBe('FoundryAgentServiceV2');
+      expect(capturedConnectionData.connectionData.type).toBe('model');
     });
 
     it('should NOT append /models for APIM connections', async () => {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connection.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connection.spec.ts
@@ -262,7 +262,7 @@ describe('StandardConnectionService', () => {
       expect(capturedConnectionData.connectionData.type).toBe('model');
     });
 
-    it('should NOT append /models for FoundryAgentServiceV2 connections', async () => {
+    it('should NOT append /models for Foundry project connections and should save type as model', async () => {
       InitLoggerService([mockLoggerService]);
       let capturedConnectionData: any;
       const writeConnection = vi.fn().mockImplementation((data: any) => {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
@@ -952,7 +952,7 @@ function convertToAgentConnectionsData(
         resourceId:
           isFoundryAgentServiceConnection || isAPIMManagementConnection ? cognitiveServiceAccountId : `${cognitiveServiceAccountId}/models`,
       }),
-      type: isFoundryAgentServiceConnection ? 'FoundryAgentServiceV2' : isAPIMManagementConnection ? 'APIMGenAIGateway' : 'model',
+      type: isAPIMManagementConnection ? 'APIMGenAIGateway' : 'model',
     },
     settings,
     pathLocation: [agentLocation],


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
When creating a Foundry project (Preview) agent connection, the serialized `type` field in `connection.json` was saved as `"FoundryAgentServiceV2"` instead of `"model"`. This caused the validate API to reject it with:
```
WorkflowConnectionsInvalidConnectionValue: The agentConnections property in connection.json has a value that cannot be parsed.
```

The root cause was in `convertToAgentConnectionsData()` where the `type` field was incorrectly set to the designer-internal manifest value (`FoundryAgentServiceV2`) instead of the API-expected value (`model`).

## Impact of Change
- **Users**: Foundry project (Preview) connections now save successfully without validation errors
- **Developers**: No API changes; `isFoundryAgentServiceConnection` is still used for `resourceId` logic
- **System**: The reading path is unaffected — `updateAgentParametersForConnection()` already falls back to regex-based resource ID detection to correctly resolve `FoundryAgentServiceV2` from the `/projects/` pattern

## Test Plan
- [x] Unit tests added/updated
- [x] Manual testing completed
- Tested in: connection.spec.ts (16 tests), all standard service tests (99), Utils/AgentUtils (169), designer and designer-v2 bjsworkflow tests — no regressions

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
N/A