### PR TITLE
feat(DesignerV2): Improve WF Assistant tool calling flow

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
@@ -196,24 +196,24 @@ describe('executeCopilotTool', () => {
       expect(mockConnectionService.getSwaggerFromConnector).not.toHaveBeenCalled();
     });
 
-    it('should limit results to top 5 connectors per capability', async () => {
+    it('should limit results to top 10 connectors per capability', async () => {
       const ops = Array.from({ length: 20 }, (_, i) => makeOperation(`Op${i}`, `/connectors/conn${i}`, `Connector ${i}`, `Operation ${i}`));
       mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
 
       const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['test capability'] }));
       const parsed = JSON.parse(result);
 
-      expect(parsed['test capability'].length).toBeLessThanOrEqual(5);
+      expect(parsed['test capability'].length).toBeLessThanOrEqual(10);
     });
 
-    it('should limit matching operations per connector to 5', async () => {
+    it('should limit matching operations per connector to 10', async () => {
       const ops = Array.from({ length: 10 }, (_, i) => makeOperation(`Op${i}`, '/connectors/test', 'Test Connector', `Operation ${i}`));
       mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
 
       const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['test'] }));
       const parsed = JSON.parse(result);
 
-      expect(parsed['test'][0].matchingOperations.length).toBeLessThanOrEqual(5);
+      expect(parsed['test'][0].matchingOperations.length).toBeLessThanOrEqual(10);
     });
   });
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
@@ -139,8 +139,9 @@ describe('executeCopilotTool', () => {
 
       const connector = parsed['email'][0];
       expect(connector.connectorId).toBe('/connectors/outlook');
-      expect(connector.matchingOperations).toContain('Send an email');
-      expect(connector.matchingOperations).toContain('Get emails');
+      const summaries = connector.matchingOperations.map((o: any) => o.summary);
+      expect(summaries).toContain('Send an email');
+      expect(summaries).toContain('Get emails');
     });
 
     it('should fall back to getBuiltInOperations and filter when getActiveSearchOperations is unavailable', async () => {
@@ -272,6 +273,40 @@ describe('executeCopilotTool', () => {
       expect(parsed.results[0].actionDefinition.type).toBe('ApiConnection');
     });
 
+    it('should filter to specific operation when operationId is provided', async () => {
+      const ops = [
+        makeOperation('SendEmail', '/connectors/outlook', 'Office 365 Outlook', 'Send an email'),
+        makeOperation('GetEmails', '/connectors/outlook', 'Office 365 Outlook', 'Get emails'),
+        makeOperation('DeleteEmail', '/connectors/outlook', 'Office 365 Outlook', 'Delete email'),
+      ];
+      mockSearchService.getOperationsByConnector.mockResolvedValue(ops);
+      mockConnectionService.getSwaggerFromConnector.mockRejectedValue(new Error('no swagger'));
+
+      const result = await executeCopilotTool(
+        'get_connector_operations',
+        JSON.stringify({ connectorId: '/connectors/outlook', operationId: 'SendEmail' })
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.results).toHaveLength(1);
+      expect(parsed.results[0].operationId).toBe('SendEmail');
+    });
+
+    it('should return message when operationId is not found', async () => {
+      const ops = [makeOperation('SendEmail', '/connectors/outlook', 'Office 365 Outlook', 'Send an email')];
+      mockSearchService.getOperationsByConnector.mockResolvedValue(ops);
+      mockConnectionService.getSwaggerFromConnector.mockRejectedValue(new Error('no swagger'));
+
+      const result = await executeCopilotTool(
+        'get_connector_operations',
+        JSON.stringify({ connectorId: '/connectors/outlook', operationId: 'NonExistentOp' })
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.results).toEqual([]);
+      expect(parsed.message).toContain('NonExistentOp');
+    });
+
     it('should handle errors gracefully', async () => {
       mockSearchService.getOperationsByConnector.mockRejectedValue(new Error('Service unavailable'));
 
@@ -322,7 +357,19 @@ describe('executeCopilotTool', () => {
 
       const connector = parsed['send email'][0];
       // "Send an email (V2)" should rank highest because it contains both "send" and "email"
-      expect(connector.matchingOperations[0]).toBe('Send an email (V2)');
+      expect(connector.matchingOperations[0].summary).toBe('Send an email (V2)');
+    });
+
+    it('should include operationId in matchingOperations', async () => {
+      const ops = [makeOperation('SendEmailV2', '/connectors/outlook', 'Office 365 Outlook', 'Send an email (V2)')];
+      mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
+
+      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['email'] }));
+      const parsed = JSON.parse(result);
+
+      const connector = parsed['email'][0];
+      expect(connector.matchingOperations[0].operationId).toBe('SendEmailV2');
+      expect(connector.matchingOperations[0].summary).toBe('Send an email (V2)');
     });
   });
 });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
@@ -341,4 +341,30 @@ describe('executeCopilotTool', () => {
       expect(parsed.error).toContain('Failed to list operations');
     });
   });
+
+  // ── re-ranking ─────────────────────────────────────────────────────────
+  describe('discover_connectors re-ranking', () => {
+    it('should boost operations whose connector name matches search terms', async () => {
+      // Simulate the real-world issue: searching "outlook email" returns irrelevant connectors first
+      const ops = [
+        makeOperation('scp-get-email-insights', '/connectors/contosohub', 'Contoso Hub', 'Enrich email summary'),
+        makeOperation('scp-get-email-summary', '/connectors/docusign', 'Docusign', 'Get email summary'),
+        makeOperation('FormatEmailGet', '/connectors/dqondemand', 'DQ on Demand', 'Format Email'),
+        makeOperation('MSOutlookCloseInstance', '/connectors/iaconnect', 'IA-Connect to Microsoft Office', 'Close MS Outlook instance'),
+        makeOperation('SendEmailV2', '/connectors/office365', 'Office 365 Outlook', 'Send an email (V2)'),
+        makeOperation('OnNewEmail', '/connectors/office365', 'Office 365 Outlook', 'When a new email arrives'),
+      ];
+      mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
+      mockConnectionService.getSwaggerFromConnector.mockRejectedValue(new Error('no swagger'));
+
+      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['outlook email'] }));
+      const parsed = JSON.parse(result);
+
+      const results = parsed['outlook email'];
+      expect(results).toBeDefined();
+      // Office 365 Outlook operations should be ranked first because "outlook" matches the connector name
+      expect(results[0].connectorName).toBe('Office 365 Outlook');
+      expect(results[1].connectorName).toBe('Office 365 Outlook');
+    });
+  });
 });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
@@ -116,7 +116,6 @@ describe('executeCopilotTool', () => {
     it('should search using getActiveSearchOperations when available', async () => {
       const ops = [makeOperation('SendEmail', '/connectors/outlook', 'Office 365 Outlook', 'Send an email')];
       mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
-      mockConnectionService.getSwaggerFromConnector.mockRejectedValue(new Error('no swagger'));
 
       const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['send email via outlook'] }));
       const parsed = JSON.parse(result);
@@ -124,7 +123,24 @@ describe('executeCopilotTool', () => {
       expect(mockSearchService.getActiveSearchOperations).toHaveBeenCalledWith('send email via outlook');
       expect(parsed['send email via outlook']).toBeDefined();
       expect(parsed['send email via outlook']).toHaveLength(1);
-      expect(parsed['send email via outlook'][0].operationId).toBe('SendEmail');
+      expect(parsed['send email via outlook'][0].connectorId).toBe('/connectors/outlook');
+      expect(parsed['send email via outlook'][0].connectorName).toBe('Office 365 Outlook');
+    });
+
+    it('should return matching operations as summaries on the connector', async () => {
+      const ops = [
+        makeOperation('SendEmail', '/connectors/outlook', 'Office 365 Outlook', 'Send an email'),
+        makeOperation('GetEmails', '/connectors/outlook', 'Office 365 Outlook', 'Get emails'),
+      ];
+      mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
+
+      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['email'] }));
+      const parsed = JSON.parse(result);
+
+      const connector = parsed['email'][0];
+      expect(connector.connectorId).toBe('/connectors/outlook');
+      expect(connector.matchingOperations).toContain('Send an email');
+      expect(connector.matchingOperations).toContain('Get emails');
     });
 
     it('should fall back to getBuiltInOperations and filter when getActiveSearchOperations is unavailable', async () => {
@@ -134,14 +150,13 @@ describe('executeCopilotTool', () => {
         makeOperation('GetRows', '/connectors/sql', 'SQL Server', 'Get rows from table'),
       ];
       mockSearchService.getBuiltInOperations = vi.fn().mockResolvedValue(builtInOps);
-      mockConnectionService.getSwaggerFromConnector.mockRejectedValue(new Error('no swagger'));
 
       const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['email'] }));
       const parsed = JSON.parse(result);
 
       expect(parsed['email']).toBeDefined();
-      // Should find the email operation via name/description/summary matching
-      expect(parsed['email'].some((op: any) => op.operationId === 'SendEmail')).toBe(true);
+      // Should find the Outlook connector via name/description/summary matching
+      expect(parsed['email'].some((c: any) => c.connectorName === 'Outlook')).toBe(true);
     });
 
     it('should return message when no operations match', async () => {
@@ -150,129 +165,54 @@ describe('executeCopilotTool', () => {
       const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['nonexistent capability'] }));
       const parsed = JSON.parse(result);
 
-      expect(parsed['nonexistent capability'].message).toContain('No operations found');
+      expect(parsed['nonexistent capability'].message).toContain('No connectors found');
     });
 
-    it('should build action templates when swagger is available', async () => {
+    it('should group operations by connector and deduplicate', async () => {
+      const ops = [
+        makeOperation('SendEmail', '/connectors/outlook', 'Office 365 Outlook', 'Send an email'),
+        makeOperation('GetEmails', '/connectors/outlook', 'Office 365 Outlook', 'Get emails'),
+        makeOperation('GetRows', '/connectors/sql', 'SQL Server', 'Get rows from table'),
+      ];
+      mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
+
+      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['data'] }));
+      const parsed = JSON.parse(result);
+
+      // Should return 2 connectors, not 3 operations
+      expect(parsed['data']).toHaveLength(2);
+      expect(parsed['data'][0].connectorId).toBe('/connectors/outlook');
+      expect(parsed['data'][1].connectorId).toBe('/connectors/sql');
+    });
+
+    it('should not fetch swagger (no action templates in discover)', async () => {
       const ops = [makeOperation('SendEmail', '/connectors/outlook', 'Office 365 Outlook')];
       mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
-      mockConnectionService.getSwaggerFromConnector.mockResolvedValue(
-        makeSwaggerDoc({
-          '/{connectionId}/v2/Mail': {
-            post: {
-              operationId: 'SendEmail',
-              summary: 'Send an email',
-              parameters: [
-                { name: 'connectionId', in: 'path', required: true, type: 'string' },
-                {
-                  name: 'body',
-                  in: 'body',
-                  schema: {
-                    properties: {
-                      To: { type: 'string', description: 'Recipients' },
-                      Subject: { type: 'string', description: 'Email subject' },
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        })
-      );
 
-      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['send email'] }));
-      const parsed = JSON.parse(result);
+      await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['send email'] }));
 
-      const template = parsed['send email'][0];
-      expect(template.actionDefinition).toBeDefined();
-      expect(template.actionDefinition.type).toBe('ApiConnection');
-      expect(template.actionDefinition.inputs.method).toBe('post');
-      // Connection ID prefix should be stripped from path
-      expect(template.actionDefinition.inputs.path).toBe('/v2/Mail');
-      expect(template.actionDefinition.inputs.host.connection.referenceName).toBeTruthy();
-      expect(template.actionDefinition.inputs.body).toBeDefined();
-      expect(template.inputDescriptions).toBeDefined();
+      // discover_connectors should NOT call getSwaggerFromConnector
+      expect(mockConnectionService.getSwaggerFromConnector).not.toHaveBeenCalled();
     });
 
-    it('should strip {connectionId} from swagger paths', async () => {
-      const ops = [makeOperation('GetItem', '/connectors/sharepoint', 'SharePoint')];
+    it('should limit results to top 5 connectors per capability', async () => {
+      const ops = Array.from({ length: 20 }, (_, i) => makeOperation(`Op${i}`, `/connectors/conn${i}`, `Connector ${i}`, `Operation ${i}`));
       mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
-      mockConnectionService.getSwaggerFromConnector.mockResolvedValue(
-        makeSwaggerDoc({
-          '/{connectionId}/datasets/{dataset}/tables/{table}/items/{id}': {
-            get: {
-              operationId: 'GetItem',
-              parameters: [
-                { name: 'connectionId', in: 'path', type: 'string' },
-                { name: 'dataset', in: 'path', type: 'string', description: 'Site URL' },
-                { name: 'table', in: 'path', type: 'string', description: 'List name' },
-                { name: 'id', in: 'path', type: 'string', description: 'Item ID' },
-              ],
-            },
-          },
-        })
-      );
-
-      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['get sharepoint item'] }));
-      const parsed = JSON.parse(result);
-
-      const template = parsed['get sharepoint item'][0];
-      // {connectionId} should be removed
-      expect(template.actionDefinition.inputs.path).not.toContain('connectionId');
-      // Other path params should be parameterized
-      expect(template.actionDefinition.inputs.path).toContain("@{encodeURIComponent('");
-    });
-
-    it('should include query parameters in the template', async () => {
-      const ops = [makeOperation('ListItems', '/connectors/sharepoint', 'SharePoint')];
-      mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
-      mockConnectionService.getSwaggerFromConnector.mockResolvedValue(
-        makeSwaggerDoc({
-          '/{connectionId}/items': {
-            get: {
-              operationId: 'ListItems',
-              parameters: [
-                { name: 'connectionId', in: 'path', type: 'string' },
-                { name: '$filter', in: 'query', type: 'string', description: 'OData filter' },
-                { name: '$top', in: 'query', type: 'integer', description: 'Number of items' },
-              ],
-            },
-          },
-        })
-      );
-
-      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['list items'] }));
-      const parsed = JSON.parse(result);
-
-      const template = parsed['list items'][0];
-      expect(template.actionDefinition.inputs.queries).toBeDefined();
-      expect(template.actionDefinition.inputs.queries['$filter']).toBeDefined();
-      expect(template.actionDefinition.inputs.queries['$top']).toBeDefined();
-    });
-
-    it('should handle swagger fetch failures gracefully', async () => {
-      const ops = [makeOperation('Op1', '/connectors/test', 'Test Connector')];
-      mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
-      mockConnectionService.getSwaggerFromConnector.mockRejectedValue(new Error('network error'));
-
-      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['test'] }));
-      const parsed = JSON.parse(result);
-
-      // Should still return results, just without actionDefinition
-      expect(parsed['test']).toBeDefined();
-      expect(parsed['test'][0].operationId).toBe('Op1');
-      expect(parsed['test'][0].note).toContain('Swagger not available');
-    });
-
-    it('should limit results to top 5 operations per capability', async () => {
-      const ops = Array.from({ length: 10 }, (_, i) => makeOperation(`Op${i}`, '/connectors/test', 'Test', `Operation ${i}`));
-      mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
-      mockConnectionService.getSwaggerFromConnector.mockRejectedValue(new Error('no swagger'));
 
       const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['test capability'] }));
       const parsed = JSON.parse(result);
 
       expect(parsed['test capability'].length).toBeLessThanOrEqual(5);
+    });
+
+    it('should limit matching operations per connector to 5', async () => {
+      const ops = Array.from({ length: 10 }, (_, i) => makeOperation(`Op${i}`, '/connectors/test', 'Test Connector', `Operation ${i}`));
+      mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
+
+      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['test'] }));
+      const parsed = JSON.parse(result);
+
+      expect(parsed['test'][0].matchingOperations.length).toBeLessThanOrEqual(5);
     });
   });
 
@@ -344,7 +284,7 @@ describe('executeCopilotTool', () => {
 
   // ── re-ranking ─────────────────────────────────────────────────────────
   describe('discover_connectors re-ranking', () => {
-    it('should boost operations whose connector name matches search terms', async () => {
+    it('should boost connectors whose name matches search terms', async () => {
       // Simulate the real-world issue: searching "outlook email" returns irrelevant connectors first
       const ops = [
         makeOperation('scp-get-email-insights', '/connectors/contosohub', 'Contoso Hub', 'Enrich email summary'),
@@ -355,16 +295,15 @@ describe('executeCopilotTool', () => {
         makeOperation('OnNewEmail', '/connectors/office365', 'Office 365 Outlook', 'When a new email arrives'),
       ];
       mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
-      mockConnectionService.getSwaggerFromConnector.mockRejectedValue(new Error('no swagger'));
 
       const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['outlook email'] }));
       const parsed = JSON.parse(result);
 
-      const results = parsed['outlook email'];
-      expect(results).toBeDefined();
-      // Office 365 Outlook operations should be ranked first because "outlook" matches the connector name
-      expect(results[0].connectorName).toBe('Office 365 Outlook');
-      expect(results[1].connectorName).toBe('Office 365 Outlook');
+      const connectors = parsed['outlook email'];
+      expect(connectors).toBeDefined();
+      // Office 365 Outlook should be the first connector because "outlook" matches the connector name
+      expect(connectors[0].connectorName).toBe('Office 365 Outlook');
+      expect(connectors[0].connectorId).toBe('/connectors/office365');
     });
   });
 });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/__test__/copilotWorkflowEditorTools.spec.ts
@@ -305,5 +305,24 @@ describe('executeCopilotTool', () => {
       expect(connectors[0].connectorName).toBe('Office 365 Outlook');
       expect(connectors[0].connectorId).toBe('/connectors/office365');
     });
+
+    it('should rank operations within a connector by relevance to the search term', async () => {
+      const ops = [
+        makeOperation('GetCalendarEvents', '/connectors/outlook', 'Office 365 Outlook', 'Get calendar events'),
+        makeOperation('DeleteEmail', '/connectors/outlook', 'Office 365 Outlook', 'Delete email'),
+        makeOperation('SendEmailV2', '/connectors/outlook', 'Office 365 Outlook', 'Send an email (V2)'),
+        makeOperation('GetAttachments', '/connectors/outlook', 'Office 365 Outlook', 'Get attachments'),
+        makeOperation('OnNewEmail', '/connectors/outlook', 'Office 365 Outlook', 'When a new email arrives'),
+        makeOperation('FlagEmail', '/connectors/outlook', 'Office 365 Outlook', 'Flag an email'),
+      ];
+      mockSearchService.getActiveSearchOperations.mockResolvedValue(ops);
+
+      const result = await executeCopilotTool('discover_connectors', JSON.stringify({ capabilities: ['send email'] }));
+      const parsed = JSON.parse(result);
+
+      const connector = parsed['send email'][0];
+      // "Send an email (V2)" should rank highest because it contains both "send" and "email"
+      expect(connector.matchingOperations[0]).toBe('Send an email (V2)');
+    });
   });
 });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
@@ -25,7 +25,7 @@ export const COPILOT_WORKFLOW_TOOLS: CopilotToolDefinition[] = [
     function: {
       name: 'discover_connectors',
       description:
-        'Search for available managed API connectors and their operations. Call this BEFORE creating ANY ApiConnection action. Returns complete, ready-to-use action definitions that you can copy directly into the workflow. Provide descriptions of the capabilities you need and this tool will return the matching operations with their full action templates.',
+        'Search for available connectors matching a capability description. Call this BEFORE creating ANY ApiConnection action to find which connectors are available. Returns a list of matching connectors with their IDs and a summary of their operations. After finding the right connector, call get_connector_operations with the connectorId to get full action templates.',
       parameters: {
         type: 'object',
         properties: {
@@ -47,13 +47,13 @@ export const COPILOT_WORKFLOW_TOOLS: CopilotToolDefinition[] = [
     function: {
       name: 'get_connector_operations',
       description:
-        'List all available operations for a specific connector by ID. Use this when you already know the connector ID (e.g. from the workflow connectionReferences) and want to see all operations it supports. Returns complete action templates for each operation.',
+        'List all available operations for a specific connector by ID. Use this after discover_connectors to get full action templates for a chosen connector, or when you already know the connector ID (e.g. from the workflow connectionReferences). Returns complete, ready-to-use action definitions that you can copy directly into the workflow.',
       parameters: {
         type: 'object',
         properties: {
           connectorId: {
             type: 'string',
-            description: 'The connector ID (e.g. from the workflow connectionReferences or from a previous discover_connectors result)',
+            description: 'The connector ID (from discover_connectors results or from the workflow connectionReferences)',
           },
         },
         required: ['connectorId'],
@@ -102,8 +102,9 @@ export async function executeCopilotTool(toolName: string, rawArgs: string): Pro
 // ---------------------------------------------------------------------------
 
 /**
- * Discovers connectors and operations matching the given capability descriptions.
- * Returns complete, ready-to-use action templates for each matched operation.
+ * Discovers connectors matching the given capability descriptions.
+ * Returns connectors grouped by ID with a summary of their matching operations.
+ * The LLM should then call get_connector_operations for the chosen connector.
  */
 async function discoverConnectors(capabilities: string[] | undefined): Promise<string> {
   if (!capabilities || capabilities.length === 0) {
@@ -112,7 +113,6 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
 
   try {
     const searchService = SearchService();
-    const connectionService = ConnectionService();
     const results: Record<string, unknown> = {};
 
     for (const capability of capabilities) {
@@ -144,59 +144,50 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
       }
 
       if (!operations || operations.length === 0) {
-        results[capability] = { message: `No operations found for "${capability}"` };
+        results[capability] = { message: `No connectors found for "${capability}"` };
         continue;
       }
 
       // Re-rank: boost operations whose connector name matches words in the search term
       operations = rerankByConnectorName(operations, capability);
 
-      // Get the top matches and build complete action templates
-      const topOps = operations.slice(0, 5);
-      const actionTemplates: unknown[] = [];
-
-      // Group by connector to batch swagger lookups
-      const byConnector = new Map<string, typeof topOps>();
-      for (const op of topOps) {
+      // Group operations by connector
+      const byConnector = new Map<string, { name: string; description: string; operations: string[] }>();
+      for (const op of operations) {
         const api = (op.properties as any)?.api;
-        const connId = api?.id ?? '';
+        const connId: string = api?.id ?? '';
+        if (!connId) {
+          continue;
+        }
         if (!byConnector.has(connId)) {
-          byConnector.set(connId, []);
+          byConnector.set(connId, {
+            name: api?.displayName ?? api?.name ?? '',
+            description: api?.description ?? '',
+            operations: [],
+          });
         }
-        byConnector.get(connId)?.push(op);
-      }
-
-      for (const [connId, ops] of byConnector.entries()) {
-        let swagger: OpenAPIV2.Document | null = null;
-        try {
-          swagger = connId ? await connectionService.getSwaggerFromConnector(connId) : null;
-        } catch {
-          // Swagger not available — still return operation info without action template
-        }
-
-        for (const op of ops) {
-          const api = (op.properties as any)?.api;
-          const swaggerOpId = (op.properties as any)?.swaggerOperationId ?? op.name;
-
-          const swaggerOp = swagger ? findSwaggerOperation(swagger, swaggerOpId) : null;
-
-          if (swaggerOp) {
-            actionTemplates.push(buildActionTemplate(op, swaggerOp, api));
-          } else {
-            // Return basic info without a full action template
-            actionTemplates.push({
-              operationId: op.name,
-              connectorId: connId,
-              connectorName: api?.displayName ?? api?.name,
-              summary: op.properties?.summary,
-              description: op.properties?.description,
-              note: swagger ? 'Operation not found in swagger — use a different operationId' : 'Swagger not available for this connector',
-            });
-          }
+        const entry = byConnector.get(connId)!;
+        const summary = op.properties?.summary ?? op.name ?? '';
+        if (!entry.operations.includes(summary)) {
+          entry.operations.push(summary);
         }
       }
 
-      results[capability] = actionTemplates;
+      // Return the top connectors (limit to 5 unique connectors)
+      const connectors: unknown[] = [];
+      for (const [connId, info] of byConnector.entries()) {
+        if (connectors.length >= 5) {
+          break;
+        }
+        connectors.push({
+          connectorId: connId,
+          connectorName: info.name,
+          description: info.description,
+          matchingOperations: info.operations.slice(0, 5),
+        });
+      }
+
+      results[capability] = connectors;
     }
 
     return JSON.stringify(results);

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
@@ -151,8 +151,12 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
       // Re-rank: boost operations whose connector name matches words in the search term
       operations = rerankByConnectorName(operations, capability);
 
-      // Group operations by connector
-      const byConnector = new Map<string, { name: string; description: string; operations: string[] }>();
+      // Group operations by connector, scoring each by relevance to the search term
+      const searchWords = capability
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((w) => w.length > 2);
+      const byConnector = new Map<string, { name: string; description: string; operations: { summary: string; score: number }[] }>();
       for (const op of operations) {
         const api = (op.properties as any)?.api;
         const connId: string = api?.id ?? '';
@@ -168,9 +172,11 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
         }
         const entry = byConnector.get(connId)!;
         const summary = op.properties?.summary ?? op.name ?? '';
-        if (!entry.operations.includes(summary)) {
-          entry.operations.push(summary);
+        if (entry.operations.some((o) => o.summary === summary)) {
+          continue;
         }
+        const score = scoreOperationRelevance(summary, op.properties?.description ?? '', searchWords);
+        entry.operations.push({ summary, score });
       }
 
       // Return the top connectors (limit to 5 unique connectors)
@@ -179,11 +185,13 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
         if (connectors.length >= 5) {
           break;
         }
+        // Sort operations within each connector by relevance score (highest first)
+        const rankedOps = info.operations.sort((a, b) => b.score - a.score).map((o) => o.summary);
         connectors.push({
           connectorId: connId,
           connectorName: info.name,
           description: info.description,
-          matchingOperations: info.operations.slice(0, 5),
+          matchingOperations: rankedOps.slice(0, 5),
         });
       }
 
@@ -224,6 +232,38 @@ function rerankByConnectorName(operations: DiscoveryOpArray, searchTerm: string)
     }
     return 0;
   });
+}
+
+/**
+ * Scores an operation's relevance to the search term.
+ * Higher score = more relevant. Uses word overlap between the search terms
+ * and the operation's summary/description.
+ */
+function scoreOperationRelevance(summary: string, description: string, searchWords: string[]): number {
+  if (searchWords.length === 0) {
+    return 0;
+  }
+
+  const summaryLower = summary.toLowerCase();
+  const descriptionLower = description.toLowerCase();
+  let score = 0;
+
+  for (const word of searchWords) {
+    // Summary matches are worth more than description matches
+    if (summaryLower.includes(word)) {
+      score += 3;
+    } else if (descriptionLower.includes(word)) {
+      score += 1;
+    }
+  }
+
+  // Bonus for exact phrase match in summary
+  const phrase = searchWords.join(' ');
+  if (summaryLower.includes(phrase)) {
+    score += 5;
+  }
+
+  return score;
 }
 
 /**

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
@@ -148,6 +148,9 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
         continue;
       }
 
+      // Re-rank: boost operations whose connector name matches words in the search term
+      operations = rerankByConnectorName(operations, capability);
+
       // Get the top matches and build complete action templates
       const topOps = operations.slice(0, 5);
       const actionTemplates: unknown[] = [];
@@ -200,6 +203,36 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
   } catch (error) {
     return JSON.stringify({ error: `Discovery failed: ${error instanceof Error ? error.message : String(error)}` });
   }
+}
+
+/**
+ * Re-ranks operations so those whose connector name matches search terms appear first.
+ * This avoids the problem where searching "outlook email" returns irrelevant connectors
+ * (e.g. Contoso Hub) whose descriptions happen to mention "email" or "outlook".
+ */
+function rerankByConnectorName(operations: DiscoveryOpArray, searchTerm: string): DiscoveryOpArray {
+  const words = searchTerm
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((w) => w.length > 2);
+
+  if (words.length === 0) {
+    return operations;
+  }
+
+  return [...operations].sort((a, b) => {
+    const nameA = ((a.properties as any)?.api?.displayName ?? (a.properties as any)?.api?.name ?? '').toLowerCase();
+    const nameB = ((b.properties as any)?.api?.displayName ?? (b.properties as any)?.api?.name ?? '').toLowerCase();
+    const matchA = words.some((w) => nameA.includes(w));
+    const matchB = words.some((w) => nameB.includes(w));
+    if (matchA && !matchB) {
+      return -1;
+    }
+    if (!matchA && matchB) {
+      return 1;
+    }
+    return 0;
+  });
 }
 
 /**

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
@@ -47,13 +47,18 @@ export const COPILOT_WORKFLOW_TOOLS: CopilotToolDefinition[] = [
     function: {
       name: 'get_connector_operations',
       description:
-        'List all available operations for a specific connector by ID. Use this after discover_connectors to get full action templates for a chosen connector, or when you already know the connector ID (e.g. from the workflow connectionReferences). Returns complete, ready-to-use action definitions that you can copy directly into the workflow.',
+        'Get full action templates for a connector. Use the operationId from discover_connectors results to get a specific operation, or omit it to list all operations. Returns complete, ready-to-use action definitions that you can copy directly into the workflow.',
       parameters: {
         type: 'object',
         properties: {
           connectorId: {
             type: 'string',
             description: 'The connector ID (from discover_connectors results or from the workflow connectionReferences)',
+          },
+          operationId: {
+            type: 'string',
+            description:
+              'Optional: the specific operationId from discover_connectors matchingOperations. When provided, returns only that operation template instead of all operations.',
           },
         },
         required: ['connectorId'],
@@ -91,7 +96,7 @@ export async function executeCopilotTool(toolName: string, rawArgs: string): Pro
       return discoverConnectors(capabilities);
     }
     case 'get_connector_operations':
-      return getConnectorOperations(String(args['connectorId'] ?? ''));
+      return getConnectorOperations(String(args['connectorId'] ?? ''), args['operationId'] as string | undefined);
     default:
       return JSON.stringify({ error: `Unknown tool: ${toolName}` });
   }
@@ -156,7 +161,10 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
         .toLowerCase()
         .split(/\s+/)
         .filter((w) => w.length > 2);
-      const byConnector = new Map<string, { name: string; description: string; operations: { summary: string; score: number }[] }>();
+      const byConnector = new Map<
+        string,
+        { name: string; description: string; operations: { operationId: string; summary: string; score: number }[] }
+      >();
       for (const op of operations) {
         const api = (op.properties as any)?.api;
         const connId: string = api?.id ?? '';
@@ -171,12 +179,13 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
           });
         }
         const entry = byConnector.get(connId)!;
+        const operationId = (op.properties as any)?.swaggerOperationId ?? op.name ?? '';
         const summary = op.properties?.summary ?? op.name ?? '';
-        if (entry.operations.some((o) => o.summary === summary)) {
+        if (entry.operations.some((o) => o.operationId === operationId)) {
           continue;
         }
         const score = scoreOperationRelevance(summary, op.properties?.description ?? '', searchWords);
-        entry.operations.push({ summary, score });
+        entry.operations.push({ operationId, summary, score });
       }
 
       // Return the top connectors (limit to 5 unique connectors)
@@ -186,12 +195,15 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
           break;
         }
         // Sort operations within each connector by relevance score (highest first)
-        const rankedOps = info.operations.sort((a, b) => b.score - a.score).map((o) => o.summary);
+        const rankedOps = info.operations
+          .sort((a, b) => b.score - a.score)
+          .slice(0, 5)
+          .map((o) => ({ operationId: o.operationId, summary: o.summary }));
         connectors.push({
           connectorId: connId,
           connectorName: info.name,
           description: info.description,
-          matchingOperations: rankedOps.slice(0, 5),
+          matchingOperations: rankedOps,
         });
       }
 
@@ -267,9 +279,10 @@ function scoreOperationRelevance(summary: string, description: string, searchWor
 }
 
 /**
- * Lists all operations for a specific connector and returns complete action templates.
+ * Lists operations for a specific connector and returns complete action templates.
+ * When operationId is provided, returns only that specific operation template.
  */
-async function getConnectorOperations(connectorId: string): Promise<string> {
+async function getConnectorOperations(connectorId: string, operationId?: string): Promise<string> {
   try {
     const searchService = SearchService();
     const connectionService = ConnectionService();
@@ -282,6 +295,18 @@ async function getConnectorOperations(connectorId: string): Promise<string> {
 
     if (!operations || operations.length === 0) {
       return JSON.stringify({ results: [], message: `No operations found for connector "${connectorId}"` });
+    }
+
+    // Filter to specific operation if operationId is provided
+    if (operationId) {
+      const targetId = operationId.toLowerCase();
+      operations = operations.filter((op) => {
+        const swaggerOpId = ((op.properties as any)?.swaggerOperationId ?? op.name ?? '').toLowerCase();
+        return swaggerOpId === targetId;
+      });
+      if (operations.length === 0) {
+        return JSON.stringify({ results: [], message: `Operation "${operationId}" not found in connector "${connectorId}"` });
+      }
     }
 
     let swagger: OpenAPIV2.Document | null = null;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilot/copilotWorkflowEditorTools.ts
@@ -191,13 +191,13 @@ async function discoverConnectors(capabilities: string[] | undefined): Promise<s
       // Return the top connectors (limit to 5 unique connectors)
       const connectors: unknown[] = [];
       for (const [connId, info] of byConnector.entries()) {
-        if (connectors.length >= 5) {
+        if (connectors.length >= 10) {
           break;
         }
         // Sort operations within each connector by relevance score (highest first)
         const rankedOps = info.operations
           .sort((a, b) => b.score - a.score)
-          .slice(0, 5)
+          .slice(0, 10)
           .map((o) => ({ operationId: o.operationId, summary: o.summary }));
         connectors.push({
           connectorId: connId,

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilotWorkflowEditor.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilotWorkflowEditor.ts
@@ -60,7 +60,7 @@ export class BaseCopilotWorkflowEditorService implements ICopilotWorkflowEditorS
     const uri = `${baseUrl}/subscriptions/${subscriptionId}/providers/Microsoft.Logic/locations/${location}/generateCopilotResponse`;
 
     const sku = this._resolveSku(workflow);
-    const maxToolRounds = 5;
+    const maxToolRounds = 10;
 
     let toolResults: Array<{ toolCallId: string; result: string }> | undefined;
     let previousToolCalls: Array<{ id: string; name: string; arguments: string }> | undefined;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/copilotWorkflowEditor.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/copilotWorkflowEditor.ts
@@ -146,7 +146,50 @@ export class BaseCopilotWorkflowEditorService implements ICopilotWorkflowEditorS
       return result;
     }
 
-    throw new Error('Tool calling exceeded maximum rounds');
+    // Tool loop exhausted — send one final request without tool results so the LLM
+    // can respond to the user asking for clarification instead of hard-failing.
+    const finalRequestBody = {
+      properties: {
+        query: prompt,
+        workflow: {
+          definition: workflow.definition,
+          kind: workflow.kind,
+          connectionReferences: workflow.connectionReferences,
+          ...(workflow.parameters && Object.keys(workflow.parameters).length > 0 ? { parameters: workflow.parameters } : {}),
+          ...(workflow.notes && Object.keys(workflow.notes).length > 0 ? { notes: workflow.notes } : {}),
+        },
+        sku,
+        toolResults: toolResults?.map((tr) => ({
+          ...tr,
+          result: JSON.stringify({ error: 'Tool calling limit reached. Ask the user to clarify which connector or operation to use.' }),
+        })),
+        toolCalls: previousToolCalls,
+      },
+    };
+
+    const finalResponse = await axios.post(uri, finalRequestBody, {
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: accessToken,
+      },
+      params: { 'api-version': apiVersion },
+      signal,
+    });
+
+    const finalText: string = finalResponse.data?.properties?.response;
+    if (finalText) {
+      const result = parseCopilotResponse(finalText, workflow);
+      if (Object.keys(discoveredConnectors).length > 0) {
+        result.discoveredConnectors = discoveredConnectors;
+      }
+      return result;
+    }
+
+    return {
+      type: 'text',
+      text: "I wasn't able to find the right connectors. Could you clarify which service or connector you'd like to use?",
+    };
   }
 
   /**


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope

This only affects preview functionality, not yet visible for any customers

## What & Why

Improves the copilot workflow editor's connector discovery to reduce token usage and increase accuracy.

Previously, `discover_connectors` returned a flat list of individual operations, causing large token overhead and making it hard for the LLM to identify which connector to use. Now it returns connector-level results with ranked matching operations, and `get_connector_operations` supports filtering to a single operation by ID.

Also increases the tool call limit from 5 to 10 and gracefully handles exhaustion by asking the user for clarification instead of throwing an error.

## Impact of Change
- **Users**: Better copilot responses when searching for connectors — faster, more relevant results, and a friendly prompt for clarification instead of a hard failure when the LLM can't find the right connector.
- **Developers**: `discover_connectors` return shape changed to `{ connectorId, connectorName, description, matchingOperations: {operationId, summary}[] }`. `get_connector_operations` now accepts optional `operationId` parameter.
- **System**: Reduced token consumption per tool call round by returning connector-level summaries instead of full operation lists. No new dependencies (scoring uses zero-dependency word overlap).

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- Tested in: `copilotWorkflowEditorTools.spec.ts` (50 tests), `copilotWorkflowEditor.spec.ts` (56 tests) — all passing

## Contributors
@rileyevans

## Screenshots/Videos
N/A — no visual changes 
