### PR TITLE
fix(DesignerV2): Fix Consumption resubmit (Retry) URL missing workflowId path (v5.961)

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/__tests__/run.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/__tests__/run.spec.ts
@@ -172,6 +172,42 @@ describe('ConsumptionRunService', () => {
     });
   });
 
+  describe('resubmitRun', () => {
+    test('should construct URL with workflowId path segment', async () => {
+      vi.mocked(mockHttpClient.post).mockResolvedValue({});
+
+      await runService.resubmitRun('run-123', 'manual');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith({
+        uri: 'https://api.example.comtest-workflow/triggers/manual/histories/run-123/resubmit?api-version=2016-06-01',
+        headers: { 'If-Match': '*' },
+      });
+    });
+
+    test('should include workflowId for ARM resource paths', async () => {
+      const armOptions = {
+        ...mockOptions,
+        baseUrl: 'https://management.azure.com',
+        workflowId: '/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Logic/workflows/my-workflow',
+      };
+      const armRunService = new ConsumptionRunService(armOptions);
+      vi.mocked(mockHttpClient.post).mockResolvedValue({});
+
+      await armRunService.resubmitRun('08584222487129015244', 'When_an_HTTP_request_is_received');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith({
+        uri: 'https://management.azure.com/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Logic/workflows/my-workflow/triggers/When_an_HTTP_request_is_received/histories/08584222487129015244/resubmit?api-version=2016-06-01',
+        headers: { 'If-Match': '*' },
+      });
+    });
+
+    test('should throw error when HTTP request fails', async () => {
+      vi.mocked(mockHttpClient.post).mockRejectedValue(new Error('Forbidden'));
+
+      await expect(runService.resubmitRun('run-123', 'manual')).rejects.toThrow('Forbidden');
+    });
+  });
+
   describe('integration with getScopeRepetitions', () => {
     test('should work with getScopeRepetitions pagination flow', async () => {
       // Mock the first page response

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/run.ts
@@ -581,10 +581,10 @@ export class ConsumptionRunService implements IRunService {
   }
 
   async resubmitRun(runId: string, triggerName: string): Promise<any> {
-    const { apiVersion, baseUrl, httpClient } = this.options;
+    const { apiVersion, baseUrl, workflowId, httpClient } = this.options;
 
     try {
-      const resubmitUrl = `${baseUrl}/triggers/${triggerName}/histories/${runId}/resubmit?api-version=${apiVersion}`;
+      const resubmitUrl = `${baseUrl}${workflowId}/triggers/${triggerName}/histories/${runId}/resubmit?api-version=${apiVersion}`;
       const headers = { 'If-Match': '*' };
       const response = await httpClient.post({
         uri: resubmitUrl,
@@ -592,7 +592,7 @@ export class ConsumptionRunService implements IRunService {
       });
       return response;
     } catch (e: any) {
-      return new Error(e.message);
+      throw new Error(e.message);
     }
   }
 


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why

Fixes #9194 — The **Retry** button in the run history blade for Consumption Logic Apps was failing silently with 404 errors.

`ConsumptionRunService.resubmitRun()` was constructing the resubmit API URL without the `workflowId` path segment, resulting in requests to `https://management.azure.com/triggers/...` instead of the correct `https://management.azure.com/{workflowId}/triggers/...`.

Added `workflowId` to the URL template, matching the pattern used by other methods in the same class (e.g., `getRuns()`, `getScopeRepetitions()`).

## Impact of Change
- **Users**: Retry button in Consumption run history blade now works correctly
- **Developers**: None
- **System**: None

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Verified via HAR file analysis that resubmit URLs were returning 404; confirmed fix produces correct URL with workflowId. All 310 existing unit tests pass.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- N/A - no visual changes -->

