### PR TITLE
fix(designer/mcp): Updating ConnectionTable component to not read store data directly (#9274)

### DIFF
--- a/apps/Standalone/src/mcp/app/McpStandard.tsx
+++ b/apps/Standalone/src/mcp/app/McpStandard.tsx
@@ -45,9 +45,9 @@ export const McpStandard = () => {
   const resourceDetails = useMemo(
     () => ({
       subscriptionId: 'f34b22a3-2202-4fb1-b040-1332bd928c84',
-      resourceGroup: 'TestACSRG',
-      location: 'westus2',
-      logicAppName: 'prititemplates',
+      resourceGroup: 'priti-rg',
+      location: 'westus',
+      logicAppName: 'pritiemptyapp',
     }),
     []
   );

--- a/libs/designer/src/lib/core/state/mcp/selector.ts
+++ b/libs/designer/src/lib/core/state/mcp/selector.ts
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 import type { RootState } from './store';
-import { equals, type ConnectionReference } from '@microsoft/logic-apps-shared';
+import { equals, type ConnectionReference, type ConnectionReferences } from '@microsoft/logic-apps-shared';
 
 export const useAreMappingsInitialized = (operations: string[]): boolean => {
   const state = useSelector((state: RootState) => state.connection);
@@ -11,6 +11,11 @@ export const useAreMappingsInitialized = (operations: string[]): boolean => {
 export const useAllReferenceKeys = (): string[] => {
   const state = useSelector((state: RootState) => state.connection);
   return Object.keys(state.connectionReferences);
+};
+
+/** Returns all connection references from the MCP store */
+export const useConnectionReferences = (): ConnectionReferences => {
+  return useSelector((state: RootState) => state.connection.connectionReferences);
 };
 
 export const useConnectionReference = (): ConnectionReference | undefined => {

--- a/libs/designer/src/lib/ui/mcp/connections/connectionselection.tsx
+++ b/libs/designer/src/lib/ui/mcp/connections/connectionselection.tsx
@@ -9,7 +9,12 @@ import {
 import { updateMcpConnection } from '../../../core/actions/bjsworkflow/connections';
 import { useConnectionsForConnector } from '../../../core/queries/connections';
 import { useConnector } from '../../../core/state/connection/connectionSelector';
-import { useAllReferenceKeys, useAreMappingsInitialized, useConnectionReference } from '../../../core/state/mcp/selector';
+import {
+  useAllReferenceKeys,
+  useAreMappingsInitialized,
+  useConnectionReference,
+  useConnectionReferences,
+} from '../../../core/state/mcp/selector';
 import type { AppDispatch, RootState } from '../../../core/state/mcp/store';
 import { isConnectionValid } from '../../../core/utils/connectors/connections';
 import { CreateConnectionInternal } from '../../panel/connectionsPanel/createConnection/createConnectionInternal';
@@ -30,6 +35,7 @@ export const ConnectionSelection = ({ connectorId, operations }: { connectorId: 
   const connectionsQuery = useConnectionsForConnector(connectorId, /* shouldNotRefetch */ true);
   const existingReferences = useAllReferenceKeys();
   const reference = useConnectionReference();
+  const connectionReferences = useConnectionReferences();
   const areMappingsInitialized = useAreMappingsInitialized(operations);
   const shouldFilterOBOConnections = useSelector(
     (state: RootState) => state.mcpSelection.disableConnectorSelection && state.mcpSelection.disableLogicAppSelection
@@ -119,6 +125,7 @@ export const ConnectionSelection = ({ connectorId, operations }: { connectorId: 
           currentConnectionId={reference?.connection.id ?? ''}
           saveSelectionCallback={saveSelectionCallback}
           isXrmConnectionReferenceMode={false}
+          connectionReferences={connectionReferences}
           addButton={{
             text: buttonAddText,
             onAdd: handleOnAdd,

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/__test__/connectionTable.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/__test__/connectionTable.spec.tsx
@@ -1,0 +1,203 @@
+import { render, screen } from '@testing-library/react';
+import type { Connection } from '@microsoft/logic-apps-shared';
+import type { ConnectionReferences } from '../../../../../common/models/workflow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionTable } from '../connectionTable';
+import '@testing-library/jest-dom/vitest';
+
+// Track if useConnectionRefs was called - it should NOT be called since we pass connectionReferences as prop
+const useConnectionRefsSpy = vi.fn();
+
+vi.mock('../../../../../core/state/connection/connectionSelector', () => ({
+  useConnectionRefs: () => {
+    useConnectionRefsSpy();
+    // Return empty object - but this should never be called if prop is used correctly
+    return {};
+  },
+}));
+
+// Mock react-intl following existing pattern
+vi.mock('react-intl', async () => {
+  const actualIntl = await vi.importActual('react-intl');
+  return {
+    ...actualIntl,
+    useIntl: () => ({
+      formatMessage: vi.fn(({ defaultMessage }) => defaultMessage),
+      formatDate: vi.fn(() => 'formatted-date'),
+    }),
+  };
+});
+
+vi.mock('@fluentui/react-components', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    DataGrid: ({ children }: any) => <table data-testid="data-grid">{children}</table>,
+    DataGridHeader: ({ children }: any) => <thead>{children}</thead>,
+    DataGridHeaderCell: ({ children }: any) => <th>{children}</th>,
+    DataGridBody: ({ children }: any) => <tbody>{children}</tbody>,
+    DataGridRow: ({ children }: any) => <tr data-testid="data-grid-row">{children}</tr>,
+    DataGridCell: ({ children }: any) => <td>{children}</td>,
+    PresenceBadge: () => <span data-testid="presence-badge" />,
+    Text: ({ children }: any) => <span>{children}</span>,
+    Tooltip: ({ children }: any) => <>{children}</>,
+    createTableColumn: (config: any) => config,
+  };
+});
+
+vi.mock('@microsoft/logic-apps-shared', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    LoggerService: () => ({
+      log: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('../connectionTableDetailsButton', () => ({
+  ConnectionTableDetailsButton: () => <button type="button">Details</button>,
+}));
+
+const createMockConnection = (id: string, displayName: string): Connection =>
+  ({
+    id: `/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/connections/${id}`,
+    name: id,
+    type: 'Microsoft.Web/connections',
+    properties: {
+      displayName,
+      statuses: [{ status: 'Connected' }],
+      api: {
+        id: '/subscriptions/sub1/providers/Microsoft.Web/locations/eastus/managedApis/sql',
+        name: 'sql',
+        displayName: 'SQL Server',
+        iconUri: 'https://example.com/sql.png',
+        brandColor: '#0078D4',
+      },
+    },
+  }) as unknown as Connection;
+
+describe('ConnectionTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('connectionReferences prop usage', () => {
+    it('should use connectionReferences from props, not from Redux store', () => {
+      const mockConnections = [createMockConnection('conn1', 'Connection 1')];
+      const mockConnectionReferences: ConnectionReferences = {
+        'ref-1': {
+          api: { id: '/subscriptions/sub1/providers/Microsoft.Web/locations/eastus/managedApis/sql' },
+          connection: { id: '/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/connections/conn1' },
+          connectionName: 'conn1',
+        },
+      };
+
+      render(
+        <ConnectionTable
+          connections={mockConnections}
+          currentConnectionId="conn1"
+          saveSelectionCallback={vi.fn()}
+          isXrmConnectionReferenceMode={false}
+          connectionReferences={mockConnectionReferences}
+        />
+      );
+
+      // The component should NOT call useConnectionRefs from the store
+      // since connectionReferences is passed as a required prop
+      expect(useConnectionRefsSpy).not.toHaveBeenCalled();
+    });
+
+    it('should correctly identify configured connections using prop connectionReferences', () => {
+      const mockConnections = [createMockConnection('conn1', 'Connection 1'), createMockConnection('conn2', 'Connection 2')];
+
+      // Only conn1 is configured in connectionReferences
+      const mockConnectionReferences: ConnectionReferences = {
+        'ref-1': {
+          api: { id: '/subscriptions/sub1/providers/Microsoft.Web/locations/eastus/managedApis/sql' },
+          connection: { id: '/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/connections/conn1' },
+          connectionName: 'conn1',
+        },
+      };
+
+      render(
+        <ConnectionTable
+          connections={mockConnections}
+          currentConnectionId="conn1"
+          saveSelectionCallback={vi.fn()}
+          isXrmConnectionReferenceMode={false}
+          connectionReferences={mockConnectionReferences}
+        />
+      );
+
+      // Verify component rendered with the connections
+      expect(screen.getByTestId('data-grid')).toBeInTheDocument();
+
+      // Store selector should never be called
+      expect(useConnectionRefsSpy).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty connectionReferences prop without calling store', () => {
+      const mockConnections = [createMockConnection('conn1', 'Connection 1')];
+
+      render(
+        <ConnectionTable
+          connections={mockConnections}
+          currentConnectionId="conn1"
+          saveSelectionCallback={vi.fn()}
+          isXrmConnectionReferenceMode={false}
+          connectionReferences={{}}
+        />
+      );
+
+      expect(screen.getByTestId('data-grid')).toBeInTheDocument();
+      expect(useConnectionRefsSpy).not.toHaveBeenCalled();
+    });
+
+    it('should render connections from different contexts (designer/MCP) using only prop data', () => {
+      // Simulate MCP context passing its own connection references
+      const mcpConnections = [createMockConnection('mcp-conn-1', 'MCP Connection')];
+      const mcpConnectionReferences: ConnectionReferences = {
+        'mcp-ref': {
+          api: { id: '/connectionProviders/agent' },
+          connection: { id: '/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/connections/mcp-conn-1' },
+          connectionName: 'mcp-conn-1',
+        },
+      };
+
+      render(
+        <ConnectionTable
+          connections={mcpConnections}
+          currentConnectionId="mcp-conn-1"
+          saveSelectionCallback={vi.fn()}
+          isXrmConnectionReferenceMode={false}
+          connectionReferences={mcpConnectionReferences}
+        />
+      );
+
+      // Even in MCP context, should not call designer's useConnectionRefs
+      expect(useConnectionRefsSpy).not.toHaveBeenCalled();
+      expect(screen.getByTestId('data-grid')).toBeInTheDocument();
+    });
+  });
+
+  describe('connection selection behavior', () => {
+    it('should render without accessing the store when connectionReferences is empty', async () => {
+      const saveCallback = vi.fn();
+      const mockConnections = [createMockConnection('conn1', 'Connection 1')];
+
+      // Empty references means conn1 is not configured
+      render(
+        <ConnectionTable
+          connections={mockConnections}
+          currentConnectionId="conn1"
+          saveSelectionCallback={saveCallback}
+          isXrmConnectionReferenceMode={false}
+          connectionReferences={{}}
+        />
+      );
+
+      expect(useConnectionRefsSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/connectionTable.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/connectionTable.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
 } from '@fluentui/react-components';
 import type { Connection } from '@microsoft/logic-apps-shared';
-import { cleanResourceId, getIdLeaf, LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
+import { cleanResourceId, equals, getIdLeaf, LogEntryLevel, LoggerService } from '@microsoft/logic-apps-shared';
 import { useCallback, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { ConnectionTableDetailsButton } from './connectionTableDetailsButton';
@@ -23,7 +23,7 @@ import {
   getLabelForConnection,
   getSubLabelForConnection,
 } from './selectConnection.helpers';
-import { useConnectionRefs } from '../../../../core/state/connection/connectionSelector';
+import type { ConnectionReferences } from '../../../../common/models/workflow';
 
 export interface ConnectionTableProps {
   connections: Connection[];
@@ -32,6 +32,8 @@ export interface ConnectionTableProps {
   cancelSelectionCallback?: () => void;
   isXrmConnectionReferenceMode: boolean;
   shouldRenderDetails?: boolean;
+  /** Required connection references, should be provided in all cases. */
+  connectionReferences: ConnectionReferences;
 }
 
 const statusColumnWidth = 36;
@@ -52,11 +54,11 @@ export const ConnectionTable = (props: ConnectionTableProps): JSX.Element => {
     cancelSelectionCallback,
     isXrmConnectionReferenceMode,
     shouldRenderDetails = false,
+    connectionReferences,
   } = props;
 
   const intl = useIntl();
   const initiallySelectedConnectionId = useRef(currentConnectionId);
-  const connectionReferences = useConnectionRefs();
 
   // Check if the currentConnectionId is actually configured in connectionReferences
   const isCurrentConnectionConfigured = useMemo(() => {
@@ -65,13 +67,16 @@ export const ConnectionTable = (props: ConnectionTableProps): JSX.Element => {
     }
     return Object.values(connectionReferences).some((ref: any) => {
       const refConnectionId = ref?.connection?.id;
-      return refConnectionId && getIdLeaf(refConnectionId) === currentConnectionId;
+      return refConnectionId && equals(refConnectionId, currentConnectionId);
     });
   }, [currentConnectionId, connectionReferences]);
 
-  const isSelectedConnection = (connection: ConnectionWithFlattenedProperties): boolean => {
-    return isCurrentConnectionConfigured && cleanResourceId(connection.id) === cleanResourceId(initiallySelectedConnectionId.current);
-  };
+  const isSelectedConnection = useCallback(
+    (connection: ConnectionWithFlattenedProperties): boolean => {
+      return isCurrentConnectionConfigured && cleanResourceId(connection.id) === cleanResourceId(initiallySelectedConnectionId.current);
+    },
+    [isCurrentConnectionConfigured]
+  );
 
   // We need to flatten the connection to allow the detail list access to nested props
   const items = useMemo(
@@ -85,10 +90,10 @@ export const ConnectionTable = (props: ConnectionTableProps): JSX.Element => {
         }
         return compareFlattenedConnections(a, b);
       }),
-    [connections]
+    [connections, isSelectedConnection]
   );
 
-  const areIdLeavesEqual = (id1?: string, id2?: string): boolean => getIdLeaf(id1) === getIdLeaf(id2);
+  const areIdLeavesEqual = (id1?: string, id2?: string): boolean => equals(getIdLeaf(id1), getIdLeaf(id2));
 
   const onConnectionSelect = useCallback(
     (connection: Connection) => {
@@ -105,7 +110,7 @@ export const ConnectionTable = (props: ConnectionTableProps): JSX.Element => {
         saveSelectionCallback(connection); // User clicked a different connection or unconfigured connection
       }
     },
-    [cancelSelectionCallback, currentConnectionId, saveSelectionCallback]
+    [cancelSelectionCallback, currentConnectionId, saveSelectionCallback, isCurrentConnectionConfigured]
   );
   const displayNameColumnWidth = shouldRenderDetails ? 180 : 420;
 

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnection.tsx
@@ -47,6 +47,7 @@ export const SelectConnectionWrapper = () => {
   const isXrmConnectionReferenceMode = useIsXrmConnectionReferenceMode();
   const referencePanelMode = usePreviousPanelMode();
   const [isInlineCreatingConnection, setIsInlineCreatingConnection] = useState(false);
+  const references = useConnectionRefs();
 
   const closeConnectionsFlow = useCallback(() => {
     const panelMode = referencePanelMode ?? 'Operation';
@@ -106,7 +107,6 @@ export const SelectConnectionWrapper = () => {
 
     return connectionData;
   }, [connectionQuery?.data, connector?.id, isA2A, connectionReferencesForConnector, isAgentSubgraph]);
-  const references = useConnectionRefs();
 
   const saveSelectionCallback = useCallback(
     (connection?: Connection) => {
@@ -191,6 +191,7 @@ export const SelectConnectionWrapper = () => {
       saveSelectionCallback={saveSelectionCallback}
       cancelSelectionCallback={closeConnectionsFlow}
       isXrmConnectionReferenceMode={!!isXrmConnectionReferenceMode}
+      connectionReferences={references}
       addButton={{
         text: isInlineCreatingConnection ? buttonAddingText : buttonAddText,
         disabled: isInlineCreatingConnection,
@@ -213,6 +214,7 @@ export const SelectConnection = ({
   saveSelectionCallback,
   cancelSelectionCallback,
   isXrmConnectionReferenceMode,
+  connectionReferences,
 }: ConnectionTableProps & {
   addButton: {
     text: string;
@@ -277,6 +279,7 @@ export const SelectConnection = ({
             saveSelectionCallback={saveSelectionCallback}
             cancelSelectionCallback={cancelSelectionCallback}
             isXrmConnectionReferenceMode={!!isXrmConnectionReferenceMode}
+            connectionReferences={connectionReferences}
           />
         </>
       )}

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnectionFromConnector.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/selectConnection/selectConnectionFromConnector.tsx
@@ -126,6 +126,7 @@ export const SelectConnectionWrapper = ({
       saveSelectionCallback={saveSelectionCallback}
       cancelSelectionCallback={onConnectionClose}
       isXrmConnectionReferenceMode={!!isXrmConnectionReferenceMode}
+      connectionReferences={references}
       addButton={{
         text: isInlineCreatingConnection ? buttonAddingText : buttonAddText,
         disabled: isInlineCreatingConnection,
@@ -148,6 +149,7 @@ export const SelectConnection = ({
   saveSelectionCallback,
   cancelSelectionCallback,
   isXrmConnectionReferenceMode,
+  connectionReferences,
 }: ConnectionTableProps & {
   addButton: {
     text: string;
@@ -192,6 +194,7 @@ export const SelectConnection = ({
     id: 'GtDOFg',
     description: 'Aria label description for cancel button',
   });
+
   return (
     <div className="msla-edit-connection-container">
       {actionBar ? actionBar : null}
@@ -213,6 +216,7 @@ export const SelectConnection = ({
             cancelSelectionCallback={cancelSelectionCallback}
             isXrmConnectionReferenceMode={!!isXrmConnectionReferenceMode}
             shouldRenderDetails={true}
+            connectionReferences={connectionReferences}
           />
         </>
       )}


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Updating the common component to not rely on store for data and pass it as props. This was causing issues for MCP server wizard where it used the connection slice but it tried to read from designer store. MCP, Knowledge, uses connection slice but have their own uber stores.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: MCP server connection selection now works correctly for creating/selecting connections.
- **Developers**: ConnectionTable now requires connectionReferences as a prop, so callers must pass it through.
- **System**: Refactor ConnectionTable to accept connection references as props so it can be reused in MCP contexts that do not use the designer store.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: public cloud locally
