### PR TITLE
fix(vscode): restore codeful bundle version setting

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppWorkspace.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppWorkspace.ts
@@ -5,6 +5,7 @@ import {
   autoRuntimeDependenciesPathSettingKey,
   azureWebJobsFeatureFlagsKey,
   azureWebJobsStorageKey,
+  codefulExtensionBundleIdSetting,
   codefulExtensionBundleVersion,
   codefulExtensionBundleVersionSetting,
   defaultVersionRange,
@@ -227,6 +228,7 @@ export async function createLocalConfigurationFiles(
   // TODO(aeldridge): Update to point to codeful private bundle once it's published.
   if (logicAppType === ProjectType.codeful) {
     localSettingsJson.Values[workflowCodefulEnabled] = 'true';
+    localSettingsJson.Values[codefulExtensionBundleIdSetting] = extensionBundleId;
     localSettingsJson.Values[codefulExtensionBundleVersionSetting] = codefulExtensionBundleVersion;
   }
 

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppWorkspace.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppWorkspace.ts
@@ -5,6 +5,8 @@ import {
   autoRuntimeDependenciesPathSettingKey,
   azureWebJobsFeatureFlagsKey,
   azureWebJobsStorageKey,
+  codefulExtensionBundleVersion,
+  codefulExtensionBundleVersionSetting,
   defaultVersionRange,
   devContainerFolderName,
   extensionBundleId,
@@ -225,6 +227,7 @@ export async function createLocalConfigurationFiles(
   // TODO(aeldridge): Update to point to codeful private bundle once it's published.
   if (logicAppType === ProjectType.codeful) {
     localSettingsJson.Values[workflowCodefulEnabled] = 'true';
+    localSettingsJson.Values[codefulExtensionBundleVersionSetting] = codefulExtensionBundleVersion;
   }
 
   const hostJsonPath: string = path.join(logicAppFolderPath, hostFileName);

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
@@ -1477,6 +1477,10 @@ describe('createLocalConfigurationFiles', () => {
     const localSettingsData = localSettingsCall![1] as any;
 
     expect(localSettingsData.Values).toHaveProperty('WORKFLOW_CODEFUL_ENABLED', 'true');
+    expect(localSettingsData.Values).toHaveProperty(
+      'AzureFunctionsJobHost__extensionBundle__id',
+      'Microsoft.Azure.Functions.ExtensionBundle.Workflows'
+    );
     expect(localSettingsData.Values).toHaveProperty('AzureFunctionsJobHost__extensionBundle__version', '1.165.50');
     expect(localSettingsData.Values).not.toHaveProperty('Functions_ExtensionBundle_Source_URI');
     expect(localSettingsData.Values).not.toHaveProperty('FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI');

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
@@ -1308,6 +1308,13 @@ describe('createLocalConfigurationFiles', () => {
     workflowName: 'TestWorkflow',
   } as any;
 
+  const mockContextCodeful: IWebviewProjectContext = {
+    workspaceName: 'TestWorkspace',
+    logicAppName: 'TestLogicApp',
+    logicAppType: ProjectType.codeful,
+    workflowName: 'TestWorkflow',
+  } as any;
+
   const logicAppFolderPath = actualPath.join('test', 'workspace', 'TestLogicApp');
 
   beforeEach(() => {
@@ -1458,6 +1465,21 @@ describe('createLocalConfigurationFiles', () => {
 
     // Verify exactly 6 properties exist (5 standard + 1 feature flag)
     expect(Object.keys(localSettingsData.Values)).toHaveLength(6);
+  });
+
+  it('should include bundle version and not source URI in local.settings.json for codeful projects', async () => {
+    await CreateLogicAppWorkspaceModule.createLocalConfigurationFiles(mockContextCodeful, logicAppFolderPath);
+
+    const localSettingsCall = vi
+      .mocked(fsUtils.writeFormattedJson)
+      .mock.calls.find((call) => call[0].toString().includes('local.settings.json'));
+    expect(localSettingsCall).toBeDefined();
+    const localSettingsData = localSettingsCall![1] as any;
+
+    expect(localSettingsData.Values).toHaveProperty('WORKFLOW_CODEFUL_ENABLED', 'true');
+    expect(localSettingsData.Values).toHaveProperty('AzureFunctionsJobHost__extensionBundle__version', '1.165.50');
+    expect(localSettingsData.Values).not.toHaveProperty('Functions_ExtensionBundle_Source_URI');
+    expect(localSettingsData.Values).not.toHaveProperty('FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI');
   });
 
   it('should include global.json in .funcignore for rules engine projects', async () => {

--- a/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
@@ -6,8 +6,10 @@ import {
   azureStorageTypeSetting,
   azureWebJobsSecretStorageTypeKey,
   azureWebJobsStorageKey,
+  codefulExtensionBundleIdSetting,
   codefulExtensionBundleVersion,
   codefulExtensionBundleVersionSetting,
+  extensionBundleId,
   localEmulatorConnectionString,
   workerRuntimeKey,
 } from '../../../../constants';
@@ -43,6 +45,7 @@ describe('utils/appSettings', () => {
 
     it('Should include codeful bundle version without source URI for codeful localsettings', () => {
       const settings = getLocalSettingsSchema(false, projectPath, true);
+      expect(settings['Values']).toHaveProperty(codefulExtensionBundleIdSetting, extensionBundleId);
       expect(settings['Values']).toHaveProperty(codefulExtensionBundleVersionSetting, codefulExtensionBundleVersion);
       expect(settings['Values']).not.toHaveProperty('Functions_ExtensionBundle_Source_URI');
       expect(settings['Values']).not.toHaveProperty('FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI');

--- a/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
@@ -6,6 +6,8 @@ import {
   azureStorageTypeSetting,
   azureWebJobsSecretStorageTypeKey,
   azureWebJobsStorageKey,
+  codefulExtensionBundleVersion,
+  codefulExtensionBundleVersionSetting,
   localEmulatorConnectionString,
   workerRuntimeKey,
 } from '../../../../constants';
@@ -37,6 +39,13 @@ describe('utils/appSettings', () => {
       const settings = getLocalSettingsSchema(false, projectPath);
       expect(settings['Values']).toHaveProperty(azureWebJobsStorageKey, localEmulatorConnectionString);
       expect(settings['Values']).toHaveProperty(ProjectDirectoryPathKey, projectPath);
+    });
+
+    it('Should include codeful bundle version without source URI for codeful localsettings', () => {
+      const settings = getLocalSettingsSchema(false, projectPath, true);
+      expect(settings['Values']).toHaveProperty(codefulExtensionBundleVersionSetting, codefulExtensionBundleVersion);
+      expect(settings['Values']).not.toHaveProperty('Functions_ExtensionBundle_Source_URI');
+      expect(settings['Values']).not.toHaveProperty('FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI');
     });
   });
 });

--- a/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
@@ -12,8 +12,10 @@ import {
   logicAppKind,
   workerRuntimeKey,
   azureStorageTypeSetting,
+  codefulExtensionBundleIdSetting,
   codefulExtensionBundleVersion,
   codefulExtensionBundleVersionSetting,
+  extensionBundleId,
   functionsInprocNet8Enabled,
   functionsInprocNet8EnabledTrue,
 } from '../../../constants';
@@ -203,6 +205,7 @@ export const getLocalSettingsSchema = (isDesignTime: boolean, projectPath?: stri
   if (isCodeful) {
     Object.assign(baseSettings.Values, {
       WORKFLOW_CODEFUL_ENABLED: 'true',
+      [codefulExtensionBundleIdSetting]: extensionBundleId,
       [codefulExtensionBundleVersionSetting]: codefulExtensionBundleVersion,
     });
   }

--- a/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
@@ -12,6 +12,8 @@ import {
   logicAppKind,
   workerRuntimeKey,
   azureStorageTypeSetting,
+  codefulExtensionBundleVersion,
+  codefulExtensionBundleVersionSetting,
   functionsInprocNet8Enabled,
   functionsInprocNet8EnabledTrue,
 } from '../../../constants';
@@ -201,6 +203,7 @@ export const getLocalSettingsSchema = (isDesignTime: boolean, projectPath?: stri
   if (isCodeful) {
     Object.assign(baseSettings.Values, {
       WORKFLOW_CODEFUL_ENABLED: 'true',
+      [codefulExtensionBundleVersionSetting]: codefulExtensionBundleVersion,
     });
   }
 

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -114,6 +114,7 @@ export const workflowAppAADClientSecret = 'WORKFLOWAPP_AAD_CLIENTSECRET';
 export const debugSymbolDll = 'Microsoft.Azure.Workflows.BuildTasks.DebugSymbolGenerator.dll';
 // Codeful settings
 export const workflowCodefulEnabled = 'WORKFLOW_CODEFUL_ENABLED';
+export const codefulExtensionBundleIdSetting = 'AzureFunctionsJobHost__extensionBundle__id';
 export const codefulExtensionBundleVersionSetting = 'AzureFunctionsJobHost__extensionBundle__version';
 export const codefulExtensionBundleVersion = '1.165.50';
 

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -114,6 +114,8 @@ export const workflowAppAADClientSecret = 'WORKFLOWAPP_AAD_CLIENTSECRET';
 export const debugSymbolDll = 'Microsoft.Azure.Workflows.BuildTasks.DebugSymbolGenerator.dll';
 // Codeful settings
 export const workflowCodefulEnabled = 'WORKFLOW_CODEFUL_ENABLED';
+export const codefulExtensionBundleVersionSetting = 'AzureFunctionsJobHost__extensionBundle__version';
+export const codefulExtensionBundleVersion = '1.165.50';
 
 export const workflowCodeType = {
   codeful: 'Codeful',


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Updating the version that the codeful experience should be tied to for public preview.

## Impact of Change
- **Users**: Codeful Logic Apps users get the latest public preview dependency assets/settings on the hotfix branch.
- **Developers**: No API changes.
- **System**: Updates bundled VS Code extension dependency assets and removes private extension bundle settings for codeful local settings.

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: `git diff --check origin/hotfix/v5.961...HEAD`; pinned Biome check on changed TypeScript files

## Contributors

## Screenshots/Videos
N/A