### PR TITLE
fix(Designer): Align frontend invalid action name characters with backend

### DIFF
--- a/libs/designer-v2/src/lib/core/utils/graph.ts
+++ b/libs/designer-v2/src/lib/core/utils/graph.ts
@@ -243,7 +243,7 @@ export const isOperationNameValid = (
     return { isValid: false, message: messages.DEFAULT };
   }
 
-  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':', '#'])) {
+  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':', '#', '<', '>', '%', '&', '\\', '?', '/'])) {
     return { isValid: false, message: messages.DEFAULT };
   }
 

--- a/libs/designer/src/lib/core/utils/graph.ts
+++ b/libs/designer/src/lib/core/utils/graph.ts
@@ -236,7 +236,7 @@ export const isOperationNameValid = (
     return { isValid: false, message: messages.DEFAULT };
   }
 
-  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':', '#'])) {
+  if (!name || isTemplateExpression(name) || name.length > 80 || hasInvalidChars(name, [':', '#', '<', '>', '%', '&', '\\', '?', '/'])) {
     return { isValid: false, message: messages.DEFAULT };
   }
 


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

The frontend's invalid action name character list only blocked `:` and `#`, while the backend (`FlowDataValidation.OperationNameInvalidCharacters`) blocks `<`, `>`, `%`, `&`, `\`, `?`, `/`. This mismatch meant users could create action names in the designer that would later be rejected by the backend, or cause issues when action names appear in URL paths (e.g., for repetitions/run history APIs).

This PR aligns the frontend validation with the backend by adding all backend-forbidden characters to `isOperationNameValid` in both `designer` and `designer-v2`.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Users will now see validation errors earlier (in the designer) if they try to use `<`, `>`, `%`, `&`, `\`, `?`, or `/` in action names, rather than getting cryptic backend errors later.
- **Developers**: No API changes. The `hasInvalidChars` call in `isOperationNameValid` now checks a larger set of characters.
- **System**: No performance or architectural impact. Validation-only change.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer — verified that action names with `<`, `>`, `%`, `&`, `\`, `?`, `/`, `#`, `:` are all rejected with the default validation message.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
N/A — no visual changes (same validation error message, just triggered for more characters)