### PR TITLE
(fix): Show managed identity picker for custom MCP connector connection creation

### DIFF
--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -232,6 +232,15 @@ export const CreateConnection = (props: CreateConnectionProps) => {
   const isMultiAuth = useMemo(() => (connectionParameterSets?.values?.length ?? 0) > 0, [connectionParameterSets?.values]);
   const showMultiAuthDropdown = useMemo(() => (connectionParameterSets?.values?.length ?? 0) > 1, [connectionParameterSets?.values]);
 
+  // Check if the currently selected multi-auth parameter set is a managed identity type.
+  // When true, we show the identity picker instead of the hidden managedIdentity parameter.
+  const isMultiAuthManagedIdentitySet = useMemo(() => {
+    if (!isMultiAuth) {
+      return false;
+    }
+    return Object.values(multiAuthParams).some((param) => param.type === ConnectionParameterTypes.managedIdentity);
+  }, [isMultiAuth, multiAuthParams]);
+
   const hasOnlyOnPremGateway = useMemo(
     () => (connectorCapabilities?.includes(Capabilities.gateway) && !connectorCapabilities?.includes(Capabilities.cloud)) ?? false,
     [connectorCapabilities]
@@ -439,6 +448,9 @@ export const CreateConnection = (props: CreateConnectionProps) => {
     if (legacyManagedIdentitySelected && !selectedManagedIdentity) {
       return false;
     }
+    if (isMultiAuthManagedIdentitySet && !selectedManagedIdentity) {
+      return false;
+    }
     if (Object.keys(capabilityEnabledParameters ?? {}).length === 0) {
       return true;
     }
@@ -497,7 +509,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
     }
 
     const alternativeParameterValues = legacyManagedIdentitySelected ? {} : undefined;
-    const identitySelected = legacyManagedIdentitySelected ? selectedManagedIdentity : undefined;
+    const identitySelected = legacyManagedIdentitySelected || isMultiAuthManagedIdentitySet ? selectedManagedIdentity : undefined;
 
     return createConnectionCallback?.(
       showNameInput ? connectionDisplayName : undefined,
@@ -917,6 +929,20 @@ export const CreateConnection = (props: CreateConnectionProps) => {
               onChange={onAuthDropdownChange}
               connectionParameterSets={connectionParameterSets}
             />
+          )}
+
+          {/* Multi-auth Managed Identity Selection (for MCP custom connectors with MI parameter set) */}
+          {isMultiAuthManagedIdentitySet && (
+            <div className="param-row">
+              <Label
+                className="label"
+                isRequiredField={true}
+                text={legacyManagedIdentityLabelText}
+                htmlFor={'connection-param-set-select'}
+                disabled={isLoading}
+              />
+              <LegacyManagedIdentityDropdown identity={identity} onChange={onLegacyManagedIdentityChange} disabled={isLoading} />
+            </div>
           )}
 
           {/* OAuth tenant ID selection */}

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -238,7 +238,11 @@ export const CreateConnection = (props: CreateConnectionProps) => {
     if (!isMultiAuth) {
       return false;
     }
-    return Object.values(multiAuthParams).some((param) => param.type === ConnectionParameterTypes.managedIdentity);
+    return Object.values(multiAuthParams).some(
+      (param) =>
+        param.type === ConnectionParameterTypes.managedIdentity ||
+        equals(param.uiDefinition?.constraints?.default, 'managedserviceidentity')
+    );
   }, [isMultiAuth, multiAuthParams]);
 
   const hasOnlyOnPremGateway = useMemo(
@@ -542,6 +546,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
     operationParameterValues,
     isUsingDynamicConnection,
     isDynamicConnectionOptionValidForConnector,
+    isMultiAuthManagedIdentitySet,
   ]);
 
   // INTL STRINGS
@@ -938,10 +943,15 @@ export const CreateConnection = (props: CreateConnectionProps) => {
                 className="label"
                 isRequiredField={true}
                 text={legacyManagedIdentityLabelText}
-                htmlFor={'connection-param-set-select'}
+                htmlFor={'multi-auth-managed-identity-select'}
                 disabled={isLoading}
               />
-              <LegacyManagedIdentityDropdown identity={identity} onChange={onLegacyManagedIdentityChange} disabled={isLoading} />
+              <LegacyManagedIdentityDropdown
+                id={'multi-auth-managed-identity-select'}
+                identity={identity}
+                onChange={onLegacyManagedIdentityChange}
+                disabled={isLoading}
+              />
             </div>
           )}
 

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -115,6 +115,7 @@ export interface CreateConnectionProps {
   operationManifest?: OperationManifest;
   workflowKind?: string;
   workflowMetadata?: ConsumptionWorkflowMetadata;
+  enableManagedIdentityPicker?: boolean;
 }
 
 export const CreateConnection = (props: CreateConnectionProps) => {
@@ -231,19 +232,6 @@ export const CreateConnection = (props: CreateConnectionProps) => {
   );
   const isMultiAuth = useMemo(() => (connectionParameterSets?.values?.length ?? 0) > 0, [connectionParameterSets?.values]);
   const showMultiAuthDropdown = useMemo(() => (connectionParameterSets?.values?.length ?? 0) > 1, [connectionParameterSets?.values]);
-
-  // Check if the currently selected multi-auth parameter set is a managed identity type.
-  // When true, we show the identity picker instead of the hidden managedIdentity parameter.
-  const isMultiAuthManagedIdentitySet = useMemo(() => {
-    if (!isMultiAuth) {
-      return false;
-    }
-    return Object.values(multiAuthParams).some(
-      (param) =>
-        param.type === ConnectionParameterTypes.managedIdentity ||
-        equals(param.uiDefinition?.constraints?.default, 'managedserviceidentity')
-    );
-  }, [isMultiAuth, multiAuthParams]);
 
   const hasOnlyOnPremGateway = useMemo(
     () => (connectorCapabilities?.includes(Capabilities.gateway) && !connectorCapabilities?.includes(Capabilities.cloud)) ?? false,
@@ -419,6 +407,15 @@ export const CreateConnection = (props: CreateConnectionProps) => {
     return output ?? {};
   }, [enabledCapabilities, parametersByCapability]);
 
+  // Show MI picker only when explicitly enabled by the caller (e.g. MCP wizard) AND
+  // there are no visible parameters (form would be empty without it).
+  const isMultiAuthManagedIdentitySet = useMemo(() => {
+    if (!props.enableManagedIdentityPicker || !isMultiAuth) {
+      return false;
+    }
+    return Object.keys(capabilityEnabledParameters ?? {}).length === 0;
+  }, [props.enableManagedIdentityPicker, isMultiAuth, capabilityEnabledParameters]);
+
   // Don't show name for simple connections
   const showNameInput = useMemo(() => {
     const isMcpClientConnection = connectorId?.toLowerCase().includes('mcpclient');
@@ -467,6 +464,7 @@ export const CreateConnection = (props: CreateConnectionProps) => {
     resourceSelectorProps,
     legacyManagedIdentitySelected,
     selectedManagedIdentity,
+    isMultiAuthManagedIdentitySet,
     capabilityEnabledParameters,
     parameterValues,
   ]);

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionInternal.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionInternal.tsx
@@ -9,6 +9,7 @@ import { CreateConnection, type CreateButtonTexts } from './createConnection';
 import { Spinner, SpinnerSize } from '@fluentui/react/lib/Spinner';
 import type {
   ConnectionParameterSetValues,
+  ConnectionParameterSets,
   ConnectionMetadata,
   ConnectionCreationInfo,
   ConnectionParametersMetadata,
@@ -46,6 +47,7 @@ export const CreateConnectionInternal = (props: {
   operationManifest?: OperationManifest;
   workflowKind?: string;
   workflowMetadata?: { agentType?: string };
+  connectionParameterSetsOverride?: ConnectionParameterSets;
 }) => {
   const {
     classes,
@@ -68,6 +70,7 @@ export const CreateConnectionInternal = (props: {
     operationManifest,
     workflowKind,
     workflowMetadata,
+    connectionParameterSetsOverride,
   } = props;
   const dispatch = useDispatch<AppDispatch>();
 
@@ -320,7 +323,7 @@ export const CreateConnectionInternal = (props: {
       classes={classes}
       connector={connector}
       connectionParameterSets={getSupportedParameterSets(
-        connector.properties.connectionParameterSets,
+        connector.properties.connectionParameterSets ?? connectionParameterSetsOverride,
         operationType,
         connector.properties.capabilities
       )}

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionInternal.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionInternal.tsx
@@ -48,6 +48,7 @@ export const CreateConnectionInternal = (props: {
   workflowKind?: string;
   workflowMetadata?: { agentType?: string };
   connectionParameterSetsOverride?: ConnectionParameterSets;
+  enableManagedIdentityPicker?: boolean;
 }) => {
   const {
     classes,
@@ -71,6 +72,7 @@ export const CreateConnectionInternal = (props: {
     workflowKind,
     workflowMetadata,
     connectionParameterSetsOverride,
+    enableManagedIdentityPicker,
   } = props;
   const dispatch = useDispatch<AppDispatch>();
 
@@ -348,6 +350,7 @@ export const CreateConnectionInternal = (props: {
       operationManifest={operationManifest}
       workflowKind={workflowKind}
       workflowMetadata={workflowMetadata}
+      enableManagedIdentityPicker={enableManagedIdentityPicker}
     />
   );
 };

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/formInputs/legacyManagedIdentityPicker.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/formInputs/legacyManagedIdentityPicker.tsx
@@ -4,13 +4,14 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 
 interface LegacyManagedIdentityDropdownProps {
+  id?: string;
   identity?: ManagedIdentity;
   onChange: (event: any, item?: IDropdownOption<any>) => void;
   disabled?: boolean;
 }
 
 const LegacyManagedIdentityDropdown = (props: LegacyManagedIdentityDropdownProps) => {
-  const { identity, onChange, disabled } = props;
+  const { id, identity, onChange, disabled } = props;
   const intl = useIntl();
   const dropdownOptions = useMemo(() => getIdentityDropdownOptions(identity, intl), [identity, intl]);
 
@@ -29,6 +30,7 @@ const LegacyManagedIdentityDropdown = (props: LegacyManagedIdentityDropdownProps
 
   return (
     <Dropdown
+      id={id}
       className={'connection-parameter-input'}
       onChange={onChange}
       placeholder={noIdentitiesAvailable ? noIdentityText : undefined}

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
@@ -37,7 +37,7 @@ import { MCP_CLIENT_CONNECTOR_ID } from '../helpers';
 /**
  * Connection parameter sets for MCP servers. Used as a fallback when a custom connector
  * doesn't have its own connectionParameterSets, so users can select auth type
- * (None, Basic, Managed Identity, OAuth, etc.) during connection creation.
+ * (None, Basic, Key, or Managed Identity) during connection creation.
  */
 const mcpConnectionParameterSets: ConnectionParameterSets = {
   uiDefinition: {

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
@@ -30,9 +30,94 @@ import { isConnectionValid, getAssistedConnectionProps } from '../../../../core/
 import { addOperation } from '../../../../core/actions/bjsworkflow/add';
 import { useMcpToolWizardStyles } from './styles/McpToolWizard.styles';
 import { useConnector } from '../../../../core/state/connection/connectionSelector';
-import type { Connection, DiscoveryOperation, DiscoveryResultTypes } from '@microsoft/logic-apps-shared';
+import type { Connection, ConnectionParameterSets, DiscoveryOperation, DiscoveryResultTypes } from '@microsoft/logic-apps-shared';
 import { useQuery } from '@tanstack/react-query';
 import { MCP_CLIENT_CONNECTOR_ID } from '../helpers';
+
+/**
+ * Connection parameter sets for MCP servers. Used as a fallback when a custom connector
+ * doesn't have its own connectionParameterSets, so users can select auth type
+ * (None, Basic, Managed Identity, OAuth, etc.) during connection creation.
+ */
+const mcpConnectionParameterSets: ConnectionParameterSets = {
+  uiDefinition: {
+    displayName: 'Authentication type',
+    description: 'The authentication type to use.',
+  },
+  values: [
+    {
+      name: 'None',
+      parameters: {},
+      uiDefinition: { displayName: 'None', description: 'None' },
+    },
+    {
+      name: 'Basic',
+      parameters: {
+        username: {
+          type: 'string',
+          uiDefinition: {
+            displayName: 'Username',
+            constraints: { propertyPath: ['authentication'], required: 'true' },
+            description: 'Username',
+          },
+        },
+        password: {
+          type: 'securestring',
+          uiDefinition: {
+            displayName: 'Password',
+            constraints: { propertyPath: ['authentication'], required: 'true' },
+            description: 'Password',
+          },
+        },
+      },
+      uiDefinition: { displayName: 'Basic', description: 'Basic authentication' },
+    },
+    {
+      name: 'Key',
+      parameters: {
+        key: {
+          type: 'securestring',
+          uiDefinition: {
+            displayName: 'Key',
+            constraints: { required: 'true', propertyPath: ['authentication'] },
+            description: 'Key',
+          },
+        },
+        keyHeaderName: {
+          type: 'string',
+          uiDefinition: {
+            displayName: 'Key Header Name',
+            constraints: { propertyPath: ['authentication'] },
+            description: 'Key header name',
+          },
+        },
+      },
+      uiDefinition: { displayName: 'Key', description: 'Key authentication' },
+    },
+    {
+      name: 'ManagedServiceIdentity',
+      parameters: {
+        identity: {
+          type: 'string',
+          uiDefinition: {
+            displayName: 'Managed identity',
+            constraints: { required: 'false', editor: 'identitypicker', propertyPath: ['authentication'] },
+            description: 'The managed identity to use for authentication',
+          },
+        },
+        audience: {
+          type: 'string',
+          uiDefinition: {
+            displayName: 'Audience',
+            constraints: { required: 'true', propertyPath: ['authentication'] },
+            description: 'The audience',
+          },
+        },
+      },
+      uiDefinition: { displayName: 'Managed identity', description: 'Managed identity authentication' },
+    },
+  ],
+};
 
 export const McpToolWizard = () => {
   const intl = useIntl();
@@ -603,6 +688,12 @@ export const McpToolWizard = () => {
     // Managed MCP servers use the default Azure connection flow
     const connectionMetadata = isManagedMcpServer ? undefined : { type: ConnectionType.Mcp, required: true };
 
+    // For managed MCP servers (custom connectors), the connector from Azure API
+    // may not include connectionParameterSets (auth options). Provide MCP auth
+    // parameter sets as a fallback so users can select auth type (None, Basic,
+    // Managed Identity, etc.) when creating a connection.
+    const parameterSetsOverride = isManagedMcpServer ? mcpConnectionParameterSets : undefined;
+
     return (
       <div className={classes.createConnectionContainer}>
         <CreateConnectionInternal
@@ -617,6 +708,7 @@ export const McpToolWizard = () => {
           onConnectionCreated={handleConnectionCreated}
           onConnectionCancelled={handleConnectionCancelled}
           description=" "
+          connectionParameterSetsOverride={parameterSetsOverride}
         />
       </div>
     );

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
@@ -709,6 +709,7 @@ export const McpToolWizard = () => {
           onConnectionCancelled={handleConnectionCancelled}
           description=" "
           connectionParameterSetsOverride={parameterSetsOverride}
+          enableManagedIdentityPicker={isManagedMcpServer}
         />
       </div>
     );


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Very less impact
- [x] Medium - Moderate changes, some user impact. The change only affects UI rendering for custom MCP connector connection creation (adding a managed identity picker that was previously hidden); no backend logic, serialization, or existing connector flows are altered.
- [ ] High - Major changes, significant user/system impact

## What & Why
Custom MCP connectors with managed identity auth show no authentication options when creating a connection. Users only see a connection name field with no identity picker.

Root cause: `CreateConnection` component explicitly hides parameters of type `managedIdentity`. When the connector's only parameter set (e.g., oauthMI) uses this type, all parameters are hidden — leaving an empty form.

Fix:
Detect when the selected multi-auth parameter set contains a `managedIdentity` type parameter 
Render the managed identity picker for that case
Add fallback MCP auth parameter sets (None, Basic, Key, MI) for custom connectors missing `connectionParameterSets`

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Custom MCP connector connection creation now shows the managed identity picker when the connector defines MI auth
- **Developers**: New optional `connectionParameterSetsOverride` prop on `CreateConnectionInternal` (designer-v2)
- **System**: No performance or architecture changes

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Consumption Logic App (Brazil South) with custom MCP connector using `oauthMI` managed identity parameter set. 
The fix adds conditional rendering of an existing component based on a new boolean flag; the component itself is already tested, and the behavior is validated through manual E2E testing with a real custom MCP connector.

## Contributors
@Bhavd13 

## Screenshots/Videos

This is the default behaviour which will appear when user will select a custom mcp server. They will have to select the auth type and fill in the details 

<img width="1847" height="1046" alt="image" src="https://github.com/user-attachments/assets/00df9773-9393-400e-b904-51b164f4debc" />

This is the behaviour when a custom deployed MCP with auth defined as MI is used. This is the use case for ICM team
<img width="1997" height="1024" alt="image" src="https://github.com/user-attachments/assets/ed3d8996-3f3e-4bd4-9f25-bb411862de0f" />




