### PR TITLE
Fix Hybrid CI sourceFolder to use project folder name

### DIFF
--- a/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/adoDeploymentScriptsSteps/GenerateADODeploymentScriptsStep.ts
+++ b/apps/vs-code-designer/src/app/commands/generateDeploymentScripts/generateDeploymentScriptsSteps/adoDeploymentScriptsSteps/GenerateADODeploymentScriptsStep.ts
@@ -675,7 +675,7 @@ jobs:
   - task: AzureLogicAppsHybridBuild@0
     displayName: 'Azure Logic Apps Hybrid Build'
     inputs:
-      sourceFolder: '${'$'}(Build.SourcesDirectory)/${'$'}(logicAppName)'
+      sourceFolder: '${'$'}(Build.SourcesDirectory)/${'$'}(sourceFolderName)'
       deploymentFolder: '${'$'}(System.DefaultWorkingDirectory)/deployment/${'$'}(logicAppName)/'
       archiveFile: '${'$'}(Build.ArtifactStagingDirectory)/${'$'}(Build.BuildId).zip'
 
@@ -798,8 +798,11 @@ jobs:
     fs.writeFileSync(path.join(pipelinesFolder, 'CD-pipeline-variables.yml'), cdVariablesContent);
 
     // CI variables
+    // sourceFolderName is the local project folder in the repo (host.json, workflows). It can differ from
+    // logicAppName, which is the deployed Logic App (Container App) name entered in the wizard.
     const ciVariablesContent = `variables:
   logicAppName: '${context.logicAppName}'
+  sourceFolderName: '${path.basename(context.projectPath)}'
   logicAppCIArtifactName: 'logic-app-artifact'
 `;
 


### PR DESCRIPTION
## Problem

The generated Hybrid CI pipeline used `$(logicAppName)` for the Hybrid Build task `sourceFolder` input:

```yaml
- task: AzureLogicAppsHybridBuild@0
  inputs:
    sourceFolder: '$(Build.SourcesDirectory)/$(logicAppName)'
```

`logicAppName` is the **deployed** Logic App (Container App) name entered in the wizard, which can differ from the **local project folder name** in the repo. When they differ, CI fails because the source path does not exist (e.g. `Not found SourceFolder`).

## Solution

Separate the two concepts:

- New `sourceFolderName` CI variable, derived from the actual project folder (`path.basename(context.projectPath)`).
- `sourceFolder` now points at `$(sourceFolderName)`.
- `logicAppName` continues to drive deployment paths/names.

```yaml
variables:
  logicAppName: '<deployed-name>'
  sourceFolderName: '<project-folder>'
```

## Testing

- Generated deployment scripts from the VS Code extension for a Hybrid project where the project folder differs from the deployed name.
- Ran the generated CI pipeline in Azure DevOps; the Hybrid Build task now resolves the correct source folder and builds successfully.
- Unit tests for the hybrid wizard/generator pass.
