### PR TITLE
fix(vscode): update codeful workflow templates

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
@@ -114,20 +114,19 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
   const testLspDirectory = '/test/lsp';
 
   describe('StatefulCodefulWorkflow template content', () => {
-    it('should avoid unsupported member-expression startup patterns while keeping MSN Weather', () => {
+    it('should use the provider-based stateful SDK template while keeping MSN Weather', () => {
       const templateContent = actualFs.readFileSync(
         new URL('../../../../../assets/CodefulProjectTemplate/StatefulCodefulWorkflow', import.meta.url),
         'utf-8'
       );
 
-      expect(templateContent).toContain('new WorkflowBuiltInTriggers().CreateHttpTrigger()');
-      expect(templateContent).toContain('new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather');
+      expect(templateContent).toContain('WorkflowTriggers.BuiltIn.CreateHttpTrigger()');
+      expect(templateContent).toContain('WorkflowActions.Managed.Msnweather("msnweather").CurrentWeather');
       expect(templateContent).toContain('location: () => "98058"');
       expect(templateContent).toContain('public class <%= flowNameClass %> : IWorkflowProvider');
-      expect(templateContent).toContain('new WorkflowBuiltInActions().Response(responseBody: () => $"{getCurrentWeatherAction.Body}")');
+      expect(templateContent).toContain('WorkflowActions.BuiltIn.Response(responseBody: () => $"{getCurrentWeatherAction.Body}")');
       expect(templateContent).toContain('WorkflowFactory.CreateStatefulWorkflow(<%= flowName %>, workflow)');
       expect(templateContent).not.toContain('WorkflowActions.BuiltIn.Compose');
-      expect(templateContent).not.toContain('WorkflowTriggers.BuiltIn');
       expect(templateContent).not.toContain('WorkflowActions.ManagedConnectors');
       expect(templateContent).not.toContain('WorkflowBuilderFactory');
       expect(templateContent).not.toContain('AddWorkflow()');
@@ -143,14 +142,12 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
       );
 
       expect(templateContent).toContain('public class <%= flowNameClass %> : IWorkflowProvider');
-      expect(templateContent).toContain('new WorkflowBuiltInTriggers().CreateConversationalAgentTrigger()');
-      expect(templateContent).toContain('new WorkflowBuiltInActions().Agent(');
+      expect(templateContent).toContain('WorkflowTriggers.BuiltIn.CreateConversationalAgentTrigger()');
+      expect(templateContent).toContain('WorkflowActions.BuiltIn.Agent(');
       expect(templateContent).toContain('WorkflowFactory.CreateAgentWorkflow(<%= flowName %>, workflow)');
-      expect(templateContent).toContain('new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather');
-      expect(templateContent).toContain('new WorkflowManagedActions().Office365("outlook").SendEmail');
+      expect(templateContent).toContain('WorkflowActions.Managed.Msnweather("msnweather").CurrentWeather');
+      expect(templateContent).toContain('WorkflowActions.Managed.Office365("outlook").SendEmail');
       expect(templateContent).not.toContain('SendEmailV2');
-      expect(templateContent).not.toContain('WorkflowTriggers.BuiltIn');
-      expect(templateContent).not.toContain('WorkflowActions.BuiltIn');
       expect(templateContent).not.toContain('WorkflowActions.ManagedConnectors');
       expect(templateContent).not.toContain('WorkflowBuilderFactory.CreateConversationalAgent');
       expect(templateContent).not.toContain('AddWorkflow()');
@@ -165,15 +162,13 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
       );
 
       expect(templateContent).toContain('public class <%= flowNameClass %> : IWorkflowProvider');
-      expect(templateContent).toContain('new WorkflowBuiltInTriggers().CreateHttpTrigger()');
-      expect(templateContent).toContain('new WorkflowBuiltInActions().Agent(');
+      expect(templateContent).toContain('WorkflowTriggers.BuiltIn.CreateHttpTrigger()');
+      expect(templateContent).toContain('WorkflowActions.BuiltIn.Agent(');
       expect(templateContent).toContain('WorkflowFactory.CreateStatefulWorkflow(<%= flowName %>, workflow)');
       expect(templateContent).toContain('MessageRole.User');
-      expect(templateContent).toContain('new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather');
-      expect(templateContent).toContain('new WorkflowManagedActions().Office365("outlook").SendEmail');
+      expect(templateContent).toContain('WorkflowActions.Managed.Msnweather("msnweather").CurrentWeather');
+      expect(templateContent).toContain('WorkflowActions.Managed.Office365("outlook").SendEmail');
       expect(templateContent).not.toContain('SendEmailV2');
-      expect(templateContent).not.toContain('WorkflowTriggers.BuiltIn');
-      expect(templateContent).not.toContain('WorkflowActions.BuiltIn');
       expect(templateContent).not.toContain('WorkflowActions.ManagedConnectors');
       expect(templateContent).not.toContain('AddWorkflow()');
     });
@@ -243,13 +238,13 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
       expect(vi.mocked(fse.readFile)).toHaveBeenCalledWith(expect.stringContaining('AgentCodefulWorkflow'), 'utf-8');
       const workflowWriteCall = vi.mocked(fse.writeFile).mock.calls.find((call: any) => call[0].includes(`${testWorkflowName}.cs`));
       expect(workflowWriteCall?.[1]).toContain(`public class ${testWorkflowName} : IWorkflowProvider`);
-      expect(workflowWriteCall?.[1]).toContain('new WorkflowBuiltInActions().Agent(');
-      expect(workflowWriteCall?.[1]).toContain('new WorkflowManagedActions().Office365("outlook").SendEmail');
+      expect(workflowWriteCall?.[1]).toContain('WorkflowActions.BuiltIn.Agent(');
+      expect(workflowWriteCall?.[1]).toContain('WorkflowActions.Managed.Office365("outlook").SendEmail');
       expect(workflowWriteCall?.[1]).toContain(`WorkflowFactory.CreateAgentWorkflow("${testWorkflowName}", workflow)`);
       expect(workflowWriteCall?.[1]).not.toContain('<%= flowName %>');
       expect(workflowWriteCall?.[1]).not.toContain('<%= flowNameClass %>');
       expect(workflowWriteCall?.[1]).not.toContain('<%= logicAppNamespace %>');
-      expect(workflowWriteCall?.[1]).not.toContain('WorkflowActions.BuiltIn');
+      expect(workflowWriteCall?.[1]).not.toContain('WorkflowActions.ManagedConnectors');
       expect(workflowWriteCall?.[1]).not.toContain('SendEmailV2');
 
       const programWriteCall = vi.mocked(fse.writeFile).mock.calls.find((call: any) => call[0].includes('Program.cs'));
@@ -292,14 +287,14 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
       expect(vi.mocked(fse.readFile)).toHaveBeenCalledWith(expect.stringContaining('AgenticCodefulWorkflow'), 'utf-8');
       const workflowWriteCall = vi.mocked(fse.writeFile).mock.calls.find((call: any) => call[0].includes(`${testWorkflowName}.cs`));
       expect(workflowWriteCall?.[1]).toContain(`public class ${testWorkflowName} : IWorkflowProvider`);
-      expect(workflowWriteCall?.[1]).toContain('new WorkflowBuiltInActions().Agent(');
-      expect(workflowWriteCall?.[1]).toContain('new WorkflowManagedActions().Office365("outlook").SendEmail');
+      expect(workflowWriteCall?.[1]).toContain('WorkflowActions.BuiltIn.Agent(');
+      expect(workflowWriteCall?.[1]).toContain('WorkflowActions.Managed.Office365("outlook").SendEmail');
       expect(workflowWriteCall?.[1]).toContain('MessageRole.User');
       expect(workflowWriteCall?.[1]).toContain(`WorkflowFactory.CreateStatefulWorkflow("${testWorkflowName}", workflow)`);
       expect(workflowWriteCall?.[1]).not.toContain('<%= flowName %>');
       expect(workflowWriteCall?.[1]).not.toContain('<%= flowNameClass %>');
       expect(workflowWriteCall?.[1]).not.toContain('<%= logicAppNamespace %>');
-      expect(workflowWriteCall?.[1]).not.toContain('WorkflowActions.BuiltIn');
+      expect(workflowWriteCall?.[1]).not.toContain('WorkflowActions.ManagedConnectors');
       expect(workflowWriteCall?.[1]).not.toContain('SendEmailV2');
 
       const programWriteCall = vi.mocked(fse.writeFile).mock.calls.find((call: any) => call[0].includes('Program.cs'));

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, type Mock } from 'vitest';
-import { WorkflowType } from '@microsoft/vscode-extension-logic-apps';
 import * as CreateLogicAppWorkspaceModule from '../CreateLogicAppWorkspace';
 import * as vscode from 'vscode';
 import * as fse from 'fs-extra';
@@ -15,6 +14,13 @@ import * as cloudToLocalUtilsModule from '../../../../utils/cloudToLocalUtils';
 import { ProjectType } from '@microsoft/vscode-extension-logic-apps';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { IWebviewProjectContext } from '@microsoft/vscode-extension-logic-apps';
+
+const WorkflowType = {
+  stateful: 'Stateful-Codeless',
+  statefulCodeful: 'Stateful-Codeful',
+  agenticCodeful: 'Agentic-Codeful',
+  agentCodeful: 'Agent-Codeful',
+} as const;
 
 vi.mock('vscode', () => ({
   window: {
@@ -62,6 +68,34 @@ vi.mock('path', () => ({
   resolve: vi.fn(),
 }));
 
+vi.mock('@microsoft/vscode-extension-logic-apps', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@microsoft/vscode-extension-logic-apps')>();
+  return {
+    ...actual,
+    ProjectType: {
+      logicApp: 'logicApp',
+      customCode: 'customCode',
+      rulesEngine: 'rulesEngine',
+      codeful: 'codeful',
+    },
+    WorkflowType: {
+      stateful: 'Stateful-Codeless',
+      stateless: 'Stateless-Codeless',
+      agentic: 'Agentic-Codeless',
+      agent: 'Agent-Codeless',
+      statefulCodeful: 'Stateful-Codeful',
+      statelessCodeful: 'Stateless-Codeful',
+      agenticCodeful: 'Agentic-Codeful',
+      agentCodeful: 'Agent-Codeful',
+    },
+    WorkerRuntime: {
+      Node: 'node',
+      Dotnet: 'dotnet',
+      DotnetIsolated: 'dotnet-isolated',
+    },
+  };
+});
+
 vi.mock('../../../../utils/vsCodeConfig/settings', () => ({
   getGlobalSetting: vi.fn(),
 }));
@@ -86,12 +120,15 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
         'utf-8'
       );
 
-      expect(templateContent).toContain('WorkflowActions.ManagedConnectors.Msnweather("msnweather").CurrentWeather');
+      expect(templateContent).toContain('new WorkflowBuiltInTriggers().CreateHttpTrigger()');
+      expect(templateContent).toContain('new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather');
       expect(templateContent).toContain('location: () => "98058"');
       expect(templateContent).toContain('public class <%= flowNameClass %> : IWorkflowProvider');
-      expect(templateContent).toContain('WorkflowActions.BuiltIn.Response(responseBody: () => $"{getCurrentWeatherAction.Body}")');
+      expect(templateContent).toContain('new WorkflowBuiltInActions().Response(responseBody: () => $"{getCurrentWeatherAction.Body}")');
       expect(templateContent).toContain('WorkflowFactory.CreateStatefulWorkflow(<%= flowName %>, workflow)');
       expect(templateContent).not.toContain('WorkflowActions.BuiltIn.Compose');
+      expect(templateContent).not.toContain('WorkflowTriggers.BuiltIn');
+      expect(templateContent).not.toContain('WorkflowActions.ManagedConnectors');
       expect(templateContent).not.toContain('WorkflowBuilderFactory');
       expect(templateContent).not.toContain('AddWorkflow()');
       expect(templateContent).not.toContain('builder.TriggerOutput.Body');
@@ -106,10 +143,15 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
       );
 
       expect(templateContent).toContain('public class <%= flowNameClass %> : IWorkflowProvider');
-      expect(templateContent).toContain('WorkflowTriggers.BuiltIn.CreateConversationalAgentTrigger()');
-      expect(templateContent).toContain('WorkflowActions.BuiltIn.Agent(');
+      expect(templateContent).toContain('new WorkflowBuiltInTriggers().CreateConversationalAgentTrigger()');
+      expect(templateContent).toContain('new WorkflowBuiltInActions().Agent(');
       expect(templateContent).toContain('WorkflowFactory.CreateAgentWorkflow(<%= flowName %>, workflow)');
-      expect(templateContent).toContain('WorkflowActions.ManagedConnectors.Office365("outlook").SendEmailV2');
+      expect(templateContent).toContain('new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather');
+      expect(templateContent).toContain('new WorkflowManagedActions().Office365("outlook").SendEmail');
+      expect(templateContent).not.toContain('SendEmailV2');
+      expect(templateContent).not.toContain('WorkflowTriggers.BuiltIn');
+      expect(templateContent).not.toContain('WorkflowActions.BuiltIn');
+      expect(templateContent).not.toContain('WorkflowActions.ManagedConnectors');
       expect(templateContent).not.toContain('WorkflowBuilderFactory.CreateConversationalAgent');
       expect(templateContent).not.toContain('AddWorkflow()');
     });
@@ -123,11 +165,16 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
       );
 
       expect(templateContent).toContain('public class <%= flowNameClass %> : IWorkflowProvider');
-      expect(templateContent).toContain('WorkflowTriggers.BuiltIn.CreateHttpTrigger()');
-      expect(templateContent).toContain('WorkflowActions.BuiltIn.Agent(');
+      expect(templateContent).toContain('new WorkflowBuiltInTriggers().CreateHttpTrigger()');
+      expect(templateContent).toContain('new WorkflowBuiltInActions().Agent(');
       expect(templateContent).toContain('WorkflowFactory.CreateStatefulWorkflow(<%= flowName %>, workflow)');
       expect(templateContent).toContain('MessageRole.User');
-      expect(templateContent).toContain('WorkflowActions.ManagedConnectors.Office365("outlook").SendEmailV2');
+      expect(templateContent).toContain('new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather');
+      expect(templateContent).toContain('new WorkflowManagedActions().Office365("outlook").SendEmail');
+      expect(templateContent).not.toContain('SendEmailV2');
+      expect(templateContent).not.toContain('WorkflowTriggers.BuiltIn');
+      expect(templateContent).not.toContain('WorkflowActions.BuiltIn');
+      expect(templateContent).not.toContain('WorkflowActions.ManagedConnectors');
       expect(templateContent).not.toContain('AddWorkflow()');
     });
   });
@@ -196,7 +243,14 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
       expect(vi.mocked(fse.readFile)).toHaveBeenCalledWith(expect.stringContaining('AgentCodefulWorkflow'), 'utf-8');
       const workflowWriteCall = vi.mocked(fse.writeFile).mock.calls.find((call: any) => call[0].includes(`${testWorkflowName}.cs`));
       expect(workflowWriteCall?.[1]).toContain(`public class ${testWorkflowName} : IWorkflowProvider`);
+      expect(workflowWriteCall?.[1]).toContain('new WorkflowBuiltInActions().Agent(');
+      expect(workflowWriteCall?.[1]).toContain('new WorkflowManagedActions().Office365("outlook").SendEmail');
       expect(workflowWriteCall?.[1]).toContain(`WorkflowFactory.CreateAgentWorkflow("${testWorkflowName}", workflow)`);
+      expect(workflowWriteCall?.[1]).not.toContain('<%= flowName %>');
+      expect(workflowWriteCall?.[1]).not.toContain('<%= flowNameClass %>');
+      expect(workflowWriteCall?.[1]).not.toContain('<%= logicAppNamespace %>');
+      expect(workflowWriteCall?.[1]).not.toContain('WorkflowActions.BuiltIn');
+      expect(workflowWriteCall?.[1]).not.toContain('SendEmailV2');
 
       const programWriteCall = vi.mocked(fse.writeFile).mock.calls.find((call: any) => call[0].includes('Program.cs'));
       expect(programWriteCall?.[1]).toContain(`namespace ${testProjectName}`);
@@ -238,7 +292,15 @@ describe('CreateLogicAppWorkspace - Codeful Workflows', () => {
       expect(vi.mocked(fse.readFile)).toHaveBeenCalledWith(expect.stringContaining('AgenticCodefulWorkflow'), 'utf-8');
       const workflowWriteCall = vi.mocked(fse.writeFile).mock.calls.find((call: any) => call[0].includes(`${testWorkflowName}.cs`));
       expect(workflowWriteCall?.[1]).toContain(`public class ${testWorkflowName} : IWorkflowProvider`);
+      expect(workflowWriteCall?.[1]).toContain('new WorkflowBuiltInActions().Agent(');
+      expect(workflowWriteCall?.[1]).toContain('new WorkflowManagedActions().Office365("outlook").SendEmail');
+      expect(workflowWriteCall?.[1]).toContain('MessageRole.User');
       expect(workflowWriteCall?.[1]).toContain(`WorkflowFactory.CreateStatefulWorkflow("${testWorkflowName}", workflow)`);
+      expect(workflowWriteCall?.[1]).not.toContain('<%= flowName %>');
+      expect(workflowWriteCall?.[1]).not.toContain('<%= flowNameClass %>');
+      expect(workflowWriteCall?.[1]).not.toContain('<%= logicAppNamespace %>');
+      expect(workflowWriteCall?.[1]).not.toContain('WorkflowActions.BuiltIn');
+      expect(workflowWriteCall?.[1]).not.toContain('SendEmailV2');
 
       const programWriteCall = vi.mocked(fse.writeFile).mock.calls.find((call: any) => call[0].includes('Program.cs'));
       expect(programWriteCall?.[1]).not.toContain(`${testWorkflowName}.AddWorkflow()`);

--- a/apps/vs-code-designer/src/app/utils/__test__/codeful.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/codeful.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { lspDirectory } from '../../../constants';
-import { invalidateCodefulSdkCacheIfNeeded, parseCsprojCopyToCodefulInfo } from '../codeful';
+import { extractHttpTriggerName, hasHttpRequestTrigger, invalidateCodefulSdkCacheIfNeeded, parseCsprojCopyToCodefulInfo } from '../codeful';
 
 const mocks = vi.hoisted(() => ({
   ensureDir: vi.fn(),
@@ -201,5 +201,35 @@ describe('parseCsprojCopyToCodefulInfo', () => {
       replaceLangAfterTargets: 'Build;Publish',
       runsOnBuild: false,
     });
+  });
+});
+
+describe('codeful HTTP trigger detection', () => {
+  it('detects HTTP triggers that use the static WorkflowTriggers accessor', () => {
+    const workflowContent = `
+      var trigger = WorkflowTriggers.BuiltIn.CreateHttpTrigger("manual");
+    `;
+
+    expect(hasHttpRequestTrigger(workflowContent)).toBe(true);
+    expect(extractHttpTriggerName(workflowContent)).toBe('manual');
+  });
+
+  it('detects HTTP triggers that use the constructor-based WorkflowBuiltInTriggers accessor', () => {
+    const workflowContent = `
+      var trigger = new WorkflowBuiltInTriggers().CreateHttpTrigger("manual");
+    `;
+
+    expect(hasHttpRequestTrigger(workflowContent)).toBe(true);
+    expect(extractHttpTriggerName(workflowContent)).toBe('manual');
+  });
+
+  it('ignores commented constructor-based HTTP triggers', () => {
+    const workflowContent = `
+      // var trigger = new WorkflowBuiltInTriggers().CreateHttpTrigger("manual");
+      var trigger = new WorkflowBuiltInTriggers().CreateTimerTrigger();
+    `;
+
+    expect(hasHttpRequestTrigger(workflowContent)).toBe(false);
+    expect(extractHttpTriggerName(workflowContent)).toBeUndefined();
   });
 });

--- a/apps/vs-code-designer/src/app/utils/codeful.ts
+++ b/apps/vs-code-designer/src/app/utils/codeful.ts
@@ -409,11 +409,13 @@ export const hasHttpRequestTrigger = (fileContent: string): boolean => {
     .replace(/\/\*[\s\S]*?\*\//g, '') // Remove /* */ comments
     .replace(/\/\/.*/g, ''); // Remove // comments
 
-  return uncommentedContent.includes('WorkflowTriggers.BuiltIn.CreateHttpTrigger');
+  return /(?:WorkflowTriggers[\s\S]*?\.BuiltIn|new\s+WorkflowBuiltInTriggers\s*\(\s*\))[\s\S]*?\.CreateHttpTrigger\s*\(/.test(
+    uncommentedContent
+  );
 };
 
 /**
- * Extracts the HTTP trigger name from WorkflowTriggers.BuiltIn.CreateHttpTrigger() call.
+ * Extracts the HTTP trigger name from a CreateHttpTrigger() call.
  * @param fileContent - The content of the C# file
  * @returns The HTTP trigger name if found, undefined otherwise
  */
@@ -423,9 +425,12 @@ export const extractHttpTriggerName = (fileContent: string): string | undefined 
     .replace(/\/\*[\s\S]*?\*\//g, '') // Remove /* */ comments
     .replace(/\/\/.*/g, ''); // Remove // comments
 
-  // Pattern to match: WorkflowTriggers.BuiltIn.CreateHttpTrigger("triggerName", ...)
+  // Pattern to match:
+  // WorkflowTriggers.BuiltIn.CreateHttpTrigger("triggerName", ...)
+  // new WorkflowBuiltInTriggers().CreateHttpTrigger("triggerName", ...)
   // Using [\s\S]*? to match any characters including newlines between parts
-  const pattern = /WorkflowTriggers[\s\S]*?\.BuiltIn[\s\S]*?\.CreateHttpTrigger\s*\(\s*["']([^"']+)["']/;
+  const pattern =
+    /(?:WorkflowTriggers[\s\S]*?\.BuiltIn|new\s+WorkflowBuiltInTriggers\s*\(\s*\))[\s\S]*?\.CreateHttpTrigger\s*\(\s*["']([^"']+)["']/;
   const match = uncommentedContent.match(pattern);
 
   if (match && match[1]) {

--- a/apps/vs-code-designer/src/assets/CodefulProjectTemplate/AgentCodefulWorkflow
+++ b/apps/vs-code-designer/src/assets/CodefulProjectTemplate/AgentCodefulWorkflow
@@ -18,9 +18,9 @@ namespace <%= logicAppNamespace %>
         /// </summary>
         public FlowDefinition[] GetWorkflows()
         {
-            var trigger = new WorkflowBuiltInTriggers().CreateConversationalAgentTrigger();
+            var trigger = WorkflowTriggers.BuiltIn.CreateConversationalAgentTrigger();
 
-            var agent = new WorkflowBuiltInActions().Agent(
+            var agent = WorkflowActions.BuiltIn.Agent(
                 agentModelType: AgentModelType.AzureOpenAI,
                 deploymentId: "gpt-4.1",
                 agentModelSettings: new AgentModelSettings
@@ -53,7 +53,7 @@ namespace <%= logicAppNamespace %>
 
             agent.AddTool(toolContext =>
                 {
-                    return new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather(
+                    return WorkflowActions.Managed.Msnweather("msnweather").CurrentWeather(
                         location: () => toolContext.Parameters.Location,
                         units: () => unitsInput.Imperial
                     );
@@ -63,7 +63,7 @@ namespace <%= logicAppNamespace %>
 
             agent.AddTool(toolContext =>
                 {
-                    return new WorkflowManagedActions().Office365("outlook").SendEmail(
+                    return WorkflowActions.Managed.Office365("outlook").SendEmail(
                         emailMessageto: () => toolContext.Parameters.Recipient,
                         emailMessagesubject: () => toolContext.Parameters.Subject,
                         emailMessagebody: () => toolContext.Parameters.Body);

--- a/apps/vs-code-designer/src/assets/CodefulProjectTemplate/AgentCodefulWorkflow
+++ b/apps/vs-code-designer/src/assets/CodefulProjectTemplate/AgentCodefulWorkflow
@@ -18,9 +18,9 @@ namespace <%= logicAppNamespace %>
         /// </summary>
         public FlowDefinition[] GetWorkflows()
         {
-            var trigger = WorkflowTriggers.BuiltIn.CreateConversationalAgentTrigger();
+            var trigger = new WorkflowBuiltInTriggers().CreateConversationalAgentTrigger();
 
-            var agent = WorkflowActions.BuiltIn.Agent(
+            var agent = new WorkflowBuiltInActions().Agent(
                 agentModelType: AgentModelType.AzureOpenAI,
                 deploymentId: "gpt-4.1",
                 agentModelSettings: new AgentModelSettings
@@ -53,7 +53,7 @@ namespace <%= logicAppNamespace %>
 
             agent.AddTool(toolContext =>
                 {
-                    return WorkflowActions.ManagedConnectors.Msnweather("msnweather").CurrentWeather(
+                    return new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather(
                         location: () => toolContext.Parameters.Location,
                         units: () => unitsInput.Imperial
                     );
@@ -63,7 +63,7 @@ namespace <%= logicAppNamespace %>
 
             agent.AddTool(toolContext =>
                 {
-                    return WorkflowActions.ManagedConnectors.Office365("outlook").SendEmailV2(
+                    return new WorkflowManagedActions().Office365("outlook").SendEmail(
                         emailMessageto: () => toolContext.Parameters.Recipient,
                         emailMessagesubject: () => toolContext.Parameters.Subject,
                         emailMessagebody: () => toolContext.Parameters.Body);

--- a/apps/vs-code-designer/src/assets/CodefulProjectTemplate/AgenticCodefulWorkflow
+++ b/apps/vs-code-designer/src/assets/CodefulProjectTemplate/AgenticCodefulWorkflow
@@ -18,9 +18,9 @@ namespace <%= logicAppNamespace %>
         /// </summary>
         public FlowDefinition[] GetWorkflows()
         {
-            var trigger = WorkflowTriggers.BuiltIn.CreateHttpTrigger();
+            var trigger = new WorkflowBuiltInTriggers().CreateHttpTrigger();
 
-            var agent = WorkflowActions.BuiltIn.Agent(
+            var agent = new WorkflowBuiltInActions().Agent(
                 agentModelType: AgentModelType.AzureOpenAI,
                 deploymentId: "gpt-4.1",
                 agentModelSettings: new AgentModelSettings
@@ -58,7 +58,7 @@ namespace <%= logicAppNamespace %>
 
             agent.AddTool(toolContext =>
                 {
-                    return WorkflowActions.ManagedConnectors.Msnweather("msnweather").CurrentWeather(
+                    return new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather(
                         location: () => toolContext.Parameters.Location,
                         units: () => unitsInput.Imperial
                     );
@@ -68,7 +68,7 @@ namespace <%= logicAppNamespace %>
 
             agent.AddTool(toolContext =>
                 {
-                    return WorkflowActions.ManagedConnectors.Office365("outlook").SendEmailV2(
+                    return new WorkflowManagedActions().Office365("outlook").SendEmail(
                         emailMessageto: () => toolContext.Parameters.Recipient,
                         emailMessagesubject: () => toolContext.Parameters.Subject,
                         emailMessagebody: () => toolContext.Parameters.Body);

--- a/apps/vs-code-designer/src/assets/CodefulProjectTemplate/AgenticCodefulWorkflow
+++ b/apps/vs-code-designer/src/assets/CodefulProjectTemplate/AgenticCodefulWorkflow
@@ -18,9 +18,9 @@ namespace <%= logicAppNamespace %>
         /// </summary>
         public FlowDefinition[] GetWorkflows()
         {
-            var trigger = new WorkflowBuiltInTriggers().CreateHttpTrigger();
+            var trigger = WorkflowTriggers.BuiltIn.CreateHttpTrigger();
 
-            var agent = new WorkflowBuiltInActions().Agent(
+            var agent = WorkflowActions.BuiltIn.Agent(
                 agentModelType: AgentModelType.AzureOpenAI,
                 deploymentId: "gpt-4.1",
                 agentModelSettings: new AgentModelSettings
@@ -58,7 +58,7 @@ namespace <%= logicAppNamespace %>
 
             agent.AddTool(toolContext =>
                 {
-                    return new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather(
+                    return WorkflowActions.Managed.Msnweather("msnweather").CurrentWeather(
                         location: () => toolContext.Parameters.Location,
                         units: () => unitsInput.Imperial
                     );
@@ -68,7 +68,7 @@ namespace <%= logicAppNamespace %>
 
             agent.AddTool(toolContext =>
                 {
-                    return new WorkflowManagedActions().Office365("outlook").SendEmail(
+                    return WorkflowActions.Managed.Office365("outlook").SendEmail(
                         emailMessageto: () => toolContext.Parameters.Recipient,
                         emailMessagesubject: () => toolContext.Parameters.Subject,
                         emailMessagebody: () => toolContext.Parameters.Body);

--- a/apps/vs-code-designer/src/assets/CodefulProjectTemplate/StatefulCodefulWorkflow
+++ b/apps/vs-code-designer/src/assets/CodefulProjectTemplate/StatefulCodefulWorkflow
@@ -17,13 +17,13 @@ namespace <%= logicAppNamespace %>
         /// </summary>
         public FlowDefinition[] GetWorkflows()
         {
-            var trigger = WorkflowTriggers.BuiltIn.CreateHttpTrigger();
+            var trigger = new WorkflowBuiltInTriggers().CreateHttpTrigger();
 
-            var getCurrentWeatherAction = WorkflowActions.ManagedConnectors.Msnweather("msnweather").CurrentWeather(
+            var getCurrentWeatherAction = new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather(
                 location: () => "98058",
                 units: () => unitsInput.Imperial);
 
-            var response = WorkflowActions.BuiltIn.Response(responseBody: () => $"{getCurrentWeatherAction.Body}");
+            var response = new WorkflowBuiltInActions().Response(responseBody: () => $"{getCurrentWeatherAction.Body}");
             var workflow = trigger.Then(getCurrentWeatherAction).Then(response);
 
             return new[] { WorkflowFactory.CreateStatefulWorkflow(<%= flowName %>, workflow) };

--- a/apps/vs-code-designer/src/assets/CodefulProjectTemplate/StatefulCodefulWorkflow
+++ b/apps/vs-code-designer/src/assets/CodefulProjectTemplate/StatefulCodefulWorkflow
@@ -17,13 +17,13 @@ namespace <%= logicAppNamespace %>
         /// </summary>
         public FlowDefinition[] GetWorkflows()
         {
-            var trigger = new WorkflowBuiltInTriggers().CreateHttpTrigger();
+            var trigger = WorkflowTriggers.BuiltIn.CreateHttpTrigger();
 
-            var getCurrentWeatherAction = new WorkflowManagedActions().Msnweather("msnweather").CurrentWeather(
+            var getCurrentWeatherAction = WorkflowActions.Managed.Msnweather("msnweather").CurrentWeather(
                 location: () => "98058",
                 units: () => unitsInput.Imperial);
 
-            var response = new WorkflowBuiltInActions().Response(responseBody: () => $"{getCurrentWeatherAction.Body}");
+            var response = WorkflowActions.BuiltIn.Response(responseBody: () => $"{getCurrentWeatherAction.Body}");
             var workflow = trigger.Then(getCurrentWeatherAction).Then(response);
 
             return new[] { WorkflowFactory.CreateStatefulWorkflow(<%= flowName %>, workflow) };


### PR DESCRIPTION
## Summary
- Update codeful workflow templates to use the constructor-based SDK style from the provided filled examples
- Keep generated template placeholders for namespace, class name, and workflow name
- Support both old static and new constructor-based HTTP trigger detection for codeful overview/run behavior

## Validation
- Generated stateful, conversational, and autonomous codeful C# templates build against the bundled `Microsoft.Azure.Workflows.Sdk.1.0.0-preview.1`
- `npx biome check --write` on changed files
- `pnpm --dir apps\vs-code-designer run test:extension-unit -- src\app\commands\createNewCodeProject\CodeProjectBase\__test__\CreateLogicAppWorkspace.test.ts src\app\utils\__test__\codeful.test.ts`