### PR TITLE
fix(portal): Fix agent AzureOpenAI resource IDs for conversational ag…

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -52,6 +52,7 @@ import {
   optional,
   BaseCognitiveServiceService,
   RoleService,
+  normalizeAgentConnectionResourceIdForRoleAssignment,
   resolveConnectionsReferences,
   BaseResourceService,
 } from '@microsoft/logic-apps-shared';
@@ -357,16 +358,17 @@ const DesignerEditor = () => {
          */
         for (const [_refKey, agentConnection] of Object.entries(newAgentConnections)) {
           if (agentConnection?.authentication?.type === 'ManagedServiceIdentity') {
+            const roleAssignmentResourceId = normalizeAgentConnectionResourceIdForRoleAssignment(agentConnection?.resourceId);
             const definitionNames = ['Azure AI User', 'Azure AI Administrator', 'Azure AI Developer', 'Cognitive Services Contributor'];
-            const missingRoleAssignments = await getMissingRoleDefinitions(agentConnection?.resourceId, definitionNames);
+            const missingRoleAssignments = await getMissingRoleDefinitions(roleAssignmentResourceId, definitionNames);
             const assignmentPromises = [];
             for (const roleDefinition of missingRoleAssignments) {
-              assignmentPromises.push(RoleService().addAppRoleAssignmentForResource(agentConnection?.resourceId, roleDefinition.id));
+              assignmentPromises.push(RoleService().addAppRoleAssignmentForResource(roleAssignmentResourceId, roleDefinition.id));
             }
             await Promise.all(assignmentPromises);
 
             // Invalidate the cache for the role assignments
-            const cacheKey = [roleQueryKeys.appIdentityRoleAssignments, agentConnection?.resourceId];
+            const cacheKey = [roleQueryKeys.appIdentityRoleAssignments, roleAssignmentResourceId];
             const queryClient = getReactQueryClient();
             queryClient.invalidateQueries(cacheKey);
           }

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
@@ -59,6 +59,7 @@ import {
   optional,
   BaseCognitiveServiceService,
   RoleService,
+  normalizeAgentConnectionResourceIdForRoleAssignment,
   resolveConnectionsReferences,
 } from '@microsoft/logic-apps-shared';
 import type { ContentType, IHostService, IWorkflowService } from '@microsoft/logic-apps-shared';
@@ -430,16 +431,17 @@ const DesignerEditor = () => {
            */
           for (const [_refKey, agentConnection] of Object.entries(newAgentConnections)) {
             if (agentConnection?.authentication?.type === 'ManagedServiceIdentity') {
+              const roleAssignmentResourceId = normalizeAgentConnectionResourceIdForRoleAssignment(agentConnection?.resourceId);
               const definitionNames = ['Azure AI User', 'Azure AI Administrator', 'Azure AI Developer', 'Cognitive Services Contributor'];
-              const missingRoleAssignments = await getMissingRoleDefinitions(agentConnection?.resourceId, definitionNames);
+              const missingRoleAssignments = await getMissingRoleDefinitions(roleAssignmentResourceId, definitionNames);
               const assignmentPromises = [];
               for (const roleDefinition of missingRoleAssignments) {
-                assignmentPromises.push(RoleService().addAppRoleAssignmentForResource(agentConnection?.resourceId, roleDefinition.id));
+                assignmentPromises.push(RoleService().addAppRoleAssignmentForResource(roleAssignmentResourceId, roleDefinition.id));
               }
               await Promise.all(assignmentPromises);
 
               // Invalidate the cache for the role assignments
-              const cacheKey = [roleQueryKeys.appIdentityRoleAssignments, agentConnection?.resourceId];
+              const cacheKey = [roleQueryKeys.appIdentityRoleAssignments, roleAssignmentResourceId];
               const queryClient = getReactQueryClient();
               queryClient.invalidateQueries(cacheKey);
             }

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/connectionsAgentV2.spec.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/connectionsAgentV2.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { foundryServiceConnectionRegex, microsoftFoundryModelsRegex } from '@microsoft/logic-apps-shared';
 import { AgentUtils } from '../../../../common/utilities/Utils';
 
 /**
@@ -14,9 +15,10 @@ function resolveAgentModelType(rawDisplayName: string, cognitiveServiceId: strin
   let agentModelTypeValue = AgentUtils.DisplayNameToManifest[rawDisplayName] ?? '';
 
   if (!agentModelTypeValue) {
-    const foundryServiceConnectionRegex = /Microsoft\.CognitiveServices\/accounts/i;
     if (foundryServiceConnectionRegex.test(cognitiveServiceId)) {
       agentModelTypeValue = 'FoundryAgentServiceV2';
+    } else if (microsoftFoundryModelsRegex.test(cognitiveServiceId)) {
+      agentModelTypeValue = 'MicrosoftFoundry';
     } else {
       agentModelTypeValue = 'AzureOpenAI';
     }
@@ -41,25 +43,33 @@ describe('updateAgentParametersForConnection – model type resolution', () => {
     });
   });
 
-  describe('Foundry fallback via cognitiveServiceAccountId', () => {
-    it('falls back to FoundryAgentServiceV2 when cognitiveServiceId matches CognitiveServices pattern', () => {
+  describe('resource ID fallback via cognitiveServiceAccountId', () => {
+    it('falls back to FoundryAgentServiceV2 when cognitiveServiceId matches Foundry project pattern', () => {
       const result = resolveAgentModelType(
         '',
-        '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount'
+        '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/projects/myproject'
       );
       expect(result).toBe('FoundryAgentServiceV2');
     });
 
-    it('does NOT fall back to FoundryAgentService (V1)', () => {
+    it('falls back to MicrosoftFoundry when cognitiveServiceId has a /models suffix', () => {
       const result = resolveAgentModelType(
         '',
-        '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount'
+        '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models'
       );
-      expect(result).not.toBe('FoundryAgentService');
+      expect(result).toBe('MicrosoftFoundry');
     });
   });
 
   describe('AzureOpenAI fallback', () => {
+    it('falls back to AzureOpenAI for account-level Azure OpenAI resource IDs', () => {
+      const result = resolveAgentModelType(
+        '',
+        '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount'
+      );
+      expect(result).toBe('AzureOpenAI');
+    });
+
     it('falls back to AzureOpenAI when no display name and no CognitiveServices pattern', () => {
       const result = resolveAgentModelType('', '');
       expect(result).toBe('AzureOpenAI');

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionInternal.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionInternal.tsx
@@ -212,6 +212,7 @@ export const CreateConnectionInternal = (props: {
               )
             : undefined,
           connectionParameters: outputParameterValues,
+          operationParameterValues,
           alternativeParameterValues,
           additionalParameterValues,
           features: isUsingDynamicConnection ? 'DynamicUserInvoked' : undefined,

--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connectionsAgent.spec.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connectionsAgent.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { foundryServiceConnectionRegex, microsoftFoundryModelsRegex } from '@microsoft/logic-apps-shared';
 import { AgentUtils } from '../../../../common/utilities/Utils';
 
 /**
@@ -14,9 +15,10 @@ function resolveAgentModelType(rawDisplayName: string, cognitiveServiceId: strin
   let agentModelTypeValue = AgentUtils.DisplayNameToManifest[rawDisplayName] ?? '';
 
   if (!agentModelTypeValue) {
-    const foundryServiceConnectionRegex = /Microsoft\.CognitiveServices\/accounts/i;
     if (foundryServiceConnectionRegex.test(cognitiveServiceId)) {
       agentModelTypeValue = 'FoundryAgentServiceV2';
+    } else if (microsoftFoundryModelsRegex.test(cognitiveServiceId)) {
+      agentModelTypeValue = 'MicrosoftFoundry';
     } else {
       agentModelTypeValue = 'AzureOpenAI';
     }
@@ -58,25 +60,33 @@ describe('updateAgentParametersForConnection – model type resolution', () => {
     });
   });
 
-  describe('Foundry fallback via cognitiveServiceAccountId', () => {
-    it('falls back to FoundryAgentServiceV2 when cognitiveServiceId matches CognitiveServices pattern', () => {
+  describe('resource ID fallback via cognitiveServiceAccountId', () => {
+    it('falls back to FoundryAgentServiceV2 when cognitiveServiceId matches Foundry project pattern', () => {
       const result = resolveAgentModelType(
         '',
-        '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount'
+        '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/projects/myproject'
       );
       expect(result).toBe('FoundryAgentServiceV2');
     });
 
-    it('is case-insensitive for the CognitiveServices regex', () => {
+    it('falls back to MicrosoftFoundry when cognitiveServiceId has a /models suffix', () => {
       const result = resolveAgentModelType(
         '',
-        '/subscriptions/abc/resourceGroups/rg/providers/microsoft.cognitiveservices/accounts/myaccount'
+        '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models'
       );
-      expect(result).toBe('FoundryAgentServiceV2');
+      expect(result).toBe('MicrosoftFoundry');
     });
   });
 
   describe('AzureOpenAI fallback', () => {
+    it('falls back to AzureOpenAI for account-level Azure OpenAI resource IDs', () => {
+      const result = resolveAgentModelType(
+        '',
+        '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount'
+      );
+      expect(result).toBe('AzureOpenAI');
+    });
+
     it('falls back to AzureOpenAI when no display name and no CognitiveServices pattern', () => {
       const result = resolveAgentModelType('', '');
       expect(result).toBe('AzureOpenAI');

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionInternal.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/createConnectionInternal.tsx
@@ -214,6 +214,7 @@ export const CreateConnectionInternal = (props: {
               )
             : undefined,
           connectionParameters: outputParameterValues,
+          operationParameterValues,
           alternativeParameterValues,
           additionalParameterValues,
           features: isUsingDynamicConnection ? 'DynamicUserInvoked' : undefined,

--- a/libs/logic-apps-shared/src/designer-client-services/lib/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/connection.ts
@@ -19,6 +19,7 @@ export interface ConnectorWithSwagger {
 export interface ConnectionCreationInfo {
   connectionParametersSet?: ConnectionParameterSetValues;
   connectionParameters?: Record<string, any>;
+  operationParameterValues?: Record<string, any>;
   alternativeParameterValues?: Record<string, any>;
   displayName?: string;
   features?: ConnectionFeatureType;

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connection.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/connection.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { StandardConnectionService, microsoftFoundryModelsRegex, foundryServiceConnectionRegex, apimanagementRegex } from '../connection';
+import {
+  StandardConnectionService,
+  microsoftFoundryModelsRegex,
+  foundryServiceConnectionRegex,
+  apimanagementRegex,
+  normalizeAgentConnectionResourceIdForRoleAssignment,
+} from '../connection';
 import type { StandardConnectionServiceOptions, ConnectionsData } from '../connection';
 import { agentConnectorId, mcpclientConnectorId } from '../../base/operationmanifest';
 import { ConnectionType } from '../../../../utils/src';
@@ -225,7 +231,7 @@ describe('StandardConnectionService', () => {
       },
     };
 
-    it('should append /models to resourceId for standard Cognitive Services connections', async () => {
+    it('should keep AzureOpenAI resourceId at the account scope for standard Cognitive Services connections', async () => {
       InitLoggerService([mockLoggerService]);
       let capturedConnectionData: any;
       const writeConnection = vi.fn().mockImplementation((data: any) => {
@@ -247,6 +253,55 @@ describe('StandardConnectionService', () => {
             },
           },
         },
+        operationParameterValues: {
+          agentModelType: 'AzureOpenAI',
+        },
+      };
+
+      const parametersMetadata = {
+        connectionMetadata: { type: ConnectionType.Agent },
+      };
+
+      await service.createConnection('test-agent', agentConnector as any, connectionInfo, parametersMetadata as any);
+
+      expect(writeConnection).toHaveBeenCalledOnce();
+      expect(capturedConnectionData.connectionData.resourceId).toBe(
+        '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount'
+      );
+      expect(capturedConnectionData.connectionData.type).toBe('model');
+    });
+
+    it('should append /models to resourceId for MicrosoftFoundry model connections', async () => {
+      InitLoggerService([mockLoggerService]);
+      let capturedConnectionData: any;
+      const writeConnection = vi.fn().mockImplementation((data: any) => {
+        capturedConnectionData = data;
+        return Promise.resolve();
+      });
+
+      const options = createMockOptions({});
+      (options as any).writeConnection = writeConnection;
+      const service = new StandardConnectionService(options);
+
+      const connectionInfo = {
+        displayName: 'test-agent-foundry-models',
+        connectionParametersSet: {
+          name: 'Key',
+          values: {
+            cognitiveServiceAccountId: {
+              value: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount',
+            },
+            openAIEndpoint: {
+              value: 'https://myaccount.cognitiveservices.azure.com/',
+            },
+            openAIKey: {
+              value: 'test-key',
+            },
+          },
+        },
+        operationParameterValues: {
+          agentModelType: 'MicrosoftFoundry',
+        },
       };
 
       const parametersMetadata = {
@@ -260,6 +315,51 @@ describe('StandardConnectionService', () => {
         '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models'
       );
       expect(capturedConnectionData.connectionData.type).toBe('model');
+    });
+
+    it('should not double-append /models for MicrosoftFoundry model connections', async () => {
+      InitLoggerService([mockLoggerService]);
+      let capturedConnectionData: any;
+      const writeConnection = vi.fn().mockImplementation((data: any) => {
+        capturedConnectionData = data;
+        return Promise.resolve();
+      });
+
+      const options = createMockOptions({});
+      (options as any).writeConnection = writeConnection;
+      const service = new StandardConnectionService(options);
+
+      const connectionInfo = {
+        displayName: 'test-agent-foundry-models',
+        connectionParametersSet: {
+          name: 'Key',
+          values: {
+            cognitiveServiceAccountId: {
+              value: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models',
+            },
+            openAIEndpoint: {
+              value: 'https://myaccount.cognitiveservices.azure.com/',
+            },
+            openAIKey: {
+              value: 'test-key',
+            },
+          },
+        },
+        operationParameterValues: {
+          agentModelType: 'MicrosoftFoundry',
+        },
+      };
+
+      const parametersMetadata = {
+        connectionMetadata: { type: ConnectionType.Agent },
+      };
+
+      await service.createConnection('test-agent', agentConnector as any, connectionInfo, parametersMetadata as any);
+
+      expect(writeConnection).toHaveBeenCalledOnce();
+      expect(capturedConnectionData.connectionData.resourceId).toBe(
+        '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models'
+      );
     });
 
     it('should NOT append /models for Foundry project connections and should save type as model', async () => {
@@ -341,6 +441,28 @@ describe('Connection regex patterns', () => {
           '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models'
         )
       ).toBe(true);
+    });
+
+    describe('normalizeAgentConnectionResourceIdForRoleAssignment', () => {
+      it('should strip terminal /models for role assignment scope', () => {
+        expect(
+          normalizeAgentConnectionResourceIdForRoleAssignment(
+            '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount/models'
+          )
+        ).toBe('/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount');
+      });
+
+      it('should leave account-level resourceIds unchanged', () => {
+        expect(
+          normalizeAgentConnectionResourceIdForRoleAssignment(
+            '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount'
+          )
+        ).toBe('/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/myaccount');
+      });
+
+      it('should not strip /models from the middle of a path', () => {
+        expect(normalizeAgentConnectionResourceIdForRoleAssignment('/some/path/models/deployments')).toBe('/some/path/models/deployments');
+      });
     });
 
     it('should not match resourceIds without /models suffix', () => {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/connection.ts
@@ -157,6 +157,8 @@ const mcpLocation = 'agentMcpConnections';
 export const foundryServiceConnectionRegex = /\/Microsoft\.CognitiveServices\/accounts\/[^/]+\/projects\/[^/]+/;
 export const apimanagementRegex = /\/Microsoft\.ApiManagement\/service\/[^/]+\/apis\/[^/]+/;
 export const microsoftFoundryModelsRegex = /\/models$/;
+export const normalizeAgentConnectionResourceIdForRoleAssignment = (resourceId?: string): string =>
+  resourceId?.replace(microsoftFoundryModelsRegex, '') ?? '';
 
 export interface StandardConnectionServiceOptions {
   apiVersion: string;
@@ -923,6 +925,8 @@ function convertToAgentConnectionsData(
   const isAPIMManagementConnection = apimanagementRegex.test(cognitiveServiceAccountId);
   const isClientCertificateAuth = equals(connectionParametersSetValues?.name ?? '', 'ClientCertificate', true);
   const isBringYourOwnKeyAuth = equals(connectionParametersSetValues?.name ?? '', 'BringYourOwnKey', true);
+  const isMicrosoftFoundry = equals(connectionInfo.operationParameterValues?.['agentModelType'] ?? '', 'MicrosoftFoundry', true);
+  const normalizedCognitiveServiceAccountId = normalizeAgentConnectionResourceIdForRoleAssignment(cognitiveServiceAccountId);
 
   // Map BringYourOwnKey parameter set to Key authentication type
   const authType = isBringYourOwnKeyAuth ? 'Key' : connectionParametersSetValues?.name;
@@ -947,10 +951,14 @@ function convertToAgentConnectionsData(
       },
       endpoint: isBringYourOwnKeyAuth || isClientCertificateAuth ? parameterValues?.['endpoint'] : parameterValues?.['openAIEndpoint'],
       // Only include resourceId if it has a value
-      // Append /models for standard Cognitive Services connections (MicrosoftFoundry) to distinguish from legacy AzureOpenAI
+      // Append /models only for MicrosoftFoundry model connections; AzureOpenAI must save the account-level resource ID.
       ...(cognitiveServiceAccountId && {
         resourceId:
-          isFoundryAgentServiceConnection || isAPIMManagementConnection ? cognitiveServiceAccountId : `${cognitiveServiceAccountId}/models`,
+          isFoundryAgentServiceConnection || isAPIMManagementConnection
+            ? cognitiveServiceAccountId
+            : isMicrosoftFoundry
+              ? `${normalizedCognitiveServiceAccountId}/models`
+              : normalizedCognitiveServiceAccountId,
       }),
       type: isAPIMManagementConnection ? 'APIMGenAIGateway' : 'model',
     },

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/index.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/index.ts
@@ -7,6 +7,7 @@ export {
   foundryServiceConnectionRegex,
   apimanagementRegex,
   microsoftFoundryModelsRegex,
+  normalizeAgentConnectionResourceIdForRoleAssignment,
 } from './connection';
 export { StandardConnectorService, type StandardConnectorServiceOptions } from './connector';
 export { StandardOperationManifestService, isServiceProviderOperation } from './operationmanifest';


### PR DESCRIPTION
…ents (#9256)

Fix agent AzureOpenAI resource IDs

Ensure AzureOpenAI agent connections persist account-level resource IDs while preserving MicrosoftFoundry model suffix handling. Normalize agent connection RBAC scopes before role lookup and assignment, and add focused unit coverage for serialization, scope normalization, and model type fallback behavior.

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Validation errors occurred after Azure OpenAI resources were selected for the agent. Saving caused validation errors due to an incorrect UX contract. Updated the contract to align with the contract.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
Users should be able to create agent connections from Azure OpenAI.
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
