### PR TITLE
fix(designer): Extract useRawInputsOutputs hook to fix portal freeze

### DIFF
--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/__test__/useRawInputsOutputs.spec.ts
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/__test__/useRawInputsOutputs.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const mockGetActionLinks = vi.fn();
+vi.mock('@microsoft/logic-apps-shared', async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    RunService: () => ({
+      getActionLinks: mockGetActionLinks,
+    }),
+  };
+});
+
+vi.mock('../../../../core/state/workflow/workflowSelectors', () => ({
+  useRunData: vi.fn(),
+}));
+
+const mockUseQuery = vi.fn(() => ({
+  data: { inputs: {}, outputs: {} },
+  isError: false,
+  isFetching: false,
+  isLoading: false,
+}));
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (...args: any[]) => mockUseQuery(...args),
+}));
+
+import { useRunData } from '../../../../core/state/workflow/workflowSelectors';
+import { useRawInputsOutputs } from '../useRawInputsOutputs';
+
+describe('useRawInputsOutputs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useRunData as any).mockReturnValue({
+      status: 'Succeeded',
+      startTime: '2024-01-01T00:00:00Z',
+      endTime: '2024-01-01T00:01:00Z',
+      correlation: { actionTrackingId: 'track-1' },
+    });
+  });
+
+  it('should use stable query key with actionTrackingId, startTime, and endTime', () => {
+    renderHook(() => useRawInputsOutputs('test-node'));
+
+    const queryKey = mockUseQuery.mock.calls.at(-1)![0];
+    expect(queryKey).toEqual([
+      'actionInputsOutputs',
+      {
+        nodeId: 'test-node',
+        actionTrackingId: 'track-1',
+        startTime: '2024-01-01T00:00:00Z',
+        endTime: '2024-01-01T00:01:00Z',
+      },
+    ]);
+  });
+
+  it('should use a stable placeholderData reference (prevents infinite re-render)', () => {
+    renderHook(() => useRawInputsOutputs('node-1'));
+    const options1 = mockUseQuery.mock.calls.at(-1)![2];
+
+    vi.clearAllMocks();
+    (useRunData as any).mockReturnValue({
+      status: 'Succeeded',
+      startTime: '2024-01-01T00:00:00Z',
+      endTime: '2024-01-01T00:01:00Z',
+      correlation: { actionTrackingId: 'track-1' },
+    });
+
+    renderHook(() => useRawInputsOutputs('node-1'));
+    const options2 = mockUseQuery.mock.calls.at(-1)![2];
+
+    // placeholderData must be the SAME reference across renders.
+    // Inline object literals create new references each render, causing
+    // data -> effect -> dispatch -> re-render -> new placeholder -> new data -> infinite loop.
+    expect(options1.placeholderData).toBe(options2.placeholderData);
+  });
+
+  it('should always call getActionLinks even when runData has existing inputs/outputs', async () => {
+    (useRunData as any).mockReturnValue({
+      status: 'Succeeded',
+      inputs: { code: { displayName: 'Code', value: 'print("hi")' } },
+      outputs: { result: { displayName: 'Result', value: 'hi' } },
+      startTime: '2024-01-01T00:00:00Z',
+      correlation: { actionTrackingId: 'track-2' },
+    });
+
+    mockGetActionLinks.mockResolvedValue({ inputs: { method: 'GET' }, outputs: { statusCode: 200 } });
+
+    renderHook(() => useRawInputsOutputs('code_interpreter'));
+
+    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
+    const result = await queryFn();
+
+    expect(mockGetActionLinks).toHaveBeenCalled();
+    expect(result).toEqual({ inputs: { method: 'GET' }, outputs: { statusCode: 200 } });
+  });
+
+  it('should not re-feed already-bound BoundParameters as raw inputs (regression)', async () => {
+    (useRunData as any).mockReturnValue({
+      status: 'Succeeded',
+      inputs: { method: { displayName: 'Method', value: 'GET' } },
+      startTime: '2024-01-01T00:00:00Z',
+      correlation: { actionTrackingId: 'track-3' },
+    });
+
+    mockGetActionLinks.mockResolvedValue({ inputs: { method: 'GET' }, outputs: {} });
+
+    renderHook(() => useRawInputsOutputs('test-node'));
+
+    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
+    const result = await queryFn();
+
+    expect(result.inputs).toEqual({ method: 'GET' });
+    expect(result.inputs).not.toHaveProperty('method.displayName');
+  });
+
+  it('should return empty inputs/outputs when getActionLinks returns nullish values', async () => {
+    mockGetActionLinks.mockResolvedValue({ inputs: null, outputs: undefined });
+    renderHook(() => useRawInputsOutputs('test-node'));
+
+    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
+    const result = await queryFn();
+
+    expect(result).toEqual({ inputs: {}, outputs: {} });
+  });
+
+  it('should handle getActionLinks returning null/undefined entirely', async () => {
+    mockGetActionLinks.mockResolvedValue(null);
+    renderHook(() => useRawInputsOutputs('test-node'));
+
+    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
+    const result = await queryFn();
+
+    expect(result).toEqual({ inputs: {}, outputs: {} });
+  });
+
+  it('should pass enabled option when provided', () => {
+    renderHook(() => useRawInputsOutputs('test-node', { enabled: false }));
+
+    const queryOptions = mockUseQuery.mock.calls.at(-1)![2];
+    expect(queryOptions.enabled).toBe(false);
+  });
+});

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__test__/monitoringTab.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__test__/monitoringTab.spec.tsx
@@ -8,7 +8,6 @@ vi.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
 }));
 
-// Mock hooks and services
 vi.mock('../../../../../../common/utilities/error', () => ({
   getMonitoringTabError: vi.fn(),
 }));
@@ -21,14 +20,21 @@ vi.mock('../../../../../../core/state/workflow/workflowSelectors', () => ({
   useRunData: vi.fn(),
 }));
 
-const mockGetActionLinks = vi.fn();
+const mockUseRawInputsOutputs = vi.fn(() => ({
+  data: { inputs: {}, outputs: {} },
+  isError: false,
+  isFetching: false,
+  isLoading: false,
+}));
+vi.mock('../../../useRawInputsOutputs', () => ({
+  useRawInputsOutputs: (...args: any[]) => mockUseRawInputsOutputs(...args),
+}));
+
 vi.mock('@microsoft/logic-apps-shared', async (importOriginal) => {
   const actual: any = await importOriginal();
   return {
     ...actual,
-    RunService: () => ({
-      getActionLinks: mockGetActionLinks,
-    }),
+    isNullOrUndefined: actual.isNullOrUndefined,
   };
 });
 
@@ -37,16 +43,6 @@ vi.mock('@microsoft/designer-ui', () => ({
   SecureDataSection: vi.fn(() => <div data-testid="secure-data-section" />),
   ValuesPanel: vi.fn(() => <div data-testid="values-panel" />),
   getStatusString: vi.fn(() => 'Succeeded'),
-}));
-
-const mockUseQuery = vi.fn(() => ({
-  data: { inputs: {}, outputs: {} },
-  isError: false,
-  isFetching: false,
-  isLoading: false,
-}));
-vi.mock('@tanstack/react-query', () => ({
-  useQuery: (...args: any[]) => mockUseQuery(...args),
 }));
 
 vi.mock('../../../../../../core/actions/bjsworkflow/monitoring', () => ({
@@ -81,118 +77,42 @@ describe('MonitoringPanel', () => {
 
   it('should render null when runMetaData is null', () => {
     (useRunData as any).mockReturnValue(null);
-
     const { container } = render(<MonitoringPanel nodeId="test-node" />);
     expect(container.innerHTML).toBe('');
   });
 
   it('should render panels when runMetaData is present', () => {
     render(<MonitoringPanel nodeId="test-node" />);
-
     expect(screen.getByTestId('error-section')).toBeDefined();
     expect(screen.getByTestId('inputs-panel')).toBeDefined();
     expect(screen.getByTestId('outputs-panel')).toBeDefined();
     expect(screen.getByTestId('properties-panel')).toBeDefined();
   });
 
-  it('should always call getActionLinks even when runData has existing inputs/outputs', async () => {
-    const existingInputs = { code: { displayName: 'Code', value: 'print("hi")' } };
-    const existingOutputs = { result: { displayName: 'Result', value: 'hi' } };
+  it('should pass nodeId to useRawInputsOutputs', () => {
+    render(<MonitoringPanel nodeId="my-action" />);
+    expect(mockUseRawInputsOutputs).toHaveBeenCalledWith('my-action');
+  });
 
-    (useRunData as any).mockReturnValue({
-      status: 'Succeeded',
-      inputs: existingInputs,
-      outputs: existingOutputs,
-      startTime: '2024-01-01T00:00:00Z',
-      correlation: { actionTrackingId: 'track-2' },
+  it('should show loading state when inputs are being fetched', () => {
+    mockUseRawInputsOutputs.mockReturnValue({
+      data: { inputs: {}, outputs: {} },
+      isError: false,
+      isFetching: true,
+      isLoading: true,
     });
-
-    mockGetActionLinks.mockResolvedValue({ inputs: { method: 'GET' }, outputs: { statusCode: 200 } });
-
-    render(<MonitoringPanel nodeId="code_interpreter" />);
-
-    // Extract the query function passed to useQuery and invoke it
-    const lastCall = mockUseQuery.mock.calls.at(-1)!;
-    const queryFn = lastCall[1] as () => Promise<any>;
-    const result = await queryFn();
-
-    // The query function should always call getActionLinks, never short-circuit
-    expect(mockGetActionLinks).toHaveBeenCalled();
-    expect(result).toEqual({ inputs: { method: 'GET' }, outputs: { statusCode: 200 } });
-  });
-
-  it('should use stable query key with actionTrackingId, startTime, and endTime', () => {
     render(<MonitoringPanel nodeId="test-node" />);
-
-    const queryKey = mockUseQuery.mock.calls.at(-1)![0];
-    expect(queryKey).toEqual([
-      'actionInputsOutputs',
-      {
-        nodeId: 'test-node',
-        actionTrackingId: 'track-1',
-        startTime: '2024-01-01T00:00:00Z',
-        endTime: '2024-01-01T00:01:00Z',
-      },
-    ]);
+    expect(screen.getByTestId('inputs-panel')).toBeDefined();
   });
 
-  it('should not re-feed already-bound BoundParameters as raw inputs (regression)', async () => {
-    // Simulate the scenario that caused infinite scrolling:
-    // runData.inputs already contains BoundParameters from a previous binding cycle
-    const alreadyBoundInputs = {
-      method: { displayName: 'Method', value: 'GET' },
-    };
-
-    (useRunData as any).mockReturnValue({
-      status: 'Succeeded',
-      inputs: alreadyBoundInputs,
-      startTime: '2024-01-01T00:00:00Z',
-      correlation: { actionTrackingId: 'track-3' },
+  it('should show error state when inputs fail to load', () => {
+    mockUseRawInputsOutputs.mockReturnValue({
+      data: { inputs: {}, outputs: {} },
+      isError: true,
+      isFetching: false,
+      isLoading: false,
     });
-
-    // getActionLinks returns fresh raw data from the API
-    mockGetActionLinks.mockResolvedValue({ inputs: { method: 'GET' }, outputs: {} });
-
     render(<MonitoringPanel nodeId="test-node" />);
-
-    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
-    const result = await queryFn();
-
-    // The query function must return raw API data, NOT the already-bound BoundParameters.
-    // If it returned alreadyBoundInputs, the binding would wrap {displayName, value}
-    // inside another {displayName, value}, creating infinite recursive nesting.
-    expect(result.inputs).toEqual({ method: 'GET' });
-    expect(result.inputs).not.toHaveProperty('method.displayName');
-  });
-
-  it('should return empty inputs/outputs when getActionLinks returns nullish values', async () => {
-    mockGetActionLinks.mockResolvedValue({ inputs: null, outputs: undefined });
-
-    render(<MonitoringPanel nodeId="test-node" />);
-
-    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
-    const result = await queryFn();
-
-    expect(result).toEqual({ inputs: {}, outputs: {} });
-  });
-
-  it('should handle getActionLinks returning null/undefined entirely', async () => {
-    mockGetActionLinks.mockResolvedValue(null);
-
-    render(<MonitoringPanel nodeId="test-node" />);
-
-    const queryFn = mockUseQuery.mock.calls.at(-1)![1] as () => Promise<any>;
-    const result = await queryFn();
-
-    expect(result).toEqual({ inputs: {}, outputs: {} });
-  });
-
-  it('should disable the query when runMetaData is null', () => {
-    (useRunData as any).mockReturnValue(null);
-
-    render(<MonitoringPanel nodeId="test-node" />);
-
-    const queryOptions = mockUseQuery.mock.calls.at(-1)![2];
-    expect(queryOptions.enabled).toBe(false);
+    expect(screen.getByTestId('inputs-panel')).toBeDefined();
   });
 });

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/monitoringTab.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/monitoringTab.tsx
@@ -2,14 +2,14 @@ import constants from '../../../../../common/constants';
 import { getMonitoringTabError } from '../../../../../common/utilities/error';
 import { useBrandColor } from '../../../../../core/state/operation/operationSelector';
 import { useRunData } from '../../../../../core/state/workflow/workflowSelectors';
+import { useRawInputsOutputs } from '../../useRawInputsOutputs';
 import { InputsPanel } from './inputsPanel';
 import { OutputsPanel } from './outputsPanel';
 import { PropertiesPanel } from './propertiesPanel';
-import { RunService, isNullOrUndefined } from '@microsoft/logic-apps-shared';
+import { isNullOrUndefined } from '@microsoft/logic-apps-shared';
 import { ErrorSection } from '@microsoft/designer-ui';
 import type { PanelTabFn, PanelTabProps } from '@microsoft/designer-ui';
-import { useCallback, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import type { AppDispatch } from '../../../../../core';
 import { initializeInputsOutputsBinding } from '../../../../../core/actions/bjsworkflow/monitoring';
@@ -22,37 +22,15 @@ export const MonitoringPanel: React.FC<PanelTabProps> = (props) => {
   const { status: statusRun, error: errorRun, code: codeRun } = runMetaData ?? {};
   const error = getMonitoringTabError(errorRun, statusRun, codeRun);
 
-  // Extract stable identifiers to detect when run data actually changes
+  const { data: inputOutputs, isError, isFetching, isLoading } = useRawInputsOutputs(selectedNodeId);
+
   const actionTrackingId = runMetaData?.correlation?.actionTrackingId;
   const startTime = runMetaData?.startTime;
   const endTime = runMetaData?.endTime;
 
-  const getActionInputsOutputs = useCallback(async () => {
-    // Always fetch fresh raw inputs/outputs from the API.
-    // Do NOT return runMetaData.inputs/outputs here — after binding, those contain
-    // BoundParameters (wrapped in {displayName, value}), and re-feeding them as raw
-    // inputs creates infinite recursive nesting.
-    const actionLinks = (await RunService().getActionLinks(runMetaData, selectedNodeId)) ?? {};
-    return {
-      inputs: actionLinks.inputs ?? {},
-      outputs: actionLinks.outputs ?? {},
-    };
-  }, [selectedNodeId, runMetaData]);
-
-  const {
-    data: inputOutputs,
-    isError,
-    isFetching,
-    isLoading,
-  } = useQuery<any>(['actionInputsOutputs', { nodeId: selectedNodeId, actionTrackingId, startTime, endTime }], getActionInputsOutputs, {
-    refetchOnWindowFocus: false,
-    placeholderData: { inputs: {}, outputs: {} },
-    enabled: !isNullOrUndefined(runMetaData),
-  });
-
   useEffect(() => {
-    if (!isLoading) {
-      dispatch(initializeInputsOutputsBinding({ nodeId: selectedNodeId, inputsOutputs: inputOutputs }));
+    if (!isLoading && inputOutputs) {
+      dispatch(initializeInputsOutputsBinding({ nodeId: selectedNodeId, inputsOutputs: inputOutputs as any }));
     }
   }, [dispatch, inputOutputs, selectedNodeId, isLoading, actionTrackingId, startTime, endTime]);
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/useRawInputsOutputs.ts
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/useRawInputsOutputs.ts
@@ -1,0 +1,43 @@
+import { useRunData } from '../../../core/state/workflow/workflowSelectors';
+import { RunService } from '@microsoft/logic-apps-shared';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+export interface RawInputsOutputs {
+  inputs: Record<string, any>;
+  outputs: Record<string, any>;
+}
+
+const emptyData: RawInputsOutputs = { inputs: {}, outputs: {} };
+
+/**
+ * Fetches the raw (pre-binding) action inputs and outputs for a node.
+ * Uses a shared React Query cache key so the data is fetched once and shared
+ * across the MonitoringTab, NodeDetailsPanel, and DesignerContextualMenu.
+ *
+ * IMPORTANT: This always calls getActionLinks() for fresh API data.
+ * Never return runData.inputs/outputs directly — after binding, those contain
+ * BoundParameters ({displayName, value}) and re-feeding them as raw inputs
+ * creates infinite recursive nesting.
+ */
+export const useRawInputsOutputs = (nodeId: string, options?: { enabled?: boolean }) => {
+  const runData = useRunData(nodeId);
+
+  const actionTrackingId = runData?.correlation?.actionTrackingId;
+  const startTime = runData?.startTime;
+  const endTime = runData?.endTime;
+
+  const getActionInputsOutputs = useCallback(async (): Promise<RawInputsOutputs> => {
+    const actionLinks = (await RunService().getActionLinks(runData, nodeId)) ?? {};
+    return {
+      inputs: actionLinks.inputs ?? {},
+      outputs: actionLinks.outputs ?? {},
+    };
+  }, [nodeId, runData]);
+
+  return useQuery<RawInputsOutputs>(['actionInputsOutputs', { nodeId, actionTrackingId, startTime, endTime }], getActionInputsOutputs, {
+    refetchOnWindowFocus: false,
+    placeholderData: emptyData,
+    ...(options?.enabled !== undefined ? { enabled: options.enabled } : {}),
+  });
+};


### PR DESCRIPTION
## Commit Type

- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level

- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

### Problem
Follow-up to PR #9123. The inline `placeholderData` fix for infinite recursive nesting worked correctly in the Standalone designer, but caused the **portal to freeze completely** when opening any action in monitoring view. The browser tab becomes unresponsive and must be force-killed.

### Root Cause
The fix in #9123 used an inline object literal for `placeholderData`:
```tsx
placeholderData: { inputs: {}, outputs: {} },
```
In the portal environment, TanStack Query returns `placeholderData` as `data` immediately (`isLoading=false`). Because a new object reference is created each render, this triggers an infinite re-render loop:
1. Component renders → inline `{ inputs: {}, outputs: {} }` creates new object reference
2. TanStack Query returns it as `data` (since `isLoading` is false with `placeholderData`)
3. `useEffect` fires on `data` change → dispatches `initializeInputsOutputsBinding`
4. Redux state updates → component re-renders → back to step 1

This did not surface in Standalone because the Standalone app initializes the query cache differently (fresh mount vs portal's persistent extension host).

### Fix
Extract a dedicated `useRawInputsOutputs` hook, porting the proven pattern from designer-v2:

1. **Module-level `emptyData` constant** — `const emptyData: RawInputsOutputs = { inputs: {}, outputs: {} }` at module scope provides a stable reference. `placeholderData: emptyData` never creates a new object, breaking the re-render loop.
2. **Dedicated hook** (`useRawInputsOutputs.ts`) — encapsulates the query logic in a reusable hook with a typed `RawInputsOutputs` interface, matching designer-v2's pattern.
3. **Simplified MonitoringPanel** — `monitoringTab.tsx` now delegates all data fetching to the hook, reducing its responsibility to layout and dispatch.

### Why designer-v2 is unaffected
designer-v2's `useRawInputsOutputs` hook already uses a module-level empty constant. This fix aligns v1 with that pattern.

## Impact of Change

- **Users**: Fixes portal freeze when opening any action in monitoring/run history view. Combined with #9123, this resolves the original infinite scrolling bug and the portal freeze regression.
- **Developers**: New reusable `useRawInputsOutputs` hook exported from `nodeDetailsPanel/` — can be shared across any panel that needs raw action inputs/outputs.
- **System**: Eliminates infinite re-render loop in portal extension. No additional API calls.

## Test Plan

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Portal local dev with pinned v5.953.2 packages

**Test details:**
- `useRawInputsOutputs.spec.ts` — 7 new unit tests covering:
  - `should use stable query key with actionTrackingId, startTime, and endTime` — verifies cache key stability
  - `should use a stable placeholderData reference (prevents infinite re-render)` — **the core regression test** — asserts `placeholderData` is referentially identical across renders
  - `should always call getActionLinks even when runData has existing inputs/outputs` — verifies no shortcut
  - `should not re-feed already-bound BoundParameters as raw inputs (regression)` — regression from #9123
  - `should return empty inputs/outputs when getActionLinks returns nullish values` — null safety
  - `should handle getActionLinks returning null/undefined entirely` — edge case
  - `should pass enabled option when provided` — API contract
- `monitoringTab.spec.tsx` — updated to mock `useRawInputsOutputs` instead of `useQuery` directly, testing integration points (nodeId passing, loading state, error state)

## Contributors

@takyyon

## Screenshots/Videos

N/A — behavioral fix (unfreezes browser), no visual changes