### PR TITLE
feat(Designer): Add gpt-5.1, gpt-5.2, gpt-5.4 to supported agent OpenAI models (#9316) [hotfix/v5.961]

### DIFF
--- a/libs/logic-apps-shared/src/utils/src/lib/models/agent.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/models/agent.ts
@@ -2,6 +2,11 @@
 export const SUPPORTED_AGENT_OPENAI_MODELS: string[] = [
   'gpt-5',
   'gpt-5-chat',
+  'gpt-5.1',
+  'gpt-5.2',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
   'gpt-4.1',
   'gpt-4',
   'gpt-4o',


### PR DESCRIPTION
## Commit Type
- [x] feature - New functionality

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
Hotfix cherry-pick of commit `5b69010` (PR #9316) onto `hotfix/v5.961`. Adds `gpt-5.1`, `gpt-5.2`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.4-nano` to `SUPPORTED_AGENT_OPENAI_MODELS` so these Azure OpenAI models are selectable for agent connections in this release line.

## Impact of Change
- **Users**: Additional GPT-5.x models become available for agent OpenAI connections.
- **Developers**: No API changes; single constant array extended.
- **System**: No architectural/perf impact.

## Test Plan
- [x] Manual testing completed
- [x] Tested in: original change validated on main via PR #9316; this is a clean cherry-pick (no conflicts)

## Contributors
@rllyy97
