### PR TITLE
fix(designer-ui): keep expression signature help below the editor and restore drag-select in the fx editor

### DIFF
--- a/libs/designer-ui/src/lib/editor/codemirror/CodeMirrorEditor.tsx
+++ b/libs/designer-ui/src/lib/editor/codemirror/CodeMirrorEditor.tsx
@@ -111,8 +111,15 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         setSelection: (range) => {
           if (viewRef.current) {
             const doc = viewRef.current.state.doc;
-            const startPos = doc.line(range.startLineNumber).from + range.startColumn - 1;
-            const endPos = doc.line(range.endLineNumber).from + range.endColumn - 1;
+            // Clamp line/column to valid ranges. Monaco silently clamped out-of-range
+            // positions, but CodeMirror's doc.line() throws a RangeError, so we guard here.
+            const toPos = (lineNumber: number, column: number) => {
+              const clampedLine = Math.min(Math.max(lineNumber, 1), doc.lines);
+              const line = doc.line(clampedLine);
+              return Math.min(Math.max(line.from + column - 1, line.from), line.to);
+            };
+            const startPos = toPos(range.startLineNumber, range.startColumn);
+            const endPos = toPos(range.endLineNumber, range.endColumn);
             viewRef.current.dispatch({
               selection: { anchor: startPos, head: endPos },
             });

--- a/libs/designer-ui/src/lib/editor/codemirror/languages/index.ts
+++ b/libs/designer-ui/src/lib/editor/codemirror/languages/index.ts
@@ -5,6 +5,6 @@ export {
   workflowHighlighting,
   workflowStreamLanguage,
   workflowCompletion,
-  workflowSignatureHelp,
   getSignatureAtPosition,
+  type SignatureInfo,
 } from './workflow';

--- a/libs/designer-ui/src/lib/editor/codemirror/languages/workflow/__tests__/signature.test.ts
+++ b/libs/designer-ui/src/lib/editor/codemirror/languages/workflow/__tests__/signature.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { workflowSignatureHelp, getSignatureAtPosition } from '../signature';
-
-describe('workflowSignatureHelp', () => {
-  it('should export signature help extension', () => {
-    expect(workflowSignatureHelp).toBeDefined();
-  });
-});
+import { getSignatureAtPosition } from '../signature';
 
 describe('getSignatureAtPosition', () => {
   it('should return null for empty text', () => {

--- a/libs/designer-ui/src/lib/editor/codemirror/languages/workflow/index.ts
+++ b/libs/designer-ui/src/lib/editor/codemirror/languages/workflow/index.ts
@@ -3,19 +3,21 @@ import { autocompletion } from '@codemirror/autocomplete';
 import { syntaxHighlighting } from '@codemirror/language';
 import { workflowLanguage, workflowHighlighting } from './tokens';
 import { workflowCompletion } from './completion';
-import { workflowSignatureHelp } from './signature';
 
 export { workflowLanguage, workflowHighlighting, workflowStreamLanguage } from './tokens';
 export { workflowCompletion } from './completion';
-export { workflowSignatureHelp, getSignatureAtPosition } from './signature';
+export { getSignatureAtPosition, type SignatureInfo } from './signature';
 
 /**
  * Complete workflow language support bundle
- * Includes syntax highlighting, autocomplete, and signature help
+ * Includes syntax highlighting and autocomplete.
+ *
+ * Signature help is intentionally NOT a floating editor tooltip — it is rendered
+ * as an in-flow panel below the expression editor (see ExpressionEditor) so it
+ * never overlaps the text being typed. See issue #9292.
  */
 export const workflow = (): Extension[] => [
   workflowLanguage,
   syntaxHighlighting(workflowHighlighting),
   autocompletion({ override: [workflowCompletion] }),
-  workflowSignatureHelp,
 ];

--- a/libs/designer-ui/src/lib/editor/codemirror/languages/workflow/signature.ts
+++ b/libs/designer-ui/src/lib/editor/codemirror/languages/workflow/signature.ts
@@ -1,5 +1,3 @@
-import type { Extension } from '@codemirror/state';
-import { showTooltip } from '@codemirror/view';
 import { FunctionGroupDefinitions, type FunctionDefinition } from '../../../../workflow/languageservice/templatefunctions';
 import { getPropertyValue, map } from '@microsoft/logic-apps-shared';
 
@@ -77,60 +75,3 @@ export const getSignatureAtPosition = (text: string, position: number): Signatur
     definition,
   };
 };
-
-export const workflowSignatureHelp: Extension = showTooltip.compute(['selection', 'doc'], (state) => {
-  // Only show when there's a potential function call
-  const text = state.doc.toString();
-  const pos = state.selection.main.head;
-  const textBefore = text.slice(Math.max(0, pos - 100), pos);
-
-  if (!textBefore.includes('(')) {
-    return null;
-  }
-
-  const signatureInfo = getSignatureAtPosition(text, pos);
-
-  if (!signatureInfo) {
-    return null;
-  }
-
-  const { definition, activeParameter } = signatureInfo;
-  const signature = definition.signatures[0]; // Use first signature
-
-  if (!signature) {
-    return null;
-  }
-
-  return {
-    pos,
-    above: true,
-    create: () => {
-      const dom = document.createElement('div');
-      dom.className = 'cm-signature-help';
-      dom.style.cssText =
-        'padding: 4px 8px; background: var(--colorNeutralBackground1, #f3f3f3); border: 1px solid var(--colorNeutralStroke1, #c8c8c8); border-radius: 3px; font-family: monospace; font-size: 12px; max-width: 400px;';
-
-      // Build signature display
-      let html = `<strong>${definition.name}</strong>(`;
-      html += signature.parameters
-        .map((param, idx) => {
-          const paramText = `${param.name}: ${param.type}`;
-          return idx === activeParameter ? `<u><strong>${paramText}</strong></u>` : paramText;
-        })
-        .join(', ');
-      html += ')';
-
-      if (signature.documentation) {
-        html += `<br/><small>${signature.documentation}</small>`;
-      }
-
-      const activeParam = signature.parameters[activeParameter];
-      if (activeParam?.documentation) {
-        html += `<br/><em>${activeParam.name}: ${activeParam.documentation}</em>`;
-      }
-
-      dom.innerHTML = html;
-      return { dom };
-    },
-  };
-});

--- a/libs/designer-ui/src/lib/expressioneditor/__test__/expressioneditorsignature.spec.tsx
+++ b/libs/designer-ui/src/lib/expressioneditor/__test__/expressioneditorsignature.spec.tsx
@@ -1,0 +1,48 @@
+import { ExpressionEditorSignature } from '../expressioneditorsignature';
+import type { SignatureInfo } from '../../editor/codemirror/languages/workflow/signature';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+describe('ExpressionEditorSignature', () => {
+  const signature: SignatureInfo = {
+    functionName: 'concat',
+    activeParameter: 1,
+    definition: {
+      name: 'concat',
+      defaultSignature: 'concat(text_1: string, text_2: string)',
+      description: 'Combines strings.',
+      signatures: [
+        {
+          definition: 'concat(text_1: string, text_2: string)',
+          documentation: 'Combines two or more strings.',
+          parameters: [
+            { name: 'text_1', type: 'string', documentation: 'First string.' },
+            { name: 'text_2', type: 'string', documentation: 'Second string.' },
+          ],
+        },
+      ],
+    },
+  };
+
+  it('renders the function name, parameters and documentation', () => {
+    const { container } = render(<ExpressionEditorSignature signature={signature} />);
+
+    const panel = container.querySelector('[data-automation-id="msla-expression-editor-signature"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.textContent).toContain('concat');
+    expect(panel?.textContent).toContain('text_1: string');
+    expect(panel?.textContent).toContain('text_2: string');
+    expect(panel?.textContent).toContain('Combines two or more strings.');
+    // Active parameter documentation is shown for the second (active) parameter.
+    expect(panel?.textContent).toContain('text_2: Second string.');
+  });
+
+  it('returns null when the definition has no signatures', () => {
+    const noSignatures: SignatureInfo = {
+      ...signature,
+      definition: { ...signature.definition, signatures: [] },
+    };
+    const { container } = render(<ExpressionEditorSignature signature={noSignatures} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/libs/designer-ui/src/lib/expressioneditor/expressioneditorsignature.tsx
+++ b/libs/designer-ui/src/lib/expressioneditor/expressioneditorsignature.tsx
@@ -1,0 +1,89 @@
+import type { SignatureInfo } from '../editor/codemirror/languages/workflow/signature';
+import { makeStyles, mergeClasses, tokens } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  container: {
+    margin: '4px 16px 8px',
+    padding: '4px 8px',
+    fontFamily: 'monospace',
+    fontSize: '12px',
+    lineHeight: '1.4',
+    color: tokens.colorNeutralForeground1,
+    backgroundColor: tokens.colorNeutralBackground3,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusMedium,
+    overflowWrap: 'anywhere',
+  },
+  signatureLine: {
+    color: tokens.colorNeutralForeground1,
+  },
+  functionName: {
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  param: {
+    color: tokens.colorNeutralForeground2,
+  },
+  activeParam: {
+    fontWeight: tokens.fontWeightSemibold,
+    textDecorationLine: 'underline',
+    color: tokens.colorNeutralForeground1,
+  },
+  documentation: {
+    display: 'block',
+    marginTop: '2px',
+    color: tokens.colorNeutralForeground3,
+  },
+  paramDocumentation: {
+    display: 'block',
+    marginTop: '2px',
+    fontStyle: 'italic',
+    color: tokens.colorNeutralForeground2,
+  },
+});
+
+export interface ExpressionEditorSignatureProps {
+  signature: SignatureInfo;
+}
+
+/**
+ * Renders function signature help for the expression editor as an in-flow panel
+ * positioned below the editor box. Rendering it outside of the editor content
+ * (rather than as a floating tooltip anchored at the cursor) ensures it never
+ * overlaps the text being typed. See issue #9292.
+ */
+export const ExpressionEditorSignature = ({ signature }: ExpressionEditorSignatureProps): JSX.Element | null => {
+  const styles = useStyles();
+  const { definition, activeParameter } = signature;
+  const signatureDetails = definition.signatures[0];
+
+  if (!signatureDetails) {
+    return null;
+  }
+
+  const { parameters } = signatureDetails;
+  const activeParam = parameters[activeParameter];
+
+  return (
+    <div className={styles.container} data-automation-id="msla-expression-editor-signature" aria-live="polite">
+      <div className={styles.signatureLine}>
+        <span className={styles.functionName}>{definition.name}</span>
+        {'('}
+        {parameters.map((param, index) => (
+          <span key={param.name}>
+            <span className={mergeClasses(styles.param, index === activeParameter && styles.activeParam)}>
+              {param.type ? `${param.name}: ${param.type}` : param.name}
+            </span>
+            {index < parameters.length - 1 ? ', ' : ''}
+          </span>
+        ))}
+        {')'}
+      </div>
+      {signatureDetails.documentation ? <small className={styles.documentation}>{signatureDetails.documentation}</small> : null}
+      {activeParam?.documentation ? (
+        <em className={styles.paramDocumentation}>
+          {activeParam.name}: {activeParam.documentation}
+        </em>
+      ) : null}
+    </div>
+  );
+};

--- a/libs/designer-ui/src/lib/expressioneditor/index.tsx
+++ b/libs/designer-ui/src/lib/expressioneditor/index.tsx
@@ -13,6 +13,19 @@ export interface ExpressionEditorEvent {
   selectionEnd: number;
 }
 
+// Two signatures are equivalent when they describe the same function and active
+// argument. `definition` is a stable reference keyed by function name, so comparing
+// functionName + activeParameter is sufficient.
+const isSameSignature = (a: SignatureInfo | null, b: SignatureInfo | null): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return a.functionName === b.functionName && a.activeParameter === b.activeParameter;
+};
+
 export interface ExpressionEditorProps {
   initialValue: string;
   editorRef?: MutableRefObject<CodeMirrorEditorRef | null>;
@@ -73,11 +86,12 @@ export function ExpressionEditor({
     const text = latestValueRef.current;
     const offset = latestOffsetRef.current;
     const textBefore = text.slice(Math.max(0, offset - 200), offset);
-    if (!textBefore.includes('(')) {
-      setSignature(null);
-      return;
-    }
-    setSignature(getSignatureAtPosition(text, offset));
+    const next = textBefore.includes('(') ? getSignatureAtPosition(text, offset) : null;
+    // Only update state when the signature meaningfully changes. recomputeSignature
+    // runs on every cursor/content change, but moving the cursor within the same
+    // argument produces an equivalent signature. Bailing out keeps the aria-live
+    // panel stable (no redundant re-renders or screen-reader announcements).
+    setSignature((prev) => (isSameSignature(prev, next) ? prev : next));
   }, []);
 
   const handleBlur = (): void => {

--- a/libs/designer-ui/src/lib/expressioneditor/index.tsx
+++ b/libs/designer-ui/src/lib/expressioneditor/index.tsx
@@ -1,9 +1,11 @@
-import type { EditorContentChangedEventArgs, CodeMirrorEditorRef } from '../editor/monaco';
+import type { EditorContentChangedEventArgs, CodeMirrorEditorRef, CursorPositionChangedEvent } from '../editor/monaco';
 import { MonacoEditor } from '../editor/monaco';
 import type { EventHandler } from '../eventhandler';
+import { getSignatureAtPosition, type SignatureInfo } from '../editor/codemirror/languages/workflow/signature';
+import { ExpressionEditorSignature } from './expressioneditorsignature';
 import { EditorLanguage, clamp } from '@microsoft/logic-apps-shared';
 import type { MutableRefObject } from 'react';
-import { useState, useEffect } from 'react';
+import { useCallback, useRef, useState, useEffect } from 'react';
 
 export interface ExpressionEditorEvent {
   value: string;
@@ -42,13 +44,44 @@ export function ExpressionEditor({
 }: ExpressionEditorProps): JSX.Element {
   const [mouseDownLocation, setMouseDownLocation] = useState(0);
   const [heightOnMouseDown, setHeightOnMouseDown] = useState(0);
+  const [signature, setSignature] = useState<SignatureInfo | null>(null);
+  const latestValueRef = useRef(initialValue);
+  const latestOffsetRef = useRef(0);
   useEffect(() => {
     if (isDragging && dragDistance) {
       setCurrentHeight(clamp(heightOnMouseDown + dragDistance - mouseDownLocation, 50, 200));
     }
   }, [isDragging, dragDistance, mouseDownLocation, currentHeight, setCurrentHeight, heightOnMouseDown]);
 
+  useEffect(() => {
+    latestValueRef.current = initialValue;
+  }, [initialValue]);
+
+  // Compute the absolute character offset from a line/column position.
+  const getOffset = (text: string, lineNumber: number, column: number): number => {
+    const lines = text.split('\n');
+    let offset = 0;
+    for (let i = 0; i < lineNumber - 1 && i < lines.length; i++) {
+      offset += lines[i].length + 1; // +1 for the newline character
+    }
+    return offset + (column - 1);
+  };
+
+  // Recompute the signature help shown below the editor (issue #9292: this is
+  // rendered in-flow instead of as a floating tooltip so it never covers text).
+  const recomputeSignature = useCallback(() => {
+    const text = latestValueRef.current;
+    const offset = latestOffsetRef.current;
+    const textBefore = text.slice(Math.max(0, offset - 200), offset);
+    if (!textBefore.includes('(')) {
+      setSignature(null);
+      return;
+    }
+    setSignature(getSignatureAtPosition(text, offset));
+  }, []);
+
   const handleBlur = (): void => {
+    setSignature(null);
     if (onBlur && editorRef?.current) {
       const currentSelection = editorRef.current.getSelection();
       const currentCursorPosition = editorRef.current.getPosition()?.column ?? 1;
@@ -63,44 +96,59 @@ export function ExpressionEditor({
     }
   };
 
-  const handleChangeEvent = (): void => {
-    setExpressionEditorError('');
+  const handleContentChanged = (e: EditorContentChangedEventArgs): void => {
+    latestValueRef.current = e.value ?? '';
+    recomputeSignature();
+    if (onContentChanged) {
+      onContentChanged(e);
+    } else {
+      setExpressionEditorError('');
+    }
+  };
+
+  const handleCursorPositionChanged = (e: CursorPositionChangedEvent): void => {
+    latestOffsetRef.current = getOffset(latestValueRef.current, e.position.lineNumber, e.position.column);
+    recomputeSignature();
   };
 
   return (
-    <div className="msla-expression-editor-container" style={{ height: currentHeight }}>
-      <MonacoEditor
-        ref={editorRef}
-        language={EditorLanguage.templateExpressionLanguage}
-        lineNumbers="off"
-        value={initialValue}
-        scrollbar={{ horizontal: 'hidden', vertical: 'hidden' }}
-        minimapEnabled={false}
-        overviewRulerLanes={0}
-        overviewRulerBorder={false}
-        contextMenu={false}
-        onBlur={handleBlur}
-        onFocus={onFocus}
-        onContentChanged={onContentChanged ?? handleChangeEvent}
-        width={'100%'}
-        wordWrap="bounded"
-        wordWrapColumn={200}
-        automaticLayout={true}
-        data-automation-id="msla-expression-editor"
-        height={`${currentHeight}px`}
-        readOnly={isReadOnly}
-        tabSize={2}
-      />
-      <div
-        className="msla-expression-editor-expand"
-        onMouseDown={(e) => {
-          setMouseDownLocation(e.clientY);
-          setIsDragging(true);
-          setHeightOnMouseDown(currentHeight);
-        }}
-      >
-        <div className="msla-expression-editor-expand-icon" /> <div className="msla-expression-editor-expand-icon-2" />
+    <div className="msla-expression-editor">
+      <div className="msla-expression-editor-container" style={{ height: currentHeight }}>
+        <MonacoEditor
+          ref={editorRef}
+          language={EditorLanguage.templateExpressionLanguage}
+          lineNumbers="off"
+          value={initialValue}
+          scrollbar={{ horizontal: 'hidden', vertical: 'hidden' }}
+          minimapEnabled={false}
+          overviewRulerLanes={0}
+          overviewRulerBorder={false}
+          contextMenu={false}
+          onBlur={handleBlur}
+          onFocus={onFocus}
+          onContentChanged={handleContentChanged}
+          onCursorPositionChanged={handleCursorPositionChanged}
+          width={'100%'}
+          wordWrap="bounded"
+          wordWrapColumn={200}
+          automaticLayout={true}
+          data-automation-id="msla-expression-editor"
+          height={`${currentHeight}px`}
+          readOnly={isReadOnly}
+          tabSize={2}
+        />
+        <div
+          className="msla-expression-editor-expand"
+          onMouseDown={(e) => {
+            setMouseDownLocation(e.clientY);
+            setIsDragging(true);
+            setHeightOnMouseDown(currentHeight);
+          }}
+        >
+          <div className="msla-expression-editor-expand-icon" /> <div className="msla-expression-editor-expand-icon-2" />
+        </div>
       </div>
+      {signature ? <ExpressionEditorSignature signature={signature} /> : null}
     </div>
   );
 }

--- a/libs/designer-ui/src/lib/expressioneditor/index.tsx
+++ b/libs/designer-ui/src/lib/expressioneditor/index.tsx
@@ -81,7 +81,13 @@ export function ExpressionEditor({
   }, []);
 
   const handleBlur = (): void => {
-    setSignature(null);
+    // NOTE: Do not clear the signature here. Clearing it on blur removes the in-flow
+    // signature panel, which shifts the elements below the editor (the token-picker
+    // tabs and token list) upward. When the blur is triggered by clicking one of those
+    // elements, the layout shift moves the target out from under the cursor mid-click,
+    // so the click misses (e.g. switching to the "Dynamic content" tab silently fails).
+    // The signature is instead cleared by recomputeSignature when the expression no
+    // longer has a function at the cursor. See issue #9292 and its follow-up.
     if (onBlur && editorRef?.current) {
       const currentSelection = editorRef.current.getSelection();
       const currentCursorPosition = editorRef.current.getPosition()?.column ?? 1;

--- a/libs/designer-ui/src/lib/tokenpicker/index.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/index.tsx
@@ -183,10 +183,10 @@ export function TokenPicker({
 
     setTimeout(() => {
       expressionEditorRef.current?.setSelection({
-        startLineNumber: escapedString.length + 1,
-        startColumn: 1,
-        endLineNumber: escapedString.length + 1,
-        endColumn: 1,
+        startLineNumber: 1,
+        startColumn: escapedString.length + 1,
+        endLineNumber: 1,
+        endColumn: escapedString.length + 1,
       });
       expressionEditorRef.current?.focus();
     }, 100);
@@ -309,6 +309,9 @@ export function TokenPicker({
         styles={styleWithMargin ? calloutStylesWithTopMargin : calloutStyles}
         layerProps={{
           hostId: 'msla-layer-host',
+          // Allow mouse events to bubble to `document` so CodeMirror's drag-to-select works
+          // inside the Callout's Fluent Layer (defaults to eventBubblingEnabled: false).
+          eventBubblingEnabled: true,
         }}
       >
         <div


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Two fixes to the token-picker expression (fx) editor in `designer-ui`, both affecting the same small CodeMirror editor.

**1. Signature help no longer overlaps the typed text (#9292).** The function signature help was rendered as a floating CodeMirror tooltip anchored at the cursor (`showTooltip`, `above: true`). In the small token-picker expression editor it overlapped the text being typed (covering earlier wrapped lines or flipping down onto the cursor line). It's now rendered in an in-flow panel directly **below** the editor box, so it can never overlap the typed text.

**2. Mouse click-drag to select text now works in the fx editor.** Click-dragging to select text did nothing (keyboard selection via Ctrl+A / Shift+Arrow worked fine). Root cause: the token picker renders CodeMirror inside a Fluent UI `Callout` → `Layer`, and Fluent `Layer` defaults to `eventBubblingEnabled: false`, which stops mouse events from propagating to `document`. CodeMirror's drag-selection attaches its `mousemove`/`mouseup` listeners at the `document` level, so the drag never reached it. Setting `eventBubblingEnabled: true` on the Callout's `layerProps` fixes it (a `hostId` is set, so events bubble through the neutral `msla-layer-host`, not the canvas). This is a pre-existing bug from the Monaco→CodeMirror migration, not from the signature-help change. Also fixed a `RangeError: Invalid line number N in 1-line document` thrown on every editor open (`handleInitializeExpression` passed the text length as the line number instead of the column), and made `CodeMirrorEditor.setSelection` clamp out-of-range positions (Monaco clamped silently; CodeMirror's `doc.line()` throws).

The two fixes are independent but touch the same component; the drag-select bug was surfaced while verifying the #9292 fix.

## Impact of Change
- **Users**: Expression signature help no longer covers what you're typing in the fx editor, and you can now click-drag to select text there. No behavior change elsewhere.
- **Developers**: `CodeMirrorEditor.setSelection` is now lenient about out-of-range line/column (clamps instead of throwing), matching prior Monaco behavior.
- **System**: Scoped to the token-picker expression editor / CodeMirror wrapper in `designer-ui`. `eventBubblingEnabled: true` only lets the token-picker Callout's events bubble out via the dedicated `msla-layer-host` (at `body` level), not the designer canvas.

## Test Plan
- [x] Unit tests added/updated <!-- existing designer-ui specs (signature + tokenpicker) updated/passing -->
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: standalone designer (`/` and `/designer-v2`) at https://localhost:4201

Details:
- Open a node with an expression (e.g. Filter array in the "Multi Variable" workflow) → open the fx expression editor.
  - Type `concat(` etc. → signature help renders below the editor, never over the text (verified in both `/` and `/designer-v2`).
  - Click-drag across the text → text is selected (native + CodeMirror selection both extend). Drag along the text line itself — the content box is taller than the single line of text.
  - No `RangeError` in the console on open; token picker still dismisses via Escape.
- `designer-ui` unit tests pass; `tsc --noEmit` clean; Biome/ESLint clean (pre-commit hooks passed).

## Contributors
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
<img width="436" height="588" alt="image" src="https://github.com/user-attachments/assets/fdc58124-e2da-466c-b1a1-d730e2b77e25" />



Fixes #9292