### PR TITLE
perf(DesignerV2): Memoize Redux selectors 

### DIFF
--- a/libs/designer-v2/src/lib/core/state/connection/connectionSelector.ts
+++ b/libs/designer-v2/src/lib/core/state/connection/connectionSelector.ts
@@ -117,8 +117,11 @@ export const useConnectionRefs = (): ConnectionReferences => {
 };
 
 export const useConnectionRefsByConnectorId = (connectorId?: string) => {
-  const allConnectionReferences = useSelector((state: RootState) => Object.values(state.connections.connectionReferences));
-  return allConnectionReferences.filter((ref: ConnectionReference) => ref.api.id === connectorId);
+  const connectionReferences = useSelector((state: RootState) => state.connections.connectionReferences);
+  return useMemo(
+    () => Object.values(connectionReferences).filter((ref: ConnectionReference) => ref.api.id === connectorId),
+    [connectionReferences, connectorId]
+  );
 };
 
 export const useIsOperationMissingConnection = (nodeId: string) => {

--- a/libs/designer-v2/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -1,4 +1,5 @@
 import { equals } from '@microsoft/logic-apps-shared';
+import { createSelector } from '@reduxjs/toolkit';
 import type { RootState } from '../../store';
 import { useSelector } from 'react-redux';
 import { isA2AWorkflow } from '../workflow/helper';
@@ -34,12 +35,20 @@ export const useIsAgenticWorkflowOnly = () => {
   return equals(workflowKind, 'agentic', true);
 };
 
+const selectIsA2AWorkflow = createSelector(
+  (state: RootState) => state.workflow,
+  (workflow) => isA2AWorkflow(workflow)
+);
+
 export const useIsA2AWorkflow = () => {
-  return useSelector((state: RootState) => isA2AWorkflow(state.workflow));
+  return useSelector(selectIsA2AWorkflow);
 };
 
+const selectWorkflowHasAgentLoop = createSelector(
+  (state: RootState) => state.workflow.operations,
+  (operations) => Object.values(operations).some((operation) => equals(operation.type, 'agent'))
+);
+
 export const useWorkflowHasAgentLoop = () => {
-  return useSelector((state: RootState) => {
-    return Object.values(state.workflow.operations).some((operation) => equals(operation.type, 'agent'));
-  });
+  return useSelector(selectWorkflowHasAgentLoop);
 };

--- a/libs/designer-v2/src/lib/core/state/operation/operationSelector.ts
+++ b/libs/designer-v2/src/lib/core/state/operation/operationSelector.ts
@@ -126,16 +126,16 @@ export const useOperationDynamicInputsError = (nodeId: string | undefined): stri
     )
   );
 
-const selectAllConnectionErrors = createSelector(getOperationState, (state) =>
-  Object.entries(state.errors ?? {}).reduce((acc: any, [nodeId, errors]) => {
+const selectAllConnectionErrors = createSelector(getOperationState, (state) => {
+  const result: Record<string, string> = {};
+  for (const [nodeId, errors] of Object.entries(state.errors ?? {})) {
     const connectionError = errors?.[ErrorLevel.Connection];
-
     if (connectionError) {
-      acc[nodeId] = connectionError.message;
+      result[nodeId] = connectionError.message;
     }
-    return acc;
-  }, {})
-);
+  }
+  return result;
+});
 
 export const useAllConnectionErrors = (): Record<string, string> => useSelector(selectAllConnectionErrors);
 

--- a/libs/designer-v2/src/lib/core/state/operation/operationSelector.ts
+++ b/libs/designer-v2/src/lib/core/state/operation/operationSelector.ts
@@ -14,29 +14,37 @@ const getOperationState = (state: RootState) => state.operations;
 
 export const useOperationVisuals = (nodeId: string) =>
   useSelector(
-    createSelector(
-      getOperationState,
-      (state) =>
-        getRecordEntry(state.operationMetadata, nodeId) ?? {
-          brandColor: '',
-          iconUri: '',
-        }
+    useMemo(
+      () =>
+        createSelector(
+          getOperationState,
+          (state) =>
+            getRecordEntry(state.operationMetadata, nodeId) ?? {
+              brandColor: '',
+              iconUri: '',
+            }
+        ),
+      [nodeId]
     )
   );
 
 export const useOperationsVisuals = (nodesId: string[]) =>
   useSelector(
-    createSelector(getOperationState, (state) => {
-      return nodesId.map((nodeId) => {
-        return {
-          ...(getRecordEntry(state.operationMetadata, nodeId) ?? {
-            brandColor: '',
-            iconUri: '',
-          }),
-          id: nodeId,
-        };
-      });
-    })
+    useMemo(
+      () =>
+        createSelector(getOperationState, (state) => {
+          return nodesId.map((nodeId) => {
+            return {
+              ...(getRecordEntry(state.operationMetadata, nodeId) ?? {
+                brandColor: '',
+                iconUri: '',
+              }),
+              id: nodeId,
+            };
+          });
+        }),
+      [nodesId]
+    )
   );
 
 export const getNodeOperationData = (state: OperationMetadataState, nodeId: string) => {
@@ -102,53 +110,65 @@ export const useOperationParameterByName = (nodeId: string, parameterName: strin
 };
 
 export const useOperationErrorInfo = (nodeId: string): ErrorInfo | undefined =>
-  useSelector(createSelector(getOperationState, (state) => getTopErrorInOperation(getRecordEntry(state.errors, nodeId))));
+  useSelector(
+    useMemo(() => createSelector(getOperationState, (state) => getTopErrorInOperation(getRecordEntry(state.errors, nodeId))), [nodeId])
+  );
 
 export const useOperationDynamicInputsError = (nodeId: string | undefined): string | undefined =>
   useSelector(
-    createSelector(getOperationState, (state) => {
-      const errors = getRecordEntry(state.errors, nodeId);
-      return errors?.[ErrorLevel.DynamicInputs]?.message;
-    })
-  );
-
-export const useAllConnectionErrors = (): Record<string, string> =>
-  useSelector(
-    createSelector(getOperationState, (state) =>
-      Object.entries(state.errors ?? {}).reduce((acc: any, [nodeId, errors]) => {
-        const connectionError = errors?.[ErrorLevel.Connection];
-        // eslint-disable-next-line no-param-reassign
-        if (connectionError) {
-          acc[nodeId] = connectionError.message;
-        }
-        return acc;
-      }, {})
+    useMemo(
+      () =>
+        createSelector(getOperationState, (state) => {
+          const errors = getRecordEntry(state.errors, nodeId);
+          return errors?.[ErrorLevel.DynamicInputs]?.message;
+        }),
+      [nodeId]
     )
   );
 
-export const useOperationsInputParameters = (): Record<string, NodeInputs> =>
-  useSelector(createSelector(getOperationState, (state) => state.inputParameters));
+const selectAllConnectionErrors = createSelector(getOperationState, (state) =>
+  Object.entries(state.errors ?? {}).reduce((acc: any, [nodeId, errors]) => {
+    const connectionError = errors?.[ErrorLevel.Connection];
+
+    if (connectionError) {
+      acc[nodeId] = connectionError.message;
+    }
+    return acc;
+  }, {})
+);
+
+export const useAllConnectionErrors = (): Record<string, string> => useSelector(selectAllConnectionErrors);
+
+const selectOperationsInputParameters = createSelector(getOperationState, (state) => state.inputParameters);
+
+export const useOperationsInputParameters = (): Record<string, NodeInputs> => useSelector(selectOperationsInputParameters);
 
 export const useSecureInputsOutputs = (nodeId: string): boolean =>
   useSelector(
-    createSelector(getOperationState, (state) => {
-      const nodeSettings = getRecordEntry(state.settings, nodeId);
-      return !!(nodeSettings?.secureInputs?.value || nodeSettings?.secureOutputs?.value);
-    })
+    useMemo(
+      () =>
+        createSelector(getOperationState, (state) => {
+          const nodeSettings = getRecordEntry(state.settings, nodeId);
+          return !!(nodeSettings?.secureInputs?.value || nodeSettings?.secureOutputs?.value);
+        }),
+      [nodeId]
+    )
   );
 
 export const useParameterStaticResult = (nodeId: string): NodeStaticResults | undefined =>
-  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.staticResults, nodeId)));
+  useSelector(useMemo(() => createSelector(getOperationState, (state) => getRecordEntry(state.staticResults, nodeId)), [nodeId]));
 
 export const useRawInputParameters = (nodeId: string): NodeInputs | undefined =>
-  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.inputParameters, nodeId)));
+  useSelector(useMemo(() => createSelector(getOperationState, (state) => getRecordEntry(state.inputParameters, nodeId)), [nodeId]));
 
 export const useRawOutputParameters = (nodeId: string): NodeOutputs | undefined =>
-  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.outputParameters, nodeId)));
+  useSelector(useMemo(() => createSelector(getOperationState, (state) => getRecordEntry(state.outputParameters, nodeId)), [nodeId]));
 
 const mockDeps: NodeDependencies = { inputs: {}, outputs: {} };
 export const useDependencies = (nodeId: string) =>
-  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.dependencies, nodeId) ?? mockDeps));
+  useSelector(
+    useMemo(() => createSelector(getOperationState, (state) => getRecordEntry(state.dependencies, nodeId) ?? mockDeps), [nodeId])
+  );
 
 interface TokenDependencies {
   dependencies: Set<string>;
@@ -234,26 +254,35 @@ export const useNodesTokenDependencies = (nodes: Set<string>) => {
   }, [nodes, operationsInputsParameters, variables]);
 };
 
-export const useAllOperationErrors = () => useSelector(createSelector(getOperationState, (state) => state.errors));
+const selectAllOperationErrors = createSelector(getOperationState, (state) => state.errors);
+
+export const useAllOperationErrors = () => useSelector(selectAllOperationErrors);
 
 export const useParameterValidationErrors = (nodeId: string) => {
   const allParameters = useOperationInputParameters(nodeId);
   return useMemo(() => allParameters.flatMap((parameter) => parameter.validationErrors).filter((error) => error), [allParameters]);
 };
 
-export const useNodesInitialized = () => useSelector(createSelector(getOperationState, (state) => state.loadStatus.nodesInitialized));
+const selectNodesInitialized = createSelector(getOperationState, (state) => state.loadStatus.nodesInitialized);
 
-export const useNodesAndDynamicDataInitialized = () =>
-  useSelector(createSelector(getOperationState, (state) => state.loadStatus.nodesAndDynamicDataInitialized));
+export const useNodesInitialized = () => useSelector(selectNodesInitialized);
+
+const selectNodesAndDynamicDataInitialized = createSelector(getOperationState, (state) => state.loadStatus.nodesAndDynamicDataInitialized);
+
+export const useNodesAndDynamicDataInitialized = () => useSelector(selectNodesAndDynamicDataInitialized);
 
 export const useIsNodeLoadingDynamicData = (nodeId: string) =>
   useSelector(
-    createSelector(getOperationState, (state) => {
-      const parameterGroups = getRecordEntry(state.inputParameters, nodeId)?.parameterGroups;
-      return Object.values(parameterGroups ?? {}).some((parameterGroup) =>
-        parameterGroup.parameters.some((parameter) => parameter.dynamicData?.status === DynamicLoadStatus.LOADING)
-      );
-    })
+    useMemo(
+      () =>
+        createSelector(getOperationState, (state) => {
+          const parameterGroups = getRecordEntry(state.inputParameters, nodeId)?.parameterGroups;
+          return Object.values(parameterGroups ?? {}).some((parameterGroup) =>
+            parameterGroup.parameters.some((parameter) => parameter.dynamicData?.status === DynamicLoadStatus.LOADING)
+          );
+        }),
+      [nodeId]
+    )
   );
 
 const getTopErrorInOperation = (errors?: Record<ErrorLevel, ErrorInfo | undefined>): ErrorInfo | undefined => {
@@ -279,23 +308,28 @@ const getTopErrorInOperation = (errors?: Record<ErrorLevel, ErrorInfo | undefine
 };
 
 export const useBrandColor = (nodeId: string) =>
-  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.operationMetadata, nodeId)?.brandColor ?? ''));
-
-export const useIconUri = (nodeId: string) =>
-  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.operationMetadata, nodeId)?.iconUri ?? ''));
-
-export const useAllIcons = () =>
   useSelector(
-    createSelector(getOperationState, (state) => {
-      const icons: Record<string, string> = {};
-      Object.entries(state.operationMetadata).forEach(([nodeId, metadata]) => {
-        if (metadata?.iconUri) {
-          icons[nodeId] = metadata.iconUri;
-        }
-      });
-      return icons;
-    })
+    useMemo(() => createSelector(getOperationState, (state) => getRecordEntry(state.operationMetadata, nodeId)?.brandColor ?? ''), [nodeId])
   );
 
+export const useIconUri = (nodeId: string) =>
+  useSelector(
+    useMemo(() => createSelector(getOperationState, (state) => getRecordEntry(state.operationMetadata, nodeId)?.iconUri ?? ''), [nodeId])
+  );
+
+const selectAllIcons = createSelector(getOperationState, (state) => {
+  const icons: Record<string, string> = {};
+  Object.entries(state.operationMetadata).forEach(([nodeId, metadata]) => {
+    if (metadata?.iconUri) {
+      icons[nodeId] = metadata.iconUri;
+    }
+  });
+  return icons;
+});
+
+export const useAllIcons = () => useSelector(selectAllIcons);
+
 export const useNodeConnectorId = (nodeId: string) =>
-  useSelector(createSelector(getOperationState, (state) => getRecordEntry(state.operationInfo, nodeId)?.connectorId));
+  useSelector(
+    useMemo(() => createSelector(getOperationState, (state) => getRecordEntry(state.operationInfo, nodeId)?.connectorId), [nodeId])
+  );

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
@@ -722,23 +722,21 @@ export const useIsWithinAgenticLoop = (id?: string): boolean => {
   );
 };
 
-export const useHasUpstreamAgenticLoop = (upstreamNodes: string[]): boolean => {
-  return useSelector(
-    useMemo(
-      () =>
-        createSelector(getWorkflowState, (state: WorkflowState) => {
-          for (const nodeId of upstreamNodes) {
-            const type = getRecordEntry(state.operations, nodeId)?.type;
-            if (equals(type, commonConstants.NODE.TYPE.AGENT)) {
-              return true;
-            }
-          }
-          return false;
-        }),
-      [upstreamNodes]
-    )
-  );
-};
+const selectHasUpstreamAgenticLoop = createSelector(
+  [getWorkflowState, (_state: RootState, upstreamNodes: string[]) => upstreamNodes],
+  (state: WorkflowState, upstreamNodes: string[]) => {
+    for (const nodeId of upstreamNodes) {
+      const type = getRecordEntry(state.operations, nodeId)?.type;
+      if (equals(type, commonConstants.NODE.TYPE.AGENT)) {
+        return true;
+      }
+    }
+    return false;
+  }
+);
+
+export const useHasUpstreamAgenticLoop = (upstreamNodes: string[]): boolean =>
+  useSelector((state: RootState) => selectHasUpstreamAgenticLoop(state, upstreamNodes));
 
 export const useAgentOperations = () => {
   const agentOperationsSelector = useMemo(

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
@@ -27,78 +27,106 @@ export const getWorkflowAndOperationState = (state: RootState): { workflow: Work
 };
 
 export const useNodeDisplayName = (id?: string) =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => labelCase(getRecordEntry(state.idReplacements, id) ?? id ?? '')));
+  useSelector(
+    useMemo(
+      () => createSelector(getWorkflowState, (state: WorkflowState) => labelCase(getRecordEntry(state.idReplacements, id) ?? id ?? '')),
+      [id]
+    )
+  );
 
 export const useNodeReplacedId = (id?: string) =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.idReplacements, id)));
+  useSelector(useMemo(() => createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.idReplacements, id)), [id]));
 
-export const useReplacedIds = () => useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.idReplacements));
+const selectReplacedIds = createSelector(getWorkflowState, (state: WorkflowState) => state.idReplacements);
+
+export const useReplacedIds = () => useSelector(selectReplacedIds);
 
 export const useNodeMetadata = (id?: string) =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)));
+  useSelector(useMemo(() => createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)), [id]));
 
 export const useActionMetadata = (id?: string) =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.operations, id)));
+  useSelector(useMemo(() => createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.operations, id)), [id]));
 
 export const useNodeDescription = (id: string) =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.operations, id)?.description));
+  useSelector(
+    useMemo(() => createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.operations, id)?.description), [id])
+  );
 
 export const useShouldNodeFocus = (id: string) =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.focusedCanvasNodeId === id));
+  useSelector(useMemo(() => createSelector(getWorkflowState, (state: WorkflowState) => state.focusedCanvasNodeId === id), [id]));
 
-export const useFocusElement = () => useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.focusElement));
+const selectFocusElement = createSelector(getWorkflowState, (state: WorkflowState) => state.focusElement);
 
-export const useIsWorkflowDirty = () => useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.isDirty));
+export const useFocusElement = () => useSelector(selectFocusElement);
+
+const selectIsWorkflowDirty = createSelector(getWorkflowState, (state: WorkflowState) => state.isDirty);
+
+export const useIsWorkflowDirty = () => useSelector(selectIsWorkflowDirty);
 
 export const useIsCopilotModifiedNode = (nodeId: string) =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => !!state.copilotModifiedNodeIds?.[nodeId]));
+  useSelector(
+    useMemo(() => createSelector(getWorkflowState, (state: WorkflowState) => !!state.copilotModifiedNodeIds?.[nodeId]), [nodeId])
+  );
 
-export const useWorkflowChangeCount = () => useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.changeCount));
+const selectWorkflowChangeCount = createSelector(getWorkflowState, (state: WorkflowState) => state.changeCount);
 
-export const useTimelineRepetitionIndex = () =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.timelineRepetitionIndex));
+export const useWorkflowChangeCount = () => useSelector(selectWorkflowChangeCount);
 
-export const useTimelineRepetitionArray = () =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.timelineRepetitionArray));
+const selectTimelineRepetitionIndex = createSelector(getWorkflowState, (state: WorkflowState) => state.timelineRepetitionIndex);
+
+export const useTimelineRepetitionIndex = () => useSelector(selectTimelineRepetitionIndex);
+
+const selectTimelineRepetitionArray = createSelector(getWorkflowState, (state: WorkflowState) => state.timelineRepetitionArray);
+
+export const useTimelineRepetitionArray = () => useSelector(selectTimelineRepetitionArray);
 
 export const useActionTimelineRepetitionCount = (actionId: string, index: number) =>
   useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      const timelineRepetitionArray = state.timelineRepetitionArray;
-      // For each timeline repetition up to the current one, add the count of action IDs that match the actionId
-      let count = 0;
-      for (let i = 0; i <= index; i++) {
-        if (timelineRepetitionArray[i]) {
-          count += timelineRepetitionArray[i].filter((id) => id === actionId).length;
-        }
-      }
-      return count;
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          const timelineRepetitionArray = state.timelineRepetitionArray;
+          // For each timeline repetition up to the current one, add the count of action IDs that match the actionId
+          let count = 0;
+          for (let i = 0; i <= index; i++) {
+            if (timelineRepetitionArray[i]) {
+              count += timelineRepetitionArray[i].filter((id) => id === actionId).length;
+            }
+          }
+          return count;
+        }),
+      [actionId, index]
+    )
   );
 
 export const useIsActionInSelectedTimelineRepetition = (actionId: string) =>
   useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (!equals(state.workflowKind, 'agent')) {
-        return true; // For non-agent workflows, always return true
-      }
-      const selectedTransitionActions = state.timelineRepetitionArray[state.timelineRepetitionIndex];
-      return selectedTransitionActions ? selectedTransitionActions.includes(actionId) : false;
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (!equals(state.workflowKind, 'agent')) {
+            return true; // For non-agent workflows, always return true
+          }
+          const selectedTransitionActions = state.timelineRepetitionArray[state.timelineRepetitionIndex];
+          return selectedTransitionActions ? selectedTransitionActions.includes(actionId) : false;
+        }),
+      [actionId]
+    )
   );
 
-export const useIsEverythingExpanded = () =>
-  useSelector(
-    createSelector(getWorkflowState, (data) => {
-      const collapsedIds = data.collapsedGraphIds;
-      const collapsedActionsIds = data.collapsedActionIds;
-      const numberOfCollapsedGraphs = Object.keys(collapsedIds ?? {}).filter((id) => collapsedIds[id]).length;
-      const numberOfCollapsedActions = Object.keys(collapsedActionsIds ?? {}).length;
-      return numberOfCollapsedGraphs === 0 && numberOfCollapsedActions === 0;
-    })
-  );
+const selectIsEverythingExpanded = createSelector(getWorkflowState, (data) => {
+  const collapsedIds = data.collapsedGraphIds;
+  const collapsedActionsIds = data.collapsedActionIds;
+  const numberOfCollapsedGraphs = Object.keys(collapsedIds ?? {}).filter((id) => collapsedIds[id]).length;
+  const numberOfCollapsedActions = Object.keys(collapsedActionsIds ?? {}).length;
+  return numberOfCollapsedGraphs === 0 && numberOfCollapsedActions === 0;
+});
 
-export const useWorkflowGraph = () => useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.graph));
+export const useIsEverythingExpanded = () => useSelector(selectIsEverythingExpanded);
+
+const selectWorkflowGraph = createSelector(getWorkflowState, (state: WorkflowState) => state.graph);
+
+export const useWorkflowGraph = () => useSelector(selectWorkflowGraph);
 
 const getHandoffAdjustedGraph = createSelector([getWorkflowAndOperationState], (rootState) => {
   const graph = rootState.workflow.graph;
@@ -247,43 +275,61 @@ const filterOutNodeIdsRecursive = (node: WorkflowNode, idsToFilter: string[]): W
 };
 
 export const useIsGraphCollapsed = (graphId: string): boolean =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState): boolean => state.collapsedGraphIds?.[graphId] ?? false));
+  useSelector(
+    useMemo(
+      () => createSelector(getWorkflowState, (state: WorkflowState): boolean => state.collapsedGraphIds?.[graphId] ?? false),
+      [graphId]
+    )
+  );
 
 export const useIsActionCollapsed = (actionId: string): boolean =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState): boolean => state.collapsedActionIds?.[actionId] ?? false));
+  useSelector(
+    useMemo(
+      () => createSelector(getWorkflowState, (state: WorkflowState): boolean => state.collapsedActionIds?.[actionId] ?? false),
+      [actionId]
+    )
+  );
 
 export const useGetSwitchOrAgentParentId = (nodeId: string): { parentId?: string; type?: string } | undefined => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      const nodeMetadata = state.nodesMetadata[nodeId];
-      const subgraphType = nodeMetadata?.subgraphType;
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          const nodeMetadata = state.nodesMetadata[nodeId];
+          const subgraphType = nodeMetadata?.subgraphType;
 
-      if (subgraphType === SUBGRAPH_TYPES.SWITCH_CASE || subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION) {
-        return { parentId: nodeMetadata?.parentNodeId, type: subgraphType };
-      }
+          if (subgraphType === SUBGRAPH_TYPES.SWITCH_CASE || subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION) {
+            return { parentId: nodeMetadata?.parentNodeId, type: subgraphType };
+          }
 
-      return undefined;
-    })
+          return undefined;
+        }),
+      [nodeId]
+    )
   );
 };
 
 export const useEdgesBySource = (parentId?: string): WorkflowEdge[] =>
   useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (!parentId || !state.graph) {
-        return [];
-      }
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (!parentId || !state.graph) {
+            return [];
+          }
 
-      const reduceGraph = (graph: WorkflowNode, arr: WorkflowEdge[] = []): WorkflowEdge[] => {
-        if (!graph.edges) {
-          return arr;
-        }
-        const edges = graph.edges.filter((x) => x.source === parentId);
-        const childEdges = graph.children?.reduce((acc, child) => reduceGraph(child, acc), edges) ?? [];
-        return [...arr, ...childEdges];
-      };
-      return reduceGraph(state.graph);
-    })
+          const reduceGraph = (graph: WorkflowNode, arr: WorkflowEdge[] = []): WorkflowEdge[] => {
+            if (!graph.edges) {
+              return arr;
+            }
+            const edges = graph.edges.filter((x) => x.source === parentId);
+            const childEdges = graph.children?.reduce((acc, child) => reduceGraph(child, acc), edges) ?? [];
+            return [...arr, ...childEdges];
+          };
+          return reduceGraph(state.graph);
+        }),
+      [parentId]
+    )
   );
 
 export { getWorkflowNodeFromGraphState };
@@ -316,27 +362,35 @@ export const useIsLeafNode = (nodeId: string): boolean => {
   return useMemo(() => targets.length === 0, [targets.length]);
 };
 
-export const useFlowErrors = () => useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.flowErrors ?? {}));
+const selectFlowErrors = createSelector(getWorkflowState, (state: WorkflowState) => state.flowErrors ?? {});
+
+export const useFlowErrors = () => useSelector(selectFlowErrors);
 
 export const useFlowErrorsForNode = (nodeId: string) => {
-  return useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.flowErrors?.[nodeId] ?? {}));
+  return useSelector(useMemo(() => createSelector(getWorkflowState, (state: WorkflowState) => state.flowErrors?.[nodeId] ?? {}), [nodeId]));
 };
 
-export const useNodeIds = () => useSelector(createSelector(getWorkflowState, (state: WorkflowState) => Object.keys(state.nodesMetadata)));
+const selectNodeIds = createSelector(getWorkflowState, (state: WorkflowState) => Object.keys(state.nodesMetadata));
+
+export const useNodeIds = () => useSelector(selectNodeIds);
 
 export const useNewAdditiveSubgraphId = (baseId: string) =>
   useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      let caseId = baseId;
-      let caseCount = 1;
-      const idSet = new Set(Object.keys(state.nodesMetadata));
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          let caseId = baseId;
+          let caseCount = 1;
+          const idSet = new Set(Object.keys(state.nodesMetadata));
 
-      while (idSet.has(caseId)) {
-        caseCount++;
-        caseId = `${baseId}_${caseCount}`;
-      }
-      return caseId;
-    })
+          while (idSet.has(caseId)) {
+            caseCount++;
+            caseId = `${baseId}_${caseCount}`;
+          }
+          return caseId;
+        }),
+      [baseId]
+    )
   );
 
 // Gets a list of all root graph children that are connected somehow to the root trigger node
@@ -387,12 +441,16 @@ export const useIsDisconnected = (nodeId: string): boolean => {
 
 export const useAllGraphParents = (graphId: string): string[] => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (state.graph) {
-        return getWorkflowGraphPath(state.graph, graphId);
-      }
-      return [];
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (state.graph) {
+            return getWorkflowGraphPath(state.graph, graphId);
+          }
+          return [];
+        }),
+      [graphId]
+    )
   );
 };
 
@@ -410,7 +468,12 @@ export const getParentsUncollapseFromGraphState = (state: WorkflowState, actionI
 };
 
 export const useNodeGraphId = (nodeId: string): string =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, nodeId)?.graphId ?? ''));
+  useSelector(
+    useMemo(
+      () => createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, nodeId)?.graphId ?? ''),
+      [nodeId]
+    )
+  );
 
 // BFS search for nodeId
 const getChildrenOfNodeId = (childrenNodes: string[], nodeId: string, rootNode?: WorkflowNode) => {
@@ -450,7 +513,7 @@ const getAllChildren = (currNode: WorkflowNode, childrenNodes: string[]) => {
 
 // given a nodeId, return all operation nodes within if a scope
 export const useGetAllOperationNodesWithin = (nodeId: string) => {
-  const graphNodes = useSelector(createSelector(getWorkflowState, (workflow) => workflow.graph));
+  const graphNodes = useSelector(selectWorkflowGraph);
   return useMemo(() => {
     const childrenNodes: string[] = [];
     getChildrenOfNodeId(childrenNodes, nodeId, graphNodes ?? undefined);
@@ -460,26 +523,43 @@ export const useGetAllOperationNodesWithin = (nodeId: string) => {
 
 export { getWorkflowGraphPath };
 
-export const useRunInstance = (): LogicAppsV2.RunInstanceDefinition | null =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.runInstance));
+const selectRunInstance = createSelector(getWorkflowState, (state: WorkflowState) => state.runInstance);
 
-export const useRunMode = (): string | null =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.runInstance?.properties?.workflow?.mode ?? null));
+export const useRunInstance = (): LogicAppsV2.RunInstanceDefinition | null => useSelector(selectRunInstance);
+
+const selectRunMode = createSelector(getWorkflowState, (state: WorkflowState) => state.runInstance?.properties?.workflow?.mode ?? null);
+
+export const useRunMode = (): string | null => useSelector(selectRunMode);
 
 export const useRetryHistory = (id: string): LogicAppsV2.RetryHistory[] | undefined =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.runData?.retryHistory));
+  useSelector(
+    useMemo(
+      () => createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.runData?.retryHistory),
+      [id]
+    )
+  );
 
 export const useRunData = (id: string): LogicAppsV2.WorkflowRunAction | LogicAppsV2.WorkflowRunTrigger | undefined =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.runData));
+  useSelector(
+    useMemo(() => createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.runData), [id])
+  );
 
 export const useToolRunData = (id: string): LogicAppsV2.WorkflowRunAction | LogicAppsV2.WorkflowRunTrigger | undefined =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.toolRunData));
+  useSelector(
+    useMemo(() => createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.toolRunData), [id])
+  );
 
 export const useSubgraphRunData = (id: string): Record<string, { actionResults: LogicAppsV2.WorkflowRunAction[] }> | undefined =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.subgraphRunData));
+  useSelector(
+    useMemo(
+      () => createSelector(getWorkflowState, (state: WorkflowState) => getRecordEntry(state.nodesMetadata, id)?.subgraphRunData),
+      [id]
+    )
+  );
 
-export const useNodesMetadata = (): NodesMetadata =>
-  useSelector(createSelector(getWorkflowState, (state: WorkflowState) => state.nodesMetadata));
+const selectNodesMetadata = createSelector(getWorkflowState, (state: WorkflowState) => state.nodesMetadata);
+
+export const useNodesMetadata = (): NodesMetadata => useSelector(selectNodesMetadata);
 
 export const getNodesWithGraphId = (graphId: string, nodesMetadata: NodesMetadata): NodesMetadata => {
   return Object.entries(nodesMetadata).reduce((acc, [nodeId, metadata]) => {
@@ -492,139 +572,171 @@ export const getNodesWithGraphId = (graphId: string, nodesMetadata: NodesMetadat
 
 export const useParentRunIndexes = (id: string | undefined): Record<string, number> => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (!id) {
-        return {};
-      }
-      const allParents = getAllParentsForNode(id, state.nodesMetadata, true);
-      const parents = allParents.filter((x) => {
-        const operationType = getRecordEntry(state.operations, x)?.type?.toLowerCase() ?? '';
-        return (
-          [commonConstants.NODE.TYPE.FOREACH, commonConstants.NODE.TYPE.UNTIL, commonConstants.NODE.TYPE.AGENT].includes(operationType) ||
-          getRecordEntry(state.nodesMetadata, x)?.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION
-        );
-      });
-      return parents.reduce((acc: Record<string, number>, parentId) => {
-        acc[parentId] = getRecordEntry(state.nodesMetadata, parentId)?.runIndex ?? 0;
-        return acc;
-      }, {});
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (!id) {
+            return {};
+          }
+          const allParents = getAllParentsForNode(id, state.nodesMetadata, true);
+          const parents = allParents.filter((x) => {
+            const operationType = getRecordEntry(state.operations, x)?.type?.toLowerCase() ?? '';
+            return (
+              [commonConstants.NODE.TYPE.FOREACH, commonConstants.NODE.TYPE.UNTIL, commonConstants.NODE.TYPE.AGENT].includes(
+                operationType
+              ) || getRecordEntry(state.nodesMetadata, x)?.subgraphType === SUBGRAPH_TYPES.AGENT_CONDITION
+            );
+          });
+          return parents.reduce((acc: Record<string, number>, parentId) => {
+            acc[parentId] = getRecordEntry(state.nodesMetadata, parentId)?.runIndex ?? 0;
+            return acc;
+          }, {});
+        }),
+      [id]
+    )
   );
 };
 
 export const useParentRunIndex = (id: string | undefined): number | undefined => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (!id) {
-        return undefined;
-      }
-      const allParents = getAllParentsForNode(id, state.nodesMetadata);
-      const parents = allParents.filter((x) => {
-        const operationType = getRecordEntry(state.operations, x)?.type?.toLowerCase() ?? '';
-        return [commonConstants.NODE.TYPE.FOREACH, commonConstants.NODE.TYPE.UNTIL, commonConstants.NODE.TYPE.AGENT].includes(
-          operationType
-        );
-      });
-      return parents.length ? (getRecordEntry(state.nodesMetadata, parents[0])?.runIndex ?? 0) : undefined;
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (!id) {
+            return undefined;
+          }
+          const allParents = getAllParentsForNode(id, state.nodesMetadata);
+          const parents = allParents.filter((x) => {
+            const operationType = getRecordEntry(state.operations, x)?.type?.toLowerCase() ?? '';
+            return [commonConstants.NODE.TYPE.FOREACH, commonConstants.NODE.TYPE.UNTIL, commonConstants.NODE.TYPE.AGENT].includes(
+              operationType
+            );
+          });
+          return parents.length ? (getRecordEntry(state.nodesMetadata, parents[0])?.runIndex ?? 0) : undefined;
+        }),
+      [id]
+    )
   );
 };
 export const useRunIndex = (id: string | undefined): number | undefined => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (!id) {
-        return undefined;
-      }
-      return getRecordEntry(state.nodesMetadata, id)?.runIndex ?? undefined;
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (!id) {
+            return undefined;
+          }
+          return getRecordEntry(state.nodesMetadata, id)?.runIndex ?? undefined;
+        }),
+      [id]
+    )
   );
 };
 
 export const useToolRunIndex = (id: string | undefined): number | undefined => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (!id) {
-        return undefined;
-      }
-      return getRecordEntry(state.nodesMetadata, id)?.toolRunIndex ?? undefined;
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (!id) {
+            return undefined;
+          }
+          return getRecordEntry(state.nodesMetadata, id)?.toolRunIndex ?? undefined;
+        }),
+      [id]
+    )
   );
 };
 
 export const useParentNodeId = (id: string | undefined): string | undefined => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (!id) {
-        return undefined;
-      }
-      const parentId = getRecordEntry(state.nodesMetadata, id)?.parentNodeId;
-      if (parentId?.includes('elseActions') || parentId?.includes('actions')) {
-        return getRecordEntry(state.nodesMetadata, parentId)?.parentNodeId;
-      }
-      return parentId;
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (!id) {
+            return undefined;
+          }
+          const parentId = getRecordEntry(state.nodesMetadata, id)?.parentNodeId;
+          if (parentId?.includes('elseActions') || parentId?.includes('actions')) {
+            return getRecordEntry(state.nodesMetadata, parentId)?.parentNodeId;
+          }
+          return parentId;
+        }),
+      [id]
+    )
   );
 };
 
-export const useRootTriggerId = (): string =>
-  useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      for (const [id, node] of Object.entries(state.nodesMetadata)) {
-        if (node?.isTrigger ?? false) {
-          return id;
-        }
-      }
-      return '';
-    })
-  );
+const selectRootTriggerId = createSelector(getWorkflowState, (state: WorkflowState) => {
+  for (const [id, node] of Object.entries(state.nodesMetadata)) {
+    if (node?.isTrigger ?? false) {
+      return id;
+    }
+  }
+  return '';
+});
+
+export const useRootTriggerId = (): string => useSelector(selectRootTriggerId);
 
 export const useIsAgentLoop = (id?: string): boolean => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (!id) {
-        return false;
-      }
-      const type = getRecordEntry(state.operations, id)?.type;
-      return equals(type, commonConstants.NODE.TYPE.AGENT);
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (!id) {
+            return false;
+          }
+          const type = getRecordEntry(state.operations, id)?.type;
+          return equals(type, commonConstants.NODE.TYPE.AGENT);
+        }),
+      [id]
+    )
   );
 };
 
 export const useIsWithinAgenticLoop = (id?: string): boolean => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      let currentId = id;
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          let currentId = id;
 
-      while (currentId) {
-        const type = getRecordEntry(state.operations, currentId)?.type;
-        if (equals(type, commonConstants.NODE.TYPE.AGENT)) {
-          return true;
-        }
-        const parentId = getRecordEntry(state.nodesMetadata, currentId)?.parentNodeId;
+          while (currentId) {
+            const type = getRecordEntry(state.operations, currentId)?.type;
+            if (equals(type, commonConstants.NODE.TYPE.AGENT)) {
+              return true;
+            }
+            const parentId = getRecordEntry(state.nodesMetadata, currentId)?.parentNodeId;
 
-        if (!parentId) {
+            if (!parentId) {
+              return false;
+            }
+
+            currentId = parentId;
+          }
+
           return false;
-        }
-
-        currentId = parentId;
-      }
-
-      return false;
-    })
+        }),
+      [id]
+    )
   );
 };
 
 export const useHasUpstreamAgenticLoop = (upstreamNodes: string[]): boolean => {
   return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      for (const nodeId of upstreamNodes) {
-        const type = getRecordEntry(state.operations, nodeId)?.type;
-        if (equals(type, commonConstants.NODE.TYPE.AGENT)) {
-          return true;
-        }
-      }
-      return false;
-    })
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          for (const nodeId of upstreamNodes) {
+            const type = getRecordEntry(state.operations, nodeId)?.type;
+            if (equals(type, commonConstants.NODE.TYPE.AGENT)) {
+              return true;
+            }
+          }
+          return false;
+        }),
+      [upstreamNodes]
+    )
   );
 };
 
@@ -646,32 +758,36 @@ export const useAgentOperations = () => {
 
 export const useUriForAgentChat = (nodeId?: string) =>
   useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      if (nodeId) {
-        const runData = getRecordEntry(state.nodesMetadata, nodeId)?.runData;
-        /**
-         * Chat input is only enabled when the node is an agent, and is currently running or succeeded,
-         * Workflow itself is running,
-         * and input channel is configured
-         * */
-        if (
-          equals(state.runInstance?.properties.status ?? '', commonConstants.FLOW_STATUS.RUNNING) &&
-          (equals(runData?.status ?? '', commonConstants.FLOW_STATUS.SUCCEEDED) ||
-            equals(runData?.status ?? '', commonConstants.FLOW_STATUS.RUNNING))
-        ) {
-          const operation = getRecordEntry(state.operations, nodeId);
-          if (operation) {
-            const operationDefinitionAsAgentOperation = operation as LogicAppsV2.AgentAction;
-            const allInputChannelKeys = Object.keys(operationDefinitionAsAgentOperation.channels?.in ?? {});
-            if (allInputChannelKeys.length > 0) {
-              return `${state.runInstance?.id ?? ''}/agents/${nodeId}/channels/${allInputChannelKeys[0]}`;
+    useMemo(
+      () =>
+        createSelector(getWorkflowState, (state: WorkflowState) => {
+          if (nodeId) {
+            const runData = getRecordEntry(state.nodesMetadata, nodeId)?.runData;
+            /**
+             * Chat input is only enabled when the node is an agent, and is currently running or succeeded,
+             * Workflow itself is running,
+             * and input channel is configured
+             * */
+            if (
+              equals(state.runInstance?.properties.status ?? '', commonConstants.FLOW_STATUS.RUNNING) &&
+              (equals(runData?.status ?? '', commonConstants.FLOW_STATUS.SUCCEEDED) ||
+                equals(runData?.status ?? '', commonConstants.FLOW_STATUS.RUNNING))
+            ) {
+              const operation = getRecordEntry(state.operations, nodeId);
+              if (operation) {
+                const operationDefinitionAsAgentOperation = operation as LogicAppsV2.AgentAction;
+                const allInputChannelKeys = Object.keys(operationDefinitionAsAgentOperation.channels?.in ?? {});
+                if (allInputChannelKeys.length > 0) {
+                  return `${state.runInstance?.id ?? ''}/agents/${nodeId}/channels/${allInputChannelKeys[0]}`;
+                }
+              }
             }
           }
-        }
-      }
 
-      return undefined;
-    })
+          return undefined;
+        }),
+      [nodeId]
+    )
   );
 
 export const useAgentLastOperations = (agentOperations: string[]): Record<string, any> => {
@@ -713,12 +829,12 @@ export const getAgentFromCondition = (state: WorkflowState, nodeId: string): str
   return state.nodesMetadata[nodeId].parentNodeId;
 };
 
+const selectAllAgentIds = createSelector(getWorkflowState, (state: WorkflowState) => {
+  return Object.keys(state.operations).filter((id) => equals(state.operations[id]?.type, commonConstants.NODE.TYPE.AGENT));
+});
+
 export const useAllAgentIds = (): string[] => {
-  return useSelector(
-    createSelector(getWorkflowState, (state: WorkflowState) => {
-      return Object.keys(state.operations).filter((id) => equals(state.operations[id]?.type, commonConstants.NODE.TYPE.AGENT));
-    })
-  );
+  return useSelector(selectAllAgentIds);
 };
 
 // These edges are not actually present in the graph, but are used to represent handoffs between agents during graph calculations


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [x] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
This memoizes Redux selectors across the `designer-v2` state layer (operation,
connection, designerView, and workflow selectors) so derived values keep a
stable reference across re-renders.

Previously, several hooks built their `createSelector` inline inside the hook
body (e.g. `useSelector(createSelector(...))`). Because a new selector instance
was created on every render, reselect's size-1 memo cache started empty each
time and recomputed the derived object/array — returning a **brand-new
reference** even when the underlying store state was unchanged. That defeats
downstream `React.memo`, `useMemo`, and `useEffect` dependency checks and causes
unnecessary re-render cascades.

The fix follows two patterns:
- **Non-parameterized selectors** are hoisted to module scope so a single stable
  selector instance is reused across all renders/components.
- **Parameterized selectors** are wrapped in `useMemo(() => createSelector(...), [args])`
  so the selector instance is stable as long as its arguments are stable.

Behavior is unchanged — only output reference identity is stabilized.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No functional or visual change. Indirect benefit from fewer
  redundant re-renders in the designer (smoother interaction on large workflows).
- **Developers**: Establishes the correct selector-memoization pattern for
  `designer-v2` (hoist non-parameterized selectors; `useMemo`-wrap parameterized
  ones). No public API changes.
- **System**: Derived selector outputs now keep referential stability across
  re-renders, restoring the effectiveness of reselect memoization and downstream
  React memoization. No new dependencies.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: standalone designer (designer-v2 state hooks)

Existing `workflowSelectors` unit tests pass. A temporary reference-stability
benchmark (renderHook + Redux Provider, 10 forced re-renders with unchanged
store state) confirmed the improvement and was then removed:

| Hook | Output-reference changes / 10 re-renders (Before) | After |
|---|---|---|
| `useAllConnectionErrors` | 10 | 0 |
| `useOperationsVisuals` | 10 | 0 |
| `useAllAgentIds` | 10 | 0 |

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A — no visual changes.