### PR TITLE
fix(standalone): Prevent node panel bottom from being clipped below command bar

### DIFF
--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/DesignerCommandBar.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/DesignerCommandBar.tsx
@@ -105,16 +105,30 @@ export const DesignerCommandBar = ({
   // Standalone-only: the Portal and VS Code hosts lay out the panel differently and are unaffected.
   useEffect(() => {
     const styleId = 'standalone-panel-command-bar-offset';
-    if (document.getElementById(styleId)) {
-      return;
-    }
     const commandBarHeightPx = 53;
-    const style = document.createElement('style');
-    style.id = styleId;
+
+    let style = document.getElementById(styleId) as HTMLStyleElement | null;
+    if (!style) {
+      style = document.createElement('style');
+      style.id = styleId;
+      style.dataset.refCount = '0';
+      document.head.appendChild(style);
+    }
+
     style.textContent = `.msla-panel-container { height: calc(100% - ${commandBarHeightPx}px) !important; }`;
-    document.head.appendChild(style);
+    style.dataset.refCount = String(Number(style.dataset.refCount ?? '0') + 1);
+
     return () => {
-      document.getElementById(styleId)?.remove();
+      const current = document.getElementById(styleId) as HTMLStyleElement | null;
+      if (!current) {
+        return;
+      }
+      const nextCount = Number(current.dataset.refCount ?? '1') - 1;
+      if (nextCount <= 0) {
+        current.remove();
+      } else {
+        current.dataset.refCount = String(nextCount);
+      }
     };
   }, []);
 

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/DesignerCommandBar.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/DesignerCommandBar.tsx
@@ -42,7 +42,7 @@ import {
   downloadDocumentAsFile,
   flushPendingFoundryUpdates,
 } from '@microsoft/logic-apps-designer';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import LogicAppsIcon from '../../../assets/logicapp.svg';
@@ -97,6 +97,27 @@ export const DesignerCommandBar = ({
   selectRun?: (runId: string) => void;
 }) => {
   const dispatch = useDispatch<AppDispatch>();
+
+  // The standalone designer renders this command bar directly above the designer canvas. The node
+  // details panel (and the agent chat panel) are sized to 100% height of an ancestor that includes
+  // the command bar, so the bottom of their content (e.g. the change-connection section) is pushed
+  // off-screen. Offset the panel height by the command bar height so the full panel stays visible.
+  // Standalone-only: the Portal and VS Code hosts lay out the panel differently and are unaffected.
+  useEffect(() => {
+    const styleId = 'standalone-panel-command-bar-offset';
+    if (document.getElementById(styleId)) {
+      return;
+    }
+    const commandBarHeightPx = 53;
+    const style = document.createElement('style');
+    style.id = styleId;
+    style.textContent = `.msla-panel-container { height: calc(100% - ${commandBarHeightPx}px) !important; }`;
+    document.head.appendChild(style);
+    return () => {
+      document.getElementById(styleId)?.remove();
+    };
+  }, []);
+
   const isCopilotReady = useNodesInitialized();
   const queryClient = useQueryClient();
   const { isLoading: isSaving, mutate: saveWorkflowMutate } = useMutation(async () => {


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
In the standalone designer, opening a node panel (e.g. the agent panel) shifted the panel content down so its bottom — like the change-connection section and the lower advanced-parameter fields — was clipped off the bottom of the screen.

The standalone designer renders the command bar directly above the designer canvas, but the node details panel (and the agent chat panel, which share the `.msla-panel-container` class) are sized to `height: 100%` of an ancestor that includes the command bar. That makes them ~53px too tall, pushing the bottom of their content off-screen.

This offsets the panel height by the command bar height so the full panel stays visible. It is scoped to the standalone host only.

## Impact of Change
- **Users**: None. This only affects the standalone dev harness (`apps/Standalone`).
- **Developers**: Node/agent panels in standalone now show their full content without bottom clipping.
- **System**: The standalone command bar injects a single scoped `<style>` (`#standalone-panel-command-bar-offset`) on mount and removes it on unmount. The Portal and VS Code hosts use their own command bars and panel layout and are unaffected.

### Notes / follow-up
This is a host-level layout workaround, not a fix in the shared panel component. The `53px` is the current command bar height; the real fix would be sizing the panel to its post-command-bar container so no fixed offset is needed. Tracked as a follow-up.

## Test Plan
- [x] Manual testing completed
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Tested in: standalone (`pnpm run start`), v1 designer — opened the agent node panel and confirmed the change-connection section and lower fields are fully visible; verified the agent chat panel is unaffected.

## Screenshots/Videos
Before: node panel content (change-connection section, model fields) clipped below the viewport bottom.
After: full panel visible within the viewport.
<img width="3011" height="1907" alt="image" src="https://github.com/user-attachments/assets/526df75e-569a-4968-b94b-37d6a7d2a916" />
