### PR TITLE
fix(designer): Fix infinite recursive nesting in monitoring run history values [hotfix]

### DIFF
--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__test__/monitoringTab.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__test__/monitoringTab.spec.tsx
@@ -32,22 +32,21 @@ vi.mock('@microsoft/logic-apps-shared', async (importOriginal) => {
   };
 });
 
-vi.mock('@microsoft/designer-ui', async (importOriginal) => {
-  const actual: any = await importOriginal();
-  return {
-    ...actual,
-    ErrorSection: vi.fn(() => <div data-testid="error-section" />),
-  };
-});
+vi.mock('@microsoft/designer-ui', () => ({
+  ErrorSection: vi.fn(() => <div data-testid="error-section" />),
+  SecureDataSection: vi.fn(() => <div data-testid="secure-data-section" />),
+  ValuesPanel: vi.fn(() => <div data-testid="values-panel" />),
+  getStatusString: vi.fn(() => 'Succeeded'),
+}));
 
+const mockUseQuery = vi.fn(() => ({
+  data: { inputs: {}, outputs: {} },
+  isError: false,
+  isFetching: false,
+  isLoading: false,
+}));
 vi.mock('@tanstack/react-query', () => ({
-  useQuery: vi.fn(() => ({
-    data: { inputs: {}, outputs: {} },
-    isError: false,
-    isFetching: false,
-    isLoading: false,
-    refetch: vi.fn(),
-  })),
+  useQuery: (...args: any[]) => mockUseQuery(...args),
 }));
 
 vi.mock('../../../../../../core/actions/bjsworkflow/monitoring', () => ({
@@ -68,7 +67,6 @@ vi.mock('../propertiesPanel', () => ({
 
 import { MonitoringPanel } from '../monitoringTab';
 import { useRunData } from '../../../../../../core/state/workflow/workflowSelectors';
-import { useQuery } from '@tanstack/react-query';
 
 describe('MonitoringPanel', () => {
   beforeEach(() => {
@@ -77,6 +75,7 @@ describe('MonitoringPanel', () => {
       status: 'Succeeded',
       startTime: '2024-01-01T00:00:00Z',
       endTime: '2024-01-01T00:01:00Z',
+      correlation: { actionTrackingId: 'track-1' },
     });
   });
 
@@ -96,35 +95,104 @@ describe('MonitoringPanel', () => {
     expect(screen.getByTestId('properties-panel')).toBeDefined();
   });
 
-  it('should use cached data for built-in tools with existing inputs/outputs', () => {
-    const cachedInputs = { code: { displayName: 'Code', value: 'print("hi")' } };
-    const cachedOutputs = { result: { displayName: 'Result', value: 'hi' } };
+  it('should always call getActionLinks even when runData has existing inputs/outputs', async () => {
+    const existingInputs = { code: { displayName: 'Code', value: 'print("hi")' } };
+    const existingOutputs = { result: { displayName: 'Result', value: 'hi' } };
 
     (useRunData as any).mockReturnValue({
       status: 'Succeeded',
-      inputs: cachedInputs,
-      outputs: cachedOutputs,
+      inputs: existingInputs,
+      outputs: existingOutputs,
       startTime: '2024-01-01T00:00:00Z',
+      correlation: { actionTrackingId: 'track-2' },
     });
+
+    mockGetActionLinks.mockResolvedValue({ inputs: { method: 'GET' }, outputs: { statusCode: 200 } });
 
     render(<MonitoringPanel nodeId="code_interpreter" />);
 
-    // The query should resolve with cached data instead of calling getActionLinks
-    // Verify that getActionLinks was NOT called
-    expect(mockGetActionLinks).not.toHaveBeenCalled();
+    // Extract the query function passed to useQuery and invoke it
+    const lastCall = mockUseQuery.mock.calls.at(-1)!;
+    const queryFn = lastCall[1] as () => Promise<any>;
+    const result = await queryFn();
+
+    // The query function should always call getActionLinks, never short-circuit
+    expect(mockGetActionLinks).toHaveBeenCalled();
+    expect(result).toEqual({ inputs: { method: 'GET' }, outputs: { statusCode: 200 } });
   });
 
-  it('should call getActionLinks for regular nodes without cached data', () => {
+  it('should use stable query key with actionTrackingId, startTime, and endTime', () => {
+    render(<MonitoringPanel nodeId="test-node" />);
+
+    const queryKey = mockUseQuery.mock.calls.at(-1)![0];
+    expect(queryKey).toEqual([
+      'actionInputsOutputs',
+      {
+        nodeId: 'test-node',
+        actionTrackingId: 'track-1',
+        startTime: '2024-01-01T00:00:00Z',
+        endTime: '2024-01-01T00:01:00Z',
+      },
+    ]);
+  });
+
+  it('should not re-feed already-bound BoundParameters as raw inputs (regression)', async () => {
+    // Simulate the scenario that caused infinite scrolling:
+    // runData.inputs already contains BoundParameters from a previous binding cycle
+    const alreadyBoundInputs = {
+      method: { displayName: 'Method', value: 'GET' },
+    };
+
     (useRunData as any).mockReturnValue({
       status: 'Succeeded',
+      inputs: alreadyBoundInputs,
       startTime: '2024-01-01T00:00:00Z',
+      correlation: { actionTrackingId: 'track-3' },
     });
 
-    // The useQuery mock handles this, but we can verify getActionLinks would be called
-    // by checking the query function behavior
-    render(<MonitoringPanel nodeId="regular-node" />);
+    // getActionLinks returns fresh raw data from the API
+    mockGetActionLinks.mockResolvedValue({ inputs: { method: 'GET' }, outputs: {} });
 
-    // The component should render successfully
-    expect(screen.getByTestId('inputs-panel')).toBeDefined();
+    render(<MonitoringPanel nodeId="test-node" />);
+
+    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
+    const result = await queryFn();
+
+    // The query function must return raw API data, NOT the already-bound BoundParameters.
+    // If it returned alreadyBoundInputs, the binding would wrap {displayName, value}
+    // inside another {displayName, value}, creating infinite recursive nesting.
+    expect(result.inputs).toEqual({ method: 'GET' });
+    expect(result.inputs).not.toHaveProperty('method.displayName');
+  });
+
+  it('should return empty inputs/outputs when getActionLinks returns nullish values', async () => {
+    mockGetActionLinks.mockResolvedValue({ inputs: null, outputs: undefined });
+
+    render(<MonitoringPanel nodeId="test-node" />);
+
+    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
+    const result = await queryFn();
+
+    expect(result).toEqual({ inputs: {}, outputs: {} });
+  });
+
+  it('should handle getActionLinks returning null/undefined entirely', async () => {
+    mockGetActionLinks.mockResolvedValue(null);
+
+    render(<MonitoringPanel nodeId="test-node" />);
+
+    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
+    const result = await queryFn();
+
+    expect(result).toEqual({ inputs: {}, outputs: {} });
+  });
+
+  it('should disable the query when runMetaData is null', () => {
+    (useRunData as any).mockReturnValue(null);
+
+    render(<MonitoringPanel nodeId="test-node" />);
+
+    const queryOptions = mockUseQuery.mock.calls.at(-1)![2];
+    expect(queryOptions.enabled).toBe(false);
   });
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/monitoringTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/monitoringTab.tsx
@@ -27,13 +27,16 @@ export const MonitoringPanel: React.FC<PanelTabProps> = (props) => {
   const startTime = runMetaData?.startTime;
   const endTime = runMetaData?.endTime;
 
-  const getActionInputsOutputs = useCallback(() => {
-    // For built-in tools that already have inputs/outputs from fetchBuiltInToolRunData,
-    // use the cached data instead of fetching via getActionLinks (which would fail)
-    if (runMetaData?.inputs || runMetaData?.outputs) {
-      return Promise.resolve({ inputs: runMetaData.inputs ?? {}, outputs: runMetaData.outputs ?? {} });
-    }
-    return RunService().getActionLinks(runMetaData, selectedNodeId);
+  const getActionInputsOutputs = useCallback(async () => {
+    // Always fetch fresh raw inputs/outputs from the API.
+    // Do NOT return runMetaData.inputs/outputs here — after binding, those contain
+    // BoundParameters (wrapped in {displayName, value}), and re-feeding them as raw
+    // inputs creates infinite recursive nesting.
+    const actionLinks = (await RunService().getActionLinks(runMetaData, selectedNodeId)) ?? {};
+    return {
+      inputs: actionLinks.inputs ?? {},
+      outputs: actionLinks.outputs ?? {},
+    };
   }, [selectedNodeId, runMetaData]);
 
   const {
@@ -41,15 +44,11 @@ export const MonitoringPanel: React.FC<PanelTabProps> = (props) => {
     isError,
     isFetching,
     isLoading,
-    refetch,
-  } = useQuery<any>(['actionInputsOutputs', { nodeId: selectedNodeId }], getActionInputsOutputs, {
+  } = useQuery<any>(['actionInputsOutputs', { nodeId: selectedNodeId, actionTrackingId, startTime, endTime }], getActionInputsOutputs, {
     refetchOnWindowFocus: false,
-    initialData: { inputs: {}, outputs: {} },
+    placeholderData: { inputs: {}, outputs: {} },
+    enabled: !isNullOrUndefined(runMetaData),
   });
-
-  useEffect(() => {
-    refetch();
-  }, [runMetaData, refetch]);
 
   useEffect(() => {
     if (!isLoading) {


### PR DESCRIPTION
## Commit Type

- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level

- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

**Cherry-pick of #9123 onto `hotfix/v5.294` for immediate release.**

## What & Why

### Problem
Multiple customers (including US Government tenants) reported that action input/output values in the workflow run history view scroll infinitely, making them unreadable. The values display as deeply nested recursive JSON with `{displayName, value}` objects nested inside each other.

This affects **both Consumption and Standard SKUs**, across **new and historical runs**. First reported April 27, 2026. The bug was introduced in v5.294 (not present in v5.273).

### Root Cause
Regression introduced in PR #8875 (commit `3e71bcde8`, March 4) which added `code_interpreter` built-in tool support. The commit added a shortcut in the v1 designer's `MonitoringPanel` that returned already-bound `BoundParameters` as raw inputs, creating an infinite feedback loop with `useEffect(() => refetch(), [runMetaData])`.

### Fix (3 changes)
1. **Remove the shortcut** — always call `getActionLinks()` for fresh raw data
2. **Stable React Query key** — include `actionTrackingId`, `startTime`, `endTime` (matching v2 pattern)
3. **Remove the refetch loop** — remove `useEffect(() => refetch(), [runMetaData])`

## Impact of Change

- **Users**: Fixes infinite scrolling in run history for all Logic App types (Consumption + Standard).
- **Developers**: No API changes. Internal data fetching pattern in v1 `MonitoringPanel` now matches v2.
- **System**: Eliminates infinite refetch loop that caused unnecessary API calls and re-renders.

## Test Plan

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer with ARM token against live Standard Logic App

**Test details:**
- `monitoringTab.spec.tsx` — 6 unit tests all passing on hotfix branch
- Regression test `should not re-feed already-bound BoundParameters as raw inputs` verifies the exact bug is fixed
- Clean cherry-pick, no conflicts

## Contributors

- @takyyon

## Screenshots/Videos

### Before (Bug) - Infinite recursive nesting
Values in the monitoring panel display as infinitely nested `{displayName, value}` objects, continuously scrolling:

![Before - Bug](https://github.com/Azure/LogicAppsUX/releases/download/pr-9123-screenshots/before-bug.png)

### After (Fix) - Clean value display
Values display correctly as flat, readable content:

![After - Fix](https://github.com/Azure/LogicAppsUX/releases/download/pr-9123-screenshots/after-fix.png)