### PR TITLE
fix(DesignerV2): Include connectionReference in discover_connectors tool results

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
@@ -272,6 +272,15 @@ interface ActionTemplate {
       headers?: Record<string, string>;
     };
   };
+  /**
+   * A ready-to-use connectionReference entry. Add this to the workflow's connectionReferences
+   * using the referenceName as the key (must match actionDefinition.inputs.host.connection.referenceName).
+   */
+  connectionReference: {
+    connectionName: string;
+    source: string;
+    id: string;
+  };
   /** Description of each input field for the body/queries */
   inputDescriptions?: Record<string, string>;
 }
@@ -376,6 +385,11 @@ function buildActionTemplate(op: DiscoveryOpArray[number], swaggerOp: SwaggerOpe
     actionDefinition: {
       type: 'ApiConnection',
       inputs,
+    },
+    connectionReference: {
+      connectionName: referenceName,
+      source: 'Embedded',
+      id: api?.id ?? '',
     },
     inputDescriptions: Object.keys(inputDescriptions).length > 0 ? inputDescriptions : undefined,
   };


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix
- [ ] feature - New functionality
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
When the copilot workflow editor uses `discover_connectors` to find connector actions, the returned `ActionTemplate` now includes a `connectionReference` object (`connectionName`, `source`, `id`). Previously the tool only returned `connectorId` as a string, leaving the LLM to construct the connectionReference entry itself — which it frequently got wrong (empty `connectionReferences`, malformed `id` paths, or missing entries entirely). This caused "Unable to initialize operation details for swagger based operation" errors in the designer because it couldn't resolve the connector's swagger without a valid connectionReference.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Copilot-generated connector actions (e.g. "add a Create Contact action") will initialize correctly in the designer instead of failing with swagger resolution errors
- **Developers**: `ActionTemplate` interface gains an optional `connectionReference` field
- **System**: No performance or architecture impact — adds a small object to existing tool output

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer with copilot workflow editing enabled, verified tool output includes connectionReference and designer initializes ApiConnection actions correctly

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
N/A — no visual changes