### PR TITLE
fix(DesignerV2): Persist search term in Redux to prevent reset

### DIFF
--- a/libs/designer-v2/src/lib/core/state/panel/panelSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/panel/panelSelectors.ts
@@ -93,6 +93,8 @@ export const usePreviousPanelMode = () => useSelector(createSelector(getPanelSta
 
 export const useIsAddingAgentTool = () => useSelector(createSelector(getPanelState, (state) => state.discoveryContent.isAddingAgentTool));
 
+export const useDiscoveryPanelSearchTerm = () => useSelector(createSelector(getPanelState, (state) => state.discoveryContent.searchTerm));
+
 export const useIsRunHistoryCollapsed = () => useSelector(createSelector(getPanelState, (state) => state.runHistoryCollapsed));
 
 export const useMcpToolWizard = () => useSelector(createSelector(getPanelState, (state) => state.discoveryContent.mcpToolWizard));

--- a/libs/designer-v2/src/lib/core/state/panel/panelSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/panel/panelSlice.ts
@@ -34,6 +34,7 @@ const getInitialDiscoveryContentState = (): DiscoveryPanelContentState => ({
   relationshipIds: {
     graphId: 'root',
   },
+  searchTerm: '',
   selectedNodeIds: [],
   selectedOperationGroupId: '',
   selectedOperationId: '',
@@ -253,6 +254,9 @@ export const panelSlice = createSlice({
     selectOperationId: (state, action: PayloadAction<string>) => {
       state.discoveryContent.selectedOperationId = action.payload;
     },
+    setDiscoverySearchTerm: (state, action: PayloadAction<string>) => {
+      state.discoveryContent.searchTerm = action.payload;
+    },
     selectBrowseCategory: (state, action: PayloadAction<{ key: string; title: string } | undefined>) => {
       state.discoveryContent.selectedBrowseCategory = action.payload;
     },
@@ -431,6 +435,7 @@ export const {
   setRunHistoryCollapsed,
   openMcpToolWizard,
   setMcpWizardStep,
+  setDiscoverySearchTerm,
   setMcpWizardConnection,
   setMcpWizardTools,
   setMcpWizardHeaders,

--- a/libs/designer-v2/src/lib/core/state/panel/panelTypes.ts
+++ b/libs/designer-v2/src/lib/core/state/panel/panelTypes.ts
@@ -68,6 +68,7 @@ export interface DiscoveryPanelContentState {
   agentToolMetadata?: { newAdditiveSubgraphId: string; subGraphManifest: OperationManifest };
   panelMode: 'Discovery';
   relationshipIds: RelationshipIds;
+  searchTerm: string;
   selectedNodeIds: string[];
   selectedOperationGroupId: string;
   selectedOperationId: string;

--- a/libs/designer-v2/src/lib/ui/panel/__test__/panelRoot.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/__test__/panelRoot.spec.tsx
@@ -1,0 +1,225 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { IntlProvider } from 'react-intl';
+import React from 'react';
+import { PanelRoot } from '../panelRoot';
+import { PanelLocation } from '@microsoft/designer-ui';
+
+// Mock FluentUI Panel to render children directly (avoids layer/portal issues in jsdom)
+vi.mock('@fluentui/react', async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    Panel: ({ children, isOpen }: any) => (isOpen ? React.createElement('div', { 'data-testid': 'fluent-panel' }, children) : null),
+  };
+});
+
+vi.mock('@fluentui/react-components', async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    Dialog: ({ children, open }: any) => (open ? React.createElement('div', { 'data-testid': 'fluent-dialog' }, children) : null),
+    Spinner: () => React.createElement('div', { 'data-testid': 'loading-spinner', role: 'progressbar' }),
+  };
+});
+
+vi.mock('../../../core/state/designerOptions/designerOptionsSelectors', () => ({
+  useIsDarkMode: vi.fn(() => false),
+}));
+
+vi.mock('../../../core/state/panel/panelSelectors', () => ({
+  useCurrentPanelMode: vi.fn(() => 'Operation'),
+  useFocusReturnElementId: vi.fn(() => undefined),
+  useIsPanelCollapsed: vi.fn(() => false),
+  useIsPanelLoading: vi.fn(() => false),
+}));
+
+vi.mock('../../../core/state/panel/panelSlice', () => ({
+  clearPanel: vi.fn(() => ({ type: 'panel/clearPanel' })),
+}));
+
+vi.mock('../nodeDetailsPanel/nodeDetailsPanel', () => ({
+  NodeDetailsPanel: () => React.createElement('div', { 'data-testid': 'node-details-panel' }, 'Node Details Panel'),
+}));
+
+vi.mock('../connectionsPanel/connectionsPanel', () => ({
+  ConnectionPanel: () => React.createElement('div', { 'data-testid': 'connection-panel' }, 'Connection Panel'),
+}));
+
+vi.mock('../errorsPanel/errorsPanel', () => ({
+  ErrorsPanel: () => React.createElement('div', { 'data-testid': 'errors-panel' }, 'Errors Panel'),
+}));
+
+vi.mock('../assertionsPanel/assertionsPanel', () => ({
+  AssertionsPanel: () => React.createElement('div', { 'data-testid': 'assertions-panel' }, 'Assertions Panel'),
+}));
+
+vi.mock('../recommendation/recommendationPanelContext', () => ({
+  RecommendationPanelContext: () => React.createElement('div', { 'data-testid': 'recommendation-panel' }, 'Recommendation Panel'),
+}));
+
+vi.mock('../workflowParametersPanel/workflowParametersPanel', () => ({
+  WorkflowParametersPanel: () => React.createElement('div', { 'data-testid': 'workflow-parameters-panel' }, 'Workflow Parameters Panel'),
+}));
+
+vi.mock('../workflowParametersPanel/workflowParametersPanelFooter', () => ({
+  WorkflowParametersPanelFooter: () => React.createElement('div', { 'data-testid': 'workflow-parameters-footer' }, 'Footer'),
+}));
+
+vi.mock('../nodeSearchPanel/nodeSearchDialog', () => ({
+  NodeSearchDialog: () => React.createElement('div', { 'data-testid': 'node-search-dialog' }, 'Node Search Dialog'),
+}));
+
+vi.mock('@microsoft/designer-ui', async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    PanelResizer: () => React.createElement('div', { 'data-testid': 'panel-resizer' }, 'Resizer'),
+  };
+});
+
+import { useCurrentPanelMode, useIsPanelCollapsed, useIsPanelLoading } from '../../../core/state/panel/panelSelectors';
+
+const mockUseCurrentPanelMode = vi.mocked(useCurrentPanelMode);
+const mockUseIsPanelCollapsed = vi.mocked(useIsPanelCollapsed);
+const mockUseIsPanelLoading = vi.mocked(useIsPanelLoading);
+
+const createTestStore = () =>
+  configureStore({
+    reducer: {
+      panel: (state = {}) => state,
+    },
+  });
+
+const createWrapper = () => {
+  const store = createTestStore();
+  return ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <IntlProvider locale="en">{children}</IntlProvider>
+    </Provider>
+  );
+};
+
+const defaultProps = {
+  panelContainerRef: { current: document.createElement('div') },
+  panelLocation: PanelLocation.Right,
+};
+
+describe('PanelRoot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCurrentPanelMode.mockReturnValue('Operation');
+    mockUseIsPanelCollapsed.mockReturnValue(false);
+    mockUseIsPanelLoading.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should return null when currentPanelMode is undefined', () => {
+    mockUseCurrentPanelMode.mockReturnValue(undefined as any);
+
+    const { container } = render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  test('should render NodeDetailsPanel when mode is Operation', () => {
+    mockUseCurrentPanelMode.mockReturnValue('Operation');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('node-details-panel')).toBeDefined();
+  });
+
+  test('should render loading spinner when isLoading is true', () => {
+    mockUseIsPanelLoading.mockReturnValue(true);
+    mockUseCurrentPanelMode.mockReturnValue('Discovery');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('loading-spinner')).toBeDefined();
+  });
+
+  test('should render RecommendationPanelContext when mode is Discovery', () => {
+    mockUseCurrentPanelMode.mockReturnValue('Discovery');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('recommendation-panel')).toBeDefined();
+  });
+
+  test('should render WorkflowParametersPanel when mode is WorkflowParameters', () => {
+    mockUseCurrentPanelMode.mockReturnValue('WorkflowParameters');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('workflow-parameters-panel')).toBeDefined();
+  });
+
+  test('should render ConnectionPanel when mode is Connection', () => {
+    mockUseCurrentPanelMode.mockReturnValue('Connection');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('connection-panel')).toBeDefined();
+  });
+
+  test('should render ErrorsPanel when mode is Error', () => {
+    mockUseCurrentPanelMode.mockReturnValue('Error');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('errors-panel')).toBeDefined();
+  });
+
+  test('should render AssertionsPanel when mode is Assertions', () => {
+    mockUseCurrentPanelMode.mockReturnValue('Assertions');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('assertions-panel')).toBeDefined();
+  });
+
+  test('should render NodeSearchDialog in a Dialog when mode is NodeSearch', () => {
+    mockUseCurrentPanelMode.mockReturnValue('NodeSearch');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('fluent-dialog')).toBeDefined();
+    expect(screen.getByTestId('node-search-dialog')).toBeDefined();
+  });
+
+  test('should render PanelResizer when isResizeable is true', () => {
+    mockUseCurrentPanelMode.mockReturnValue('Discovery');
+
+    render(<PanelRoot {...defaultProps} isResizeable={true} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('panel-resizer')).toBeDefined();
+  });
+
+  test('should not render PanelResizer when isResizeable is falsy', () => {
+    mockUseCurrentPanelMode.mockReturnValue('Discovery');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.queryByTestId('panel-resizer')).toBeNull();
+  });
+
+  test('should not render panel content when collapsed', () => {
+    mockUseIsPanelCollapsed.mockReturnValue(true);
+    mockUseCurrentPanelMode.mockReturnValue('Discovery');
+
+    render(<PanelRoot {...defaultProps} />, { wrapper: createWrapper() });
+
+    // Mocked Panel returns null when isOpen is false (collapsed = true => isOpen = false)
+    expect(screen.queryByTestId('fluent-panel')).toBeNull();
+    expect(screen.queryByTestId('recommendation-panel')).toBeNull();
+  });
+});

--- a/libs/designer-v2/src/lib/ui/panel/panelRoot.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/panelRoot.tsx
@@ -99,13 +99,12 @@ export const PanelRoot = (props: PanelRootProps): JSX.Element | null => {
     return {
       isCollapsed: collapsed,
       toggleCollapse: dismissPanel,
-      width,
       layerProps,
       panelLocation: customLocation ?? panelLocation ?? PanelLocation.Right,
       isResizeable,
       mountNode: panelContainerElement || undefined,
     };
-  }, [customPanelLocations, collapsed, dismissPanel, width, panelContainerElement, panelLocation, isResizeable, currentPanelMode]);
+  }, [customPanelLocations, collapsed, dismissPanel, panelContainerElement, panelLocation, isResizeable, currentPanelMode]);
 
   const onRenderFooterContent = useMemo(
     () => (currentPanelMode === 'WorkflowParameters' ? () => <WorkflowParametersPanelFooter /> : undefined),

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/__test__/recommendationPanelContext.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/__test__/recommendationPanelContext.spec.tsx
@@ -24,6 +24,7 @@ vi.mock('../../../../core/state/panel/panelSelectors', () => ({
   useDiscoveryPanelSelectedOperationId: vi.fn(() => ''),
   useDiscoveryPanelSelectedBrowseCategory: vi.fn(() => null),
   useDiscoveryPanelSelectionState: vi.fn(() => SELECTION_STATES.SEARCH),
+  useDiscoveryPanelSearchTerm: vi.fn(() => ''),
   useMcpToolWizard: vi.fn(() => null),
   useIsAddingAgentTool: vi.fn(() => false),
 }));
@@ -37,6 +38,7 @@ vi.mock('../../../../core/state/panel/panelSlice', () => ({
   selectOperationId: vi.fn((id) => ({ type: 'panel/selectOperationId', payload: id })),
   selectBrowseCategory: vi.fn((category) => ({ type: 'panel/selectBrowseCategory', payload: category })),
   setDiscoverySelectionState: vi.fn((state) => ({ type: 'panel/setDiscoverySelectionState', payload: state })),
+  setDiscoverySearchTerm: vi.fn((term) => ({ type: 'panel/setDiscoverySearchTerm', payload: term })),
   openMcpToolWizard: vi.fn((payload) => ({ type: 'panel/openMcpToolWizard', payload })),
 }));
 
@@ -112,6 +114,7 @@ import {
   useDiscoveryPanelSelectedOperationId,
   useDiscoveryPanelSelectedBrowseCategory,
   useDiscoveryPanelSelectionState,
+  useDiscoveryPanelSearchTerm,
   useMcpToolWizard,
 } from '../../../../core/state/panel/panelSelectors';
 import { selectOperationGroupId, selectBrowseCategory } from '../../../../core/state/panel/panelSlice';
@@ -122,6 +125,7 @@ const mockUseDiscoveryPanelSelectedOperationGroupId = vi.mocked(useDiscoveryPane
 const mockUseDiscoveryPanelSelectedOperationId = vi.mocked(useDiscoveryPanelSelectedOperationId);
 const mockUseDiscoveryPanelSelectedBrowseCategory = vi.mocked(useDiscoveryPanelSelectedBrowseCategory);
 const mockUseDiscoveryPanelSelectionState = vi.mocked(useDiscoveryPanelSelectionState);
+const mockUseDiscoveryPanelSearchTerm = vi.mocked(useDiscoveryPanelSearchTerm);
 const mockUseMcpToolWizard = vi.mocked(useMcpToolWizard);
 const mockSelectOperationGroupId = vi.mocked(selectOperationGroupId);
 const mockSelectBrowseCategory = vi.mocked(selectBrowseCategory);
@@ -289,10 +293,9 @@ describe('RecommendationPanelContext', () => {
     });
 
     test('should render SearchView when search term is entered', () => {
-      render(<RecommendationPanelContext {...defaultProps} />, { wrapper: createWrapper() });
+      mockUseDiscoveryPanelSearchTerm.mockReturnValue('http');
 
-      const searchInput = screen.getByTestId('search-input');
-      fireEvent.change(searchInput, { target: { value: 'http' } });
+      render(<RecommendationPanelContext {...defaultProps} />, { wrapper: createWrapper() });
 
       expect(screen.getByTestId('search-view')).toBeDefined();
       expect(screen.getByTestId('search-view').textContent).toContain('Search: http');

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/recommendationPanelContext.tsx
@@ -11,6 +11,7 @@ import {
   useDiscoveryPanelSelectedOperationId,
   useDiscoveryPanelSelectedBrowseCategory,
   useDiscoveryPanelSelectionState,
+  useDiscoveryPanelSearchTerm,
   useMcpToolWizard,
   useIsAddingAgentTool,
 } from '../../../core/state/panel/panelSelectors';
@@ -19,6 +20,7 @@ import {
   selectOperationId,
   selectBrowseCategory,
   setDiscoverySelectionState,
+  setDiscoverySearchTerm,
   openMcpToolWizard,
 } from '../../../core/state/panel/panelSlice';
 import { SELECTION_STATES } from '../../../core/state/panel/panelTypes';
@@ -50,7 +52,8 @@ export const RecommendationPanelContext = (props: CommonPanelProps) => {
   const dispatch = useDispatch<AppDispatch>();
   const classes = useRecommendationPanelContextStyles();
   const isTrigger = useDiscoveryPanelIsAddingTrigger();
-  const [searchTerm, setSearchTerm] = useState('');
+  const searchTerm = useDiscoveryPanelSearchTerm();
+  const setSearchTerm = useCallback((term: string) => dispatch(setDiscoverySearchTerm(term)), [dispatch]);
 
   const selectedBrowseCategory = useDiscoveryPanelSelectedBrowseCategory();
   const mcpToolWizard = useMcpToolWizard();


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixes #9173 - The search text in the "Add a trigger/action" panel was being cleared whenever the panel was resized (enlarged/collapsed).

**Root cause**: Two issues combined:
1. `width` was included in the `commonPanelProps` useMemo dependency array, causing child components to re-render on every resize pixel change.
2. The search term was stored in local `useState`, which resets when the component re-mounts due to the parent re-render.

**Fix**: Moved the search term to Redux state so it persists across re-renders, and removed the unused `width` prop from `commonPanelProps` (it wasn't part of the `CommonPanelProps` type interface).

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Search text now persists when resizing the discovery panel - no longer need to re-type searches after enlarging
- **Developers**: New `setDiscoverySearchTerm` action and `useDiscoveryPanelSearchTerm` selector available in the panel state
- **System**: Slight reduction in unnecessary re-renders when panel is resized

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: Standalone designer, verified search term persists across panel resize

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->

