### PR TITLE
[cherry-pick] Add Hybrid (Container Apps) deployment script generation for ADO (#9158)

### DIFF
--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScripts.ts
@@ -15,7 +15,7 @@ import { addLocalFuncTelemetry } from '../../utils/funcCoreTools/funcVersion';
 import { isLogicAppProject, tryGetLogicAppProjectRoot } from '../../utils/verifyIsProject';
 import { getWorkspaceFolder, isMultiRootWorkspace } from '../../utils/workspace';
 import { AzureWizard, UserCancelledError, type IActionContext } from '@microsoft/vscode-azext-utils';
-import type { IProjectWizardContext } from '@microsoft/vscode-extension-logic-apps';
+import type { IProjectWizardContext, DeploymentTargetType } from '@microsoft/vscode-extension-logic-apps';
 import { DeploymentScriptTypeStep } from './generateDeploymentScriptsSteps/DeploymentScriptTypeStep';
 import { convertToWorkspace } from '../convertToWorkspace';
 import type { SlotTreeItem } from '../../tree/slotsTree/SlotTreeItem';
@@ -39,6 +39,10 @@ export interface IAzureDeploymentScriptsContext extends IProjectWizardContext, I
   isValidWorkspace: boolean;
   logicAppNode?: SlotTreeItem;
   msiClientId?: string;
+  // Hybrid deployment support — determines which pipeline templates and ARM templates are generated.
+  deploymentTarget?: DeploymentTargetType;
+  connectedEnvironmentName?: string;
+  connectedEnvironmentResourceGroup?: string;
 }
 
 /**

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/DeploymentScriptTypeStep.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/DeploymentScriptTypeStep.ts
@@ -16,11 +16,11 @@ import { GenerateDeploymentCenterScriptsStep } from './deploymentCenterScriptsSt
 import * as path from 'path';
 import { SubscriptionAndResourceGroupStep } from './SubscriptionAndResourceGroupStep';
 import { LogicAppNameStep } from './adoDeploymentScriptsSteps/LogicAppNameStep';
-import { StorageAccountNameStep } from './adoDeploymentScriptsSteps/StorageAccountNameStep';
-import { AppServicePlanNameStep } from './adoDeploymentScriptsSteps/AppServicePlanNameStep';
 import { LogicAppStep } from './deploymentCenterScriptsSteps/LogicAppStep';
 import { LogicAppMSIStep } from './deploymentCenterScriptsSteps/LogicAppMSIStep';
+import { DeploymentTargetStep } from './DeploymentTargetStep';
 
+// Added DeploymentTargetStep to ADO pipeline flow to support Hybrid deployment.
 export class DeploymentScriptTypeStep extends AzureWizardPromptStep<IAzureDeploymentScriptsContext> {
   public hideStepCount = true;
 
@@ -51,11 +51,12 @@ export class DeploymentScriptTypeStep extends AzureWizardPromptStep<IAzureDeploy
     let executeSteps: AzureWizardExecuteStep<IAzureDeploymentScriptsContext>[] = [];
     if (context.deploymentScriptType === DeploymentScriptType.azureDevOpsPipeline) {
       context.telemetry.properties.deploymentScriptType = 'azureDevOpsPipeline';
+      // DeploymentTargetStep branches to Standard or Hybrid sub-wizard.
+      // Each branch injects SubscriptionAndResourceGroupStep before its target-specific steps
+      // so subscriptionId is available when needed (e.g. ConnectedEnvironmentStep for Hybrid).
       promptSteps = [
-        new SubscriptionAndResourceGroupStep(),
+        new DeploymentTargetStep(),
         new LogicAppNameStep(),
-        new StorageAccountNameStep(),
-        new AppServicePlanNameStep(),
       ];
       executeSteps = [new GenerateADODeploymentScriptsStep()];
     } else {

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/DeploymentTargetStep.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/DeploymentTargetStep.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { localize } from '../../../../localize';
+import { AzureWizardPromptStep, type IAzureQuickPickItem, type IWizardOptions } from '@microsoft/vscode-azext-utils';
+import { DeploymentTargetType } from '@microsoft/vscode-extension-logic-apps';
+import type { IAzureDeploymentScriptsContext } from '../generateDeploymentScripts';
+import { StorageAccountNameStep } from './adoDeploymentScriptsSteps/StorageAccountNameStep';
+import { AppServicePlanNameStep } from './adoDeploymentScriptsSteps/AppServicePlanNameStep';
+import { ConnectedEnvironmentStep } from './adoDeploymentScriptsSteps/ConnectedEnvironmentStep';
+import { SubscriptionAndResourceGroupStep } from './SubscriptionAndResourceGroupStep';
+
+// Prompts user to choose Standard (App Service) vs Hybrid (Container Apps) deployment target.
+export class DeploymentTargetStep extends AzureWizardPromptStep<IAzureDeploymentScriptsContext> {
+  public hideStepCount = true;
+
+  public shouldPrompt(): boolean {
+    return true;
+  }
+
+  public async prompt(context: IAzureDeploymentScriptsContext): Promise<void> {
+    context.telemetry.properties.lastStep = 'DeploymentTargetStep';
+    const placeHolder = localize('setDeploymentTarget', 'Select deployment target');
+    const picks: IAzureQuickPickItem<DeploymentTargetType>[] = [
+      {
+        label: localize('standardTarget', 'Standard (Azure App Service)'),
+        description: localize('standardTargetDescription', 'Deploy to Logic Apps Standard on Azure App Service'),
+        data: DeploymentTargetType.standard,
+      },
+      {
+        label: localize('hybridTarget', 'Hybrid (Container Apps)'),
+        description: localize('hybridTargetDescription', 'Deploy to Logic Apps Hybrid on Azure Container Apps'),
+        data: DeploymentTargetType.hybrid,
+      },
+    ];
+    context.deploymentTarget = (await context.ui.showQuickPick(picks, { placeHolder })).data;
+    context.telemetry.properties.deploymentTarget = context.deploymentTarget;
+  }
+
+  // Branches wizard steps based on deployment target.
+  // SubscriptionAndResourceGroupStep is injected here (after target selection) so subscriptionId
+  // is available for ConnectedEnvironmentStep in the Hybrid path.
+  public async getSubWizard(context: IAzureDeploymentScriptsContext): Promise<IWizardOptions<IAzureDeploymentScriptsContext>> {
+    if (context.deploymentTarget === DeploymentTargetType.hybrid) {
+      return { promptSteps: [new SubscriptionAndResourceGroupStep(), new ConnectedEnvironmentStep()] };
+    }
+    return { promptSteps: [new SubscriptionAndResourceGroupStep(), new StorageAccountNameStep(), new AppServicePlanNameStep()] };
+  }
+}

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/__test__/hybridWizardSteps.test.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/__test__/hybridWizardSteps.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Override the global AzureWizardPromptStep mock: the test-setup version returns `{}`
+// from its constructor, which throws away subclass prototype methods. Use real classes.
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+  AzureWizardPromptStep: class {},
+  AzureWizardExecuteStep: class {},
+  AzureWizard: class {},
+}));
+
+// Sub-step modules pull in tree items / azureappservice / azureappsettings, which all do
+// a CommonJS require('vscode') at module load. Stub them so the three SUTs load cleanly.
+vi.mock('../adoDeploymentScriptsSteps/LogicAppNameStep', () => ({ LogicAppNameStep: class {} }));
+vi.mock('../adoDeploymentScriptsSteps/StorageAccountNameStep', () => ({ StorageAccountNameStep: class {} }));
+vi.mock('../adoDeploymentScriptsSteps/AppServicePlanNameStep', () => ({ AppServicePlanNameStep: class {} }));
+vi.mock('../adoDeploymentScriptsSteps/GenerateADODeploymentScriptsStep', () => ({ GenerateADODeploymentScriptsStep: class {} }));
+vi.mock('../deploymentCenterScriptsSteps/LogicAppStep', () => ({ LogicAppStep: class {} }));
+vi.mock('../deploymentCenterScriptsSteps/LogicAppMSIStep', () => ({ LogicAppMSIStep: class {} }));
+vi.mock('../deploymentCenterScriptsSteps/GenerateDeploymentCenterScriptsStep', () => ({ GenerateDeploymentCenterScriptsStep: class {} }));
+vi.mock('../SubscriptionAndResourceGroupStep', () => ({ SubscriptionAndResourceGroupStep: class {} }));
+vi.mock('../../../../utils/azureClients', () => ({ createContainerClient: vi.fn() }));
+
+import { DeploymentScriptType, DeploymentTargetType } from '@microsoft/vscode-extension-logic-apps';
+import { DeploymentScriptTypeStep } from '../DeploymentScriptTypeStep';
+import { DeploymentTargetStep } from '../DeploymentTargetStep';
+import { ConnectedEnvironmentStep } from '../adoDeploymentScriptsSteps/ConnectedEnvironmentStep';
+
+// Minimal context — only the fields these steps read.
+const makeContext = (overrides: Record<string, any> = {}) => ({
+  telemetry: { properties: {}, measurements: {} },
+  ui: { showQuickPick: vi.fn().mockResolvedValue({ data: undefined }) },
+  ...overrides,
+});
+
+describe('DeploymentScriptTypeStep', () => {
+  const step = new DeploymentScriptTypeStep();
+
+  it('always prompts', () => {
+    expect(step.shouldPrompt()).toBe(true);
+  });
+
+  it('captures the selected script type and stores it on telemetry', async () => {
+    const ctx = makeContext();
+    ctx.ui.showQuickPick = vi.fn().mockResolvedValue({ data: DeploymentScriptType.azureDevOpsPipeline });
+    await step.prompt(ctx as any);
+    expect((ctx as any).deploymentScriptType).toBe(DeploymentScriptType.azureDevOpsPipeline);
+    expect(ctx.telemetry.properties.lastStep).toBe('DeploymentScriptTypeStep');
+  });
+
+  it('returns the ADO sub-wizard when ADO pipeline is chosen', async () => {
+    const ctx = makeContext({ deploymentScriptType: DeploymentScriptType.azureDevOpsPipeline });
+    const sub = await step.getSubWizard(ctx as any);
+    // Two prompt steps + one execute step for the ADO flow.
+    expect(sub.promptSteps).toHaveLength(2);
+    expect(sub.executeSteps).toHaveLength(1);
+    expect(ctx.telemetry.properties.deploymentScriptType).toBe('azureDevOpsPipeline');
+  });
+
+  it('returns the Deployment Center sub-wizard otherwise', async () => {
+    const ctx = makeContext({
+      deploymentScriptType: DeploymentScriptType.azureDeploymentCenter,
+      projectPath: '/path/to/MyLogicApp',
+    });
+    const sub = await step.getSubWizard(ctx as any);
+    expect(sub.promptSteps).toHaveLength(3);
+    expect(sub.executeSteps).toHaveLength(1);
+    expect(ctx.telemetry.properties.deploymentScriptType).toBe('azureDeploymentCenter');
+    expect((ctx as any).localLogicAppName).toBe('MyLogicApp');
+  });
+});
+
+describe('DeploymentTargetStep', () => {
+  const step = new DeploymentTargetStep();
+
+  it('always prompts', () => {
+    expect(step.shouldPrompt()).toBe(true);
+  });
+
+  it('records the chosen target on context and telemetry', async () => {
+    const ctx = makeContext();
+    ctx.ui.showQuickPick = vi.fn().mockResolvedValue({ data: DeploymentTargetType.hybrid });
+    await step.prompt(ctx as any);
+    expect((ctx as any).deploymentTarget).toBe(DeploymentTargetType.hybrid);
+    expect(ctx.telemetry.properties.deploymentTarget).toBe(DeploymentTargetType.hybrid);
+  });
+
+  it('returns Hybrid sub-steps when target is hybrid', async () => {
+    const ctx = makeContext({ deploymentTarget: DeploymentTargetType.hybrid });
+    const sub = await step.getSubWizard(ctx as any);
+    // SubscriptionAndResourceGroupStep + ConnectedEnvironmentStep
+    expect(sub.promptSteps).toHaveLength(2);
+  });
+
+  it('returns Standard sub-steps for any other target', async () => {
+    const ctx = makeContext({ deploymentTarget: DeploymentTargetType.standard });
+    const sub = await step.getSubWizard(ctx as any);
+    // SubscriptionAndResourceGroupStep + StorageAccountNameStep + AppServicePlanNameStep
+    expect(sub.promptSteps).toHaveLength(3);
+  });
+});
+
+describe('ConnectedEnvironmentStep', () => {
+  const step = new ConnectedEnvironmentStep();
+
+  it('always prompts', () => {
+    expect(step.shouldPrompt()).toBe(true);
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/adoDeploymentScriptsSteps/ConnectedEnvironmentStep.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/adoDeploymentScriptsSteps/ConnectedEnvironmentStep.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { AzureWizardPromptStep, type IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
+import type { ConnectedEnvironment } from '@azure/arm-appcontainers';
+import { uiUtils } from '@microsoft/vscode-azext-azureutils';
+import { createContainerClient } from '../../../../utils/azureClients';
+import { localize } from '../../../../../localize';
+import { ext } from '../../../../../extensionVariables';
+import type { IAzureDeploymentScriptsContext } from '../../generateDeploymentScripts';
+
+// Prompts user to select an existing Connected Environment for Hybrid deployment.
+// Extracts the connected environment name and its resource group from the ARM resource ID.
+export class ConnectedEnvironmentStep extends AzureWizardPromptStep<IAzureDeploymentScriptsContext> {
+  public hideStepCount = true;
+
+  public shouldPrompt(): boolean {
+    return true;
+  }
+
+  public async prompt(context: IAzureDeploymentScriptsContext): Promise<void> {
+    context.telemetry.properties.lastStep = 'ConnectedEnvironmentStep';
+    const placeHolder = localize('selectConnectedEnvironment', 'Select a Connected Environment');
+    const picked = (await context.ui.showQuickPick(this.getPicks(context), { placeHolder })).data;
+
+    context.connectedEnvironmentName = picked.name;
+    // Extract resource group from the ARM resource ID
+    const rgMatch = picked.id?.match(/\/resourceGroups\/([^/]+)\//i);
+    context.connectedEnvironmentResourceGroup = rgMatch ? rgMatch[1] : context.resourceGroup?.name;
+
+    context.telemetry.properties.connectedEnvironmentName = context.connectedEnvironmentName;
+  }
+
+  private async getPicks(context: IAzureDeploymentScriptsContext): Promise<IAzureQuickPickItem<ConnectedEnvironment>[]> {
+    // Spread subscription onto context to satisfy AzExtClientContext — same pattern as LogicAppStep.
+    const subscriptionNode = await ext.rgApi.appResourceTree.findTreeItem(`/subscriptions/${context.subscriptionId}`, context);
+    if (!subscriptionNode) {
+      throw new Error(`Failed to find a subscription with ID "${context.subscriptionId}".`);
+    }
+    const client = await createContainerClient({ ...context, ...subscriptionNode.subscription });
+    const allEnvs = await uiUtils.listAllIterator(client.connectedEnvironments.listBySubscription());
+    // Filter by the selected resource group's location to avoid cross-region mismatches.
+    const location = context.resourceGroup?.location;
+    const envList = location ? allEnvs.filter((env) => env.location === location) : allEnvs;
+    const picks = envList.map((env) => ({
+      label: env.name,
+      description: env.location,
+      data: env,
+    }));
+    picks.sort((a, b) => a.label.localeCompare(b.label));
+    return picks;
+  }
+}

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/adoDeploymentScriptsSteps/GenerateADODeploymentScriptsStep.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/adoDeploymentScriptsSteps/GenerateADODeploymentScriptsStep.ts
@@ -5,7 +5,7 @@
 import { isEmptyString } from '@microsoft/logic-apps-shared';
 import { AzureWizardExecuteStep, DialogResponses, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import type { ConnectionsData } from '@microsoft/vscode-extension-logic-apps';
-import { getBaseGraphApi, OpenBehavior } from '@microsoft/vscode-extension-logic-apps';
+import { getBaseGraphApi, OpenBehavior, DeploymentTargetType } from '@microsoft/vscode-extension-logic-apps';
 import { getConnectionsJson } from '../../../../utils/codeless/connection';
 import { areAllConnectionsParameterized } from '../../../../utils/codeless/parameterizer';
 import axios from 'axios';
@@ -88,13 +88,28 @@ export class GenerateADODeploymentScriptsStep extends AzureWizardExecuteStep<IAz
     context.telemetry.properties.lastStep = 'generateManagedConnectionsDeploymentArtifacts';
     await GenerateADODeploymentScriptsStep.generateManagedConnectionsDeploymentArtifacts(context);
 
-    context.telemetry.properties.lastStep = 'getLogicAppDeploymentArtifactsBuffer';
-    const logicAppArtifactsBuffer = await GenerateADODeploymentScriptsStep.getLogicAppDeploymentArtifactsBuffer(context);
-    if (!logicAppArtifactsBuffer) {
-      throw new Error('Failed getting Logic App deployment artifacts. No content received from the standard resources API.');
+    // For Hybrid, skip the Standard IaC API — it generates App Service infrastructure.
+    // Instead, generate ARM templates and pipeline YAML for Container Apps directly.
+    if (context.deploymentTarget === DeploymentTargetType.hybrid) {
+      context.telemetry.properties.lastStep = 'generateHybridDeploymentArtifacts';
+      await GenerateADODeploymentScriptsStep.generateHybridDeploymentArtifacts(context);
+
+      // Transform managed connection templates for Hybrid — replace Microsoft.Web/Sites
+      // identity references with AAD parameters since Hybrid uses Container Apps, not App Service.
+      context.telemetry.properties.lastStep = 'transformConnectionTemplatesForHybrid';
+      const hybridInfraFolder = path.join(context.deploymentFolderPath, context.logicAppName, 'infrastructure');
+      GenerateADODeploymentScriptsStep.transformConnectionTemplatesForHybrid(hybridInfraFolder);
+
+      ext.outputChannel.appendLog(localize('hybridArtifactsGenerated', 'Hybrid deployment artifacts generated successfully.'));
+    } else {
+      context.telemetry.properties.lastStep = 'getLogicAppDeploymentArtifactsBuffer';
+      const logicAppArtifactsBuffer = await GenerateADODeploymentScriptsStep.getLogicAppDeploymentArtifactsBuffer(context);
+      if (!logicAppArtifactsBuffer) {
+        throw new Error('Failed getting Logic App deployment artifacts. No content received from the standard resources API.');
+      }
+      await unzipLogicAppArtifacts(logicAppArtifactsBuffer, context.deploymentFolderPath);
+      ext.outputChannel.appendLog(localize('logicAppDeploymentArtifactsUnzipped', 'Logic app deployment artifacts successfully unzipped.'));
     }
-    await unzipLogicAppArtifacts(logicAppArtifactsBuffer, context.deploymentFolderPath);
-    ext.outputChannel.appendLog(localize('logicAppDeploymentArtifactsUnzipped', 'Logic app deployment artifacts successfully unzipped.'));
 
     const localizedLogMessage = localize(
       'scriptGenSuccess',
@@ -354,5 +369,440 @@ export class GenerateADODeploymentScriptsStep extends AzureWizardExecuteStep<IAz
       }
     }
     return managedConnections;
+  }
+
+  // Generates all Hybrid deployment artifacts: ARM infrastructure templates + pipeline YAML.
+  // Hybrid Logic Apps are Microsoft.App/containerApps (kind: workflowapp), NOT Microsoft.Web/sites.
+  // Three ARM resources: containerApp, logicApp (scoped on containerApp), connectedEnvironments/storages (SMB).
+  // Secrets (AAD creds, SQL connection string, SMB password) must be supplied via ADO secret variables.
+  private static async generateHybridDeploymentArtifacts(context: IAzureDeploymentScriptsContext): Promise<void> {
+    // Place artifacts under deployment/<logicAppName>/ to match the Standard IaC API structure.
+    const logicAppFolder = path.join(context.deploymentFolderPath, context.logicAppName);
+    const infraFolder = path.join(logicAppFolder, 'infrastructure');
+    const pipelinesFolder = path.join(logicAppFolder, 'pipelines');
+
+    if (!fs.existsSync(infraFolder)) {
+      fs.mkdirSync(infraFolder, { recursive: true });
+    }
+    if (!fs.existsSync(pipelinesFolder)) {
+      fs.mkdirSync(pipelinesFolder, { recursive: true });
+    }
+
+    // --- Workflow parameters ---
+    // The Build task requires workflowparameters/parameters.json when deploymentFolder is set.
+    // Copy the app's parameters.json so the build task can overlay deployment-specific values.
+    const workflowParamsFolder = path.join(logicAppFolder, 'workflowparameters');
+    if (!fs.existsSync(workflowParamsFolder)) {
+      fs.mkdirSync(workflowParamsFolder, { recursive: true });
+    }
+    const sourceParametersFile = path.join(context.workspacePath, 'parameters.json');
+    const destParametersFile = path.join(workflowParamsFolder, 'parameters.json');
+    if (fs.existsSync(sourceParametersFile)) {
+      fs.copyFileSync(sourceParametersFile, destParametersFile);
+    } else {
+      fs.writeFileSync(destParametersFile, JSON.stringify({}, null, 2));
+    }
+
+    // --- ARM template ---
+    const armTemplate = GenerateADODeploymentScriptsStep.generateHybridArmTemplate();
+    fs.writeFileSync(path.join(infraFolder, 'hybrid-logicapp-template.json'), JSON.stringify(armTemplate, null, 2));
+
+    // --- ARM parameters ---
+    const armParameters = GenerateADODeploymentScriptsStep.generateHybridArmParameters(context);
+    fs.writeFileSync(path.join(infraFolder, 'hybrid-logicapp-parameters.json'), JSON.stringify(armParameters, null, 2));
+
+    // --- Pipeline YAML ---
+    GenerateADODeploymentScriptsStep.generateHybridPipelineTemplates(context, pipelinesFolder);
+  }
+
+  // ARM template for Hybrid Logic Apps — 3 resources matching Azure Portal deployment:
+  // 1. Microsoft.App/containerApps (kind: workflowapp) — the Container App hosting the logic app
+  // 2. Microsoft.App/logicApps — the logic app scoped on the container app
+  // 3. Microsoft.App/connectedEnvironments/storages — SMB file share for artifacts
+  private static generateHybridArmTemplate(): Record<string, unknown> {
+    return {
+      $schema: 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#',
+      contentVersion: '1.0.0.0',
+      parameters: {
+        subscriptionId: { type: 'string' },
+        logicAppName: { type: 'string' },
+        location: { type: 'string' },
+        connectedEnvironmentName: { type: 'string' },
+        connectedEnvironmentResourceGroup: { type: 'string' },
+        customLocationId: { type: 'string', metadata: { description: 'Resource ID of the custom location tied to the connected environment' } },
+        sqlConnectionString: { type: 'securestring' },
+        fileShareHostName: { type: 'string' },
+        fileSharePath: { type: 'string' },
+        fileShareUsername: { type: 'string' },
+        fileSharePassword: { type: 'securestring' },
+        aadClientId: { type: 'string' },
+        aadClientSecret: { type: 'securestring' },
+        aadObjectId: { type: 'string' },
+        aadTenantId: { type: 'string' },
+      },
+      variables: {
+        connectedEnvironmentId:
+          "[resourceId(parameters('connectedEnvironmentResourceGroup'), 'Microsoft.App/connectedEnvironments', parameters('connectedEnvironmentName'))]",
+        storageShareName: "[concat(parameters('logicAppName'), '-fs')]",
+      },
+      resources: [
+        {
+          type: 'Microsoft.Resources/deployments',
+          apiVersion: '2021-04-01',
+          name: 'PersistentStorageTemplate',
+          resourceGroup: "[parameters('connectedEnvironmentResourceGroup')]",
+          subscriptionId: "[parameters('subscriptionId')]",
+          properties: {
+            mode: 'Incremental',
+            expressionEvaluationOptions: {
+              scope: 'outer',
+            },
+            template: {
+              $schema: 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#',
+              contentVersion: '1.0.0.0',
+              resources: [
+                {
+                  apiVersion: '2024-02-02-preview',
+                  name: "[concat(parameters('connectedEnvironmentName'), '/', variables('storageShareName'))]",
+                  type: 'Microsoft.App/connectedEnvironments/storages',
+                  properties: {
+                    smb: {
+                      accessMode: 'ReadWrite',
+                      host: "[parameters('fileShareHostName')]",
+                      shareName: "[parameters('fileSharePath')]",
+                      username: "[parameters('fileShareUsername')]",
+                      password: "[parameters('fileSharePassword')]",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          type: 'Microsoft.App/containerApps',
+          apiVersion: '2024-02-02-preview',
+          name: "[parameters('logicAppName')]",
+          kind: 'workflowapp',
+          location: "[parameters('location')]",
+          extendedLocation: {
+            name: "[parameters('customLocationId')]",
+            type: 'CustomLocation',
+          },
+          dependsOn: ['Microsoft.Resources/deployments/PersistentStorageTemplate'],
+          properties: {
+            environmentId: "[variables('connectedEnvironmentId')]",
+            configuration: {
+              activeRevisionsMode: 'Single',
+              secrets: [
+                { name: 'sql-connection-string', value: "[parameters('sqlConnectionString')]" },
+                { name: 'aad-client-secret', value: "[parameters('aadClientSecret')]" },
+              ],
+              ingress: {
+                external: true,
+                targetPort: 80,
+                allowInsecure: false,
+              },
+            },
+            template: {
+              containers: [
+                {
+                  name: "[parameters('logicAppName')]",
+                  image: 'mcr.microsoft.com/azurelogicapps/logicapps-base:latest',
+                  resources: { cpu: 1.0, memory: '2Gi' },
+                  env: [
+                    { name: 'APP_KIND', value: 'workflowapp' },
+                    { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' },
+                    {
+                      name: 'AzureFunctionsJobHost__extensionBundle__id',
+                      value: 'Microsoft.Azure.Functions.ExtensionBundle.Workflows',
+                    },
+                    { name: 'AzureWebJobsSecretStorageType', value: 'files' },
+                    { name: 'IS_ZIP_DEPLOY_ENABLED', value: 'true' },
+                    { name: 'Workflows.Sql.ConnectionString', secretRef: 'sql-connection-string' },
+                    { name: 'WORKFLOWAPP_AAD_CLIENTID', value: "[parameters('aadClientId')]" },
+                    { name: 'WORKFLOWAPP_AAD_CLIENTSECRET', secretRef: 'aad-client-secret' },
+                    { name: 'WORKFLOWAPP_AAD_OBJECTID', value: "[parameters('aadObjectId')]" },
+                    { name: 'WORKFLOWAPP_AAD_TENANTID', value: "[parameters('aadTenantId')]" },
+                  ],
+                  volumeMounts: [{ volumeName: 'fileshare', mountPath: '/home/site/wwwroot' }],
+                },
+              ],
+              scale: { minReplicas: 1, maxReplicas: 30 },
+              volumes: [
+                {
+                  name: 'fileshare',
+                  storageType: 'Smb',
+                  storageName: "[variables('storageShareName')]",
+                },
+              ],
+            },
+          },
+        },
+        {
+          type: 'Microsoft.App/logicApps',
+          apiVersion: '2024-02-02-preview',
+          name: "[parameters('logicAppName')]",
+          scope: "[concat('Microsoft.App/containerApps/', parameters('logicAppName'))]",
+          dependsOn: [
+            "[concat('Microsoft.App/containerApps/', parameters('logicAppName'))]",
+          ],
+          properties: {},
+        },
+      ],
+    };
+  }
+
+  // Post-process managed connection templates for Hybrid deployments.
+  // The Consumption API generates access policies referencing Microsoft.Web/Sites to resolve managed identity,
+  // but Hybrid Logic Apps are Container Apps — replace with explicit AAD parameters.
+  private static transformConnectionTemplatesForHybrid(infraFolder: string): void {
+    if (!fs.existsSync(infraFolder)) {
+      return;
+    }
+
+    const templateFiles = fs
+      .readdirSync(infraFolder)
+      .filter((f) => f.endsWith('.template.json') && f !== 'hybrid-logicapp-template.json');
+
+    for (const file of templateFiles) {
+      const filePath = path.join(infraFolder, file);
+      const template = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+      // Add aadObjectId and aadTenantId parameters to the template
+      if (template.parameters) {
+        if (!template.parameters.aadObjectId) {
+          template.parameters.aadObjectId = { type: 'String' };
+        }
+        if (!template.parameters.aadTenantId) {
+          template.parameters.aadTenantId = { type: 'String' };
+        }
+      }
+
+      // Walk resources and fix access policy identity references
+      GenerateADODeploymentScriptsStep.fixAccessPolicyIdentityForHybrid(template.resources || []);
+
+      fs.writeFileSync(filePath, JSON.stringify(template, null, 2), 'utf-8');
+    }
+
+    // Also update corresponding parameter files
+    const paramFiles = fs
+      .readdirSync(infraFolder)
+      .filter((f) => f.endsWith('.parameters.json') && f !== 'hybrid-logicapp-parameters.json');
+
+    for (const file of paramFiles) {
+      const filePath = path.join(infraFolder, file);
+      const params = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+      if (params.parameters) {
+        if (!params.parameters.aadObjectId) {
+          params.parameters.aadObjectId = { value: '' };
+        }
+        if (!params.parameters.aadTenantId) {
+          params.parameters.aadTenantId = { value: '' };
+        }
+      }
+
+      fs.writeFileSync(filePath, JSON.stringify(params, null, 2), 'utf-8');
+    }
+  }
+
+  // Recursively walk ARM template resources and replace Microsoft.Web/Sites identity references
+  // in accessPolicies with explicit AAD parameter references for Hybrid.
+  private static fixAccessPolicyIdentityForHybrid(resources: any[]): void {
+    for (const resource of resources) {
+      if (resource.type === 'accessPolicies' && resource.properties?.principal?.identity) {
+        const identity = resource.properties.principal.identity;
+        if (typeof identity.objectId === 'string' && identity.objectId.toLowerCase().includes('microsoft.web/sites')) {
+          identity.objectId = "[parameters('aadObjectId')]";
+        }
+        if (typeof identity.tenantId === 'string' && identity.tenantId.toLowerCase().includes('microsoft.web/sites')) {
+          identity.tenantId = "[parameters('aadTenantId')]";
+        }
+      }
+      // Recurse into nested resources
+      if (resource.resources) {
+        GenerateADODeploymentScriptsStep.fixAccessPolicyIdentityForHybrid(resource.resources);
+      }
+    }
+  }
+
+  // ARM parameters file — secrets are excluded and must be supplied via ADO pipeline secret variables
+  // using overrideParameters in the CD pipeline's ARM deployment task.
+  private static generateHybridArmParameters(context: IAzureDeploymentScriptsContext): Record<string, unknown> {
+    return {
+      $schema: 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#',
+      contentVersion: '1.0.0.0',
+      parameters: {
+        subscriptionId: { value: context.subscriptionId || '<your-subscription-id>' },
+        logicAppName: { value: context.logicAppName },
+        location: { value: context.resourceGroup?.location || '' },
+        connectedEnvironmentName: { value: context.connectedEnvironmentName || '' },
+        connectedEnvironmentResourceGroup: { value: context.connectedEnvironmentResourceGroup || '' },
+        customLocationId: { value: '<your-custom-location-resource-id>' },
+        fileShareHostName: { value: '<your-smb-host>' },
+        fileSharePath: { value: '<your-smb-share-name>' },
+        fileShareUsername: { value: '<your-smb-username>' },
+        aadClientId: { value: '<your-aad-client-id>' },
+        aadObjectId: { value: '<your-aad-object-id>' },
+        aadTenantId: { value: '<your-aad-tenant-id>' },
+        // DO NOT add secrets here — supply via ADO pipeline secret variables:
+        // sqlConnectionString, fileSharePassword, aadClientSecret
+      },
+    };
+  }
+
+  // Generates Hybrid CI/CD pipeline YAML and variable files.
+  // CI: HybridBuild task (copy, transform auth, archive).
+  // CD: ARM deployment (infrastructure) → ConnectionsDeployment → HybridRelease.
+  private static generateHybridPipelineTemplates(context: IAzureDeploymentScriptsContext, pipelinesFolder: string): void {
+    // CI pipeline — HybridBuild copies files, transforms MSI→AAD OAuth auth, and archives.
+    const ciPipelineContent = `trigger:
+- main
+
+pr: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+- template: CI-pipeline-variables.yml
+
+jobs:
+- job: logic_app_build
+  displayName: 'Build and publish Hybrid Logic App'
+  steps:
+  - task: AzureLogicAppsHybridBuild@0
+    displayName: 'Azure Logic Apps Hybrid Build'
+    inputs:
+      sourceFolder: '${'$'}(Build.SourcesDirectory)/${'$'}(logicAppName)'
+      deploymentFolder: '${'$'}(System.DefaultWorkingDirectory)/deployment/${'$'}(logicAppName)/'
+      archiveFile: '${'$'}(Build.ArtifactStagingDirectory)/${'$'}(Build.BuildId).zip'
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish logic app zip artifact'
+    inputs:
+      targetPath: '${'$'}(Build.ArtifactStagingDirectory)/${'$'}(Build.BuildId).zip'
+      artifact: '${'$'}(logicAppCIArtifactName)'
+      publishLocation: 'pipeline'
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish infrastructure artifacts'
+    inputs:
+      targetPath: '${'$'}(Build.SourcesDirectory)/deployment/${'$'}(logicAppName)/infrastructure'
+      artifact: 'infrastructure'
+      publishLocation: 'pipeline'
+`;
+
+    fs.writeFileSync(path.join(pipelinesFolder, 'CI-pipeline.yml'), ciPipelineContent);
+
+    // CD pipeline — ARM deploy infrastructure → ConnectionsDeployment → HybridRelease.
+    const cdPipelineContent = `trigger: none
+
+pr: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+- template: CD-pipeline-variables.yml
+
+resources:
+  pipelines:
+  - pipeline: cipipeline
+    # TODO: Update with the name of your CI pipeline
+    source: CI Pipeline
+    trigger:
+      branches:
+      - main
+
+jobs:
+- deployment: deploy_hybrid_logicapp
+  displayName: Deploy Hybrid Logic App
+  environment: ${'$'}(logicAppEnvironment)
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - task: AzureResourceManagerTemplateDeployment@3
+          displayName: 'Deploy Hybrid Logic App Infrastructure'
+          inputs:
+            deploymentScope: 'Resource Group'
+            azureResourceManagerConnection: '${'$'}(azureServiceConnection)'
+            subscriptionId: '${'$'}(subscriptionId)'
+            action: 'Create Or Update Resource Group'
+            resourceGroupName: '${'$'}(resourceGroupName)'
+            location: '${'$'}(location)'
+            templateLocation: 'Linked artifact'
+            csmFile: '${'$'}(Pipeline.Workspace)/cipipeline/infrastructure/hybrid-logicapp-template.json'
+            csmParametersFile: '${'$'}(Pipeline.Workspace)/cipipeline/infrastructure/hybrid-logicapp-parameters.json'
+            overrideParameters: >-
+              -sqlConnectionString "${'$'}(sqlConnectionString)"
+              -fileSharePassword "${'$'}(fileSharePassword)"
+              -aadClientSecret "${'$'}(aadClientSecret)"
+            deploymentMode: 'Incremental'
+
+        - task: AzureLogicAppsHybridConnectionsDeployment@0
+          displayName: 'Deploy Managed Connections'
+          condition: eq(variables['deployConnections'], 'true')
+          inputs:
+            connectedServiceName: '${'$'}(azureServiceConnection)'
+            subscriptionId: '${'$'}(subscriptionId)'
+            resourceGroupName: '${'$'}(resourceGroupName)'
+            location: '${'$'}(location)'
+            sourcePackagePath: '${'$'}(Pipeline.Workspace)/cipipeline/${'$'}(logicAppCIArtifactName)/${'$'}(resources.pipeline.cipipeline.runID).zip'
+            outputPackagePath: '${'$'}(Pipeline.Workspace)/cipipeline/${'$'}(logicAppCIArtifactName)/${'$'}(resources.pipeline.cipipeline.runID)-transformed.zip'
+            armTemplatePath: '${'$'}(Pipeline.Workspace)/cipipeline/infrastructure'
+            deployConnections: true
+
+        - script: |
+            transformedZip="${'$'}(Pipeline.Workspace)/cipipeline/${'$'}(logicAppCIArtifactName)/${'$'}(resources.pipeline.cipipeline.runID)-transformed.zip"
+            originalZip="${'$'}(Pipeline.Workspace)/cipipeline/${'$'}(logicAppCIArtifactName)/${'$'}(resources.pipeline.cipipeline.runID).zip"
+            if [ -f "$transformedZip" ]; then
+              echo "##vso[task.setvariable variable=deployPackagePath]$transformedZip"
+            else
+              echo "##vso[task.setvariable variable=deployPackagePath]$originalZip"
+            fi
+          displayName: 'Resolve deploy package path'
+
+        - task: AzureLogicAppsHybridRelease@0
+          displayName: 'Azure Logic Apps Hybrid Release'
+          inputs:
+            connectedServiceName: '${'$'}(azureServiceConnection)'
+            hybridConnectionName: '${'$'}(hybridServiceConnection)'
+            containerAppName: '${'$'}(containerAppName)'
+            resourceGroupName: '${'$'}(resourceGroupName)'
+            package: '${'$'}(deployPackagePath)'
+`;
+
+    fs.writeFileSync(path.join(pipelinesFolder, 'CD-pipeline.yml'), cdPipelineContent);
+
+    // CD variables — includes all inputs for ARM deploy, ConnectionsDeployment, and HybridRelease.
+    // Secrets (sqlConnectionString, fileSharePassword, aadClientSecret) should be set as ADO secret variables.
+    const cdVariablesContent = `variables:
+  azureServiceConnection: '<your-azure-service-connection>'
+  hybridServiceConnection: '<your-hybrid-service-connection>'
+  subscriptionId: '<your-subscription-id>'
+  containerAppName: '${context.logicAppName}'
+  resourceGroupName: '${context.resourceGroup?.name || '<your-resource-group>'}'
+  location: '${context.resourceGroup?.location || '<your-location>'}'
+  logicAppCIArtifactName: 'logic-app-artifact'
+  logicAppEnvironment: 'production'
+  # Set to 'true' to deploy managed connections via ARM templates
+  deployConnections: 'false'
+  # Secrets — set these as pipeline secret variables in ADO (Variables button in pipeline editor)
+  # Do NOT define them here — YAML variables override pipeline variables
+  # Required secrets: sqlConnectionString, fileSharePassword, aadClientSecret
+`;
+
+    fs.writeFileSync(path.join(pipelinesFolder, 'CD-pipeline-variables.yml'), cdVariablesContent);
+
+    // CI variables
+    const ciVariablesContent = `variables:
+  logicAppName: '${context.logicAppName}'
+  logicAppCIArtifactName: 'logic-app-artifact'
+`;
+
+    fs.writeFileSync(path.join(pipelinesFolder, 'CI-pipeline-variables.yml'), ciVariablesContent);
   }
 }

--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/adoDeploymentScriptsSteps/__test__/GenerateADODeploymentScriptsStep.hybrid.test.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/adoDeploymentScriptsSteps/__test__/GenerateADODeploymentScriptsStep.hybrid.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Extend the partial `fs` mock from test-setup with the sync APIs this suite needs.
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  statSync: vi.fn(),
+  copyFileSync: vi.fn(),
+  chmodSync: vi.fn(),
+  createWriteStream: vi.fn(),
+}));
+
+import * as fs from 'fs';
+import { GenerateADODeploymentScriptsStep } from '../GenerateADODeploymentScriptsStep';
+
+// Reach into the class for the private static helpers under test.
+const Cls = GenerateADODeploymentScriptsStep as unknown as {
+  generateHybridArmTemplate: () => any;
+  generateHybridArmParameters: (context: any) => any;
+  transformConnectionTemplatesForHybrid: (folder: string) => void;
+  fixAccessPolicyIdentityForHybrid: (resources: any[]) => void;
+};
+
+describe('generateHybridArmTemplate', () => {
+  const template = Cls.generateHybridArmTemplate();
+
+  it('declares the three Container Apps + nested storage resources', () => {
+    const types = (template.resources as any[]).map((r) => r.type);
+    expect(types).toContain('Microsoft.Resources/deployments');
+    expect(types).toContain('Microsoft.App/containerApps');
+    expect(types).toContain('Microsoft.App/logicApps');
+  });
+
+  it('declares secrets as securestring parameters', () => {
+    const params = template.parameters as Record<string, { type: string }>;
+    expect(params.sqlConnectionString.type).toBe('securestring');
+    expect(params.fileSharePassword.type).toBe('securestring');
+    expect(params.aadClientSecret.type).toBe('securestring');
+  });
+
+  it('container app exposes WORKFLOWAPP_AAD_* env vars from parameters and secret refs', () => {
+    const containerApp = (template.resources as any[]).find((r) => r.type === 'Microsoft.App/containerApps');
+    const env = containerApp.properties.template.containers[0].env as { name: string; value?: string; secretRef?: string }[];
+    const names = env.map((e) => e.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'WORKFLOWAPP_AAD_CLIENTID',
+        'WORKFLOWAPP_AAD_CLIENTSECRET',
+        'WORKFLOWAPP_AAD_OBJECTID',
+        'WORKFLOWAPP_AAD_TENANTID',
+      ])
+    );
+    expect(env.find((e) => e.name === 'WORKFLOWAPP_AAD_CLIENTSECRET')?.secretRef).toBe('aad-client-secret');
+  });
+
+  it('nested storage deployment uses outer-scope expression evaluation', () => {
+    const nested = (template.resources as any[]).find((r) => r.type === 'Microsoft.Resources/deployments');
+    expect(nested.properties.expressionEvaluationOptions.scope).toBe('outer');
+  });
+});
+
+describe('generateHybridArmParameters', () => {
+  it('populates context-derived values and omits secret parameters', () => {
+    const params = Cls.generateHybridArmParameters({
+      subscriptionId: 'sub-1',
+      logicAppName: 'la-1',
+      resourceGroup: { name: 'rg-1', location: 'eastus' },
+      connectedEnvironmentName: 'ce-1',
+      connectedEnvironmentResourceGroup: 'rg-ce',
+    } as any).parameters as Record<string, { value: string }>;
+
+    expect(params.logicAppName.value).toBe('la-1');
+    expect(params.location.value).toBe('eastus');
+    expect(params.connectedEnvironmentName.value).toBe('ce-1');
+    expect(params.connectedEnvironmentResourceGroup.value).toBe('rg-ce');
+
+    // Secrets must be set via ADO pipeline secret variables, never the parameters file.
+    expect(params.sqlConnectionString).toBeUndefined();
+    expect(params.fileSharePassword).toBeUndefined();
+    expect(params.aadClientSecret).toBeUndefined();
+  });
+
+  it('falls back to placeholders when optional context fields are missing', () => {
+    const params = Cls.generateHybridArmParameters({
+      logicAppName: 'la-1',
+      resourceGroup: undefined,
+    } as any).parameters as Record<string, { value: string }>;
+
+    expect(params.subscriptionId.value).toBe('<your-subscription-id>');
+    expect(params.location.value).toBe('');
+    expect(params.connectedEnvironmentName.value).toBe('');
+  });
+});
+
+describe('fixAccessPolicyIdentityForHybrid', () => {
+  it('replaces Microsoft.Web/Sites identity refs with AAD parameter references', () => {
+    const resources = [
+      {
+        type: 'accessPolicies',
+        properties: {
+          principal: {
+            identity: {
+              objectId:
+                "[reference(resourceId('Microsoft.Web/sites', parameters('logicAppName')), '2018-02-01', 'Full').identity.principalId]",
+              tenantId:
+                "[reference(resourceId('Microsoft.Web/sites', parameters('logicAppName')), '2018-02-01', 'Full').identity.tenantId]",
+            },
+          },
+        },
+      },
+    ];
+
+    Cls.fixAccessPolicyIdentityForHybrid(resources);
+
+    expect(resources[0].properties.principal.identity.objectId).toBe("[parameters('aadObjectId')]");
+    expect(resources[0].properties.principal.identity.tenantId).toBe("[parameters('aadTenantId')]");
+  });
+
+  it('recurses into nested resources', () => {
+    const resources = [
+      {
+        type: 'parent',
+        resources: [
+          {
+            type: 'accessPolicies',
+            properties: {
+              principal: {
+                identity: {
+                  objectId: 'something microsoft.web/sites else',
+                  tenantId: 'static-tenant',
+                },
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    Cls.fixAccessPolicyIdentityForHybrid(resources);
+
+    const inner = (resources[0] as any).resources[0];
+    expect(inner.properties.principal.identity.objectId).toBe("[parameters('aadObjectId')]");
+    // tenantId did not reference Microsoft.Web/sites, so it stays untouched.
+    expect(inner.properties.principal.identity.tenantId).toBe('static-tenant');
+  });
+
+  it('leaves non-accessPolicies resources untouched', () => {
+    const resources = [{ type: 'Microsoft.Web/connections', properties: { displayName: 'sql' } }];
+
+    Cls.fixAccessPolicyIdentityForHybrid(resources);
+
+    expect(resources[0]).toEqual({ type: 'Microsoft.Web/connections', properties: { displayName: 'sql' } });
+  });
+});
+
+describe('transformConnectionTemplatesForHybrid', () => {
+  const sampleTemplate = {
+    parameters: { existing: { type: 'String' } },
+    resources: [
+      {
+        type: 'accessPolicies',
+        properties: {
+          principal: {
+            identity: {
+              objectId: "[reference(resourceId('Microsoft.Web/sites', 'la'), '2018-02-01', 'Full').identity.principalId]",
+              tenantId: "[reference(resourceId('Microsoft.Web/sites', 'la'), '2018-02-01', 'Full').identity.tenantId]",
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const sampleParameters = { parameters: { existing: { value: 'x' } } };
+
+  let writes: Record<string, string>;
+
+  beforeEach(() => {
+    writes = {};
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync as any).mockImplementation(((p: string) => {
+      // Two passes: template files first, then parameters files.
+      if ((fs.readdirSync as any).mock.calls.length === 1) {
+        return ['sql.template.json', 'hybrid-logicapp-template.json'];
+      }
+      return ['sql.parameters.json', 'hybrid-logicapp-parameters.json'];
+    }) as any);
+    vi.mocked(fs.readFileSync as any).mockImplementation(((p: string) => {
+      if (String(p).endsWith('.template.json')) return JSON.stringify(sampleTemplate);
+      if (String(p).endsWith('.parameters.json')) return JSON.stringify(sampleParameters);
+      return '{}';
+    }) as any);
+    vi.mocked(fs.writeFileSync as any).mockImplementation(((p: string, data: string) => {
+      writes[String(p)] = String(data);
+    }) as any);
+  });
+
+  it('adds AAD parameters, rewrites identity refs, and ignores the hybrid template files', () => {
+    Cls.transformConnectionTemplatesForHybrid('/fake/infra');
+
+    const written = Object.keys(writes);
+    // Only the per-connection files should be rewritten.
+    expect(written.some((p) => p.endsWith('sql.template.json'))).toBe(true);
+    expect(written.some((p) => p.endsWith('sql.parameters.json'))).toBe(true);
+    expect(written.some((p) => p.endsWith('hybrid-logicapp-template.json'))).toBe(false);
+    expect(written.some((p) => p.endsWith('hybrid-logicapp-parameters.json'))).toBe(false);
+
+    const updatedTemplate = JSON.parse(writes[written.find((p) => p.endsWith('sql.template.json'))!]);
+    expect(updatedTemplate.parameters.aadObjectId).toEqual({ type: 'String' });
+    expect(updatedTemplate.parameters.aadTenantId).toEqual({ type: 'String' });
+    expect(updatedTemplate.resources[0].properties.principal.identity.objectId).toBe("[parameters('aadObjectId')]");
+
+    const updatedParams = JSON.parse(writes[written.find((p) => p.endsWith('sql.parameters.json'))!]);
+    expect(updatedParams.parameters.aadObjectId).toEqual({ value: '' });
+    expect(updatedParams.parameters.aadTenantId).toEqual({ value: '' });
+  });
+
+  it('is a no-op when the infrastructure folder does not exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    Cls.transformConnectionTemplatesForHybrid('/missing');
+
+    expect(fs.readdirSync as any).not.toHaveBeenCalled();
+    expect(fs.writeFileSync as any).not.toHaveBeenCalled();
+  });
+});

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -422,6 +422,9 @@ export const workspaceNameValidation = /^[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*$/i;
 export const deployedLogicAppNameValidation = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,62}[a-zA-Z0-9])?$/;
 export const deployedStorageAccountNameValidation = /^[a-z0-9]{3,24}$/;
 export const deployedAppServicePlanNameValidation = /^[a-zA-Z0-9-]{1,60}$/;
+// Connected environment names follow the same rules as Container Apps resource names.
+export const connectedEnvironmentNameValidation = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,60}[a-zA-Z0-9])?$/;
+export const resourceGroupNameValidation = /^[-\w._()]{1,90}$/;
 export const namespaceValidation = /^([A-Za-z_][A-Za-z0-9_]*)(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
 
 // Codeful SDK versions

--- a/libs/vscode-extension/src/lib/models/project.ts
+++ b/libs/vscode-extension/src/lib/models/project.ts
@@ -133,6 +133,13 @@ export const DeploymentScriptType = {
 } as const;
 export type DeploymentScriptType = (typeof DeploymentScriptType)[keyof typeof DeploymentScriptType];
 
+// Standard deploys to App Service, Hybrid deploys to Container Apps.
+export const DeploymentTargetType = {
+  standard: 'standard',
+  hybrid: 'hybrid',
+} as const;
+export type DeploymentTargetType = (typeof DeploymentTargetType)[keyof typeof DeploymentTargetType];
+
 export const RouteName = {
   export: 'export',
   instance_selection: 'instance-selection',


### PR DESCRIPTION

## Commit Type
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Adds support for generating Azure DevOps CI/CD artifacts for **Hybrid Logic Apps (Container Apps)** in addition to Standard (App Service). The VS Code "Generate Deployment Scripts" wizard now prompts users to choose a deployment target (Standard vs Hybrid), and generates the correct ARM templates, pipeline YAML, and connection transforms for each.

**Why:** Customers deploying Logic Apps to Container Apps (Hybrid) need different infrastructure (Microsoft.App/containerApps instead of Microsoft.Web/sites) and different connection authentication (AAD OAuth instead of managed identity). This enables generating correct deployment artifacts directly from the VS Code wizard.

## Impact of Change
- **Users**: New "Hybrid (Container Apps)" option in the VS Code Generate Deployment Scripts wizard. Adds a new wizard path and generated artifacts (ARM templates, ADO pipeline YAML). Existing Standard flow remains unchanged.
- **Developers**: Public API change: added ``DeploymentTargetType`` to ``libs/vscode-extension``. New wizard step classes (``DeploymentTargetStep``, ``ConnectedEnvironmentStep``) and helper utilities (``transformConnectionTemplatesForHybrid``, ``fixAccessPolicyIdentityForHybrid``). Consumers of the libs package may need to accommodate the new enum/type.
- **System**: New telemetry properties added (``deploymentTarget``, ``lastStep`` values for Hybrid steps). Generated pipeline templates reference new ADO tasks (``AzureLogicAppsHybridBuild@0``, ``AzureLogicAppsHybridRelease@0``, ``AzureLogicAppsHybridConnectionsDeployment@0``). Secrets (SQL connection string, SMB password, AAD client secret) must be supplied via ADO pipeline secret variables only -- they are excluded from generated parameter files.

## Test Plan
- [x] Manual testing completed
- Tested in: Dev subscription with Container Apps Connected Environment
  - Verified Standard path still works unchanged (regression)
  - Verified Hybrid path generates correct ARM templates (containerApp, logicApp, SMB storage)
  - Verified pipeline YAML references correct ADO tasks (HybridBuild, HybridRelease, HybridConnectionsDeployment)
  - Verified managed connection templates are transformed (Microsoft.Web/Sites identity refs replaced with AAD parameters)
  - Verified workflowparameters/parameters.json is copied for Build task compatibility
  - E2E tested generated pipelines against live Container App deployment

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
TODO
