### PR TITLE
fix(DesignerV2): Fix DatePicker mount node stale reference

### DIFF
--- a/libs/designer-v2/src/lib/ui/panel/runHistoryPanel/runHistoryPanel.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/runHistoryPanel/runHistoryPanel.tsx
@@ -475,8 +475,9 @@ export const RunHistoryPanel = () => {
   // If a runId filter is set, prefetch that run's data
   const { isFetching: isFetchingFilteredRun } = useRun(filters?.['runId'] ?? undefined, runIdRegex.test(filters?.['runId'] ?? ''));
 
-  const compatMountNode = useMemo(() => {
-    return document.getElementById('fluent-compat-component-mount') ?? undefined;
+  const [compatMountNode, setCompatMountNode] = useState<HTMLElement | undefined>(undefined);
+  useEffect(() => {
+    setCompatMountNode(document.getElementById('fluent-compat-component-mount') ?? undefined);
   }, []);
 
   // MARK: Components


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Fixes the "Custom range" DatePicker/TimePicker in the run history panel being unselectable when viewing production runs (#8857).

The `compatMountNode` was resolved via `useMemo` with empty dependencies, which runs during the render phase — before the sibling `fluent-compat-component-mount` div exists in the DOM. On initial load this works by coincidence (the div is already mounted from a prior render cycle), but when the Portal switches from Draft to Prod mode, `setDesignerID(guid())` changes the `key` on `DesignerProvider`, causing a full unmount/remount. The old div is destroyed and a new one is created, but `useMemo` never re-queries, leaving DatePicker with a stale (detached) mount node.

Changed to `useState` + `useEffect` so the DOM query runs after mount when the sibling div is guaranteed to exist.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Custom date range filtering in run history now works correctly after switching between Draft and Prod views
- **Developers**: None — no API changes
- **System**: None — minimal change (3 lines), same behavior on initial mount

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- Tested in: Standalone designer, Portal (Draft→Prod mode switch reproduces the issue)

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
N/A — no visual changes; the DatePicker popup now correctly appears when it previously did not.