### PR TITLE
fix(vscode): Start codeful language server only when codeful projects exist, add telemetry

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppProjects.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppProjects.ts
@@ -70,7 +70,7 @@ export async function createLogicAppProject(context: IActionContext, options: an
   mySubContext.workspacePath = workspaceFolder;
 
   if (!doesLogicAppExist) {
-    await createLogicAppAndWorkflow(webviewProjectContext, logicAppFolderPath);
+    await createLogicAppAndWorkflow(webviewProjectContext, logicAppFolderPath, context);
 
     // .vscode folder
     await createLogicAppVsCodeContents(webviewProjectContext, logicAppFolderPath);

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppWorkspace.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppWorkspace.ts
@@ -97,8 +97,16 @@ export async function getHostContent(): Promise<IHostJsonV2> {
   return hostJson;
 }
 
-export async function createLogicAppAndWorkflow(webviewProjectContext: IWebviewProjectContext, logicAppFolderPath: string) {
+export async function createLogicAppAndWorkflow(
+  webviewProjectContext: IWebviewProjectContext,
+  logicAppFolderPath: string,
+  context: IActionContext
+) {
   const { logicAppType, workflowType, functionName, workflowName, logicAppName } = webviewProjectContext;
+
+  context.telemetry.properties.logicAppType = logicAppType || 'logicApp';
+  context.telemetry.properties.workflowType = workflowType || 'unknown';
+  context.telemetry.properties.isCodefulWorkflow = String(logicAppType === ProjectType.codeful);
 
   await fse.ensureDir(logicAppFolderPath);
   if (logicAppType === ProjectType.codeful) {
@@ -373,7 +381,7 @@ export async function createLogicAppWorkspace(context: IActionContext, options: 
     mySubContext.packagePath = options.packagePath.fsPath;
     await unzipLogicAppPackageIntoWorkspace(mySubContext);
   } else {
-    await createLogicAppAndWorkflow(webviewProjectContext, logicAppFolderPath);
+    await createLogicAppAndWorkflow(webviewProjectContext, logicAppFolderPath, context);
   }
 
   // .vscode folder
@@ -449,7 +457,7 @@ export async function createLogicAppProject(context: IActionContext, options: an
   mySubContext.workspacePath = workspaceFolder;
 
   if (!doesLogicAppExist) {
-    await createLogicAppAndWorkflow(webviewProjectContext, logicAppFolderPath);
+    await createLogicAppAndWorkflow(webviewProjectContext, logicAppFolderPath, context);
 
     // .vscode folder
     await createLogicAppVsCodeContents(webviewProjectContext, logicAppFolderPath);

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppProject.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppProject.test.ts
@@ -144,7 +144,7 @@ describe('createLogicAppProject', () => {
     // Logic app folder doesn't exist yet
     await createLogicAppProject(mockContext, mockOptions, workspaceRootFolder);
 
-    expect(createLogicAppAndWorkflow).toHaveBeenCalledWith(mockOptions, logicAppFolderPath);
+    expect(createLogicAppAndWorkflow).toHaveBeenCalledWith(mockOptions, logicAppFolderPath, mockContext);
     expect(createLogicAppVsCodeContents).toHaveBeenCalledWith(mockOptions, logicAppFolderPath);
     expect(createLocalConfigurationFiles).toHaveBeenCalledWith(mockOptions, logicAppFolderPath);
   });
@@ -191,7 +191,7 @@ describe('createLogicAppProject', () => {
     await createLogicAppProject(mockContext, mockOptions, workspaceRootFolder);
 
     // Should still create logic app files since it's not a valid logic app
-    expect(createLogicAppAndWorkflow).toHaveBeenCalledWith(mockOptions, logicAppFolderPath);
+    expect(createLogicAppAndWorkflow).toHaveBeenCalledWith(mockOptions, logicAppFolderPath, mockContext);
     expect(createLogicAppVsCodeContents).toHaveBeenCalledWith(mockOptions, logicAppFolderPath);
     expect(createLocalConfigurationFiles).toHaveBeenCalledWith(mockOptions, logicAppFolderPath);
   });
@@ -483,7 +483,7 @@ describe('createLogicAppProject', () => {
 
       // Verify the logic app folder path was constructed correctly
       const expectedPath = path.join(workspaceRootFolder, 'TestLogicApp');
-      expect(createLogicAppAndWorkflow).toHaveBeenCalledWith(expect.anything(), expectedPath);
+      expect(createLogicAppAndWorkflow).toHaveBeenCalledWith(expect.anything(), expectedPath, mockContext);
     });
 
     it('should verify workspace file path is set correctly', async () => {
@@ -591,7 +591,8 @@ describe('createLogicAppProject', () => {
         expect.objectContaining({
           logicAppName: longName,
         }),
-        expect.stringContaining(longName)
+        expect.stringContaining(longName),
+        mockContext
       );
     });
 

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspaceIntegration.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspaceIntegration.test.ts
@@ -180,7 +180,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       // Create parent directory
       await fse.ensureDir(workspaceRootFolder);
 
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       // Verify logic app folder exists
       const logicAppExists = await fse.pathExists(logicAppFolderPath);
@@ -223,7 +223,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, workflowName, 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -247,7 +247,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, workflowName, 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -271,7 +271,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, workflowName, 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -587,7 +587,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowPath = path.join(logicAppFolderPath, workflowName, 'workflow.json');
       const workflowContent = await fse.readJson(workflowPath);
@@ -633,7 +633,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, workflowName, 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -676,7 +676,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, workflowName, 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -714,7 +714,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, workflowName, 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -744,7 +744,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, 'AgentWithTools', 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -775,7 +775,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, 'StandardWorkflow', 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -804,7 +804,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, 'CustomCodeWorkflow', 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -851,7 +851,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, 'RulesWorkflow', 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -898,7 +898,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, 'CustomWorkflow', 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);
@@ -930,7 +930,7 @@ describe('createLogicAppWorkspace - Integration Tests', () => {
       };
 
       await fse.ensureDir(workspaceRootFolder);
-      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath);
+      await createLogicAppAndWorkflow(mockContextIntegration, logicAppFolderPath, mockContext);
 
       const workflowJsonPath = path.join(logicAppFolderPath, 'XmlRulesWorkflow', 'workflow.json');
       const workflowContent = await fse.readJson(workflowJsonPath);

--- a/apps/vs-code-designer/src/app/commands/createWorkflow/__test__/createLogicAppWorkflow.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createWorkflow/__test__/createLogicAppWorkflow.test.ts
@@ -58,7 +58,7 @@ describe('createLogicAppWorkflow', () => {
       functionFolderName: 'Functions',
       targetFramework: 'net8.0',
     });
-    expect(createLogicAppAndWorkflow).toHaveBeenCalledWith(options, logicAppFolderPath);
+    expect(createLogicAppAndWorkflow).toHaveBeenCalledWith(options, logicAppFolderPath, context);
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Finished creating workflow.');
   });
 

--- a/apps/vs-code-designer/src/app/commands/createWorkflow/createLogicAppWorkflow.ts
+++ b/apps/vs-code-designer/src/app/commands/createWorkflow/createLogicAppWorkflow.ts
@@ -33,7 +33,7 @@ export async function createLogicAppWorkflow(context: IActionContext, options: a
     mySubContext.functionFolderName = options.functionFolderName;
     mySubContext.targetFramework = options.targetFramework;
 
-    await createLogicAppAndWorkflow(webviewProjectContext, logicAppFolderPath);
+    await createLogicAppAndWorkflow(webviewProjectContext, logicAppFolderPath, context);
     vscode.window.showInformationMessage(localize('finishedCreatingWorkflow', 'Finished creating workflow.'));
   } else {
     // Fall back to the newly created workspace folder if not in a workspace

--- a/apps/vs-code-designer/src/app/languageServer/__test__/languageServer.test.ts
+++ b/apps/vs-code-designer/src/app/languageServer/__test__/languageServer.test.ts
@@ -12,7 +12,6 @@ const mocks = vi.hoisted(() => ({
   readFile: vi.fn(),
   readdir: vi.fn(),
   showWarningMessage: vi.fn(),
-  tryGetLogicAppCustomCodeFunctionsProjects: vi.fn(),
   tryGetLogicAppProjectRoot: vi.fn(),
   getDotNetCommand: vi.fn(),
 }));
@@ -50,10 +49,6 @@ vi.mock('../../commands/workflows/switchDebugMode/switchDebugMode', () => ({
 
 vi.mock('../../utils/verifyIsProject', () => ({
   tryGetLogicAppProjectRoot: mocks.tryGetLogicAppProjectRoot,
-}));
-
-vi.mock('../../utils/customCodeUtils', () => ({
-  tryGetLogicAppCustomCodeFunctionsProjects: mocks.tryGetLogicAppCustomCodeFunctionsProjects,
 }));
 
 vi.mock('../../utils/dotnet/dotnet', () => ({
@@ -100,7 +95,6 @@ describe('LogicAppsLanguageServer', () => {
     mocks.readFile.mockResolvedValue('{}');
     mocks.readdir.mockResolvedValue([]);
     mocks.tryGetLogicAppProjectRoot.mockResolvedValue(projectPath);
-    mocks.tryGetLogicAppCustomCodeFunctionsProjects.mockResolvedValue(['D:\\workspace\\custom-code-project']);
     mocks.getDotNetCommand.mockReturnValue('D:\\dependencies\\DotNetSDK\\dotnet.exe');
     mocks.getAzureConnectorDetailsForLocalProject.mockResolvedValue({
       accessToken: 'Bearer token',
@@ -114,19 +108,6 @@ describe('LogicAppsLanguageServer', () => {
 
     await new LogicAppsLanguageServer({} as any).start();
 
-    expect(mocks.readdir).not.toHaveBeenCalled();
-    expect(mocks.getAzureConnectorDetailsForLocalProject).not.toHaveBeenCalled();
-    expect(mocks.languageClient).not.toHaveBeenCalled();
-    expect(mocks.showWarningMessage).not.toHaveBeenCalled();
-  });
-
-  it('does not start or prompt for Azure connector metadata when no linked custom code project is found', async () => {
-    mocks.tryGetLogicAppCustomCodeFunctionsProjects.mockResolvedValue([]);
-
-    await new LogicAppsLanguageServer({} as any).start();
-
-    expect(mocks.tryGetLogicAppCustomCodeFunctionsProjects).toHaveBeenCalledWith(projectPath);
-    expect(mocks.pathExists).not.toHaveBeenCalled();
     expect(mocks.readdir).not.toHaveBeenCalled();
     expect(mocks.getAzureConnectorDetailsForLocalProject).not.toHaveBeenCalled();
     expect(mocks.languageClient).not.toHaveBeenCalled();

--- a/apps/vs-code-designer/src/app/languageServer/languageServer.ts
+++ b/apps/vs-code-designer/src/app/languageServer/languageServer.ts
@@ -4,7 +4,7 @@ import {
   autoRuntimeDependenciesPathSettingKey,
   connectionsFileName,
   lspDirectory,
-  onStartLanguageServerProtocol,
+  onStartLanguageServer,
   workflowAppApiVersion,
 } from '../../constants';
 import { workspace, window, MarkdownString } from 'vscode';
@@ -20,7 +20,6 @@ import type { AzureConnectorDetails } from '@microsoft/vscode-extension-logic-ap
 import { getAzureConnectorDetailsForLocalProject } from '../utils/codeless/common';
 import * as vscode from 'vscode';
 import { filterCompletionResult } from './completionFilter';
-import { tryGetLogicAppCustomCodeFunctionsProjects } from '../utils/customCodeUtils';
 import { getDotNetCommand } from '../utils/dotnet/dotnet';
 
 export default class LogicAppsLanguageServer {
@@ -43,11 +42,6 @@ export default class LogicAppsLanguageServer {
     this.projectPath = await tryGetLogicAppProjectRoot(this.context, workspaceFolder, true /* suppressPrompt */);
 
     if (!this.projectPath) {
-      return;
-    }
-
-    const customCodeProjectPaths = await tryGetLogicAppCustomCodeFunctionsProjects(this.projectPath);
-    if (!customCodeProjectPaths || customCodeProjectPaths.length === 0) {
       return;
     }
 
@@ -272,8 +266,8 @@ export default class LogicAppsLanguageServer {
   }
 }
 
-export const startLanguageServerProtocol = async () => {
-  await callWithTelemetryAndErrorHandling(onStartLanguageServerProtocol, async (context: IActionContext) => {
+export const startLanguageServer = async () => {
+  await callWithTelemetryAndErrorHandling(onStartLanguageServer, async (context: IActionContext) => {
     const languageServer = new LogicAppsLanguageServer(context);
     await languageServer.start();
   });

--- a/apps/vs-code-designer/src/app/utils/__test__/codeful.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/codeful.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { lspDirectory } from '../../../constants';
-import { invalidateCodefulSdkCacheIfNeeded, parseCsprojCopyToCodefulInfo } from '../codeful';
+import { codefulProjectsExist, invalidateCodefulSdkCacheIfNeeded, parseCsprojCopyToCodefulInfo } from '../codeful';
 
 const mocks = vi.hoisted(() => ({
   ensureDir: vi.fn(),
@@ -11,7 +11,16 @@ const mocks = vi.hoisted(() => ({
   readFile: vi.fn(),
   remove: vi.fn(),
   statSync: vi.fn(),
+  workspaceFolders: undefined as { uri: { fsPath: string } }[] | undefined,
   writeFile: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  workspace: {
+    get workspaceFolders() {
+      return mocks.workspaceFolders;
+    },
+  },
 }));
 
 vi.mock('fs-extra', () => ({
@@ -201,5 +210,96 @@ describe('parseCsprojCopyToCodefulInfo', () => {
       replaceLangAfterTargets: 'Build;Publish',
       runsOnBuild: false,
     });
+  });
+});
+
+describe('codefulProjectsExist', () => {
+  const codefulSettingsJson = JSON.stringify({
+    IsEncrypted: false,
+    Values: { WORKFLOW_CODEFUL_ENABLED: 'true' },
+  });
+  const nonCodefulSettingsJson = JSON.stringify({
+    IsEncrypted: false,
+    Values: { AzureWebJobsStorage: 'UseDevelopmentStorage=true' },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.workspaceFolders = undefined;
+  });
+
+  it('returns false when there are no workspace folders', async () => {
+    mocks.workspaceFolders = undefined;
+
+    const result = await codefulProjectsExist();
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when workspace folders array is empty', async () => {
+    mocks.workspaceFolders = [];
+
+    const result = await codefulProjectsExist();
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when a workspace folder has WORKFLOW_CODEFUL_ENABLED', async () => {
+    const folderPath = 'D:\\workspace\\codeful-project';
+    mocks.workspaceFolders = [{ uri: { fsPath: folderPath } }];
+    mocks.pathExists.mockResolvedValue(true);
+    mocks.readFile.mockResolvedValue(codefulSettingsJson);
+
+    const result = await codefulProjectsExist();
+
+    expect(result).toBe(true);
+    expect(mocks.pathExists).toHaveBeenCalledWith(path.join(folderPath, 'local.settings.json'));
+  });
+
+  it('returns false when workspace folder does not have WORKFLOW_CODEFUL_ENABLED', async () => {
+    const folderPath = 'D:\\workspace\\standard-project';
+    mocks.workspaceFolders = [{ uri: { fsPath: folderPath } }];
+    mocks.pathExists.mockResolvedValue(true);
+    mocks.readFile.mockResolvedValue(nonCodefulSettingsJson);
+
+    const result = await codefulProjectsExist();
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when at least one of multiple folders is codeful', async () => {
+    const standardPath = 'D:\\workspace\\standard-project';
+    const codefulPath = 'D:\\workspace\\codeful-project';
+    mocks.workspaceFolders = [{ uri: { fsPath: standardPath } }, { uri: { fsPath: codefulPath } }];
+    mocks.pathExists.mockResolvedValue(true);
+    mocks.readFile.mockImplementation(async (filePath: string) => {
+      if (filePath === path.join(codefulPath, 'local.settings.json')) {
+        return codefulSettingsJson;
+      }
+      return nonCodefulSettingsJson;
+    });
+
+    const result = await codefulProjectsExist();
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when local.settings.json does not exist', async () => {
+    mocks.workspaceFolders = [{ uri: { fsPath: 'D:\\workspace\\empty-project' } }];
+    mocks.pathExists.mockResolvedValue(false);
+
+    const result = await codefulProjectsExist();
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when local.settings.json contains invalid JSON', async () => {
+    mocks.workspaceFolders = [{ uri: { fsPath: 'D:\\workspace\\broken-project' } }];
+    mocks.pathExists.mockResolvedValue(true);
+    mocks.readFile.mockResolvedValue('not valid json');
+
+    const result = await codefulProjectsExist();
+
+    expect(result).toBe(false);
   });
 });

--- a/apps/vs-code-designer/src/app/utils/__test__/codeful.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/codeful.test.ts
@@ -267,6 +267,17 @@ describe('codefulProjectsExist', () => {
     expect(result).toBe(false);
   });
 
+  it('returns false when WORKFLOW_CODEFUL_ENABLED is set to "false"', async () => {
+    const folderPath = 'D:\\workspace\\disabled-codeful-project';
+    mocks.workspaceFolders = [{ uri: { fsPath: folderPath } }];
+    mocks.pathExists.mockResolvedValue(true);
+    mocks.readFile.mockResolvedValue(JSON.stringify({ IsEncrypted: false, Values: { WORKFLOW_CODEFUL_ENABLED: 'false' } }));
+
+    const result = await codefulProjectsExist();
+
+    expect(result).toBe(false);
+  });
+
   it('returns true when at least one of multiple folders is codeful', async () => {
     const standardPath = 'D:\\workspace\\standard-project';
     const codefulPath = 'D:\\workspace\\codeful-project';

--- a/apps/vs-code-designer/src/app/utils/codeful.ts
+++ b/apps/vs-code-designer/src/app/utils/codeful.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import * as fse from 'fs-extra';
+import * as vscode from 'vscode';
 import { autoRuntimeDependenciesPathSettingKey, localSettingsFileName, lspDirectory } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { getGlobalSetting } from './vsCodeConfig/settings';
@@ -8,6 +9,23 @@ const codefulSdkPackageId = 'Microsoft.Azure.Workflows.Sdk';
 const codefulSdkPackageVersion = '1.0.0-preview.1';
 const lspSdkHashMarkerName = '.lspsdk-hash';
 const codefulSdkProjectHashMarkerName = '.logicapps-lspsdk-hash';
+
+/**
+ * Checks whether any workspace folder contains a codeful Logic Apps project.
+ */
+export async function codefulProjectsExist(): Promise<boolean> {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders || workspaceFolders.length === 0) {
+    return false;
+  }
+
+  for (const folder of workspaceFolders) {
+    if (await hasCodefulWorkflowSetting(folder.uri.fsPath)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /**
  * Checks if the codeful agent is enabled for a given folder by examining the local settings file.

--- a/apps/vs-code-designer/src/app/utils/codeful.ts
+++ b/apps/vs-code-designer/src/app/utils/codeful.ts
@@ -45,7 +45,7 @@ export const hasCodefulWorkflowSetting = async (folderPath: string): Promise<boo
   try {
     const localSettingsData = await fse.readFile(localSettingsFilePath, 'utf-8');
     const localSettings = JSON.parse(localSettingsData);
-    return localSettings.Values?.WORKFLOW_CODEFUL_ENABLED ? true : false;
+    return localSettings.Values?.WORKFLOW_CODEFUL_ENABLED === "true" ? true : false;
   } catch {
     return false;
   }

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -282,7 +282,7 @@ export const dependencyTimeoutSettingKey = 'dependencyTimeout';
 export const unitTestExplorer = 'unitTestExplorer';
 export const verifyConnectionKeysSetting = 'verifyConnectionKeys';
 export const useSmbDeployment = 'useSmbDeploymentForHybrid';
-export const onStartLanguageServerProtocol = 'onStartLanguageServerProtocol';
+export const onStartLanguageServer = 'onStartLanguageServer';
 
 // host.json
 export const extensionBundleId = 'Microsoft.Azure.Functions.ExtensionBundle.Workflows';

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -37,8 +37,9 @@ import { createVSCodeAzureSubscriptionProvider } from './app/utils/services/VSCo
 import { logExtensionSettings, logSubscriptions } from './app/utils/telemetry';
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
 import { getAzExtResourceType, getAzureResourcesExtensionApi } from '@microsoft/vscode-azureresources-api';
-import { startLanguageServerProtocol } from './app/languageServer/languageServer';
+import { startLanguageServer } from './app/languageServer/languageServer';
 import { runPostExtractStepsFromCache } from './app/utils/cloudToLocalUtils';
+import { codefulProjectsExist } from './app/utils/codeful';
 
 const perfStats = {
   loadStartTime: Date.now(),
@@ -155,7 +156,10 @@ export async function activate(context: vscode.ExtensionContext) {
     verifyLocalConnectionKeys(activateContext);
     await startOnboarding(activateContext);
 
-    startLanguageServerProtocol();
+    const hasCodefulProjects = await codefulProjectsExist();
+    if (hasCodefulProjects) {
+      startLanguageServer();
+    }
 
     ext.rgApi = await getResourceGroupsApi();
     // @ts-expect-error _rootTreeItem does not exist on type AzExtTreeDataProvider


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
- Remove check for custom code projects in language server start method, which was preventing language server from starting for codeful projects
- Add check to confirm codeful projects exist (WORKFLOWS_CODEFUL_ENABLED flag is "true") before starting language server

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes regression where language server not starting for any codeful workflows
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge @lambrianmsft @wsilveiranz 
