### PR TITLE
fix(designer-ui): center code view find matches in viewport

### DIFF
--- a/libs/designer-ui/src/lib/editor/codemirror/CodeMirrorEditor.tsx
+++ b/libs/designer-ui/src/lib/editor/codemirror/CodeMirrorEditor.tsx
@@ -212,7 +212,9 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         highlightActiveLine(),
         highlightActiveLineGutter(),
         keymap.of([...closeBracketsKeymap, ...completionKeymap, ...searchKeymap, ...defaultKeymap]),
-        search(),
+        // Center the match in the viewport when navigating search results so users don't
+        // have to scroll after each "Find Next" (default reveals at the nearest edge).
+        search({ scrollToMatch: (range) => EditorView.scrollIntoView(range, { y: 'center' }) }),
         themeCompartment.of(createFluentTheme(isInverted)),
         languageCompartment.of(getLanguageExtension(language)),
         readOnlyCompartment.of(EditorState.readOnly.of(readOnly)),

--- a/libs/designer-ui/src/lib/editor/codemirror/__tests__/CodeMirrorEditor.test.tsx
+++ b/libs/designer-ui/src/lib/editor/codemirror/__tests__/CodeMirrorEditor.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { EditorView } from '@codemirror/view';
+import { findNext, setSearchQuery, SearchQuery } from '@codemirror/search';
 import { CodeMirrorEditor } from '../CodeMirrorEditor';
 import { createRef } from 'react';
 import type { CodeMirrorEditorRef } from '../types';
@@ -49,6 +51,35 @@ describe('CodeMirrorEditor', () => {
     ref.current?.setValue('new content');
 
     expect(onContentChanged).toHaveBeenCalled();
+  });
+
+  describe('search', () => {
+    it('centers the match in the viewport when navigating with Find Next', () => {
+      const ref = createRef<CodeMirrorEditorRef>();
+      // A tall document so there is room to scroll the match into the center.
+      const doc = Array.from({ length: 200 }, (_, i) => (i === 150 ? 'line NEEDLE here' : `line ${i} filler`)).join('\n');
+      render(<CodeMirrorEditor ref={ref} defaultValue={doc} />);
+
+      const view = ref.current?.getView() as EditorView | null;
+      expect(view).not.toBeNull();
+
+      const scrollSpy = vi.spyOn(EditorView, 'scrollIntoView');
+      try {
+        view?.dispatch({ effects: setSearchQuery.of(new SearchQuery({ search: 'NEEDLE' })) });
+        scrollSpy.mockClear();
+
+        const found = findNext(view as EditorView);
+
+        expect(found).toBe(true);
+        expect(scrollSpy).toHaveBeenCalled();
+        // The default search reveal uses { y: 'nearest' }, which pins matches to the
+        // viewport edge. Our override centers them so users don't have to scroll (issue #9327).
+        const lastCall = scrollSpy.mock.calls.at(-1);
+        expect(lastCall?.[1]).toMatchObject({ y: 'center' });
+      } finally {
+        scrollSpy.mockRestore();
+      }
+    });
   });
 
   describe('showMerge', () => {


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Fixes #9327. In the code view (CodeMirror editor, used by both Standard and Consumption logic apps), pressing **Ctrl+F** and clicking **Next** revealed each match at the *nearest viewport edge*. In practice this landed matches at the very bottom of the visible window, forcing the user to scroll up a little after every result.

The fix configures the `@codemirror/search` extension's `scrollToMatch` option to center matches vertically when navigating search results:

```ts
search({ scrollToMatch: (range) => EditorView.scrollIntoView(range, { y: 'center' }) })
```

`@codemirror/search` (6.5.11) exposes this hook specifically for search navigation, so it only affects Find Next / Find Previous — not ordinary cursor movement or typing. This applies everywhere the shared `CodeMirrorEditor` (re-exported as `MonacoEditor`) is used, so it covers the code view for both logic app types and the merge/diff view.

## Impact of Change
- **Users**: Find Next / Find Previous in the code view now centers the matched text in the viewport instead of pinning it to the bottom edge, removing the need to scroll on each result. Affects both Standard and Consumption code views.
- **Developers**: No API changes. One-line config addition to the shared editor's `search()` extension, plus a regression test.
- **System**: No new dependencies, no performance or architectural impact.

## Test Plan
- [x] Unit tests added/updated — new `search` test in `CodeMirrorEditor.test.tsx` asserts `findNext` dispatches a `{ y: 'center' }` scroll effect (full suite 16/16 passing)
- [ ] E2E tests added/updated
- [x] Manual testing completed — verified live in the Standalone code view: after Find Next the match lands at ~49% of the viewport height (measured match center === scroller center), confirming it is centered rather than at the bottom edge
- [x] Tested in: Standalone designer (`pnpm run start`), `biome check` clean, `tsc --noEmit` (designer-ui) clean

## Contributors
@rllyy97

## Screenshots/Videos
Code view after Find Next — the active match (line 43) is centered in the editor viewport rather than pinned to the bottom edge.