### PR TITLE
fix(designer): Restore Azure OpenAI as agent model source option

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
@@ -17,11 +17,17 @@ describe('agentloop – Foundry V2 regression', () => {
     });
 
     it('should contain the full expected set of dropdown values', () => {
-      expect(dropdownValues).toEqual(['MicrosoftFoundry', 'FoundryAgentServiceV2', 'APIMGenAIGateway', 'V1ChatCompletionsService']);
+      expect(dropdownValues).toEqual([
+        'MicrosoftFoundry',
+        'AzureOpenAI',
+        'FoundryAgentServiceV2',
+        'APIMGenAIGateway',
+        'V1ChatCompletionsService',
+      ]);
     });
 
-    it('should NOT include AzureOpenAI (removed from new connection creation)', () => {
-      expect(dropdownValues).not.toContain('AzureOpenAI');
+    it('should include AzureOpenAI as a selectable model source', () => {
+      expect(dropdownValues).toContain('AzureOpenAI');
     });
 
     it('should label the V2 option as "Foundry project (Preview)"', () => {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -54,6 +54,10 @@ export default {
                 displayName: 'Foundry Models (Preview)',
               },
               {
+                value: 'AzureOpenAI',
+                displayName: 'Azure OpenAI',
+              },
+              {
                 value: 'FoundryAgentServiceV2',
                 displayName: 'Foundry project (Preview)',
                 unSupportedWorkflowKind: ['agent'],


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
PR #9028 ("fix(designer): Default agent connection type to MicrosoftFoundry") removed `AzureOpenAI` from the `agentModelType` dropdown options in the agent loop manifest (`agentloop.ts`) and changed the default to `MicrosoftFoundry`.

This restores `AzureOpenAI` ("Azure OpenAI") as a selectable agent model source. The default remains `MicrosoftFoundry` — only the option was re-added, not the default.

Note: `AzureOpenAI` was only ever removed from the dropdown. The `x-ms-input-dependencies` visibility rules and the connection/serialization logic already continue to handle `'AzureOpenAI'` (see the existing `values: ['AzureOpenAI', 'MicrosoftFoundry']` entries throughout the manifest), so no other changes are needed.

## Impact of Change
- **Users**: Azure OpenAI is once again available in the "Agent model source" dropdown when configuring an agent. New agents still default to Foundry Models.
- **Developers**: No API changes.
- **System**: No architecture, performance, or dependency changes.

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: Standalone designer — confirm "Azure OpenAI" appears in the Agent model source dropdown

## Contributors

## Screenshots/Videos
