### PR TITLE
fix(designer-ui): open function editor for all dynamic content tokens

### DIFF
--- a/e2e/designer/TokenPicker.spec.ts
+++ b/e2e/designer/TokenPicker.spec.ts
@@ -15,16 +15,19 @@ test.describe(
       await page.getByLabel('Parse JSON operation, Data').click();
       await page.getByLabel('Content').click();
       await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-dynamic-content"]').click();
-      await expect(page.getByRole('button', { name: 'EILCO Admin Nominations-OCSA' })).toBeVisible();
+      // Scope to the token picker so we match the dynamic-content list option and not the
+      // (now clickable) token chip already present in the editor, which shares the same name.
+      const tokenPicker = page.locator('.msla-token-picker-container-v3');
+      await expect(tokenPicker.getByRole('button', { name: 'EILCO Admin Nominations-OCSA' })).toBeVisible();
       await page.getByPlaceholder('Search').click();
       await page.getByPlaceholder('Search').fill('OCSA');
-      await expect(page.getByRole('button', { name: 'EILCO Admin Nominations-OCSA' })).toBeVisible();
+      await expect(tokenPicker.getByRole('button', { name: 'EILCO Admin Nominations-OCSA' })).toBeVisible();
       await page.getByPlaceholder('Search').click();
       await page.getByPlaceholder('Search').fill('_L2');
-      await expect(page.getByRole('button', { name: 'EILCO Admin Nominations-OCSA' })).toBeVisible();
+      await expect(tokenPicker.getByRole('button', { name: 'EILCO Admin Nominations-OCSA' })).toBeVisible();
       await page.getByPlaceholder('Search').click();
       await page.getByPlaceholder('Search').fill('OCSR');
-      await expect(page.getByRole('button', { name: 'EILCO Admin Nominations-OCSA' })).toBeVisible();
+      await expect(tokenPicker.getByRole('button', { name: 'EILCO Admin Nominations-OCSA' })).toBeVisible();
     });
 
     test('Expression Editor works with dynamic content', async ({ page }) => {

--- a/libs/designer-ui/src/lib/editor/base/plugins/OpenTokenPicker.tsx
+++ b/libs/designer-ui/src/lib/editor/base/plugins/OpenTokenPicker.tsx
@@ -27,13 +27,15 @@ export default function OpenTokenPicker({ openTokenPicker }: OpenTokenPickerProp
       OPEN_TOKEN_PICKER,
       (payload: OPEN_TOKEN_PICKER_PAYLOAD) => {
         const { token } = payload;
-        if (token?.tokenType === TokenType.FX) {
-          openTokenPicker(TokenPickerMode.EXPRESSION, () => {
-            editor.dispatchCommand(INITIALIZE_TOKENPICKER_EXPRESSION, payload);
-          });
-        } else if (token?.tokenType === TokenType.AGENTPARAMETER) {
+        if (token?.tokenType === TokenType.AGENTPARAMETER) {
           openTokenPicker(TokenPickerMode.AGENT_PARAMETER_CREATE, () => {
             editor.dispatchCommand(INITIALIZE_TOKENPICKER_AGENT_PARAMETER, payload);
+          });
+        } else {
+          // FX expressions and dynamic content tokens (outputs, variables, parameters, items)
+          // all open the function/expression editor so they can be edited.
+          openTokenPicker(TokenPickerMode.EXPRESSION, () => {
+            editor.dispatchCommand(INITIALIZE_TOKENPICKER_EXPRESSION, payload);
           });
         }
         return true;

--- a/libs/designer-ui/src/lib/token/inputToken.tsx
+++ b/libs/designer-ui/src/lib/token/inputToken.tsx
@@ -1,4 +1,3 @@
-import { TokenType } from '../editor';
 import { CLOSE_TOKENPICKER } from '../editor/base/plugins/CloseTokenPicker';
 import { DELETE_TOKEN_NODE } from '../editor/base/plugins/DeleteTokenNode';
 import { OPEN_TOKEN_PICKER } from '../editor/base/plugins/OpenTokenPicker';
@@ -140,12 +139,11 @@ export const InputToken: React.FC<InputTokenProps> = ({ value, brandColor, icon,
   const styles = useStyles();
   const [isClickable, setIsClickable] = useState(false);
   useEffect(() => {
-    // Check if token is clickable (FX or AGENTPARAMETER)
+    // Any non-readonly token (function or dynamic content) can be opened in the function editor.
     editor.getEditorState().read(() => {
       const node: TokenNode | null = $getNodeByKey(nodeKey);
       const token = node?.['__data']?.token;
-      const tokenType = token?.tokenType;
-      setIsClickable(!readonly && (tokenType === TokenType.FX || tokenType === TokenType.AGENTPARAMETER));
+      setIsClickable(!readonly && !!token);
     });
   }, [editor, nodeKey, readonly]);
   useEffect(() => {
@@ -175,11 +173,11 @@ export const InputToken: React.FC<InputTokenProps> = ({ value, brandColor, icon,
     editor.getEditorState().read(() => {
       const node: TokenNode | null = $getNodeByKey(nodeKey);
       const token = node?.['__data']?.token;
-      const tokenType = token?.tokenType;
       if (!token) {
         return;
       }
-      if (!readonly && (tokenType === TokenType.FX || tokenType === TokenType.AGENTPARAMETER)) {
+      // Any non-readonly token (function or dynamic content) opens the function editor window.
+      if (!readonly) {
         editor.dispatchCommand(OPEN_TOKEN_PICKER, { token, nodeKey });
         return;
       }

--- a/libs/designer-ui/src/lib/tokenpicker/plugins/InitializeTokenPickerExpressionHandler.tsx
+++ b/libs/designer-ui/src/lib/tokenpicker/plugins/InitializeTokenPickerExpressionHandler.tsx
@@ -1,7 +1,8 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import type { LexicalCommand, NodeKey } from 'lexical';
-import { COMMAND_PRIORITY_EDITOR, createCommand } from 'lexical';
+import { $getNodeByKey, COMMAND_PRIORITY_EDITOR, createCommand } from 'lexical';
 import type { OPEN_TOKEN_PICKER_PAYLOAD } from '../../editor/base/plugins/OpenTokenPicker';
+import { $isTokenNode } from '../../editor/base/nodes/tokenNode';
 import { useEffect } from 'react';
 
 export const INITIALIZE_TOKENPICKER_EXPRESSION: LexicalCommand<OPEN_TOKEN_PICKER_PAYLOAD> = createCommand();
@@ -18,8 +19,19 @@ export default function TokenPickerExpressionHandler({ handleInitializeExpressio
       INITIALIZE_TOKENPICKER_EXPRESSION,
       (payload: OPEN_TOKEN_PICKER_PAYLOAD) => {
         const { token, nodeKey } = payload;
-        if (token?.value) {
-          handleInitializeExpression?.(token.value, nodeKey);
+        // Prefer the token's value, but fall back to the node's segment value for token types
+        // (e.g. parameters, iteration indexes) that don't store a value on the token itself.
+        let expressionValue = token?.value;
+        if (!expressionValue) {
+          editor.getEditorState().read(() => {
+            const node = $getNodeByKey(nodeKey);
+            if ($isTokenNode(node)) {
+              expressionValue = node.__data?.value;
+            }
+          });
+        }
+        if (expressionValue) {
+          handleInitializeExpression?.(expressionValue, nodeKey);
         }
         return true;
       },


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Fixes #9315.

Clicking a token chip inside an action input only reopened the function/expression editor when the token's `tokenType` was `FX` or `AGENTPARAMETER`. When a user referenced a deeply‑nested JSON property (e.g. `outputs('action')?['body']?['a']?['b']`), the parser recognizes it as an `OUTPUTS` "dynamic content" token, which was **not** clickable. That produced the long‑standing, inconsistent "sometimes it opens, sometimes it doesn't" behavior reported in the issue — plain expressions opened, but recognized dynamic‑content references could not be reopened for editing.

This change makes **any** non‑readonly token (function or dynamic content) clickable and routes it to the editor:
- `token/inputToken.tsx` — a token is now clickable whenever it's non-readonly and has a token, and dispatches `OPEN_TOKEN_PICKER` on click/keyboard.
- `editor/base/plugins/OpenTokenPicker.tsx` — agent-parameter tokens open the agent-parameter editor; all other tokens (FX + outputs/variables/parameters/items) open the expression/function editor.
- `tokenpicker/plugins/InitializeTokenPickerExpressionHandler.tsx` — falls back to the node's segment value when `token.value` is absent (e.g. parameter / iteration-index tokens) so the editor always initializes with the correct expression.

## Impact of Change
- **Users**: Any function or dynamic-content token in an action input can now be clicked to reopen the function editor, every time — no more toggling to code view and copy/pasting to edit a nested reference. Applies to both old and new view, Consumption and Standard.
- **Developers**: No API changes. Behavior is centralized in the shared `designer-ui` token components.
- **System**: No performance, architecture, or dependency changes.

> Risk set to **Medium**: while scoped to the shared token components, this broadens click behavior for all token chips across every action input, so it touches a high-traffic interaction surface.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer (local). Existing designer-ui editor/tokenpicker unit suites pass (67 tests); Biome lint and `tsc --noEmit` clean for `designer-ui`. Updated `e2e/designer/TokenPicker.spec.ts` so the dynamic-content assertions scope to the token picker popup (token chips in the editor are now clickable buttons too); both TokenPicker E2E tests pass locally.

## Contributors
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A