### PR TITLE
fix(Designer): Allow # in action names by switching meta-node suffix to %

### DIFF
--- a/e2e/designer/scopeActions.spec.ts
+++ b/e2e/designer/scopeActions.spec.ts
@@ -19,7 +19,7 @@ test.describe(
       await page.getByLabel('True condition, collapse').click();
 
       // Check no actions message is visible
-      await expect(page.getByTestId('subgraph-Condition-actions-#subgraph-no-actions')).toBeVisible();
+      await expect(page.getByTestId('subgraph-Condition-actions-%subgraph-no-actions')).toBeVisible();
 
       // Check items inside true side are hidden
       await expect(page.getByTestId('card-terminate').getByRole('button', { name: 'Terminate' })).not.toBeVisible();
@@ -31,7 +31,7 @@ test.describe(
       await page.getByLabel('False condition, collapse').click();
 
       // Check no actions message is visible
-      await expect(page.getByTestId('subgraph-Condition-elseActions-#subgraph-no-actions')).toBeVisible();
+      await expect(page.getByTestId('subgraph-Condition-elseActions-%subgraph-no-actions')).toBeVisible();
 
       // Check items inside false side are hidden
       await expect(page.getByTestId('card-terminate 2').getByRole('button', { name: 'Terminate' })).not.toBeVisible();
@@ -44,7 +44,7 @@ test.describe(
       await expect(page.getByLabel('False condition, collapse')).not.toBeVisible();
 
       // Check no actions message is visible
-      await expect(page.getByTestId('scope-Condition-#scope-no-actions')).toBeVisible();
+      await expect(page.getByTestId('scope-Condition-%scope-no-actions')).toBeVisible();
     });
 
     test('Should collapse for each actions', async ({ page }) => {
@@ -80,8 +80,8 @@ test.describe(
       await expect(page.getByLabel('ForEach empty operation')).toBeVisible();
 
       // Check message no actions is visible
-      await expect(page.getByTestId('scope-ForEach_nested-#scope-no-actions')).toBeVisible();
-      await expect(page.getByTestId('scope-ForEach_empty-#scope-no-actions')).toBeVisible();
+      await expect(page.getByTestId('scope-ForEach_nested-%scope-no-actions')).toBeVisible();
+      await expect(page.getByTestId('scope-ForEach_empty-%scope-no-actions')).toBeVisible();
     });
 
     test('Should collapse do until actions', async ({ page }) => {
@@ -100,7 +100,7 @@ test.describe(
       await expect(page.getByTestId('card-until_action_2').getByRole('button', { name: 'Until Action' })).not.toBeVisible();
 
       // Check no actions message is visible
-      await expect(page.getByTestId('subgraph-Until-#subgraph-no-actions')).toBeVisible();
+      await expect(page.getByTestId('subgraph-Until-%subgraph-no-actions')).toBeVisible();
 
       // Check until box is visible
       await expect(page.getByLabel('Until operation')).toBeVisible();
@@ -125,7 +125,7 @@ test.describe(
       await page.getByTestId('Conditional_Case-collapse-toggle').click();
 
       // Check no actions message is visible in case
-      await expect(page.getByTestId('subgraph-Conditional_Case-#subgraph-no-actions')).toBeVisible();
+      await expect(page.getByTestId('subgraph-Conditional_Case-%subgraph-no-actions')).toBeVisible();
 
       // Check items inside default are visible
       await expect(page.getByTestId('card-default_compose').getByRole('button', { name: 'Default-Compose' })).toBeVisible();
@@ -138,18 +138,18 @@ test.describe(
       await expect(page.getByTestId('card-foreach_action_2').getByRole('button', { name: 'ForEach Action' })).toBeVisible();
 
       // Check no actions message is visible in default case
-      await expect(page.getByTestId('subgraph-Switch-defaultCase-#subgraph-no-actions')).toBeVisible();
+      await expect(page.getByTestId('subgraph-Switch-defaultCase-%subgraph-no-actions')).toBeVisible();
 
       // Collapse whole switcha action
       await page.getByTestId('Switch-collapse-toggle').click();
 
       // Check items inside switch action are non visible
-      await expect(page.getByTestId('subgraph-Switch-defaultCase-#subgraph-no-actions')).not.toBeVisible();
+      await expect(page.getByTestId('subgraph-Switch-defaultCase-%subgraph-no-actions')).not.toBeVisible();
       await expect(page.getByTestId('card-foreach_action_2').getByRole('button', { name: 'ForEach Action' })).not.toBeVisible();
       await expect(page.getByTestId('card-default_compose').getByRole('button', { name: 'Default-Compose' })).not.toBeVisible();
 
       // Check no actions message is visible in switch action
-      await expect(page.getByTestId('scope-Switch-#scope-no-actions')).toBeVisible();
+      await expect(page.getByTestId('scope-Switch-%scope-no-actions')).toBeVisible();
     });
   }
 );

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/handoff.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/handoff.ts
@@ -71,7 +71,7 @@ export const addAgentHandoff = createAsyncThunk('addAgentHandoff', async (payloa
         relationshipIds: {
           graphId: sourceId,
           subgraphId: newToolId,
-          parentId: `${newToolId}-#subgraph`,
+          parentId: `${newToolId}-%subgraph`,
         },
       })
     );

--- a/libs/designer-v2/src/lib/core/graphlayout/elklayout.tsx
+++ b/libs/designer-v2/src/lib/core/graphlayout/elklayout.tsx
@@ -220,7 +220,7 @@ const convertWorkflowGraphToElkGraph = (node: WorkflowNode): ElkNode => {
           'elk.padding': '[top=0,left=20,bottom=60,right=20]',
         }),
       // If graph has a footer, reduce bottom padding further
-      ...(node.children?.findIndex((child) => child.id.endsWith('#footer')) !== -1 && {
+      ...(node.children?.findIndex((child) => child.id.endsWith('%footer')) !== -1 && {
         'elk.padding': '[top=0,left=20,bottom=0,right=20]',
       }),
     },

--- a/libs/designer-v2/src/lib/core/graphlayout/helpers.ts
+++ b/libs/designer-v2/src/lib/core/graphlayout/helpers.ts
@@ -1,7 +1,7 @@
 import { WORKFLOW_EDGE_TYPES } from '@microsoft/logic-apps-shared';
 import type { WorkflowNode } from '../parsers/models/workflowNode';
 
-export const footerMarker = '#footer';
+export const footerMarker = '%footer';
 
 export interface LayoutRelevantData {
   id: string;

--- a/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -533,7 +533,7 @@ export const processScopeActions = (
   const nodes: WorkflowNode[] = [];
   const edges: WorkflowEdge[] = [];
 
-  const headerId = `${actionName}-#scope`;
+  const headerId = `${actionName}-%scope`;
   const scopeCardNode = createWorkflowNode(headerId, WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE);
   nodes.push(scopeCardNode);
 
@@ -606,7 +606,7 @@ export const processScopeActions = (
     allActions = { ...allActions, ...operations };
     nodesMetadata = { ...nodesMetadata, ...metadata };
 
-    const rootId = `${subgraphId}-#subgraph`;
+    const rootId = `${subgraphId}-%subgraph`;
     const subgraphCardNode = createWorkflowNode(rootId, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
 
     const isAddCase = subgraphType === SUBGRAPH_TYPES.SWITCH_ADD_CASE || subgraphType === SUBGRAPH_TYPES.AGENT_ADD_CONDITON;
@@ -639,7 +639,7 @@ export const processScopeActions = (
   //   having the main node at the bottom and a subgraph node at the top,
   //   use this instead of complicating the other setup functions
   const applyUntilActions = (graphId: string, actions: LogicAppsV2.Actions | undefined) => {
-    scopeCardNode.id = scopeCardNode.id.replace('#scope', '#subgraph');
+    scopeCardNode.id = scopeCardNode.id.replace('%scope', '%subgraph');
     scopeCardNode.type = WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE;
 
     const [graph, operations, metadata] = processNestedActions(
@@ -679,7 +679,7 @@ export const processScopeActions = (
       }
     }
 
-    const footerId = `${graphId}-#footer`;
+    const footerId = `${graphId}-%footer`;
     const allEdgeSources = edges.map((edge) => edge.source);
     const leafNodes = nodes.filter((node) => !allEdgeSources.includes(node.id));
     leafNodes.forEach((node) => {

--- a/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/agentMcpWorkflowDefinition.ts
+++ b/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/agentMcpWorkflowDefinition.ts
@@ -77,7 +77,7 @@ export const expectedAgentMcpWorkflowDefinitionOutput = {
         children: [
           {
             height: 40,
-            id: 'WorkflowAgent-#scope',
+            id: 'WorkflowAgent-%scope',
             type: 'SCOPE_CARD_NODE',
             width: 200,
           },
@@ -92,7 +92,7 @@ export const expectedAgentMcpWorkflowDefinitionOutput = {
             children: [
               {
                 height: 40,
-                id: 'WorkflowAgent-addCase-#subgraph',
+                id: 'WorkflowAgent-addCase-%subgraph',
                 type: 'SUBGRAPH_CARD_NODE',
                 width: 200,
               },
@@ -105,14 +105,14 @@ export const expectedAgentMcpWorkflowDefinitionOutput = {
         ],
         edges: [
           {
-            id: 'WorkflowAgent-#scope-McpFileServer',
-            source: 'WorkflowAgent-#scope',
+            id: 'WorkflowAgent-%scope-McpFileServer',
+            source: 'WorkflowAgent-%scope',
             target: 'McpFileServer',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'WorkflowAgent-#scope-WorkflowAgent-addCase',
-            source: 'WorkflowAgent-#scope',
+            id: 'WorkflowAgent-%scope-WorkflowAgent-addCase',
+            source: 'WorkflowAgent-%scope',
             target: 'WorkflowAgent-addCase',
             type: 'HIDDEN_EDGE',
           },

--- a/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/scopedWorkflowDefinition.ts
+++ b/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/scopedWorkflowDefinition.ts
@@ -111,19 +111,19 @@ export const expectedScopedWorkflowDefinitionOutput: { graph: WorkflowNode; acti
         height: 40,
         width: 200,
         children: [
-          createWorkflowNode('ActionIf-#scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE),
+          createWorkflowNode('ActionIf-%scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE),
           {
             id: 'ActionIf-actions',
             type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
             subGraphLocation: 'actions',
             children: [
-              createWorkflowNode('ActionIf-actions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
+              createWorkflowNode('ActionIf-actions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
               createWorkflowNode('Increment_variable2'),
               createWorkflowNode('Increment_variable4'),
             ],
             edges: [
               createWorkflowEdge('Increment_variable2', 'Increment_variable4'),
-              createWorkflowEdge('ActionIf-actions-#subgraph', 'Increment_variable2', WORKFLOW_EDGE_TYPES.HEADING_EDGE),
+              createWorkflowEdge('ActionIf-actions-%subgraph', 'Increment_variable2', WORKFLOW_EDGE_TYPES.HEADING_EDGE),
             ],
           },
           {
@@ -131,15 +131,15 @@ export const expectedScopedWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
             subGraphLocation: 'else',
             children: [
-              createWorkflowNode('ActionIf-elseActions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
+              createWorkflowNode('ActionIf-elseActions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
               createWorkflowNode('Increment_variable3'),
             ],
-            edges: [createWorkflowEdge('ActionIf-elseActions-#subgraph', 'Increment_variable3', WORKFLOW_EDGE_TYPES.HEADING_EDGE)],
+            edges: [createWorkflowEdge('ActionIf-elseActions-%subgraph', 'Increment_variable3', WORKFLOW_EDGE_TYPES.HEADING_EDGE)],
           },
         ],
         edges: [
-          createWorkflowEdge('ActionIf-#scope', 'ActionIf-actions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
-          createWorkflowEdge('ActionIf-#scope', 'ActionIf-elseActions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
+          createWorkflowEdge('ActionIf-%scope', 'ActionIf-actions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
+          createWorkflowEdge('ActionIf-%scope', 'ActionIf-elseActions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
         ],
       },
       {
@@ -147,7 +147,7 @@ export const expectedScopedWorkflowDefinitionOutput: { graph: WorkflowNode; acti
         type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
         height: 40,
         width: 200,
-        children: [createWorkflowNode('EmptyScope-#scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE)],
+        children: [createWorkflowNode('EmptyScope-%scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE)],
         edges: [],
       },
       createWorkflowNode('Response'),

--- a/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/switchWorkflowDefinition.ts
+++ b/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/switchWorkflowDefinition.ts
@@ -81,7 +81,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
         type: 'GRAPH_NODE',
         children: [
           {
-            id: 'Switch_1-#scope',
+            id: 'Switch_1-%scope',
             width: 200,
             height: 40,
             type: 'SCOPE_CARD_NODE',
@@ -90,7 +90,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             id: 'Case 2',
             children: [
               {
-                id: 'Case 2-#subgraph',
+                id: 'Case 2-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -104,8 +104,8 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             ],
             edges: [
               {
-                id: 'Case 2-#subgraph-Compose_5',
-                source: 'Case 2-#subgraph',
+                id: 'Case 2-%subgraph-Compose_5',
+                source: 'Case 2-%subgraph',
                 target: 'Compose_5',
                 type: 'HEADING_EDGE',
               },
@@ -117,7 +117,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             id: 'Case 3',
             children: [
               {
-                id: 'Case 3-#subgraph',
+                id: 'Case 3-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -131,8 +131,8 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             ],
             edges: [
               {
-                id: 'Case 3-#subgraph-Compose_4',
-                source: 'Case 3-#subgraph',
+                id: 'Case 3-%subgraph-Compose_4',
+                source: 'Case 3-%subgraph',
                 target: 'Compose_4',
                 type: 'HEADING_EDGE',
               },
@@ -144,7 +144,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             id: 'Switch_1-addCase',
             children: [
               {
-                id: 'Switch_1-addCase-#subgraph',
+                id: 'Switch_1-addCase-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -158,7 +158,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             id: 'Switch_1-defaultCase',
             children: [
               {
-                id: 'Switch_1-defaultCase-#subgraph',
+                id: 'Switch_1-defaultCase-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -171,26 +171,26 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
         ],
         edges: [
           {
-            id: 'Switch_1-#scope-Case 2',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Case 2',
+            source: 'Switch_1-%scope',
             target: 'Case 2',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Case 3',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Case 3',
+            source: 'Switch_1-%scope',
             target: 'Case 3',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Switch_1-addCase',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Switch_1-addCase',
+            source: 'Switch_1-%scope',
             target: 'Switch_1-addCase',
             type: 'HIDDEN_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Switch_1-defaultCase',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Switch_1-defaultCase',
+            source: 'Switch_1-%scope',
             target: 'Switch_1-defaultCase',
             type: 'ONLY_EDGE',
           },
@@ -286,7 +286,7 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
         type: 'GRAPH_NODE',
         children: [
           {
-            id: 'Switch_1-#scope',
+            id: 'Switch_1-%scope',
             width: 200,
             height: 40,
             type: 'SCOPE_CARD_NODE',
@@ -295,7 +295,7 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             id: 'Case 2',
             children: [
               {
-                id: 'Case 2-#subgraph',
+                id: 'Case 2-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -309,8 +309,8 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             ],
             edges: [
               {
-                id: 'Case 2-#subgraph-Compose_5',
-                source: 'Case 2-#subgraph',
+                id: 'Case 2-%subgraph-Compose_5',
+                source: 'Case 2-%subgraph',
                 target: 'Compose_5',
                 type: 'HEADING_EDGE',
               },
@@ -322,7 +322,7 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             id: 'Case 3',
             children: [
               {
-                id: 'Case 3-#subgraph',
+                id: 'Case 3-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -336,8 +336,8 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             ],
             edges: [
               {
-                id: 'Case 3-#subgraph-Compose_4',
-                source: 'Case 3-#subgraph',
+                id: 'Case 3-%subgraph-Compose_4',
+                source: 'Case 3-%subgraph',
                 target: 'Compose_4',
                 type: 'HEADING_EDGE',
               },
@@ -349,7 +349,7 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             id: 'Switch_1-defaultCase',
             children: [
               {
-                id: 'Switch_1-defaultCase-#subgraph',
+                id: 'Switch_1-defaultCase-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -362,20 +362,20 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
         ],
         edges: [
           {
-            id: 'Switch_1-#scope-Case 2',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Case 2',
+            source: 'Switch_1-%scope',
             target: 'Case 2',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Case 3',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Case 3',
+            source: 'Switch_1-%scope',
             target: 'Case 3',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Switch_1-defaultCase',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Switch_1-defaultCase',
+            source: 'Switch_1-%scope',
             target: 'Switch_1-defaultCase',
             type: 'ONLY_EDGE',
           },

--- a/libs/designer-v2/src/lib/core/parsers/__test__/respectExistingWorkflowDimensions.spec.ts
+++ b/libs/designer-v2/src/lib/core/parsers/__test__/respectExistingWorkflowDimensions.spec.ts
@@ -37,7 +37,7 @@ describe('respect existing workflow dimensions', () => {
       type: 'GRAPH_NODE',
       children: [
         {
-          id: 'Condition-#scope',
+          id: 'Condition-%scope',
           width: 200,
           height: 40,
           type: 'SCOPE_CARD_NODE',
@@ -46,7 +46,7 @@ describe('respect existing workflow dimensions', () => {
           id: 'Condition-actions',
           children: [
             {
-              id: 'Condition-actions-#subgraph',
+              id: 'Condition-actions-%subgraph',
               width: 200,
               height: 40,
               type: 'SUBGRAPH_CARD_NODE',
@@ -84,8 +84,8 @@ describe('respect existing workflow dimensions', () => {
               type: 'BUTTON_EDGE',
             },
             {
-              id: 'Condition-actions-#subgraph-Create_file',
-              source: 'Condition-actions-#subgraph',
+              id: 'Condition-actions-%subgraph-Create_file',
+              source: 'Condition-actions-%subgraph',
               target: 'Create_file',
               type: 'HEADING_EDGE',
             },
@@ -97,7 +97,7 @@ describe('respect existing workflow dimensions', () => {
           id: 'Condition-elseActions',
           children: [
             {
-              id: 'Condition-elseActions-#subgraph',
+              id: 'Condition-elseActions-%subgraph',
               width: 200,
               height: 40,
               type: 'SUBGRAPH_CARD_NODE',
@@ -110,14 +110,14 @@ describe('respect existing workflow dimensions', () => {
       ],
       edges: [
         {
-          id: 'Condition-#scope-Condition-actions',
-          source: 'Condition-#scope',
+          id: 'Condition-%scope-Condition-actions',
+          source: 'Condition-%scope',
           target: 'Condition-actions',
           type: 'ONLY_EDGE',
         },
         {
-          id: 'Condition-#scope-Condition-elseActions',
-          source: 'Condition-#scope',
+          id: 'Condition-%scope-Condition-elseActions',
+          source: 'Condition-%scope',
           target: 'Condition-elseActions',
           type: 'ONLY_EDGE',
         },
@@ -140,13 +140,13 @@ describe('respect existing workflow dimensions', () => {
         type: 'OPERATION_NODE',
       },
       {
-        id: 'Condition-#scope',
+        id: 'Condition-%scope',
         width: 200,
         height: 40,
         type: 'SCOPE_CARD_NODE',
       },
       {
-        id: 'Condition-actions-#subgraph',
+        id: 'Condition-actions-%subgraph',
         width: 200,
         height: 40,
         type: 'SUBGRAPH_CARD_NODE',
@@ -185,8 +185,8 @@ describe('respect existing workflow dimensions', () => {
             type: 'BUTTON_EDGE',
           },
           {
-            id: 'Condition-actions-#subgraph-Create_file',
-            source: 'Condition-actions-#subgraph',
+            id: 'Condition-actions-%subgraph-Create_file',
+            source: 'Condition-actions-%subgraph',
             target: 'Create_file',
             type: 'HEADING_EDGE',
           },
@@ -195,7 +195,7 @@ describe('respect existing workflow dimensions', () => {
         subGraphLocation: 'actions',
       },
       {
-        id: 'Condition-elseActions-#subgraph',
+        id: 'Condition-elseActions-%subgraph',
         width: 200,
         height: 40,
         type: 'SUBGRAPH_CARD_NODE',
@@ -213,14 +213,14 @@ describe('respect existing workflow dimensions', () => {
         type: 'GRAPH_NODE',
         edges: [
           {
-            id: 'Condition-#scope-Condition-actions',
-            source: 'Condition-#scope',
+            id: 'Condition-%scope-Condition-actions',
+            source: 'Condition-%scope',
             target: 'Condition-actions',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Condition-#scope-Condition-elseActions',
-            source: 'Condition-#scope',
+            id: 'Condition-%scope-Condition-elseActions',
+            source: 'Condition-%scope',
             target: 'Condition-elseActions',
             type: 'ONLY_EDGE',
           },
@@ -339,7 +339,7 @@ describe('respect existing workflow dimensions', () => {
   it('should update the dimensions of currentChildren recursively', () => {
     const previousChildren: WorkflowNode[] = [
       {
-        id: 'Condition-actions-#subgraph',
+        id: 'Condition-actions-%subgraph',
         width: 200,
         height: 28,
         type: 'SUBGRAPH_CARD_NODE',
@@ -378,7 +378,7 @@ describe('respect existing workflow dimensions', () => {
         type: 'GRAPH_NODE',
         children: [
           {
-            id: 'Condition-#scope',
+            id: 'Condition-%scope',
             width: 200,
             height: 40,
             type: 'SCOPE_CARD_NODE',
@@ -387,7 +387,7 @@ describe('respect existing workflow dimensions', () => {
             id: 'Condition-actions',
             children: [
               {
-                id: 'Condition-actions-#subgraph',
+                id: 'Condition-actions-%subgraph',
                 width: 200,
                 height: 28,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -425,8 +425,8 @@ describe('respect existing workflow dimensions', () => {
                 type: 'BUTTON_EDGE',
               },
               {
-                id: 'Condition-actions-#subgraph-Create_file',
-                source: 'Condition-actions-#subgraph',
+                id: 'Condition-actions-%subgraph-Create_file',
+                source: 'Condition-actions-%subgraph',
                 target: 'Create_file',
                 type: 'HEADING_EDGE',
               },
@@ -438,7 +438,7 @@ describe('respect existing workflow dimensions', () => {
             id: 'Condition-elseActions',
             children: [
               {
-                id: 'Condition-elseActions-#subgraph',
+                id: 'Condition-elseActions-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -451,14 +451,14 @@ describe('respect existing workflow dimensions', () => {
         ],
         edges: [
           {
-            id: 'Condition-#scope-Condition-actions',
-            source: 'Condition-#scope',
+            id: 'Condition-%scope-Condition-actions',
+            source: 'Condition-%scope',
             target: 'Condition-actions',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Condition-#scope-Condition-elseActions',
-            source: 'Condition-#scope',
+            id: 'Condition-%scope-Condition-elseActions',
+            source: 'Condition-%scope',
             target: 'Condition-elseActions',
             type: 'ONLY_EDGE',
           },

--- a/libs/designer-v2/src/lib/core/parsers/__test__/updateAgenticGraph.spec.ts
+++ b/libs/designer-v2/src/lib/core/parsers/__test__/updateAgenticGraph.spec.ts
@@ -29,15 +29,15 @@ const createMockState = (overrides: Partial<WorkflowState> = {}): WorkflowState 
 const createMockAgentGraph = (overrides: Partial<WorkflowNode> = {}): WorkflowNode => ({
   id: 'agent1',
   children: [
-    { id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
+    { id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
     {
       id: 'myTool',
-      children: [{ id: 'myTool-#subgraph', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
+      children: [{ id: 'myTool-%subgraph', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
       edges: [],
       type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
     },
   ],
-  edges: [{ id: 'agent1-#scope-myTool', source: 'agent1-#scope', target: 'myTool', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE }],
+  edges: [{ id: 'agent1-%scope-myTool', source: 'agent1-%scope', target: 'myTool', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE }],
   type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
   ...overrides,
 });
@@ -96,12 +96,12 @@ describe('updateAgenticSubgraph', () => {
     const codeInterpreterChild = agentGraph.children?.find((c) => c.id === 'code_interpreter');
     expect(codeInterpreterChild).toBeDefined();
     expect(codeInterpreterChild?.type).toBe(WORKFLOW_NODE_TYPES.SUBGRAPH_NODE);
-    expect(codeInterpreterChild?.children?.[0]?.id).toBe('code_interpreter-#subgraph');
+    expect(codeInterpreterChild?.children?.[0]?.id).toBe('code_interpreter-%subgraph');
   });
 
   it('should not inject non-built-in tools as new children', () => {
     const agentGraph = createMockAgentGraph({
-      children: [{ id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
+      children: [{ id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
       edges: [],
     });
     const state = createMockState();
@@ -119,12 +119,12 @@ describe('updateAgenticSubgraph', () => {
   it('should not duplicate already-existing built-in tool child nodes', () => {
     const existingCodeInterpreter: WorkflowNode = {
       id: 'code_interpreter',
-      children: [{ id: 'code_interpreter-#subgraph', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
+      children: [{ id: 'code_interpreter-%subgraph', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
       edges: [],
       type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
     };
     const agentGraph = createMockAgentGraph({
-      children: [{ id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }, existingCodeInterpreter],
+      children: [{ id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }, existingCodeInterpreter],
     });
     const state = createMockState();
     const payload: UpdateAgenticGraphPayload = {
@@ -157,12 +157,12 @@ describe('updateAgenticSubgraph', () => {
   it('should filter children to only visible tools from scopeRepetitionRunData.tools', () => {
     const agentGraph = createMockAgentGraph({
       children: [
-        { id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
+        { id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
         { id: 'toolA', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE },
         { id: 'toolB', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE },
       ],
       edges: [
-        { id: 'agent1-#scope-toolA', source: 'agent1-#scope', target: 'toolA', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE },
+        { id: 'agent1-%scope-toolA', source: 'agent1-%scope', target: 'toolA', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE },
         { id: 'toolA-toolB', source: 'toolA', target: 'toolB', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE },
       ],
     });
@@ -175,7 +175,7 @@ describe('updateAgenticSubgraph', () => {
     updateAgenticSubgraph(payload, agentGraph, state);
 
     const childIds = agentGraph.children?.map((c) => c.id);
-    expect(childIds).toContain('agent1-#scope');
+    expect(childIds).toContain('agent1-%scope');
     expect(childIds).toContain('toolA');
     expect(childIds).not.toContain('toolB');
   });
@@ -183,7 +183,7 @@ describe('updateAgenticSubgraph', () => {
   it('should preserve #scope and -addCase children regardless of visibility', () => {
     const agentGraph = createMockAgentGraph({
       children: [
-        { id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
+        { id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
         { id: 'agent1-addCase', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
         { id: 'someTool', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE },
       ],
@@ -198,7 +198,7 @@ describe('updateAgenticSubgraph', () => {
     updateAgenticSubgraph(payload, agentGraph, state);
 
     const childIds = agentGraph.children?.map((c) => c.id);
-    expect(childIds).toContain('agent1-#scope');
+    expect(childIds).toContain('agent1-%scope');
     expect(childIds).toContain('agent1-addCase');
     expect(childIds).not.toContain('someTool');
   });
@@ -206,10 +206,10 @@ describe('updateAgenticSubgraph', () => {
   it('should call reassignEdgeSources and removeEdge for hidden tools', () => {
     const agentGraph = createMockAgentGraph({
       children: [
-        { id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
+        { id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
         { id: 'hiddenTool', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE },
       ],
-      edges: [{ id: 'agent1-#scope-hiddenTool', source: 'agent1-#scope', target: 'hiddenTool', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE }],
+      edges: [{ id: 'agent1-%scope-hiddenTool', source: 'agent1-%scope', target: 'hiddenTool', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE }],
     });
     const state = createMockState();
     const payload: UpdateAgenticGraphPayload = {
@@ -219,8 +219,8 @@ describe('updateAgenticSubgraph', () => {
 
     updateAgenticSubgraph(payload, agentGraph, state);
 
-    expect(mockReassignEdgeSources).toHaveBeenCalledWith(state, 'hiddenTool', 'agent1-#scope', agentGraph, true);
-    expect(mockRemoveEdge).toHaveBeenCalledWith(state, 'agent1-#scope', 'hiddenTool', agentGraph);
+    expect(mockReassignEdgeSources).toHaveBeenCalledWith(state, 'hiddenTool', 'agent1-%scope', agentGraph, true);
+    expect(mockRemoveEdge).toHaveBeenCalledWith(state, 'agent1-%scope', 'hiddenTool', agentGraph);
   });
 
   it('should be a no-op when scopeRepetitionRunData is falsy', () => {

--- a/libs/designer-v2/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer-v2/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import CONSTANTS from '../../common/constants';
 import type { RelationshipIds } from '../state/panel/panelTypes';
 import type { NodesMetadata, WorkflowState } from '../state/workflow/workflowInterfaces';
@@ -114,7 +113,7 @@ const createSubgraphNode = (
   const node = createWorkflowNode(id, WORKFLOW_NODE_TYPES.SUBGRAPH_NODE);
   node.subGraphLocation = location;
   addChildNode(parent, node);
-  const graphHeading = createWorkflowNode(`${id}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+  const graphHeading = createWorkflowNode(`${id}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
   addChildNode(node, graphHeading);
   nodesMetadata[id] = {
     graphId: parent.id,
@@ -122,7 +121,7 @@ const createSubgraphNode = (
     actionCount: 0,
     parentNodeId: parent.id === 'root' ? undefined : parent.id,
   };
-  addChildEdge(parent, createWorkflowEdge(`${parent.id}-#scope`, node.id, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
+  addChildEdge(parent, createWorkflowEdge(`${parent.id}-%scope`, node.id, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
 };
 
 const handleExtraScopeNodeSetup = (
@@ -133,10 +132,10 @@ const handleExtraScopeNodeSetup = (
 ) => {
   node.type = WORKFLOW_NODE_TYPES.GRAPH_NODE;
 
-  let scopeHeadingId = `${node.id}-#scope`;
+  let scopeHeadingId = `${node.id}-%scope`;
   let scopeHeadingType = WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE;
   if (operation.type.toLowerCase() === CONSTANTS.NODE.TYPE.UNTIL) {
-    scopeHeadingId = `${node.id}-#subgraph`;
+    scopeHeadingId = `${node.id}-%subgraph`;
     scopeHeadingType = WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE;
   }
   const scopeHeadingNode = createWorkflowNode(scopeHeadingId, scopeHeadingType);
@@ -161,7 +160,7 @@ const handleExtraScopeNodeSetup = (
     const addCaseGraph = createWorkflowNode(addCaseGraphId, WORKFLOW_NODE_TYPES.HIDDEN_NODE);
     addCaseGraph.subGraphLocation = 'addCase';
     addChildNode(node, addCaseGraph);
-    const addCaseGraphHeading = createWorkflowNode(`${addCaseGraphId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+    const addCaseGraphHeading = createWorkflowNode(`${addCaseGraphId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
     addChildNode(addCaseGraph, addCaseGraphHeading);
     nodesMetadata[addCaseGraphId] = {
       graphId: node.id,
@@ -190,7 +189,7 @@ const handleExtraScopeNodeSetup = (
     const addCaseGraph = createWorkflowNode(addCaseGraphId, WORKFLOW_NODE_TYPES.HIDDEN_NODE);
     addCaseGraph.subGraphLocation = 'addCase';
     addChildNode(node, addCaseGraph);
-    const addCaseGraphHeading = createWorkflowNode(`${addCaseGraphId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+    const addCaseGraphHeading = createWorkflowNode(`${addCaseGraphId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
     addChildNode(addCaseGraph, addCaseGraphHeading);
     nodesMetadata[addCaseGraphId] = {
       graphId: node.id,
@@ -210,7 +209,7 @@ const handleExtraScopeNodeSetup = (
 
   if (operation.type.toLowerCase() === CONSTANTS.NODE.TYPE.UNTIL) {
     // Create Footer node
-    const footerNode = createWorkflowNode(`${node.id}-#footer`, WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE);
+    const footerNode = createWorkflowNode(`${node.id}-%footer`, WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE);
     addChildNode(node, footerNode);
     addChildEdge(node, createWorkflowEdge(scopeHeadingNode.id, footerNode.id, WORKFLOW_EDGE_TYPES.HIDDEN_EDGE));
   }
@@ -221,7 +220,7 @@ export const addSwitchCaseToWorkflow = (caseId: string, switchNode: WorkflowNode
   caseNode.subGraphLocation = 'cases';
   // addChildNode(switchNode, caseNode);
   switchNode.children?.splice(switchNode.children.length - 2, 0, caseNode);
-  const caseHeading = createWorkflowNode(`${caseId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+  const caseHeading = createWorkflowNode(`${caseId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
   addChildNode(caseNode, caseHeading);
   nodesMetadata[caseId] = {
     graphId: switchNode.id,
@@ -229,7 +228,7 @@ export const addSwitchCaseToWorkflow = (caseId: string, switchNode: WorkflowNode
     subgraphType: SUBGRAPH_TYPES.SWITCH_CASE,
     actionCount: 0,
   };
-  addChildEdge(switchNode, createWorkflowEdge(`${switchNode.id}-#scope`, caseId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
+  addChildEdge(switchNode, createWorkflowEdge(`${switchNode.id}-%scope`, caseId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
 
   // Add Case to Switch operation data
   const switchAction = state.operations[switchNode.id] as LogicAppsV2.SwitchAction;
@@ -248,7 +247,7 @@ export const addAgentToolToWorkflow = (toolId: string, agentNode: WorkflowNode, 
   const conditionNode = createWorkflowNode(toolId, WORKFLOW_NODE_TYPES.SUBGRAPH_NODE);
   conditionNode.subGraphLocation = 'tools';
   agentNode.children?.splice(agentNode.children.length - 2, 0, conditionNode);
-  const conditionHeading = createWorkflowNode(`${toolId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+  const conditionHeading = createWorkflowNode(`${toolId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
   addChildNode(conditionNode, conditionHeading);
   nodesMetadata[toolId] = {
     graphId: agentNode.id,
@@ -256,7 +255,7 @@ export const addAgentToolToWorkflow = (toolId: string, agentNode: WorkflowNode, 
     subgraphType: SUBGRAPH_TYPES.AGENT_CONDITION,
     actionCount: 0,
   };
-  addChildEdge(agentNode, createWorkflowEdge(`${agentNode.id}-#scope`, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
+  addChildEdge(agentNode, createWorkflowEdge(`${agentNode.id}-%scope`, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
 
   // Add Condion to Agent operation data
   const agentAction = state.operations[agentNode.id] as LogicAppsV2.AgentAction;
@@ -288,7 +287,7 @@ export const addMcpServerToWorkflow = (
     subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
   };
 
-  addChildEdge(agentNode, createWorkflowEdge(`${agentNode.id}-#scope`, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
+  addChildEdge(agentNode, createWorkflowEdge(`${agentNode.id}-%scope`, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
 
   if (operation) {
     state.operations[toolId] = { ...state.operations[toolId], type: operation.type };

--- a/libs/designer-v2/src/lib/core/parsers/updateAgenticGraph.ts
+++ b/libs/designer-v2/src/lib/core/parsers/updateAgenticGraph.ts
@@ -39,7 +39,7 @@ export const updateAgenticSubgraph = (payload: UpdateAgenticGraphPayload, agentG
 
       // Create graph node only if it doesn't exist yet
       if (!existingChildIds.has(toolId)) {
-        const subgraphCardNode = createWorkflowNode(`${toolId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+        const subgraphCardNode = createWorkflowNode(`${toolId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
         const toolGraph: WorkflowNode = {
           id: toolId,
           children: [subgraphCardNode],
@@ -49,7 +49,7 @@ export const updateAgenticSubgraph = (payload: UpdateAgenticGraphPayload, agentG
         };
         agentGraph.children = [...(agentGraph.children ?? []), toolGraph];
 
-        const headerId = `${agentGraph.id}-#scope`;
+        const headerId = `${agentGraph.id}-%scope`;
         agentGraph.edges = [...(agentGraph.edges ?? []), createWorkflowEdge(headerId, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE)];
 
         // Update the saved original graph so the node persists across iteration switches
@@ -81,7 +81,7 @@ export const updateAgenticSubgraph = (payload: UpdateAgenticGraphPayload, agentG
     const hidingTools: string[] = [];
 
     const filteredTools = agentTools.filter((tool) => {
-      if (tool.id.includes('#scope') || tool.id.includes('-addCase')) {
+      if (tool.id.includes('%scope') || tool.id.includes('-addCase')) {
         return true;
       }
 

--- a/libs/designer-v2/src/lib/core/state/workflow/__test__/wrapNodesInScope.spec.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/__test__/wrapNodesInScope.spec.ts
@@ -76,7 +76,7 @@ describe('workflowSlice - wrapNodesInScope', () => {
 
     // The else branch only contains its header.
     const elseChildIds = (elseActions?.children ?? []).map((c) => c.id);
-    expect(elseChildIds).toEqual(['Condition-elseActions-#subgraph']);
+    expect(elseChildIds).toEqual(['Condition-elseActions-%subgraph']);
   });
 
   test('connects the subgraph header to the first node so it lays out inside the branch', () => {
@@ -95,7 +95,7 @@ describe('workflowSlice - wrapNodesInScope', () => {
 
     // The fix: header -> first node edge keeps the chain inside the true branch
     // instead of beside the true/false labels.
-    expect(edges).toContain('Condition-actions-#subgraph->Initialize_variable');
+    expect(edges).toContain('Condition-actions-%subgraph->Initialize_variable');
     expect(edges).toContain('Initialize_variable->Increment_variable');
     expect(edges).toContain('Increment_variable->Response');
 
@@ -126,7 +126,7 @@ describe('workflowSlice - wrapNodesInScope', () => {
     }
 
     const edges = edgeStrings(scope);
-    expect(edges).toContain('Scope-#scope->Initialize_variable');
+    expect(edges).toContain('Scope-%scope->Initialize_variable');
     expect(edges).toContain('Initialize_variable->Increment_variable');
     expect(edges).toContain('Increment_variable->Response');
   });

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSelectors.ts
@@ -337,7 +337,7 @@ export { getWorkflowNodeFromGraphState };
 export const useNodeEdgeTargets = (nodeId?: string): string[] => {
   const edges = useEdges()
     .filter((edge) => edge.source === nodeId)
-    .filter((edge) => !edge.target.includes('-#footer'));
+    .filter((edge) => !edge.target.includes('-%footer'));
   return edges.map((edge) => edge.target);
 };
 

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
@@ -211,7 +211,7 @@ export const workflowSlice = createSlice({
         targetGraph = getWorkflowNodeFromGraphState(state, targetGraphId) as WorkflowNode;
         // Chain the first moved node off the subgraph header so it lays out inside the
         // "true" branch (below the header) instead of beside the true/false branch labels.
-        previousNodeId = `${targetGraphId}-#subgraph`;
+        previousNodeId = `${targetGraphId}-%subgraph`;
       }
 
       if (!targetGraph) {

--- a/libs/designer-v2/src/lib/core/utils/__test__/graph.spec.ts
+++ b/libs/designer-v2/src/lib/core/utils/__test__/graph.spec.ts
@@ -18,7 +18,7 @@ describe('Graph Utilities', () => {
         height: 40,
         type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
         children: [
-          createWorkflowNode('Scope-#scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
+          createWorkflowNode('Scope-%scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
           createWorkflowNode('Compose_10'),
           createWorkflowNode('Compose_3'),
           createWorkflowNode('Compose_4'),
@@ -30,7 +30,7 @@ describe('Graph Utilities', () => {
             height: 40,
             type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
             children: [
-              createWorkflowNode('Scope_2-#scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
+              createWorkflowNode('Scope_2-%scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
               createWorkflowNode('Compose_7'),
               createWorkflowNode('Compose_8'),
               createWorkflowNode('Compose_9'),
@@ -38,7 +38,7 @@ describe('Graph Utilities', () => {
             edges: [
               createWorkflowEdge('Compose_7', 'Compose_8'),
               createWorkflowEdge('Compose_7', 'Compose_9'),
-              createWorkflowEdge('Scope_2-#scope', 'Compose_7'),
+              createWorkflowEdge('Scope_2-%scope', 'Compose_7'),
             ],
           },
         ],
@@ -48,7 +48,7 @@ describe('Graph Utilities', () => {
           createWorkflowEdge('Compose_3', 'Compose_5'),
           createWorkflowEdge('Compose_4', 'Compose_6'),
           createWorkflowEdge('Compose_5', 'Scope_2'),
-          createWorkflowEdge('Scope-#scope', 'Compose_10'),
+          createWorkflowEdge('Scope-%scope', 'Compose_10'),
         ],
       },
     ],

--- a/libs/designer-v2/src/lib/core/utils/__test__/tokens.spec.ts
+++ b/libs/designer-v2/src/lib/core/utils/__test__/tokens.spec.ts
@@ -20,7 +20,7 @@ describe('Token Picker Utilities', () => {
         height: 40,
         type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
         children: [
-          createWorkflowNode('Until-#scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
+          createWorkflowNode('Until-%scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
           createWorkflowNode('Compose_10'),
           createWorkflowNode('Compose_3'),
           createWorkflowNode('Compose_4'),
@@ -32,7 +32,7 @@ describe('Token Picker Utilities', () => {
             height: 40,
             type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
             children: [
-              createWorkflowNode('Until_2-#scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
+              createWorkflowNode('Until_2-%scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
               createWorkflowNode('Compose_7'),
               createWorkflowNode('Compose_8'),
               createWorkflowNode('Compose_9'),
@@ -40,7 +40,7 @@ describe('Token Picker Utilities', () => {
             edges: [
               createWorkflowEdge('Compose_7', 'Compose_8'),
               createWorkflowEdge('Compose_7', 'Compose_9'),
-              createWorkflowEdge('Until_2-#scope', 'Compose_7'),
+              createWorkflowEdge('Until_2-%scope', 'Compose_7'),
             ],
           },
         ],
@@ -50,7 +50,7 @@ describe('Token Picker Utilities', () => {
           createWorkflowEdge('Compose_3', 'Compose_5'),
           createWorkflowEdge('Compose_4', 'Compose_6'),
           createWorkflowEdge('Compose_5', 'Until_2'),
-          createWorkflowEdge('Until-#scope', 'Compose_10'),
+          createWorkflowEdge('Until-%scope', 'Compose_10'),
         ],
       },
     ],

--- a/libs/designer-v2/src/lib/core/utils/graph.ts
+++ b/libs/designer-v2/src/lib/core/utils/graph.ts
@@ -124,7 +124,7 @@ export const getGraphNode = (nodeId: string, node: WorkflowNode, nodesMetadata: 
 
 export const getImmediateSourceNodeIds = (graph: WorkflowNode, nodeId: string): string[] => {
   return (graph?.edges ?? [])
-    .filter((edge) => edge.target === nodeId && !/#(scope|subgraph|footer)/i.test(edge.id))
+    .filter((edge) => edge.target === nodeId && !/%(scope|subgraph|footer)/i.test(edge.id))
     .map((edge) => edge.source);
 };
 
@@ -243,7 +243,7 @@ export const isOperationNameValid = (
     return { isValid: false, message: messages.DEFAULT };
   }
 
-  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':', '#'])) {
+  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':'])) {
     return { isValid: false, message: messages.DEFAULT };
   }
 

--- a/libs/designer-v2/src/lib/core/utils/graph.ts
+++ b/libs/designer-v2/src/lib/core/utils/graph.ts
@@ -243,7 +243,7 @@ export const isOperationNameValid = (
     return { isValid: false, message: messages.DEFAULT };
   }
 
-  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':'])) {
+  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':', '<', '>', '%', '&', '\\', '?', '/'])) {
     return { isValid: false, message: messages.DEFAULT };
   }
 

--- a/libs/designer-v2/src/lib/core/utils/multiselect.ts
+++ b/libs/designer-v2/src/lib/core/utils/multiselect.ts
@@ -25,7 +25,7 @@ export const getCommonGraphId = (state: WorkflowState, nodeIds: string[]): strin
 };
 
 const getChildEdgeTargets = (graph: WorkflowNode, nodeId: string): string[] =>
-  (graph?.edges ?? []).filter((edge) => edge.source === nodeId && !/#(scope|subgraph|footer)/i.test(edge.id)).map((edge) => edge.target);
+  (graph?.edges ?? []).filter((edge) => edge.source === nodeId && !/%(scope|subgraph|footer)/i.test(edge.id)).map((edge) => edge.target);
 
 /**
  * Determines whether the selected nodes form a contiguous connected subgraph on

--- a/libs/designer-v2/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -411,7 +411,7 @@ const ScopeCardNode = ({ id }: NodeProps) => {
         ? intlText.caseString
         : intlText.actionString;
 
-  const isFooter = id.endsWith('#footer');
+  const isFooter = id.endsWith('%footer');
   const showEmptyGraphComponents = isLeaf && !graphCollapsed && !isFooter && !isAgent;
 
   const shouldShowPager = (normalizedType === constants.NODE.TYPE.FOREACH || isAgent) && isMonitoringView;

--- a/libs/designer-v2/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
@@ -126,7 +126,7 @@ const SubgraphCardNode = ({ id }: NodeProps) => {
           const relationshipIds = {
             graphId,
             subgraphId: newAdditiveSubgraphId,
-            parentId: `${newAdditiveSubgraphId}-#subgraph`,
+            parentId: `${newAdditiveSubgraphId}-%subgraph`,
           };
           dispatch(expandDiscoveryPanel({ nodeId: guid(), relationshipIds, isAgentTool: true }));
         } else {

--- a/libs/designer-v2/src/lib/ui/CustomNodes/__test__/ScopeCardNode.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/__test__/ScopeCardNode.spec.tsx
@@ -211,7 +211,7 @@ vi.mock('../../common/DesignerContextualMenu/CopyTooltip', () => ({
 import ScopeCardNode from '../ScopeCardNode';
 
 describe('ScopeCardNode (v2)', () => {
-  const defaultProps = { id: 'testScope-#scope' } as NodeProps;
+  const defaultProps = { id: 'testScope-%scope' } as NodeProps;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -271,14 +271,14 @@ describe('ScopeCardNode (v2)', () => {
   });
 
   it('should render EdgeDrawSourceHandle for footer nodes', () => {
-    const footerProps = { id: 'testScope-#footer' } as NodeProps;
+    const footerProps = { id: 'testScope-%footer' } as NodeProps;
     render(<ScopeCardNode {...footerProps} />);
     expect(screen.getByTestId('edge-draw-source-handle')).toBeInTheDocument();
   });
 
   it('should pass highlighted=true to EdgeDrawSourceHandle on footer when selected', () => {
     mockUseIsNodeSelectedInOperationPanel.mockReturnValue(true);
-    const footerProps = { id: 'testScope-#footer' } as NodeProps;
+    const footerProps = { id: 'testScope-%footer' } as NodeProps;
 
     render(<ScopeCardNode {...footerProps} />);
     const sourceHandle = screen.getByTestId('edge-draw-source-handle');
@@ -287,7 +287,7 @@ describe('ScopeCardNode (v2)', () => {
 
   it('should pass highlighted=false to EdgeDrawSourceHandle on footer when not selected', () => {
     mockUseIsNodeSelectedInOperationPanel.mockReturnValue(false);
-    const footerProps = { id: 'testScope-#footer' } as NodeProps;
+    const footerProps = { id: 'testScope-%footer' } as NodeProps;
 
     render(<ScopeCardNode {...footerProps} />);
     const sourceHandle = screen.getByTestId('edge-draw-source-handle');
@@ -357,7 +357,7 @@ describe('ScopeCardNode (v2)', () => {
 
   it('should not show collapsed text for footer nodes even when collapsed', () => {
     mockUseIsGraphCollapsed.mockReturnValue(true);
-    const footerProps = { id: 'testScope-#footer' } as NodeProps;
+    const footerProps = { id: 'testScope-%footer' } as NodeProps;
 
     render(<ScopeCardNode {...footerProps} />);
     expect(screen.queryByText(/2 Actions/)).not.toBeInTheDocument();

--- a/libs/designer-v2/src/lib/ui/CustomNodes/__test__/SubgraphCardNode.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/__test__/SubgraphCardNode.spec.tsx
@@ -167,7 +167,7 @@ vi.mock('../components/card/subgraphCard', () => ({
 import SubgraphCardNode from '../SubgraphCardNode';
 
 describe('SubgraphCardNode (v2)', () => {
-  const defaultProps = { id: 'testNode-#subgraph' } as NodeProps;
+  const defaultProps = { id: 'testNode-%subgraph' } as NodeProps;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/libs/designer-v2/src/lib/ui/DesignerReactFlow.tsx
+++ b/libs/designer-v2/src/lib/ui/DesignerReactFlow.tsx
@@ -191,7 +191,7 @@ const DesignerReactFlow = (props: any) => {
   // Flow's internal selection state and the previously-selected nodes lose their highlight.
   //
   // Redux `selectedNodeIds` holds bare action ids (e.g. 'WorkflowAgent'), but the visible card
-  // for a scope/agent is `SCOPE_CARD_NODE` with id `'WorkflowAgent-#scope'`. We must normalize
+  // for a scope/agent is `SCOPE_CARD_NODE` with id `'WorkflowAgent-%scope'`. We must normalize
   // the idTag suffix when looking up, and only stamp the user-facing card variants — stamping a
   // GRAPH/SUBGRAPH container would shift React Flow's internal selection onto a node that has
   // no visible selected state and would then be filtered out of `onSelectionChange`, causing

--- a/libs/designer-v2/src/lib/ui/connections/__tests__/edge.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/connections/__tests__/edge.spec.tsx
@@ -184,8 +184,8 @@ describe('ButtonEdge', () => {
   it('should strip id tags from source and target for selection check', () => {
     const propsWithIdTags = {
       ...defaultProps,
-      source: 'sourceNode-#scope',
-      target: 'targetNode-#scope',
+      source: 'sourceNode-%scope',
+      target: 'targetNode-%scope',
     };
 
     render(

--- a/libs/designer-v2/src/lib/ui/connections/__tests__/helpers.spec.ts
+++ b/libs/designer-v2/src/lib/ui/connections/__tests__/helpers.spec.ts
@@ -29,12 +29,12 @@ describe('getDownstreamDependencies', () => {
 
   it('should handle node IDs with and without tags', () => {
     const allNodesDependencies = {
-      node1: new Set(['node2-#tag']),
+      node1: new Set(['node2-%tag']),
       node2: new Set(['node3']),
       node3: new Set(['node2']),
     };
 
-    const result = getDownstreamDependencies('node2-#tag', allNodesDependencies);
+    const result = getDownstreamDependencies('node2-%tag', allNodesDependencies);
     expect(result.size).toBe(2);
     expect(result.has('node1')).toBe(true);
     expect(result.has('node3')).toBe(true);
@@ -47,7 +47,7 @@ describe('canDropItem', () => {
   it('Try to drag item to right above same node', () => {
     expect(
       canDropItem(
-        { id: 'Condition-#scope', dependencies: [], isScope: true },
+        { id: 'Condition-%scope', dependencies: [], isScope: true },
         emptySet,
         {
           Complete_the_message_in_a_queue: emptySet,
@@ -65,7 +65,7 @@ describe('canDropItem', () => {
   it('Try to drag item to top of the parent node', () => {
     expect(
       canDropItem(
-        { id: 'Condition-#scope', dependencies: [], isScope: true },
+        { id: 'Condition-%scope', dependencies: [], isScope: true },
         emptySet,
         { Scope: emptySet, Business_logic: emptySet, 'When_one_or_more_messages_are_received_from_a_queue_(browse-lock)': emptySet },
         emptySet,
@@ -78,12 +78,12 @@ describe('canDropItem', () => {
   it('Try to drag scope item to in its own node', () => {
     expect(
       canDropItem(
-        { id: 'Scope-#scope', dependencies: [], isScope: true },
+        { id: 'Scope-%scope', dependencies: [], isScope: true },
         emptySet,
         { 'When_one_or_more_messages_are_received_from_a_queue_(browse-lock)': emptySet, Scope: emptySet },
         emptySet,
         'Business_logic',
-        'Scope-#scope'
+        'Scope-%scope'
       )
     ).toBeFalsy();
   });

--- a/libs/designer/src/lib/core/actions/bjsworkflow/handoff.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/handoff.ts
@@ -71,7 +71,7 @@ export const addAgentHandoff = createAsyncThunk('addAgentHandoff', async (payloa
         relationshipIds: {
           graphId: sourceId,
           subgraphId: newToolId,
-          parentId: `${newToolId}-#subgraph`,
+          parentId: `${newToolId}-%subgraph`,
         },
       })
     );

--- a/libs/designer/src/lib/core/graphlayout/__test__/elklayout.spec.ts
+++ b/libs/designer/src/lib/core/graphlayout/__test__/elklayout.spec.ts
@@ -56,16 +56,16 @@ describe('elklayout', () => {
             id: 'ActionIf',
             type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
             children: [
-              createWorkflowNode('ActionIf-#scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE),
+              createWorkflowNode('ActionIf-%scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE),
               {
                 id: 'ActionIf-actions',
                 children: [
-                  createWorkflowNode('ActionIf-actions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
+                  createWorkflowNode('ActionIf-actions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
                   createWorkflowNode('Increment_variable2'),
                   createWorkflowNode('Increment_variable4'),
                 ],
                 edges: [
-                  createWorkflowEdge('ActionIf-actions-#subgraph', 'Increment_variable2'),
+                  createWorkflowEdge('ActionIf-actions-%subgraph', 'Increment_variable2'),
                   createWorkflowEdge('Increment_variable2', 'Increment_variable4'),
                 ],
                 type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
@@ -73,16 +73,16 @@ describe('elklayout', () => {
               {
                 id: 'ActionIf-elseActions',
                 children: [
-                  createWorkflowNode('ActionIf-elseActions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
+                  createWorkflowNode('ActionIf-elseActions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
                   createWorkflowNode('Increment_variable3'),
                 ],
-                edges: [createWorkflowEdge('ActionIf-elseActions-#subgraph', 'Increment_variable3')],
+                edges: [createWorkflowEdge('ActionIf-elseActions-%subgraph', 'Increment_variable3')],
                 type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
               },
             ],
             edges: [
-              createWorkflowEdge('ActionIf-#scope', 'ActionIf-actions'),
-              createWorkflowEdge('ActionIf-#scope', 'ActionIf-elseActions'),
+              createWorkflowEdge('ActionIf-%scope', 'ActionIf-actions'),
+              createWorkflowEdge('ActionIf-%scope', 'ActionIf-elseActions'),
             ],
           },
           createWorkflowNode('Response'),
@@ -105,17 +105,17 @@ describe('elklayout', () => {
             id: 'ActionIf',
             layoutOptions: elkGraphLayoutOptions,
             children: [
-              createElkNode('ActionIf-#scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE),
+              createElkNode('ActionIf-%scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE),
               {
                 id: 'ActionIf-actions',
                 layoutOptions: elkSubgraphLayoutOptions,
                 children: [
-                  createElkNode('ActionIf-actions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
+                  createElkNode('ActionIf-actions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
                   createElkNode('Increment_variable2'),
                   createElkNode('Increment_variable4'),
                 ],
                 edges: [
-                  createElkEdge('ActionIf-actions-#subgraph', 'Increment_variable2'),
+                  createElkEdge('ActionIf-actions-%subgraph', 'Increment_variable2'),
                   createElkEdge('Increment_variable2', 'Increment_variable4'),
                 ],
               },
@@ -123,13 +123,13 @@ describe('elklayout', () => {
                 id: 'ActionIf-elseActions',
                 layoutOptions: elkSubgraphLayoutOptions,
                 children: [
-                  createElkNode('ActionIf-elseActions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
+                  createElkNode('ActionIf-elseActions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
                   createElkNode('Increment_variable3'),
                 ],
-                edges: [createElkEdge('ActionIf-elseActions-#subgraph', 'Increment_variable3')],
+                edges: [createElkEdge('ActionIf-elseActions-%subgraph', 'Increment_variable3')],
               },
             ],
-            edges: [createElkEdge('ActionIf-#scope', 'ActionIf-actions'), createElkEdge('ActionIf-#scope', 'ActionIf-elseActions')],
+            edges: [createElkEdge('ActionIf-%scope', 'ActionIf-actions'), createElkEdge('ActionIf-%scope', 'ActionIf-elseActions')],
           },
           createElkNode('Response'),
         ],
@@ -215,17 +215,17 @@ describe('elklayout', () => {
             x: 307,
             y: 308,
             children: [
-              { ...createElkNode('ActionIf-#scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE), x: 307, y: 308 },
+              { ...createElkNode('ActionIf-%scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE), x: 307, y: 308 },
               {
                 id: 'ActionIf-actions',
                 layoutOptions: elkSubgraphLayoutOptions,
                 children: [
-                  { ...createElkNode('ActionIf-actions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE), x: 50, y: 100 },
+                  { ...createElkNode('ActionIf-actions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE), x: 50, y: 100 },
                   { ...createElkNode('Increment_variable2'), x: 150, y: 200 },
                   { ...createElkNode('Increment_variable4'), x: 300, y: 301 },
                 ],
                 edges: [
-                  createElkEdge('ActionIf-actions-#subgraph', 'Increment_variable2'),
+                  createElkEdge('ActionIf-actions-%subgraph', 'Increment_variable2'),
                   createElkEdge('Increment_variable2', 'Increment_variable4'),
                 ],
               },
@@ -233,15 +233,15 @@ describe('elklayout', () => {
                 id: 'ActionIf-elseActions',
                 layoutOptions: elkSubgraphLayoutOptions,
                 children: [
-                  { ...createElkNode('ActionIf-elseActions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE), x: 0, y: 0 },
+                  { ...createElkNode('ActionIf-elseActions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE), x: 0, y: 0 },
                   { ...createElkNode('Increment_variable3'), x: 302, y: 303 },
                 ],
-                edges: [createElkEdge('ActionIf-elseActions-#subgraph', 'Increment_variable3')],
+                edges: [createElkEdge('ActionIf-elseActions-%subgraph', 'Increment_variable3')],
               },
             ],
             edges: [
-              createElkEdge('ActionIf-#scope', 'ActionIf-actions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
-              createElkEdge('ActionIf-#scope', 'ActionIf-elseActions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
+              createElkEdge('ActionIf-%scope', 'ActionIf-actions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
+              createElkEdge('ActionIf-%scope', 'ActionIf-elseActions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
             ],
           },
           {
@@ -249,7 +249,7 @@ describe('elklayout', () => {
             layoutOptions: elkGraphLayoutOptions,
             x: 307,
             y: 308,
-            children: [createElkNode('EmptyScope-#scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE)],
+            children: [createElkNode('EmptyScope-%scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE)],
             edges: [],
           },
           { ...createElkNode('Response'), x: 304, y: 305 },
@@ -293,10 +293,10 @@ describe('elklayout', () => {
             parentId: undefined,
           },
           {
-            id: 'ActionIf-#scope',
+            id: 'ActionIf-%scope',
             type: WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE,
             position: { x: 307, y: 308 },
-            data: { label: 'ActionIf-#scope' },
+            data: { label: 'ActionIf-%scope' },
             parentId: 'ActionIf',
           },
           {
@@ -307,10 +307,10 @@ describe('elklayout', () => {
             parentId: 'ActionIf',
           },
           {
-            id: 'ActionIf-actions-#subgraph',
+            id: 'ActionIf-actions-%subgraph',
             type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE,
             position: { x: 50, y: 100 },
-            data: { label: 'ActionIf-actions-#subgraph' },
+            data: { label: 'ActionIf-actions-%subgraph' },
             parentId: 'ActionIf-actions',
           },
           {
@@ -335,10 +335,10 @@ describe('elklayout', () => {
             parentId: 'ActionIf',
           },
           {
-            id: 'ActionIf-elseActions-#subgraph',
+            id: 'ActionIf-elseActions-%subgraph',
             type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE,
             position: { x: 0, y: 0 },
-            data: { label: 'ActionIf-elseActions-#subgraph' },
+            data: { label: 'ActionIf-elseActions-%subgraph' },
             parentId: 'ActionIf-elseActions',
           },
           {
@@ -356,10 +356,10 @@ describe('elklayout', () => {
             parentId: undefined,
           },
           {
-            id: 'EmptyScope-#scope',
+            id: 'EmptyScope-%scope',
             type: WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE,
             position: { x: 0, y: 0 },
-            data: { label: 'EmptyScope-#scope' },
+            data: { label: 'EmptyScope-%scope' },
             parentId: 'EmptyScope',
           },
           {
@@ -375,11 +375,11 @@ describe('elklayout', () => {
           createSharedEdge('Increment_variable', 'ActionIf'),
           createSharedEdge('ActionIf', 'EmptyScope'),
           createSharedEdge('EmptyScope', 'Response'),
-          createSharedEdge('ActionIf-#scope', 'ActionIf-actions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
-          createSharedEdge('ActionIf-#scope', 'ActionIf-elseActions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
-          createSharedEdge('ActionIf-actions-#subgraph', 'Increment_variable2'),
+          createSharedEdge('ActionIf-%scope', 'ActionIf-actions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
+          createSharedEdge('ActionIf-%scope', 'ActionIf-elseActions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
+          createSharedEdge('ActionIf-actions-%subgraph', 'Increment_variable2'),
           createSharedEdge('Increment_variable2', 'Increment_variable4'),
-          createSharedEdge('ActionIf-elseActions-#subgraph', 'Increment_variable3'),
+          createSharedEdge('ActionIf-elseActions-%subgraph', 'Increment_variable3'),
         ],
         [507, 348],
       ];

--- a/libs/designer/src/lib/core/graphlayout/elklayout.tsx
+++ b/libs/designer/src/lib/core/graphlayout/elklayout.tsx
@@ -205,7 +205,7 @@ const convertWorkflowGraphToElkGraph = (node: WorkflowNode): ElkNode => {
         'elk.layered.spacing.nodeNodeBetweenLayers': spacing.onlyEdge,
         'elk.layered.crossingMinimization.forceNodeModelOrder': 'true',
       }),
-      ...(node.children?.findIndex((child) => child.id.endsWith('#footer')) !== -1 && {
+      ...(node.children?.findIndex((child) => child.id.endsWith('%footer')) !== -1 && {
         'elk.padding': '[top=0,left=16,bottom=0,right=16]',
       }),
     },

--- a/libs/designer/src/lib/core/graphlayout/helpers.ts
+++ b/libs/designer/src/lib/core/graphlayout/helpers.ts
@@ -1,7 +1,7 @@
 import { WORKFLOW_EDGE_TYPES } from '@microsoft/logic-apps-shared';
 import type { WorkflowNode } from '../parsers/models/workflowNode';
 
-export const footerMarker = '#footer';
+export const footerMarker = '%footer';
 
 export interface LayoutRelevantData {
   id: string;

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -533,7 +533,7 @@ export const processScopeActions = (
   const nodes: WorkflowNode[] = [];
   const edges: WorkflowEdge[] = [];
 
-  const headerId = `${actionName}-#scope`;
+  const headerId = `${actionName}-%scope`;
   const scopeCardNode = createWorkflowNode(headerId, WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE);
   nodes.push(scopeCardNode);
 
@@ -606,7 +606,7 @@ export const processScopeActions = (
     allActions = { ...allActions, ...operations };
     nodesMetadata = { ...nodesMetadata, ...metadata };
 
-    const rootId = `${subgraphId}-#subgraph`;
+    const rootId = `${subgraphId}-%subgraph`;
     const subgraphCardNode = createWorkflowNode(rootId, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
 
     const isAddCase = subgraphType === SUBGRAPH_TYPES.SWITCH_ADD_CASE || subgraphType === SUBGRAPH_TYPES.AGENT_ADD_CONDITON;
@@ -639,7 +639,7 @@ export const processScopeActions = (
   //   having the main node at the bottom and a subgraph node at the top,
   //   use this instead of complicating the other setup functions
   const applyUntilActions = (graphId: string, actions: LogicAppsV2.Actions | undefined) => {
-    scopeCardNode.id = scopeCardNode.id.replace('#scope', '#subgraph');
+    scopeCardNode.id = scopeCardNode.id.replace('%scope', '%subgraph');
     scopeCardNode.type = WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE;
 
     const [graph, operations, metadata] = processNestedActions(
@@ -679,7 +679,7 @@ export const processScopeActions = (
       }
     }
 
-    const footerId = `${graphId}-#footer`;
+    const footerId = `${graphId}-%footer`;
     const allEdgeSources = edges.map((edge) => edge.source);
     const leafNodes = nodes.filter((node) => !allEdgeSources.includes(node.id));
     leafNodes.forEach((node) => {

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/__test__/scopedWorkflowDefinition.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/__test__/scopedWorkflowDefinition.ts
@@ -111,19 +111,19 @@ export const expectedScopedWorkflowDefinitionOutput: { graph: WorkflowNode; acti
         height: 40,
         width: 200,
         children: [
-          createWorkflowNode('ActionIf-#scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE),
+          createWorkflowNode('ActionIf-%scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE),
           {
             id: 'ActionIf-actions',
             type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
             subGraphLocation: 'actions',
             children: [
-              createWorkflowNode('ActionIf-actions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
+              createWorkflowNode('ActionIf-actions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
               createWorkflowNode('Increment_variable2'),
               createWorkflowNode('Increment_variable4'),
             ],
             edges: [
               createWorkflowEdge('Increment_variable2', 'Increment_variable4'),
-              createWorkflowEdge('ActionIf-actions-#subgraph', 'Increment_variable2', WORKFLOW_EDGE_TYPES.HEADING_EDGE),
+              createWorkflowEdge('ActionIf-actions-%subgraph', 'Increment_variable2', WORKFLOW_EDGE_TYPES.HEADING_EDGE),
             ],
           },
           {
@@ -131,15 +131,15 @@ export const expectedScopedWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
             subGraphLocation: 'else',
             children: [
-              createWorkflowNode('ActionIf-elseActions-#subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
+              createWorkflowNode('ActionIf-elseActions-%subgraph', WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE),
               createWorkflowNode('Increment_variable3'),
             ],
-            edges: [createWorkflowEdge('ActionIf-elseActions-#subgraph', 'Increment_variable3', WORKFLOW_EDGE_TYPES.HEADING_EDGE)],
+            edges: [createWorkflowEdge('ActionIf-elseActions-%subgraph', 'Increment_variable3', WORKFLOW_EDGE_TYPES.HEADING_EDGE)],
           },
         ],
         edges: [
-          createWorkflowEdge('ActionIf-#scope', 'ActionIf-actions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
-          createWorkflowEdge('ActionIf-#scope', 'ActionIf-elseActions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
+          createWorkflowEdge('ActionIf-%scope', 'ActionIf-actions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
+          createWorkflowEdge('ActionIf-%scope', 'ActionIf-elseActions', WORKFLOW_EDGE_TYPES.ONLY_EDGE),
         ],
       },
       {
@@ -147,7 +147,7 @@ export const expectedScopedWorkflowDefinitionOutput: { graph: WorkflowNode; acti
         type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
         height: 40,
         width: 200,
-        children: [createWorkflowNode('EmptyScope-#scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE)],
+        children: [createWorkflowNode('EmptyScope-%scope', WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE)],
         edges: [],
       },
       createWorkflowNode('Response'),

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/__test__/switchWorkflowDefinition.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/__test__/switchWorkflowDefinition.ts
@@ -81,7 +81,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
         type: 'GRAPH_NODE',
         children: [
           {
-            id: 'Switch_1-#scope',
+            id: 'Switch_1-%scope',
             width: 200,
             height: 40,
             type: 'SCOPE_CARD_NODE',
@@ -90,7 +90,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             id: 'Case 2',
             children: [
               {
-                id: 'Case 2-#subgraph',
+                id: 'Case 2-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -104,8 +104,8 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             ],
             edges: [
               {
-                id: 'Case 2-#subgraph-Compose_5',
-                source: 'Case 2-#subgraph',
+                id: 'Case 2-%subgraph-Compose_5',
+                source: 'Case 2-%subgraph',
                 target: 'Compose_5',
                 type: 'HEADING_EDGE',
               },
@@ -117,7 +117,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             id: 'Case 3',
             children: [
               {
-                id: 'Case 3-#subgraph',
+                id: 'Case 3-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -131,8 +131,8 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             ],
             edges: [
               {
-                id: 'Case 3-#subgraph-Compose_4',
-                source: 'Case 3-#subgraph',
+                id: 'Case 3-%subgraph-Compose_4',
+                source: 'Case 3-%subgraph',
                 target: 'Compose_4',
                 type: 'HEADING_EDGE',
               },
@@ -144,7 +144,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             id: 'Switch_1-addCase',
             children: [
               {
-                id: 'Switch_1-addCase-#subgraph',
+                id: 'Switch_1-addCase-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -158,7 +158,7 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
             id: 'Switch_1-defaultCase',
             children: [
               {
-                id: 'Switch_1-defaultCase-#subgraph',
+                id: 'Switch_1-defaultCase-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -171,26 +171,26 @@ export const expectedSwitchWorkflowDefinitionOutput: { graph: WorkflowNode; acti
         ],
         edges: [
           {
-            id: 'Switch_1-#scope-Case 2',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Case 2',
+            source: 'Switch_1-%scope',
             target: 'Case 2',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Case 3',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Case 3',
+            source: 'Switch_1-%scope',
             target: 'Case 3',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Switch_1-addCase',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Switch_1-addCase',
+            source: 'Switch_1-%scope',
             target: 'Switch_1-addCase',
             type: 'HIDDEN_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Switch_1-defaultCase',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Switch_1-defaultCase',
+            source: 'Switch_1-%scope',
             target: 'Switch_1-defaultCase',
             type: 'ONLY_EDGE',
           },
@@ -286,7 +286,7 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
         type: 'GRAPH_NODE',
         children: [
           {
-            id: 'Switch_1-#scope',
+            id: 'Switch_1-%scope',
             width: 200,
             height: 40,
             type: 'SCOPE_CARD_NODE',
@@ -295,7 +295,7 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             id: 'Case 2',
             children: [
               {
-                id: 'Case 2-#subgraph',
+                id: 'Case 2-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -309,8 +309,8 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             ],
             edges: [
               {
-                id: 'Case 2-#subgraph-Compose_5',
-                source: 'Case 2-#subgraph',
+                id: 'Case 2-%subgraph-Compose_5',
+                source: 'Case 2-%subgraph',
                 target: 'Compose_5',
                 type: 'HEADING_EDGE',
               },
@@ -322,7 +322,7 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             id: 'Case 3',
             children: [
               {
-                id: 'Case 3-#subgraph',
+                id: 'Case 3-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -336,8 +336,8 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             ],
             edges: [
               {
-                id: 'Case 3-#subgraph-Compose_4',
-                source: 'Case 3-#subgraph',
+                id: 'Case 3-%subgraph-Compose_4',
+                source: 'Case 3-%subgraph',
                 target: 'Compose_4',
                 type: 'HEADING_EDGE',
               },
@@ -349,7 +349,7 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
             id: 'Switch_1-defaultCase',
             children: [
               {
-                id: 'Switch_1-defaultCase-#subgraph',
+                id: 'Switch_1-defaultCase-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -362,20 +362,20 @@ export const expectedSwitchWorkflowDefinitionOutputWithoutAddCase: {
         ],
         edges: [
           {
-            id: 'Switch_1-#scope-Case 2',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Case 2',
+            source: 'Switch_1-%scope',
             target: 'Case 2',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Case 3',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Case 3',
+            source: 'Switch_1-%scope',
             target: 'Case 3',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Switch_1-#scope-Switch_1-defaultCase',
-            source: 'Switch_1-#scope',
+            id: 'Switch_1-%scope-Switch_1-defaultCase',
+            source: 'Switch_1-%scope',
             target: 'Switch_1-defaultCase',
             type: 'ONLY_EDGE',
           },

--- a/libs/designer/src/lib/core/parsers/__test__/respectExistingWorkflowDimensions.spec.ts
+++ b/libs/designer/src/lib/core/parsers/__test__/respectExistingWorkflowDimensions.spec.ts
@@ -37,7 +37,7 @@ describe('respect existing workflow dimensions', () => {
       type: 'GRAPH_NODE',
       children: [
         {
-          id: 'Condition-#scope',
+          id: 'Condition-%scope',
           width: 200,
           height: 40,
           type: 'SCOPE_CARD_NODE',
@@ -46,7 +46,7 @@ describe('respect existing workflow dimensions', () => {
           id: 'Condition-actions',
           children: [
             {
-              id: 'Condition-actions-#subgraph',
+              id: 'Condition-actions-%subgraph',
               width: 200,
               height: 40,
               type: 'SUBGRAPH_CARD_NODE',
@@ -84,8 +84,8 @@ describe('respect existing workflow dimensions', () => {
               type: 'BUTTON_EDGE',
             },
             {
-              id: 'Condition-actions-#subgraph-Create_file',
-              source: 'Condition-actions-#subgraph',
+              id: 'Condition-actions-%subgraph-Create_file',
+              source: 'Condition-actions-%subgraph',
               target: 'Create_file',
               type: 'HEADING_EDGE',
             },
@@ -97,7 +97,7 @@ describe('respect existing workflow dimensions', () => {
           id: 'Condition-elseActions',
           children: [
             {
-              id: 'Condition-elseActions-#subgraph',
+              id: 'Condition-elseActions-%subgraph',
               width: 200,
               height: 40,
               type: 'SUBGRAPH_CARD_NODE',
@@ -110,14 +110,14 @@ describe('respect existing workflow dimensions', () => {
       ],
       edges: [
         {
-          id: 'Condition-#scope-Condition-actions',
-          source: 'Condition-#scope',
+          id: 'Condition-%scope-Condition-actions',
+          source: 'Condition-%scope',
           target: 'Condition-actions',
           type: 'ONLY_EDGE',
         },
         {
-          id: 'Condition-#scope-Condition-elseActions',
-          source: 'Condition-#scope',
+          id: 'Condition-%scope-Condition-elseActions',
+          source: 'Condition-%scope',
           target: 'Condition-elseActions',
           type: 'ONLY_EDGE',
         },
@@ -140,13 +140,13 @@ describe('respect existing workflow dimensions', () => {
         type: 'OPERATION_NODE',
       },
       {
-        id: 'Condition-#scope',
+        id: 'Condition-%scope',
         width: 200,
         height: 40,
         type: 'SCOPE_CARD_NODE',
       },
       {
-        id: 'Condition-actions-#subgraph',
+        id: 'Condition-actions-%subgraph',
         width: 200,
         height: 40,
         type: 'SUBGRAPH_CARD_NODE',
@@ -185,8 +185,8 @@ describe('respect existing workflow dimensions', () => {
             type: 'BUTTON_EDGE',
           },
           {
-            id: 'Condition-actions-#subgraph-Create_file',
-            source: 'Condition-actions-#subgraph',
+            id: 'Condition-actions-%subgraph-Create_file',
+            source: 'Condition-actions-%subgraph',
             target: 'Create_file',
             type: 'HEADING_EDGE',
           },
@@ -195,7 +195,7 @@ describe('respect existing workflow dimensions', () => {
         subGraphLocation: 'actions',
       },
       {
-        id: 'Condition-elseActions-#subgraph',
+        id: 'Condition-elseActions-%subgraph',
         width: 200,
         height: 40,
         type: 'SUBGRAPH_CARD_NODE',
@@ -213,14 +213,14 @@ describe('respect existing workflow dimensions', () => {
         type: 'GRAPH_NODE',
         edges: [
           {
-            id: 'Condition-#scope-Condition-actions',
-            source: 'Condition-#scope',
+            id: 'Condition-%scope-Condition-actions',
+            source: 'Condition-%scope',
             target: 'Condition-actions',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Condition-#scope-Condition-elseActions',
-            source: 'Condition-#scope',
+            id: 'Condition-%scope-Condition-elseActions',
+            source: 'Condition-%scope',
             target: 'Condition-elseActions',
             type: 'ONLY_EDGE',
           },
@@ -339,7 +339,7 @@ describe('respect existing workflow dimensions', () => {
   it('should update the dimensions of currentChildren recursively', () => {
     const previousChildren: WorkflowNode[] = [
       {
-        id: 'Condition-actions-#subgraph',
+        id: 'Condition-actions-%subgraph',
         width: 200,
         height: 28,
         type: 'SUBGRAPH_CARD_NODE',
@@ -378,7 +378,7 @@ describe('respect existing workflow dimensions', () => {
         type: 'GRAPH_NODE',
         children: [
           {
-            id: 'Condition-#scope',
+            id: 'Condition-%scope',
             width: 200,
             height: 40,
             type: 'SCOPE_CARD_NODE',
@@ -387,7 +387,7 @@ describe('respect existing workflow dimensions', () => {
             id: 'Condition-actions',
             children: [
               {
-                id: 'Condition-actions-#subgraph',
+                id: 'Condition-actions-%subgraph',
                 width: 200,
                 height: 28,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -425,8 +425,8 @@ describe('respect existing workflow dimensions', () => {
                 type: 'BUTTON_EDGE',
               },
               {
-                id: 'Condition-actions-#subgraph-Create_file',
-                source: 'Condition-actions-#subgraph',
+                id: 'Condition-actions-%subgraph-Create_file',
+                source: 'Condition-actions-%subgraph',
                 target: 'Create_file',
                 type: 'HEADING_EDGE',
               },
@@ -438,7 +438,7 @@ describe('respect existing workflow dimensions', () => {
             id: 'Condition-elseActions',
             children: [
               {
-                id: 'Condition-elseActions-#subgraph',
+                id: 'Condition-elseActions-%subgraph',
                 width: 200,
                 height: 40,
                 type: 'SUBGRAPH_CARD_NODE',
@@ -451,14 +451,14 @@ describe('respect existing workflow dimensions', () => {
         ],
         edges: [
           {
-            id: 'Condition-#scope-Condition-actions',
-            source: 'Condition-#scope',
+            id: 'Condition-%scope-Condition-actions',
+            source: 'Condition-%scope',
             target: 'Condition-actions',
             type: 'ONLY_EDGE',
           },
           {
-            id: 'Condition-#scope-Condition-elseActions',
-            source: 'Condition-#scope',
+            id: 'Condition-%scope-Condition-elseActions',
+            source: 'Condition-%scope',
             target: 'Condition-elseActions',
             type: 'ONLY_EDGE',
           },

--- a/libs/designer/src/lib/core/parsers/__test__/updateAgenticGraph.spec.ts
+++ b/libs/designer/src/lib/core/parsers/__test__/updateAgenticGraph.spec.ts
@@ -29,15 +29,15 @@ const createMockState = (overrides: Partial<WorkflowState> = {}): WorkflowState 
 const createMockAgentGraph = (overrides: Partial<WorkflowNode> = {}): WorkflowNode => ({
   id: 'agent1',
   children: [
-    { id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
+    { id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
     {
       id: 'myTool',
-      children: [{ id: 'myTool-#subgraph', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
+      children: [{ id: 'myTool-%subgraph', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
       edges: [],
       type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
     },
   ],
-  edges: [{ id: 'agent1-#scope-myTool', source: 'agent1-#scope', target: 'myTool', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE }],
+  edges: [{ id: 'agent1-%scope-myTool', source: 'agent1-%scope', target: 'myTool', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE }],
   type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
   ...overrides,
 });
@@ -98,12 +98,12 @@ describe('updateAgenticSubgraph', () => {
     const codeInterpreterChild = agentGraph.children?.find((c) => c.id === 'code_interpreter');
     expect(codeInterpreterChild).toBeDefined();
     expect(codeInterpreterChild?.type).toBe(WORKFLOW_NODE_TYPES.SUBGRAPH_NODE);
-    expect(codeInterpreterChild?.children?.[0]?.id).toBe('code_interpreter-#subgraph');
+    expect(codeInterpreterChild?.children?.[0]?.id).toBe('code_interpreter-%subgraph');
   });
 
   it('should not inject non-built-in tools as new children', () => {
     const agentGraph = createMockAgentGraph({
-      children: [{ id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
+      children: [{ id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
       edges: [],
     });
     const state = createMockState();
@@ -122,12 +122,12 @@ describe('updateAgenticSubgraph', () => {
   it('should not duplicate already-existing built-in tool child nodes', () => {
     const existingCodeInterpreter: WorkflowNode = {
       id: 'code_interpreter',
-      children: [{ id: 'code_interpreter-#subgraph', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
+      children: [{ id: 'code_interpreter-%subgraph', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }],
       edges: [],
       type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE,
     };
     const agentGraph = createMockAgentGraph({
-      children: [{ id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }, existingCodeInterpreter],
+      children: [{ id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE }, existingCodeInterpreter],
     });
     const state = createMockState();
     const payload: UpdateAgenticGraphPayload = {
@@ -160,12 +160,12 @@ describe('updateAgenticSubgraph', () => {
   it('should filter children to only visible tools from scopeRepetitionRunData.tools', () => {
     const agentGraph = createMockAgentGraph({
       children: [
-        { id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
+        { id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
         { id: 'toolA', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE },
         { id: 'toolB', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE },
       ],
       edges: [
-        { id: 'agent1-#scope-toolA', source: 'agent1-#scope', target: 'toolA', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE },
+        { id: 'agent1-%scope-toolA', source: 'agent1-%scope', target: 'toolA', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE },
         { id: 'toolA-toolB', source: 'toolA', target: 'toolB', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE },
       ],
     });
@@ -179,7 +179,7 @@ describe('updateAgenticSubgraph', () => {
     updateAgenticSubgraph(payload, agentGraph, state);
 
     const childIds = agentGraph.children?.map((c) => c.id);
-    expect(childIds).toContain('agent1-#scope');
+    expect(childIds).toContain('agent1-%scope');
     expect(childIds).toContain('toolA');
     expect(childIds).not.toContain('toolB');
   });
@@ -187,7 +187,7 @@ describe('updateAgenticSubgraph', () => {
   it('should preserve #scope and -addCase children regardless of visibility', () => {
     const agentGraph = createMockAgentGraph({
       children: [
-        { id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
+        { id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
         { id: 'agent1-addCase', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
         { id: 'someTool', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE },
       ],
@@ -203,7 +203,7 @@ describe('updateAgenticSubgraph', () => {
     updateAgenticSubgraph(payload, agentGraph, state);
 
     const childIds = agentGraph.children?.map((c) => c.id);
-    expect(childIds).toContain('agent1-#scope');
+    expect(childIds).toContain('agent1-%scope');
     expect(childIds).toContain('agent1-addCase');
     expect(childIds).not.toContain('someTool');
   });
@@ -211,10 +211,10 @@ describe('updateAgenticSubgraph', () => {
   it('should call reassignEdgeSources and removeEdge for hidden tools', () => {
     const agentGraph = createMockAgentGraph({
       children: [
-        { id: 'agent1-#scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
+        { id: 'agent1-%scope', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE },
         { id: 'hiddenTool', children: [], edges: [], type: WORKFLOW_NODE_TYPES.SUBGRAPH_NODE },
       ],
-      edges: [{ id: 'agent1-#scope-hiddenTool', source: 'agent1-#scope', target: 'hiddenTool', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE }],
+      edges: [{ id: 'agent1-%scope-hiddenTool', source: 'agent1-%scope', target: 'hiddenTool', type: WORKFLOW_EDGE_TYPES.ONLY_EDGE }],
     });
     const state = createMockState();
     const payload: UpdateAgenticGraphPayload = {
@@ -224,8 +224,8 @@ describe('updateAgenticSubgraph', () => {
 
     updateAgenticSubgraph(payload, agentGraph, state);
 
-    expect(mockReassignEdgeSources).toHaveBeenCalledWith(state, 'hiddenTool', 'agent1-#scope', agentGraph, true);
-    expect(mockRemoveEdge).toHaveBeenCalledWith(state, 'agent1-#scope', 'hiddenTool', agentGraph);
+    expect(mockReassignEdgeSources).toHaveBeenCalledWith(state, 'hiddenTool', 'agent1-%scope', agentGraph, true);
+    expect(mockRemoveEdge).toHaveBeenCalledWith(state, 'agent1-%scope', 'hiddenTool', agentGraph);
   });
 
   it('should be a no-op when scopeRepetitionRunData is falsy', () => {

--- a/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
+++ b/libs/designer/src/lib/core/parsers/addNodeToWorkflow.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import CONSTANTS from '../../common/constants';
 import type { RelationshipIds } from '../state/panel/panelTypes';
 import type { NodesMetadata, WorkflowState } from '../state/workflow/workflowInterfaces';
@@ -114,7 +113,7 @@ const createSubgraphNode = (
   const node = createWorkflowNode(id, WORKFLOW_NODE_TYPES.SUBGRAPH_NODE);
   node.subGraphLocation = location;
   addChildNode(parent, node);
-  const graphHeading = createWorkflowNode(`${id}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+  const graphHeading = createWorkflowNode(`${id}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
   addChildNode(node, graphHeading);
   nodesMetadata[id] = {
     graphId: parent.id,
@@ -122,7 +121,7 @@ const createSubgraphNode = (
     actionCount: 0,
     parentNodeId: parent.id === 'root' ? undefined : parent.id,
   };
-  addChildEdge(parent, createWorkflowEdge(`${parent.id}-#scope`, node.id, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
+  addChildEdge(parent, createWorkflowEdge(`${parent.id}-%scope`, node.id, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
 };
 
 const handleExtraScopeNodeSetup = (
@@ -133,10 +132,10 @@ const handleExtraScopeNodeSetup = (
 ) => {
   node.type = WORKFLOW_NODE_TYPES.GRAPH_NODE;
 
-  let scopeHeadingId = `${node.id}-#scope`;
+  let scopeHeadingId = `${node.id}-%scope`;
   let scopeHeadingType = WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE;
   if (operation.type.toLowerCase() === CONSTANTS.NODE.TYPE.UNTIL) {
-    scopeHeadingId = `${node.id}-#subgraph`;
+    scopeHeadingId = `${node.id}-%subgraph`;
     scopeHeadingType = WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE;
   }
   const scopeHeadingNode = createWorkflowNode(scopeHeadingId, scopeHeadingType);
@@ -161,7 +160,7 @@ const handleExtraScopeNodeSetup = (
     const addCaseGraph = createWorkflowNode(addCaseGraphId, WORKFLOW_NODE_TYPES.HIDDEN_NODE);
     addCaseGraph.subGraphLocation = 'addCase';
     addChildNode(node, addCaseGraph);
-    const addCaseGraphHeading = createWorkflowNode(`${addCaseGraphId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+    const addCaseGraphHeading = createWorkflowNode(`${addCaseGraphId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
     addChildNode(addCaseGraph, addCaseGraphHeading);
     nodesMetadata[addCaseGraphId] = {
       graphId: node.id,
@@ -190,7 +189,7 @@ const handleExtraScopeNodeSetup = (
     const addCaseGraph = createWorkflowNode(addCaseGraphId, WORKFLOW_NODE_TYPES.HIDDEN_NODE);
     addCaseGraph.subGraphLocation = 'addCase';
     addChildNode(node, addCaseGraph);
-    const addCaseGraphHeading = createWorkflowNode(`${addCaseGraphId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+    const addCaseGraphHeading = createWorkflowNode(`${addCaseGraphId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
     addChildNode(addCaseGraph, addCaseGraphHeading);
     nodesMetadata[addCaseGraphId] = {
       graphId: node.id,
@@ -210,7 +209,7 @@ const handleExtraScopeNodeSetup = (
 
   if (operation.type.toLowerCase() === CONSTANTS.NODE.TYPE.UNTIL) {
     // Create Footer node
-    const footerNode = createWorkflowNode(`${node.id}-#footer`, WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE);
+    const footerNode = createWorkflowNode(`${node.id}-%footer`, WORKFLOW_NODE_TYPES.SCOPE_CARD_NODE);
     addChildNode(node, footerNode);
     addChildEdge(node, createWorkflowEdge(scopeHeadingNode.id, footerNode.id, WORKFLOW_EDGE_TYPES.HIDDEN_EDGE));
   }
@@ -221,7 +220,7 @@ export const addSwitchCaseToWorkflow = (caseId: string, switchNode: WorkflowNode
   caseNode.subGraphLocation = 'cases';
   // addChildNode(switchNode, caseNode);
   switchNode.children?.splice(switchNode.children.length - 2, 0, caseNode);
-  const caseHeading = createWorkflowNode(`${caseId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+  const caseHeading = createWorkflowNode(`${caseId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
   addChildNode(caseNode, caseHeading);
   nodesMetadata[caseId] = {
     graphId: switchNode.id,
@@ -229,7 +228,7 @@ export const addSwitchCaseToWorkflow = (caseId: string, switchNode: WorkflowNode
     subgraphType: SUBGRAPH_TYPES.SWITCH_CASE,
     actionCount: 0,
   };
-  addChildEdge(switchNode, createWorkflowEdge(`${switchNode.id}-#scope`, caseId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
+  addChildEdge(switchNode, createWorkflowEdge(`${switchNode.id}-%scope`, caseId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
 
   // Add Case to Switch operation data
   const switchAction = state.operations[switchNode.id] as LogicAppsV2.SwitchAction;
@@ -248,7 +247,7 @@ export const addAgentToolToWorkflow = (toolId: string, agentNode: WorkflowNode, 
   const conditionNode = createWorkflowNode(toolId, WORKFLOW_NODE_TYPES.SUBGRAPH_NODE);
   conditionNode.subGraphLocation = 'tools';
   agentNode.children?.splice(agentNode.children.length - 2, 0, conditionNode);
-  const conditionHeading = createWorkflowNode(`${toolId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+  const conditionHeading = createWorkflowNode(`${toolId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
   addChildNode(conditionNode, conditionHeading);
   nodesMetadata[toolId] = {
     graphId: agentNode.id,
@@ -256,7 +255,7 @@ export const addAgentToolToWorkflow = (toolId: string, agentNode: WorkflowNode, 
     subgraphType: SUBGRAPH_TYPES.AGENT_CONDITION,
     actionCount: 0,
   };
-  addChildEdge(agentNode, createWorkflowEdge(`${agentNode.id}-#scope`, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
+  addChildEdge(agentNode, createWorkflowEdge(`${agentNode.id}-%scope`, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
 
   // Add Condion to Agent operation data
   const agentAction = state.operations[agentNode.id] as LogicAppsV2.AgentAction;
@@ -288,7 +287,7 @@ export const addMcpServerToWorkflow = (
     subgraphType: SUBGRAPH_TYPES.MCP_CLIENT,
   };
 
-  addChildEdge(agentNode, createWorkflowEdge(`${agentNode.id}-#scope`, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
+  addChildEdge(agentNode, createWorkflowEdge(`${agentNode.id}-%scope`, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE));
 
   if (operation) {
     state.operations[toolId] = { ...state.operations[toolId], type: operation.type };

--- a/libs/designer/src/lib/core/parsers/updateAgenticGraph.ts
+++ b/libs/designer/src/lib/core/parsers/updateAgenticGraph.ts
@@ -39,7 +39,7 @@ export const updateAgenticSubgraph = (payload: UpdateAgenticGraphPayload, agentG
 
       // Create graph node only if it doesn't exist yet
       if (!existingChildIds.has(toolId)) {
-        const subgraphCardNode = createWorkflowNode(`${toolId}-#subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
+        const subgraphCardNode = createWorkflowNode(`${toolId}-%subgraph`, WORKFLOW_NODE_TYPES.SUBGRAPH_CARD_NODE);
         const toolGraph: WorkflowNode = {
           id: toolId,
           children: [subgraphCardNode],
@@ -49,7 +49,7 @@ export const updateAgenticSubgraph = (payload: UpdateAgenticGraphPayload, agentG
         };
         agentGraph.children = [...(agentGraph.children ?? []), toolGraph];
 
-        const headerId = `${agentGraph.id}-#scope`;
+        const headerId = `${agentGraph.id}-%scope`;
         agentGraph.edges = [...(agentGraph.edges ?? []), createWorkflowEdge(headerId, toolId, WORKFLOW_EDGE_TYPES.ONLY_EDGE)];
 
         // Update the saved original graph so the node persists across iteration switches
@@ -81,7 +81,7 @@ export const updateAgenticSubgraph = (payload: UpdateAgenticGraphPayload, agentG
     const hidingTools: string[] = [];
 
     const filteredTools = agentTools.filter((tool) => {
-      if (tool.id.includes('#scope') || tool.id.includes('-addCase')) {
+      if (tool.id.includes('%scope') || tool.id.includes('-addCase')) {
         return true;
       }
 

--- a/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSelectors.ts
@@ -288,7 +288,7 @@ export const getWorkflowNodeFromGraphState = (state: WorkflowState, actionId: st
 export const useNodeEdgeTargets = (nodeId?: string): string[] => {
   const edges = useEdges()
     .filter((edge) => edge.source === nodeId)
-    .filter((edge) => !edge.target.includes('-#footer'));
+    .filter((edge) => !edge.target.includes('-%footer'));
   return edges.map((edge) => edge.target);
 };
 
@@ -324,7 +324,7 @@ export const useNewAdditiveSubgraphId = (baseId: string) =>
       let caseId = baseId;
       let caseCount = 1;
       const idList = Object.keys(state.nodesMetadata);
-      // eslint-disable-next-line no-loop-func
+
       while (idList.some((id) => id === caseId)) {
         caseCount++;
         caseId = `${baseId}_${caseCount}`;

--- a/libs/designer/src/lib/core/utils/__test__/graph.spec.ts
+++ b/libs/designer/src/lib/core/utils/__test__/graph.spec.ts
@@ -18,7 +18,7 @@ describe('Graph Utilities', () => {
         height: 40,
         type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
         children: [
-          createWorkflowNode('Scope-#scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
+          createWorkflowNode('Scope-%scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
           createWorkflowNode('Compose_10'),
           createWorkflowNode('Compose_3'),
           createWorkflowNode('Compose_4'),
@@ -30,7 +30,7 @@ describe('Graph Utilities', () => {
             height: 40,
             type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
             children: [
-              createWorkflowNode('Scope_2-#scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
+              createWorkflowNode('Scope_2-%scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
               createWorkflowNode('Compose_7'),
               createWorkflowNode('Compose_8'),
               createWorkflowNode('Compose_9'),
@@ -38,7 +38,7 @@ describe('Graph Utilities', () => {
             edges: [
               createWorkflowEdge('Compose_7', 'Compose_8'),
               createWorkflowEdge('Compose_7', 'Compose_9'),
-              createWorkflowEdge('Scope_2-#scope', 'Compose_7'),
+              createWorkflowEdge('Scope_2-%scope', 'Compose_7'),
             ],
           },
         ],
@@ -48,7 +48,7 @@ describe('Graph Utilities', () => {
           createWorkflowEdge('Compose_3', 'Compose_5'),
           createWorkflowEdge('Compose_4', 'Compose_6'),
           createWorkflowEdge('Compose_5', 'Scope_2'),
-          createWorkflowEdge('Scope-#scope', 'Compose_10'),
+          createWorkflowEdge('Scope-%scope', 'Compose_10'),
         ],
       },
     ],

--- a/libs/designer/src/lib/core/utils/__test__/tokens.spec.ts
+++ b/libs/designer/src/lib/core/utils/__test__/tokens.spec.ts
@@ -20,7 +20,7 @@ describe('Token Picker Utilities', () => {
         height: 40,
         type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
         children: [
-          createWorkflowNode('Until-#scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
+          createWorkflowNode('Until-%scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
           createWorkflowNode('Compose_10'),
           createWorkflowNode('Compose_3'),
           createWorkflowNode('Compose_4'),
@@ -32,7 +32,7 @@ describe('Token Picker Utilities', () => {
             height: 40,
             type: WORKFLOW_NODE_TYPES.GRAPH_NODE,
             children: [
-              createWorkflowNode('Until_2-#scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
+              createWorkflowNode('Until_2-%scope', WORKFLOW_NODE_TYPES.SCOPE_NODE),
               createWorkflowNode('Compose_7'),
               createWorkflowNode('Compose_8'),
               createWorkflowNode('Compose_9'),
@@ -40,7 +40,7 @@ describe('Token Picker Utilities', () => {
             edges: [
               createWorkflowEdge('Compose_7', 'Compose_8'),
               createWorkflowEdge('Compose_7', 'Compose_9'),
-              createWorkflowEdge('Until_2-#scope', 'Compose_7'),
+              createWorkflowEdge('Until_2-%scope', 'Compose_7'),
             ],
           },
         ],
@@ -50,7 +50,7 @@ describe('Token Picker Utilities', () => {
           createWorkflowEdge('Compose_3', 'Compose_5'),
           createWorkflowEdge('Compose_4', 'Compose_6'),
           createWorkflowEdge('Compose_5', 'Until_2'),
-          createWorkflowEdge('Until-#scope', 'Compose_10'),
+          createWorkflowEdge('Until-%scope', 'Compose_10'),
         ],
       },
     ],

--- a/libs/designer/src/lib/core/utils/graph.ts
+++ b/libs/designer/src/lib/core/utils/graph.ts
@@ -236,7 +236,7 @@ export const isOperationNameValid = (
     return { isValid: false, message: messages.DEFAULT };
   }
 
-  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':'])) {
+  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':', '<', '>', '%', '&', '\\', '?', '/'])) {
     return { isValid: false, message: messages.DEFAULT };
   }
 

--- a/libs/designer/src/lib/core/utils/graph.ts
+++ b/libs/designer/src/lib/core/utils/graph.ts
@@ -119,7 +119,7 @@ export const getGraphNode = (nodeId: string, node: WorkflowNode, nodesMetadata: 
 
 export const getImmediateSourceNodeIds = (graph: WorkflowNode, nodeId: string): string[] => {
   return (graph?.edges ?? [])
-    .filter((edge) => edge.target === nodeId && !/#(scope|subgraph|footer)/i.test(edge.id))
+    .filter((edge) => edge.target === nodeId && !/%(scope|subgraph|footer)/i.test(edge.id))
     .map((edge) => edge.source);
 };
 
@@ -236,7 +236,7 @@ export const isOperationNameValid = (
     return { isValid: false, message: messages.DEFAULT };
   }
 
-  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':', '#'])) {
+  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':'])) {
     return { isValid: false, message: messages.DEFAULT };
   }
 

--- a/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/ScopeCardNode.tsx
@@ -406,7 +406,7 @@ const ScopeCardNode = ({ id }: NodeProps) => {
       ? intlText.caseString
       : intlText.actionString;
 
-  const isFooter = id.endsWith('#footer');
+  const isFooter = id.endsWith('%footer');
   const showEmptyGraphComponents = isLeaf && !graphCollapsed && !isFooter && !isAgent;
 
   const shouldShowPager = (normalizedType === constants.NODE.TYPE.FOREACH || isAgent) && isMonitoringView;

--- a/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/SubgraphCardNode.tsx
@@ -112,7 +112,7 @@ const SubgraphCardNode = ({ id }: NodeProps) => {
               setEdgeContextMenuData({
                 graphId,
                 subgraphId: newAdditiveSubgraphId,
-                parentId: `${newAdditiveSubgraphId}-#subgraph`,
+                parentId: `${newAdditiveSubgraphId}-%subgraph`,
                 isLeaf: true,
                 location: {
                   x: rect ? rect.left + rect.width / 2 : window.innerWidth / 2,
@@ -125,7 +125,7 @@ const SubgraphCardNode = ({ id }: NodeProps) => {
             const relationshipIds = {
               graphId,
               subgraphId: newAdditiveSubgraphId,
-              parentId: `${newAdditiveSubgraphId}-#subgraph`,
+              parentId: `${newAdditiveSubgraphId}-%subgraph`,
             };
             dispatch(expandDiscoveryPanel({ nodeId: guid(), relationshipIds, isAgentTool: true }));
           }

--- a/libs/designer/src/lib/ui/CustomNodes/__test__/SubgraphCardNode.spec.tsx
+++ b/libs/designer/src/lib/ui/CustomNodes/__test__/SubgraphCardNode.spec.tsx
@@ -157,7 +157,7 @@ vi.mock(import('@microsoft/designer-ui'), async (importOriginal) => {
 import SubgraphCardNode from '../SubgraphCardNode';
 
 describe('SubgraphCardNode', () => {
-  const defaultProps = { id: 'testNode-#subgraph' } as NodeProps;
+  const defaultProps = { id: 'testNode-%subgraph' } as NodeProps;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/libs/designer/src/lib/ui/connections/__tests__/helpers.spec.ts
+++ b/libs/designer/src/lib/ui/connections/__tests__/helpers.spec.ts
@@ -47,7 +47,7 @@ describe('canDropItem', () => {
   it('Try to drag item to right above same node', () => {
     expect(
       canDropItem(
-        { id: 'Condition-#scope', dependencies: [], isScope: true },
+        { id: 'Condition-%scope', dependencies: [], isScope: true },
         emptySet,
         {
           Complete_the_message_in_a_queue: emptySet,
@@ -65,7 +65,7 @@ describe('canDropItem', () => {
   it('Try to drag item to top of the parent node', () => {
     expect(
       canDropItem(
-        { id: 'Condition-#scope', dependencies: [], isScope: true },
+        { id: 'Condition-%scope', dependencies: [], isScope: true },
         emptySet,
         { Scope: emptySet, Business_logic: emptySet, 'When_one_or_more_messages_are_received_from_a_queue_(browse-lock)': emptySet },
         emptySet,
@@ -78,12 +78,12 @@ describe('canDropItem', () => {
   it('Try to drag scope item to in its own node', () => {
     expect(
       canDropItem(
-        { id: 'Scope-#scope', dependencies: [], isScope: true },
+        { id: 'Scope-%scope', dependencies: [], isScope: true },
         emptySet,
         { 'When_one_or_more_messages_are_received_from_a_queue_(browse-lock)': emptySet, Scope: emptySet },
         emptySet,
         'Business_logic',
-        'Scope-#scope'
+        'Scope-%scope'
       )
     ).toBeFalsy();
   });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/run.ts
@@ -181,7 +181,7 @@ export class ConsumptionRunService implements IRunService {
     const headers = this.getAccessTokenHeaders();
 
     const filter = status ? `&$filter=status eq '${status}'` : '';
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/scopeRepetitions?api-version=${apiVersion}${filter}`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/scopeRepetitions?api-version=${apiVersion}${filter}`;
 
     try {
       const response = await httpClient.get<{ value: LogicAppsV2.RunRepetition[] }>({
@@ -262,7 +262,7 @@ export class ConsumptionRunService implements IRunService {
     const { apiVersion, baseUrl, httpClient } = this.options;
     const headers = this.getAccessTokenHeaders();
 
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/agentRepetitions/${repetitionId}?api-version=${apiVersion}`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/agentRepetitions/${repetitionId}?api-version=${apiVersion}`;
 
     try {
       const response = await httpClient.get<LogicAppsV2.RunRepetition>({
@@ -290,7 +290,7 @@ export class ConsumptionRunService implements IRunService {
     const { apiVersion, baseUrl, httpClient } = this.options;
     const headers = this.getAccessTokenHeaders();
 
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/agentRepetitions?api-version=${apiVersion}`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/agentRepetitions?api-version=${apiVersion}`;
 
     try {
       const response = await httpClient.get<LogicAppsV2.RunRepetition[]>({
@@ -316,7 +316,7 @@ export class ConsumptionRunService implements IRunService {
     const { apiVersion, baseUrl, httpClient } = this.options;
     const headers = this.getAccessTokenHeaders();
 
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/agentRepetitions/${repetitionId}/actions?api-version=${apiVersion}`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/agentRepetitions/${repetitionId}/actions?api-version=${apiVersion}`;
 
     try {
       const response = await httpClient.get<LogicAppsV2.RunRepetition>({
@@ -366,7 +366,7 @@ export class ConsumptionRunService implements IRunService {
     const { nodeId, runId } = action;
     const headers = this.getAccessTokenHeaders();
 
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/repetitions/${repetitionId}?api-version=${apiVersion}`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/repetitions/${repetitionId}?api-version=${apiVersion}`;
     try {
       const response = await httpClient.get<LogicAppsV2.RunRepetition>({
         uri,
@@ -388,7 +388,7 @@ export class ConsumptionRunService implements IRunService {
     const { nodeId, runId } = action;
     const headers = this.getAccessTokenHeaders();
 
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/repetitions?api-version=${apiVersion}`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/repetitions?api-version=${apiVersion}`;
     try {
       const response = await httpClient.get<LogicAppsV2.RunRepetition[]>({
         uri,
@@ -553,7 +553,7 @@ export class ConsumptionRunService implements IRunService {
     const { nodeId, runId } = action;
     const headers = this.getAccessTokenHeaders();
 
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/chatHistory?api-version=${apiVersion}`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/chatHistory?api-version=${apiVersion}`;
     try {
       const response = await httpClient.get<any>({
         uri,

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/run.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/__tests__/run.spec.ts
@@ -44,7 +44,7 @@ describe('StandardRunService', () => {
 
     it('should construct correct filter query parameter when status is provided', async () => {
       const status = 'Succeeded';
-      const expectedUri = `${mockOptions.baseUrl}${mockAction.runId}/actions/${mockAction.nodeId}/scopeRepetitions`;
+      const expectedUri = `${mockOptions.baseUrl}${mockAction.runId}/actions/${encodeURIComponent(mockAction.nodeId)}/scopeRepetitions`;
 
       vi.mocked(mockHttpClient.get).mockResolvedValue(mockRepetitionsResponse);
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/run.ts
@@ -178,7 +178,7 @@ export class StandardRunService implements IRunService {
     if (status) {
       queryParameters['$filter'] = `status eq '${status}'`;
     }
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/scopeRepetitions`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/scopeRepetitions`;
 
     try {
       if (isHybridLogicApp(uri)) {
@@ -261,7 +261,7 @@ export class StandardRunService implements IRunService {
   ): Promise<LogicAppsV2.RunRepetition> {
     const { nodeId, runId } = action;
     const { apiVersion, baseUrl, httpClient } = this.options;
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/agentRepetitions/${repetitionId}`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/agentRepetitions/${repetitionId}`;
 
     try {
       if (isHybridLogicApp(uri)) {
@@ -289,7 +289,7 @@ export class StandardRunService implements IRunService {
   async getAgentRepetitions(action: { nodeId: string; runId: string | undefined }): Promise<LogicAppsV2.RunRepetition[]> {
     const { nodeId, runId } = action;
     const { apiVersion, baseUrl, httpClient } = this.options;
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/agentRepetitions`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/agentRepetitions`;
     try {
       if (isHybridLogicApp(uri)) {
         return this.fetchHybridLogicAppRunRepetitions(uri, 'GET', httpClient);
@@ -318,7 +318,7 @@ export class StandardRunService implements IRunService {
   async getAgentActionsRepetition(action: { nodeId: string; runId: string | undefined }, repetitionId: string): Promise<any> {
     const { nodeId, runId } = action;
     const { apiVersion, baseUrl, httpClient } = this.options;
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/agentRepetitions/${repetitionId}/actions`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/agentRepetitions/${repetitionId}/actions`;
 
     try {
       if (isHybridLogicApp(uri)) {
@@ -368,7 +368,7 @@ export class StandardRunService implements IRunService {
     const { apiVersion, baseUrl, httpClient } = this.options;
     const { nodeId, runId } = action;
 
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/repetitions/${repetitionId}`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/repetitions/${repetitionId}`;
 
     try {
       if (isHybridLogicApp(uri)) {
@@ -393,7 +393,7 @@ export class StandardRunService implements IRunService {
     const { apiVersion, baseUrl, httpClient } = this.options;
     const { nodeId, runId } = action;
 
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/repetitions`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/repetitions`;
 
     try {
       if (isHybridLogicApp(uri)) {
@@ -558,7 +558,7 @@ export class StandardRunService implements IRunService {
   async getActionChatHistory(action: { nodeId: string; runId: string | undefined }): Promise<any> {
     const { apiVersion, baseUrl, httpClient } = this.options;
     const { nodeId, runId } = action;
-    const uri = `${baseUrl}${runId}/actions/${nodeId}/chatHistory`;
+    const uri = `${baseUrl}${runId}/actions/${encodeURIComponent(nodeId)}/chatHistory`;
 
     try {
       if (isHybridLogicApp(uri)) {

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/stringFunctions.spec.ts
@@ -12,7 +12,7 @@ describe('label_case', () => {
 
 describe('idDisplayCase', () => {
   it('should correctly format a string with an ID tag', () => {
-    expect(idDisplayCase('Test_ID-#Scope')).toEqual('Test ID');
+    expect(idDisplayCase('Test_ID-%scope')).toEqual('Test ID');
   });
 
   it('should correctly format a string without an ID tag', () => {
@@ -24,7 +24,7 @@ describe('idDisplayCase', () => {
   });
 
   it('should handle a string with only an ID tag', () => {
-    expect(idDisplayCase('-#Scope')).toEqual('');
+    expect(idDisplayCase('-%scope')).toEqual('');
   });
 });
 

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/stringFunctions.ts
@@ -5,8 +5,8 @@ export const replaceWhiteSpaceWithUnderscore = (uiElementName: string): string =
   return uiElementName?.replace(/\W/g, '_')?.toLowerCase();
 };
 
-export const containsIdTag = (id: string) => id?.includes('-#');
-export const removeIdTag = (id: string) => id?.split('-#')[0];
+export const containsIdTag = (id: string) => id?.includes('-%');
+export const removeIdTag = (id: string) => id?.split('-%')[0];
 export const containsCaseTag = (id: string) => id?.includes('-addCase');
 
 export const getIdLeaf = (id?: string) => id?.split('/').at(-1) ?? '';


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

The frontend previously forbade `#` in action names, but the backend allows it. The `#` restriction existed because `#` was used internally as a meta-node ID suffix delimiter (e.g., `ActionIf-#scope`, `Case_1-#subgraph`, `Scope_1-#footer`).

This PR switches the internal meta-node suffix character from `#` to `%`. Since `%` is already forbidden by the backend's `OperationNameInvalidCharacters` list, users can never have `%` in their action names, making it a collision-safe delimiter. This allows us to remove `#` from the frontend's invalid character list, aligning the frontend validation with the backend.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users can now use `#` in action names (e.g., `Step#2`, `Process#Items`). Previously this was incorrectly blocked.
- **Developers**: Internal meta-node IDs now use `-%scope`, `-%subgraph`, `-%footer` suffixes instead of `-#scope`, `-#subgraph`, `-#footer`. The `containsIdTag()` and `removeIdTag()` utilities in `logic-apps-shared` are updated accordingly.
- **System**: No performance or architectural impact. Pure string delimiter change across graph construction, parsing, and filtering logic.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in: Unit tests (vitest) — 38/38 stringFunctions tests pass, 65/65 graph/parser/selector/slice assertion tests pass

All test fixtures updated to use new `-%` suffix patterns. E2E test data (`e2e/designer/scopeActions.spec.ts`) also updated.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
N/A — no visual changes