### PR TITLE
fix(DesignerV2): Added `forceSave` on run button, fixed connection panel issue

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumptionV2.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerConsumptionV2.tsx
@@ -490,10 +490,7 @@ const DesignerEditorConsumption = () => {
                   if (newWorkflow.parameters) {
                     setParameters(newWorkflow.parameters);
                   }
-                  setWorkflow({
-                    ...newWorkflow,
-                    id: guid(),
-                  });
+                  setWorkflow({ ...newWorkflow });
                   DesignerStore.dispatch(setIsWorkflowDirty(true));
                   if (changes) {
                     const nodeIds = changes.flatMap((change) => change.nodeIds);

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
@@ -2,7 +2,14 @@ import { environment } from '../../../environments/environment';
 import type { AppDispatch, RootState } from '../../state/store';
 import { changeRunId, setIsChatBotEnabled, setMonitoringView, setReadOnly, setRunHistoryEnabled } from '../../state/workflowLoadingSlice';
 import { DesignerCommandBar } from './DesignerCommandBarV2';
-import type { ConnectionAndAppSetting, ConnectionReferenceModel, ConnectionsData, NotesData, ParametersData } from './Models/Workflow';
+import type {
+  ConnectionAndAppSetting,
+  ConnectionReferenceModel,
+  ConnectionsData,
+  NotesData,
+  ParametersData,
+  WorkflowJson,
+} from './Models/Workflow';
 import { Artifact, VfsArtifact } from './Models/Workflow';
 import type { WorkflowApp } from './Models/WorkflowApp';
 import { ArtifactService } from './Services/Artifact';
@@ -127,7 +134,7 @@ const DesignerEditor = () => {
 
   // State props
   const [designerID, setDesignerID] = useState(guid());
-  const [workflow, setWorkflow] = useState<Workflow>(); // Current workflow on the designer
+  const [workflow, setWorkflow] = useState<WorkflowJson>(); // Current workflow on the designer
   const [isDesignerView, setIsDesignerView] = useState(true);
   const [isCodeView, setIsCodeView] = useState(false);
   const [isDraftMode, setIsDraftMode] = useState(true);
@@ -193,7 +200,7 @@ const DesignerEditor = () => {
     setIsDraftMode(draftMode);
   }, []);
 
-  const getConnectionConfiguration = async (connectionId: string, _manifest: any, useMcpConnections?: boolean): Promise<any> => {
+  const getConnectionConfiguration = async (connectionId: string, _manifest?: any, useMcpConnections?: boolean): Promise<any> => {
     if (!connectionId) {
       return Promise.resolve();
     }
@@ -291,10 +298,8 @@ const DesignerEditor = () => {
   const hideMonitoringView = useCallback(() => {
     if (isMonitoringView) {
       toggleMonitoringView();
-      setWorkflow({
-        ...artifactData?.properties.files[Artifact.WorkflowFile],
-        id: guid(),
-      });
+      const wf = artifactData?.properties.files[Artifact.WorkflowFile];
+      setWorkflow({ definition: wf?.definition, kind: wf?.kind, metadata: wf?.metadata });
     }
   }, [artifactData?.properties.files, isMonitoringView, toggleMonitoringView]);
 
@@ -353,9 +358,6 @@ const DesignerEditor = () => {
         definition,
         kind,
       };
-
-      delete workflowToSave.id;
-      delete workflowToSave.notes;
 
       const newManagedApiConnections = {
         ...(connectionsData?.managedApiConnections ?? {}),
@@ -565,8 +567,6 @@ const DesignerEditor = () => {
           ...prevState,
           definition: codeToConvert.definition,
           kind: codeToConvert.kind,
-          connectionReferences: codeToConvert.connectionReferences ?? {},
-          id: guid(),
         }));
         setIsDesignerView(true);
         setIsCodeView(false);
@@ -589,7 +589,7 @@ const DesignerEditor = () => {
 
   useEffect(() => {
     if (isMonitoringView && runInstanceData) {
-      setWorkflow((previousWorkflow?: Workflow) => {
+      setWorkflow((previousWorkflow?: WorkflowJson) => {
         if (!previousWorkflow) {
           // Do not update the workflow if previousWorkflow is undefined; return previous value unchanged
           return previousWorkflow;
@@ -640,7 +640,7 @@ const DesignerEditor = () => {
   return (
     <div key={designerID} style={{ height: 'inherit', width: 'inherit' }}>
       <DesignerProvider
-        id={workflow?.id}
+        id={designerID}
         key={designerID}
         locale={language}
         options={{
@@ -667,7 +667,7 @@ const DesignerEditor = () => {
               notes: currentNotes,
               kind: workflow?.kind,
             }}
-            workflowId={workflow?.id}
+            workflowId={designerID}
             customCode={customCodeData}
             runInstance={runInstanceData as any}
             appSettings={settingsData?.properties}
@@ -720,8 +720,9 @@ const DesignerEditor = () => {
                       setCurrentParameters(newWorkflow.parameters as unknown as ParametersData);
                     }
                     setWorkflow({
-                      ...newWorkflow,
-                      id: guid(),
+                      definition: newWorkflow.definition,
+                      kind: newWorkflow.kind ?? 'stateful',
+                      metadata: (newWorkflow as any)?.metadata ?? workflow?.metadata,
                     });
                     DesignerStore.dispatch(setIsWorkflowDirty(true));
                     if (changes) {

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -87,6 +87,7 @@ export interface FloatingRunButtonProps {
     tooltipText?: string;
   };
   isConsumption?: boolean;
+  forceSave?: boolean;
 }
 
 export const FloatingRunButton = ({
@@ -101,6 +102,7 @@ export const FloatingRunButton = ({
   tooltipOverride,
   chatProps,
   isConsumption,
+  forceSave,
 }: FloatingRunButtonProps) => {
   const intl = useIntl();
 
@@ -209,7 +211,7 @@ export const FloatingRunButton = ({
     });
 
     // If workflowReadOnly is true, skip the actual save and just return the serialized workflow
-    if (workflowReadOnly || !isDirty) {
+    if (workflowReadOnly || (!isDirty && !forceSave)) {
       return serializedWorkflow;
     }
 
@@ -242,7 +244,7 @@ export const FloatingRunButton = ({
         isDraftMode
       );
     }
-  }, [workflowReadOnly, dispatch, saveDraftWorkflow, isDraftMode, isDirty]);
+  }, [workflowReadOnly, dispatch, saveDraftWorkflow, isDraftMode, isDirty, forceSave]);
 
   const {
     mutate: runMutate,

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/allConnections/__test__/nodeLinkButton.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/allConnections/__test__/nodeLinkButton.spec.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { NodeLinkButton } from '../nodeLinkButton';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockDispatch = vi.fn();
+const mockUseNodeDisplayName = vi.fn();
+
+vi.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+vi.mock('../../../../../core', () => ({
+  useNodeDisplayName: (...args: any[]) => mockUseNodeDisplayName(...args),
+  openPanel: vi.fn((payload: any) => ({ type: 'panel/openPanel', payload })),
+}));
+
+describe('NodeLinkButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseNodeDisplayName.mockReturnValue('My Test Action');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the node display name', () => {
+    render(<NodeLinkButton nodeId="node-1" />);
+    expect(screen.getByText('My Test Action')).toBeDefined();
+  });
+
+  it('renders with icon when iconUri is provided', () => {
+    const { container } = render(<NodeLinkButton nodeId="node-1" iconUri="https://example.com/icon.svg" />);
+    const img = container.querySelector('img');
+    expect(img).toBeDefined();
+    expect(img?.getAttribute('src')).toBe('https://example.com/icon.svg');
+  });
+
+  it('renders icon without position absolute styling', () => {
+    const { container } = render(<NodeLinkButton nodeId="node-1" iconUri="https://example.com/icon.svg" />);
+    const img = container.querySelector('img');
+    expect(img?.style.position).not.toBe('absolute');
+  });
+
+  it('renders button with left-aligned content', () => {
+    render(<NodeLinkButton nodeId="node-1" />);
+    const button = screen.getByRole('button');
+    expect(button.style.justifyContent).toBe('flex-start');
+  });
+
+  it('dispatches openPanel with correct payload on click', () => {
+    render(<NodeLinkButton nodeId="node-1" />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'panel/openPanel',
+      payload: { nodeId: 'node-1', panelMode: 'Connection', referencePanelMode: 'Connection' },
+    });
+  });
+
+  it('passes nodeId to useNodeDisplayName', () => {
+    render(<NodeLinkButton nodeId="node-42" />);
+    expect(mockUseNodeDisplayName).toHaveBeenCalledWith('node-42');
+  });
+
+  it('renders icon with msla-action-icon class', () => {
+    const { container } = render(<NodeLinkButton nodeId="node-1" iconUri="https://example.com/icon.svg" />);
+    const img = container.querySelector('img');
+    expect(img?.classList.contains('msla-action-icon')).toBe(true);
+  });
+});

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/allConnections/nodeLinkButton.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/allConnections/nodeLinkButton.tsx
@@ -14,8 +14,9 @@ export const NodeLinkButton = ({ nodeId, iconUri }: { nodeId: string; iconUri?: 
   return (
     <Button
       appearance="transparent"
-      icon={<img className="msla-action-icon" src={iconUri} alt="" style={{ position: 'absolute', left: '4px' }} />}
+      icon={<img className="msla-action-icon" src={iconUri} alt="" />}
       onClick={nodeClick}
+      style={{ justifyContent: 'flex-start', gap: '8px' }}
     >
       {id}
     </Button>

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/__test__/nodeLinkButton.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/__test__/nodeLinkButton.spec.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { NodeLinkButton } from '../nodeLinkButton';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockDispatch = vi.fn();
+const mockUseNodeDisplayName = vi.fn();
+
+vi.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+vi.mock('../../../../../core', () => ({
+  useNodeDisplayName: (...args: any[]) => mockUseNodeDisplayName(...args),
+  openPanel: vi.fn((payload: any) => ({ type: 'panel/openPanel', payload })),
+}));
+
+describe('NodeLinkButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseNodeDisplayName.mockReturnValue('My Test Action');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the node display name', () => {
+    render(<NodeLinkButton nodeId="node-1" />);
+    expect(screen.getByText('My Test Action')).toBeDefined();
+  });
+
+  it('renders with icon when iconUri is provided', () => {
+    const { container } = render(<NodeLinkButton nodeId="node-1" iconUri="https://example.com/icon.svg" />);
+    const img = container.querySelector('img');
+    expect(img).toBeDefined();
+    expect(img?.getAttribute('src')).toBe('https://example.com/icon.svg');
+  });
+
+  it('renders icon without position absolute styling', () => {
+    const { container } = render(<NodeLinkButton nodeId="node-1" iconUri="https://example.com/icon.svg" />);
+    const img = container.querySelector('img');
+    expect(img?.style.position).not.toBe('absolute');
+  });
+
+  it('renders button with left-aligned content', () => {
+    render(<NodeLinkButton nodeId="node-1" />);
+    const button = screen.getByRole('button');
+    expect(button.style.justifyContent).toBe('flex-start');
+  });
+
+  it('dispatches openPanel with correct payload on click', () => {
+    render(<NodeLinkButton nodeId="node-1" />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'panel/openPanel',
+      payload: { nodeId: 'node-1', panelMode: 'Connection', referencePanelMode: 'Connection' },
+    });
+  });
+
+  it('passes nodeId to useNodeDisplayName', () => {
+    render(<NodeLinkButton nodeId="node-42" />);
+    expect(mockUseNodeDisplayName).toHaveBeenCalledWith('node-42');
+  });
+
+  it('renders icon with msla-action-icon class', () => {
+    const { container } = render(<NodeLinkButton nodeId="node-1" iconUri="https://example.com/icon.svg" />);
+    const img = container.querySelector('img');
+    expect(img?.classList.contains('msla-action-icon')).toBe(true);
+  });
+});

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/nodeLinkButton.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/nodeLinkButton.tsx
@@ -14,8 +14,9 @@ export const NodeLinkButton = ({ nodeId, iconUri }: { nodeId: string; iconUri?: 
   return (
     <Button
       appearance="transparent"
-      icon={<img className="msla-action-icon" src={iconUri} alt="" style={{ position: 'absolute', left: '4px' }} />}
+      icon={<img className="msla-action-icon" src={iconUri} alt="" />}
       onClick={nodeClick}
+      style={{ justifyContent: 'flex-start', gap: '18px' }}
     >
       {id}
     </Button>

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/connectionsPanel.less
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/connectionsPanel.less
@@ -20,12 +20,12 @@
 
 .msla-action-icon {
   width: 24px;
-  height: 60px;
+  height: 24px;
   border-radius: 2px;
 
   &.large {
     width: 32px;
-    height: 52px;
+    height: 32px;
   }
 }
 


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why

Added `forceSave` option to the `FloatingRunButton` component.
Fixed some standalone v2 issues.
Fixed some connection panel render issues.

## Impact of Change
- **Users**: Connections panel action list now renders icons inline and left-aligned instead of overlapping/centered
- **Developers**: `FloatingRunButton` accepts a new `forceSave` prop; `getConnectionConfiguration` manifest param is now optional
- **System**: Cleaner separation between designer identity (`designerID`) and workflow content state (`WorkflowJson`)

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer (Standard + Consumption), connections panel with multiple connectors

## Contributors
@rllyy97

## Screenshots/Videos
N/A