### PR TITLE
fix(designer): restore deploymentModelProperties for AzureOpenAI agent connections

### DIFF
--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -1087,11 +1087,11 @@ export const ParameterSection = ({
         const selectedModelId = value?.length ? value[0]?.value : undefined;
         const currentModelType = findFoundryParam(nodeInputs.parameterGroups, group.id, agentModelTypeParameterKey)?.value?.[0]?.value;
 
-        // Only populate deploymentModelProperties for MicrosoftFoundry.
-        // For AzureOpenAI the backend derives model info from the deployment itself.
-        if (currentModelType === 'MicrosoftFoundry' && selectedModelId) {
+        // Populate deploymentModelProperties for both AzureOpenAI and MicrosoftFoundry.
+        // The backend requires name/format/version for AzureOpenAI model type.
+        if ((currentModelType === 'MicrosoftFoundry' || currentModelType === 'AzureOpenAI') && selectedModelId) {
           const deploymentInfo = deploymentsForCognitiveServiceAccount?.find((deployment: any) => deployment.name === selectedModelId);
-          const modelName = deploymentInfo?.properties?.model?.name;
+          const modelName = deploymentInfo?.properties?.model?.name ?? selectedModelId;
           let modelFormat = deploymentInfo?.properties?.model?.format;
           let modelVersion = deploymentInfo?.properties?.model?.version;
           if (!modelFormat || !modelVersion) {

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -1096,11 +1096,11 @@ export const ParameterSection = ({
         const selectedModelId = value?.length ? value[0]?.value : undefined;
         const currentModelType = findFoundryParam(nodeInputs.parameterGroups, group.id, agentModelTypeParameterKey)?.value?.[0]?.value;
 
-        // Only populate deploymentModelProperties for MicrosoftFoundry.
-        // For AzureOpenAI the backend derives model info from the deployment itself.
-        if (currentModelType === 'MicrosoftFoundry' && selectedModelId) {
+        // Populate deploymentModelProperties for both AzureOpenAI and MicrosoftFoundry.
+        // The backend requires name/format/version for AzureOpenAI model type.
+        if ((currentModelType === 'MicrosoftFoundry' || currentModelType === 'AzureOpenAI') && selectedModelId) {
           const deploymentInfo = deploymentsForCognitiveServiceAccount?.find((deployment: any) => deployment.name === selectedModelId);
-          const modelName = deploymentInfo?.properties?.model?.name;
+          const modelName = deploymentInfo?.properties?.model?.name ?? selectedModelId;
           let modelFormat = deploymentInfo?.properties?.model?.format;
           let modelVersion = deploymentInfo?.properties?.model?.version;
           if (!modelFormat || !modelVersion) {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
@@ -116,4 +116,20 @@ describe('agentloop – Foundry V2 regression', () => {
       expect(field.type).toBe('string');
     });
   });
+
+  describe('deploymentModelProperties visibility', () => {
+    const agentModelSettings = inputs.agentModelSettings?.properties as Record<string, any>;
+    const deploymentModelProps = agentModelSettings?.deploymentModelProperties?.properties as Record<string, any>;
+
+    it.each(['name', 'format', 'version'])('%s should be visible for both AzureOpenAI and MicrosoftFoundry', (field) => {
+      const visValues = deploymentModelProps[field]['x-ms-input-dependencies'].parameters[0].values as string[];
+      expect(visValues).toContain('AzureOpenAI');
+      expect(visValues).toContain('MicrosoftFoundry');
+    });
+
+    it.each(['name', 'format', 'version'])('%s should NOT be visible for FoundryAgentServiceV2', (field) => {
+      const visValues = deploymentModelProps[field]['x-ms-input-dependencies'].parameters[0].values as string[];
+      expect(visValues).not.toContain('FoundryAgentServiceV2');
+    });
+  });
 });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -476,7 +476,7 @@ export default {
                     parameters: [
                       {
                         name: 'agentModelType',
-                        values: ['MicrosoftFoundry'],
+                        values: ['AzureOpenAI', 'MicrosoftFoundry'],
                       },
                     ],
                   },
@@ -490,7 +490,7 @@ export default {
                     parameters: [
                       {
                         name: 'agentModelType',
-                        values: ['MicrosoftFoundry'],
+                        values: ['AzureOpenAI', 'MicrosoftFoundry'],
                       },
                     ],
                   },
@@ -504,7 +504,7 @@ export default {
                     parameters: [
                       {
                         name: 'agentModelType',
-                        values: ['MicrosoftFoundry'],
+                        values: ['AzureOpenAI', 'MicrosoftFoundry'],
                       },
                     ],
                   },


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

Regression from PR #9012 (merged April 6) which removed `AzureOpenAI` from the visibility dependencies of `deploymentModelProperties` in the agent loop manifest. This causes saving agent workflows with AzureOpenAI model type to fail with:

```
InvalidAgentModelSettings: The 'name' parameter value can't be null or empty for 'AzureOpenAI' model type.
```

PR #9012 assumed the backend derives model info from the deployment for AzureOpenAI. The backend does not — it requires `deploymentModelProperties.name`, `.format`, `.version` explicitly.

### Root Cause

The manifest at `agentloop.ts` had its `deploymentModelProperties` fields (name, format, version) restricted to `values: ['MicrosoftFoundry']` only. When `agentModelType` is `AzureOpenAI`, these fields were hidden by the conditional visibility system and never serialized.

### Fix

1. **Manifest** (`agentloop.ts`): Restore `AzureOpenAI` in the visibility `values` array for all three `deploymentModelProperties` fields
2. **parametersTab** (both designer + designer-v2): Restore the deployment-info lookup for AzureOpenAI so model properties are auto-populated from the ARM deployment response when a user selects a deployment
3. **Test**: Added regression tests verifying `deploymentModelProperties` visibility includes both AzureOpenAI and MicrosoftFoundry

MicrosoftFoundry behavior is unchanged.

## Impact of Change
- **Users**: AzureOpenAI agent connections can be saved again. MicrosoftFoundry behavior unchanged.
- **Developers**: No API changes.
- **System**: No performance impact.

## Test Plan
- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] Tested in: agentloop.spec.ts (23/23 pass including 6 new regression tests)

## Contributors
@takyyon

## Screenshots/Videos
N/A