### PR TITLE
feat(Designer): Add gpt-5.1, gpt-5.2, gpt-5.4 to supported agent OpenAI models

### DIFF
--- a/libs/logic-apps-shared/src/utils/src/lib/models/agent.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/agent.ts
@@ -2,6 +2,11 @@
 export const SUPPORTED_AGENT_OPENAI_MODELS: string[] = [
   'gpt-5',
   'gpt-5-chat',
+  'gpt-5.1',
+  'gpt-5.2',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
   'gpt-4.1',
   'gpt-4',
   'gpt-4o',


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Adds `gpt-5.1`, `gpt-5.2`, and `gpt-5.4` (+ mini and nano) to the `SUPPORTED_AGENT_OPENAI_MODELS` list in `logic-apps-shared`. These newer Azure OpenAI models were not previously selectable for agent connections, so users could not configure agents to use them.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Can now select `gpt-5.1`, `gpt-5.2`, and `gpt-5.4` when configuring AzureOpenAI agent connections.
- **Developers**: No API changes — purely an additive update to an existing constant array.
- **System**: No performance or architectural impact; no new dependencies.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer — verified the new models appear in the agent model dropdown.

## Contributors
@rileyevans

## Screenshots/Videos
N/A — no visual changes beyond the additional dropdown entries.