### PR TITLE
fix(DesignerV2): Fix Agent Activity tab disabled for MCP-only agent

### DIFF
--- a/libs/designer-v2/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -1,4 +1,4 @@
-import { equals, SUBGRAPH_TYPES } from '@microsoft/logic-apps-shared';
+import { equals } from '@microsoft/logic-apps-shared';
 import type { RootState } from '../../store';
 import { useSelector } from 'react-redux';
 import { isA2AWorkflow } from '../workflow/helper';
@@ -40,6 +40,6 @@ export const useIsA2AWorkflow = () => {
 
 export const useWorkflowHasAgentLoop = () => {
   return useSelector((state: RootState) => {
-    return Object.values(state.workflow.nodesMetadata).some((node) => node.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION);
+    return Object.values(state.workflow.operations).some((operation) => equals(operation.type, 'agent'));
   });
 };


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

The **Agent Activity** tab in the designer-v2 run history panel is permanently disabled for workflows where Agent actions only contain MCP client tools (e.g., `McpClientTool`).

`useWorkflowHasAgentLoop` checked `state.workflow.nodesMetadata` for nodes with `subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION`. However, during deserialization, MCP client tools are assigned `SUBGRAPH_TYPES.MCP_CLIENT` — not `AGENT_CONDITION`. Workflows whose Agent actions have *only* MCP tools never produce an `AGENT_CONDITION` node, so the selector always returned `false`.

Changed the selector to check `state.workflow.operations` for any operation with `type === 'agent'`, matching the v1 designer's existing implementation.

Fixes #9174

## Impact of Change
- **Users**: Agent Activity tab now correctly appears for all agent workflows, including those with only MCP client tools
- **Developers**: No API changes
- **System**: No performance or architecture impact — single selector change

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Traced through customer's workflow definition (Agent action with single McpClientTool) confirming old selector returns `false` and new selector returns `true`. Verified v1 designer already uses this approach.

## Contributors

## Screenshots/Videos