### PR TITLE
fix(vscode): Guard against bundle download corruption (#9294) [hotfix/v5.961]

### DIFF
--- a/apps/vs-code-designer/src/__test__/onboarding.test.ts
+++ b/apps/vs-code-designer/src/__test__/onboarding.test.ts
@@ -32,6 +32,7 @@ describe('onboardBinaries', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.LA_E2E_STRICT_DEPENDENCY_VALIDATION;
     mockContext = {
       telemetry: {
         properties: {},
@@ -97,6 +98,18 @@ describe('onboardBinaries', () => {
       expect(validateAndInstallBinaries).not.toHaveBeenCalled();
       expect(validateTasksJson).not.toHaveBeenCalled();
     });
+
+    it('should rethrow dependency validation failures in strict E2E mode', async () => {
+      process.env.LA_E2E_STRICT_DEPENDENCY_VALIDATION = '1';
+      vi.mocked(isDevContainerWorkspace).mockResolvedValue(false);
+      vi.mocked(getGlobalSetting).mockReturnValue(true);
+      vi.mocked(validateAndInstallBinaries).mockRejectedValue(new Error('Bundle sidecar missing'));
+
+      await expect(onboardBinaries(mockContext)).rejects.toThrow('Bundle sidecar missing');
+
+      expect(validateAndInstallBinaries).toHaveBeenCalled();
+      expect(validateTasksJson).not.toHaveBeenCalled();
+    });
   });
 
   describe('validateTasksJson integration', () => {
@@ -131,6 +144,7 @@ describe('startOnboarding', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.LA_E2E_STRICT_DEPENDENCY_VALIDATION;
     mockContext = {
       telemetry: {
         properties: {},
@@ -174,6 +188,19 @@ describe('startOnboarding', () => {
     expect(scheduleStartAllDesignTimeApis).not.toHaveBeenCalled();
     expect(typeof mockContext.telemetry.measurements.binariesInstallDuration).toBe('number');
     expect(mockContext.telemetry.measurements.binariesInstallDuration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should rethrow dependency onboarding failures before design-time startup in strict E2E mode', async () => {
+    process.env.LA_E2E_STRICT_DEPENDENCY_VALIDATION = '1';
+    vi.mocked(isDevContainerWorkspace).mockResolvedValue(false);
+    vi.mocked(getGlobalSetting).mockReturnValue(true);
+    vi.mocked(validateAndInstallBinaries).mockRejectedValue(new Error('Bundle sidecar missing'));
+    vi.mocked(promptStartDesignTimeOption).mockResolvedValue(undefined);
+
+    await expect(startOnboarding(mockContext)).rejects.toThrow('Bundle sidecar missing');
+
+    expect(validateAndInstallBinaries).toHaveBeenCalled();
+    expect(promptStartDesignTimeOption).not.toHaveBeenCalled();
   });
 
   it('should wait for dependency onboarding before prompting for design-time startup', async () => {

--- a/apps/vs-code-designer/src/app/commands/__test__/installRuntimeDependencies.test.ts
+++ b/apps/vs-code-designer/src/app/commands/__test__/installRuntimeDependencies.test.ts
@@ -3,6 +3,7 @@ import { PackageManager, dotnetDependencyName, funcDependencyName, nodeJsDepende
 import { downloadAndExtractDependency } from '../../utils/binaries';
 import { executeCommand } from '../../utils/funcCoreTools/cpUtils';
 import { getNpmDistTag } from '../../utils/funcCoreTools/getNpmDistTag';
+import { setNodeJsCommand } from '../../utils/nodeJs/nodeJsVersion';
 import { ensureRuntimeDependenciesPath } from '../../utils/runtimeDependenciesPath';
 import { promptForFuncVersion } from '../../utils/vsCodeConfig/settings';
 import { installDotNet } from '../dotnet/installDotNet';
@@ -42,6 +43,10 @@ vi.mock('../../utils/funcCoreTools/getBrewPackageName', () => ({
 
 vi.mock('../../utils/funcCoreTools/getNpmDistTag', () => ({
   getNpmDistTag: vi.fn(),
+}));
+
+vi.mock('../../utils/nodeJs/nodeJsVersion', () => ({
+  setNodeJsCommand: vi.fn(),
 }));
 
 vi.mock('../../utils/vsCodeConfig/settings', () => ({
@@ -115,6 +120,7 @@ describe('runtime dependency installers', () => {
       'D:\\dependencies',
       nodeJsDependencyName
     );
+    expect(setNodeJsCommand).toHaveBeenCalledOnce();
   });
 
   it('uses the Linux Node.js binary release when running on Linux', async () => {
@@ -128,6 +134,7 @@ describe('runtime dependency installers', () => {
       'D:\\dependencies',
       nodeJsDependencyName
     );
+    expect(setNodeJsCommand).toHaveBeenCalledOnce();
   });
 
   it('installs Functions Core Tools through npm when system installation is selected', async () => {

--- a/apps/vs-code-designer/src/app/commands/binaries/__test__/validateAndInstallBinaries.test.ts
+++ b/apps/vs-code-designer/src/app/commands/binaries/__test__/validateAndInstallBinaries.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { autoRuntimeDependenciesPathSettingKey, defaultDependencyPathValue } from '../../../../constants';
 import { ext } from '../../../../extensionVariables';
 import { getDependencyTimeout } from '../../../utils/binaries';
-import { getDependenciesVersion } from '../../../utils/bundleFeed';
+import { ensureExtensionBundleHealthy, getDependenciesVersion } from '../../../utils/bundleFeed';
 import { setDotNetCommand } from '../../../utils/dotnet/dotnet';
 import { setFunctionsCommand } from '../../../utils/funcCoreTools/funcVersion';
 import { installLSPSDK } from '../../../utils/languageServerProtocol';
@@ -27,6 +27,7 @@ vi.mock('../../../utils/binaries', () => ({
 
 vi.mock('../../../utils/bundleFeed', () => ({
   getDependenciesVersion: vi.fn(),
+  ensureExtensionBundleHealthy: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../../utils/dotnet/dotnet', () => ({
@@ -106,6 +107,8 @@ describe('validateAndInstallBinaries', () => {
     (setNodeJsCommand as Mock).mockResolvedValue(undefined);
     (setFunctionsCommand as Mock).mockResolvedValue(undefined);
     (setDotNetCommand as Mock).mockResolvedValue(undefined);
+    (ensureExtensionBundleHealthy as Mock).mockResolvedValue(undefined);
+    delete process.env.LA_E2E_STRICT_DEPENDENCY_VALIDATION;
   });
 
   it('orchestrates dependency validation, command setup, and success logging', async () => {
@@ -145,6 +148,7 @@ describe('validateAndInstallBinaries', () => {
     expect(setNodeJsCommand).toHaveBeenCalled();
     expect(setFunctionsCommand).toHaveBeenCalled();
     expect(setDotNetCommand).toHaveBeenCalledTimes(2);
+    expect(ensureExtensionBundleHealthy).toHaveBeenCalledWith(context, { requireInstalled: false });
     expect(progress.report).toHaveBeenCalledWith({ increment: 20, message: 'NodeJS' });
     expect(ext.outputChannel.appendLog).toHaveBeenCalledWith(
       'Azure Logic Apps Standard Runtime Dependencies validation and installation completed successfully.'
@@ -165,6 +169,22 @@ describe('validateAndInstallBinaries', () => {
     );
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
       expect.stringContaining('The Validation and Installation of Runtime Dependencies encountered an error.')
+    );
+  });
+
+  it('requires an installed bundle and rethrows dependency validation errors in strict E2E mode', async () => {
+    process.env.LA_E2E_STRICT_DEPENDENCY_VALIDATION = '1';
+    (ensureExtensionBundleHealthy as Mock).mockRejectedValueOnce(new Error('Bundle sidecar missing'));
+
+    await expect(validateAndInstallBinaries(context)).rejects.toThrow('Bundle sidecar missing');
+
+    expect(ensureExtensionBundleHealthy).toHaveBeenCalledWith(context, { requireInstalled: true });
+    expect(context.telemetry.properties).toMatchObject({
+      lastStep: 'ensureExtensionBundleHealthy',
+      dependenciesError: 'Bundle sidecar missing',
+    });
+    expect(ext.outputChannel.appendLog).not.toHaveBeenCalledWith(
+      'Azure Logic Apps Standard Runtime Dependencies validation and installation completed successfully.'
     );
   });
 });

--- a/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
+++ b/apps/vs-code-designer/src/app/commands/binaries/validateAndInstallBinaries.ts
@@ -5,13 +5,14 @@
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { getDependencyTimeout } from '../../utils/binaries';
-import { getDependenciesVersion } from '../../utils/bundleFeed';
+import { getDependenciesVersion, ensureExtensionBundleHealthy } from '../../utils/bundleFeed';
 import { setDotNetCommand } from '../../utils/dotnet/dotnet';
 import { executeCommand } from '../../utils/funcCoreTools/cpUtils';
 import { setFunctionsCommand } from '../../utils/funcCoreTools/funcVersion';
 import { installLSPSDK } from '../../utils/languageServerProtocol';
 import { setNodeJsCommand } from '../../utils/nodeJs/nodeJsVersion';
 import { ensureRuntimeDependenciesPath } from '../../utils/runtimeDependenciesPath';
+import { shouldRequireStrictDependencyValidation } from '../../utils/strictDependencyValidation';
 import { runWithDurationTelemetry } from '../../utils/telemetry';
 import { timeout } from '../../utils/timeout';
 import { validateDotNetIsLatest } from '../dotnet/validateDotNetIsLatest';
@@ -23,6 +24,7 @@ import * as vscode from 'vscode';
 
 export async function validateAndInstallBinaries(context: IActionContext) {
   const helpLink = 'https://aka.ms/lastandard/onboarding/troubleshoot';
+  const requireStrictDependencyValidation = shouldRequireStrictDependencyValidation();
 
   await vscode.window.withProgress(
     {
@@ -104,6 +106,16 @@ export async function validateAndInstallBinaries(context: IActionContext) {
           await setDotNetCommand();
         });
 
+        // Block validation success on a healthy extension bundle. The bundle
+        // download is fired-and-forgotten from activation so the UI stays
+        // responsive, but validation is the right place to surface a failed
+        // install: without a healthy bundle, the design-time host and any
+        // workflow runtime will be broken, and we'd rather fail loudly here
+        // than let func.exe spawn against a missing/corrupt bundle.
+        context.telemetry.properties.lastStep = 'ensureExtensionBundleHealthy';
+        progress.report({ increment: 5, message: 'Extension Bundle' });
+        await ensureExtensionBundleHealthy(context, { requireInstalled: requireStrictDependencyValidation });
+
         ext.outputChannel.appendLog(
           localize(
             'azureLogicApsBinariesSucessfull',
@@ -111,16 +123,20 @@ export async function validateAndInstallBinaries(context: IActionContext) {
           )
         );
       } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
         ext.outputChannel.appendLog(
-          localize('azureLogicApsBinariesError', 'Error in dependencies validation and installation: "{0}"...', error?.message)
+          localize('azureLogicApsBinariesError', 'Error in dependencies validation and installation: "{0}"...', errorMessage)
         );
-        context.telemetry.properties.dependenciesError = error?.message;
+        context.telemetry.properties.dependenciesError = errorMessage;
         vscode.window.showErrorMessage(
           localize(
             'binariesTroubleshoot',
             `The Validation and Installation of Runtime Dependencies encountered an error. To resolve this issue, please click [here](${helpLink}) to access our troubleshooting documentation for step-by-step instructions.`
           )
         );
+        if (requireStrictDependencyValidation) {
+          throw error;
+        }
       }
     }
   );

--- a/apps/vs-code-designer/src/app/commands/nodeJs/__test__/installNodeJs.test.ts
+++ b/apps/vs-code-designer/src/app/commands/nodeJs/__test__/installNodeJs.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { installNodeJs } from '../installNodeJs';
+import {
+  downloadAndExtractDependency,
+  getCpuArchitecture,
+  getLatestNodeJsVersion,
+  getNodeJsBinariesReleaseUrl,
+} from '../../../utils/binaries';
+import { setNodeJsCommand } from '../../../utils/nodeJs/nodeJsVersion';
+import { ensureRuntimeDependenciesPath } from '../../../utils/runtimeDependenciesPath';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+
+vi.mock('../../../utils/binaries', () => ({
+  downloadAndExtractDependency: vi.fn(),
+  getCpuArchitecture: vi.fn(),
+  getLatestNodeJsVersion: vi.fn(),
+  getNodeJsBinariesReleaseUrl: vi.fn(),
+}));
+
+vi.mock('../../../utils/nodeJs/nodeJsVersion', () => ({
+  setNodeJsCommand: vi.fn(),
+}));
+
+vi.mock('../../../utils/runtimeDependenciesPath', () => ({
+  ensureRuntimeDependenciesPath: vi.fn(),
+}));
+
+vi.mock('../../../extensionVariables', () => ({
+  ext: {
+    outputChannel: {
+      show: vi.fn(),
+    },
+  },
+}));
+
+describe('installNodeJs', () => {
+  const context = {
+    telemetry: {
+      properties: {},
+    },
+  } as IActionContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context.telemetry.properties = {};
+    vi.mocked(getCpuArchitecture).mockReturnValue('x64');
+    vi.mocked(ensureRuntimeDependenciesPath).mockResolvedValue('dependencies');
+    vi.mocked(getLatestNodeJsVersion).mockResolvedValue('20.20.2');
+    vi.mocked(getNodeJsBinariesReleaseUrl).mockReturnValue('https://example.com/node.zip');
+    vi.mocked(downloadAndExtractDependency).mockResolvedValue(undefined);
+    vi.mocked(setNodeJsCommand).mockResolvedValue(undefined);
+  });
+
+  it('updates the NodeJS command after successfully extracting NodeJS', async () => {
+    await installNodeJs(context, '20');
+
+    expect(downloadAndExtractDependency).toHaveBeenCalledWith(context, 'https://example.com/node.zip', 'dependencies', 'NodeJs');
+    expect(setNodeJsCommand).toHaveBeenCalledOnce();
+    expect(downloadAndExtractDependency.mock.invocationCallOrder[0]).toBeLessThan(setNodeJsCommand.mock.invocationCallOrder[0]);
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/nodeJs/__test__/validateNodeJsIsLatest.test.ts
+++ b/apps/vs-code-designer/src/app/commands/nodeJs/__test__/validateNodeJsIsLatest.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { validateNodeJsIsLatest } from '../validateNodeJsIsLatest';
+import { binariesExist } from '../../../utils/binaries';
+import { getNodeJsCommand, setNodeJsCommand } from '../../../utils/nodeJs/nodeJsVersion';
+import { getWorkspaceSetting } from '../../../utils/vsCodeConfig/settings';
+import { installNodeJs } from '../installNodeJs';
+
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+  callWithTelemetryAndErrorHandling: vi.fn(async (_eventName: string, callback: (context: any) => Promise<void>) =>
+    callback({
+      errorHandling: {},
+      telemetry: {
+        properties: {},
+      },
+      ui: {
+        showWarningMessage: vi.fn(),
+      },
+    })
+  ),
+  DialogResponses: {
+    learnMore: { title: 'Learn More' },
+    dontWarnAgain: { title: "Don't Warn Again" },
+  },
+  openUrl: vi.fn(),
+}));
+
+vi.mock('../../../utils/binaries', () => ({
+  binariesExist: vi.fn(),
+  getLatestNodeJsVersion: vi.fn(),
+}));
+
+vi.mock('../../../utils/nodeJs/nodeJsVersion', () => ({
+  getLocalNodeJsVersion: vi.fn(),
+  getNodeJsCommand: vi.fn(),
+  setNodeJsCommand: vi.fn(),
+}));
+
+vi.mock('../../../utils/vsCodeConfig/settings', () => ({
+  getWorkspaceSetting: vi.fn(),
+  updateGlobalSetting: vi.fn(),
+}));
+
+vi.mock('../installNodeJs', () => ({
+  installNodeJs: vi.fn(),
+}));
+
+vi.mock('../../../localize', () => ({
+  localize: vi.fn((_key: string, defaultValue: string) => defaultValue),
+}));
+
+describe('validateNodeJsIsLatest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getWorkspaceSetting).mockReturnValue(false);
+    vi.mocked(getNodeJsCommand).mockReturnValue('node');
+    vi.mocked(setNodeJsCommand).mockResolvedValue(undefined);
+    vi.mocked(installNodeJs).mockResolvedValue(undefined);
+  });
+
+  it('installs NodeJS when the binaries check resolves false', async () => {
+    vi.mocked(binariesExist).mockResolvedValue(false);
+
+    await validateNodeJsIsLatest('20');
+
+    expect(installNodeJs).toHaveBeenCalledWith(expect.anything(), '20');
+  });
+
+  it('repairs the NodeJS command before checking whether binaries exist', async () => {
+    vi.mocked(binariesExist).mockResolvedValue(true);
+
+    await validateNodeJsIsLatest('20');
+
+    expect(setNodeJsCommand).toHaveBeenCalledOnce();
+    expect(binariesExist).toHaveBeenCalledOnce();
+    expect(setNodeJsCommand.mock.invocationCallOrder[0]).toBeLessThan(binariesExist.mock.invocationCallOrder[0]);
+  });
+
+  it('does not install NodeJS when binaries exist and update warnings are disabled', async () => {
+    vi.mocked(binariesExist).mockResolvedValue(true);
+
+    await validateNodeJsIsLatest('20');
+
+    expect(installNodeJs).not.toHaveBeenCalled();
+  });
+
+  it('does not reinstall after the first validation repairs the NodeJS binary state', async () => {
+    vi.mocked(binariesExist).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await validateNodeJsIsLatest('20');
+    await validateNodeJsIsLatest('20');
+
+    expect(installNodeJs).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/nodeJs/installNodeJs.ts
+++ b/apps/vs-code-designer/src/app/commands/nodeJs/installNodeJs.ts
@@ -11,6 +11,7 @@ import {
   getLatestNodeJsVersion,
   getNodeJsBinariesReleaseUrl,
 } from '../../utils/binaries';
+import { setNodeJsCommand } from '../../utils/nodeJs/nodeJsVersion';
 import { ensureRuntimeDependenciesPath } from '../../utils/runtimeDependenciesPath';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 
@@ -42,4 +43,5 @@ export async function installNodeJs(context: IActionContext, majorVersion?: stri
 
   context.telemetry.properties.lastStep = 'downloadAndExtractBinaries';
   await downloadAndExtractDependency(context, nodeJsReleaseUrl, targetDirectory, nodeJsDependencyName);
+  await setNodeJsCommand();
 }

--- a/apps/vs-code-designer/src/app/commands/nodeJs/validateNodeJsIsLatest.ts
+++ b/apps/vs-code-designer/src/app/commands/nodeJs/validateNodeJsIsLatest.ts
@@ -5,7 +5,7 @@
 import { nodeJsDependencyName } from '../../../constants';
 import { localize } from '../../../localize';
 import { binariesExist, getLatestNodeJsVersion } from '../../utils/binaries';
-import { getLocalNodeJsVersion, getNodeJsCommand } from '../../utils/nodeJs/nodeJsVersion';
+import { getLocalNodeJsVersion, getNodeJsCommand, setNodeJsCommand } from '../../utils/nodeJs/nodeJsVersion';
 import { getWorkspaceSetting, updateGlobalSetting } from '../../utils/vsCodeConfig/settings';
 import { installNodeJs } from './installNodeJs';
 import { callWithTelemetryAndErrorHandling, DialogResponses, openUrl } from '@microsoft/vscode-azext-utils';
@@ -19,7 +19,8 @@ export async function validateNodeJsIsLatest(majorVersion?: string): Promise<voi
     context.telemetry.properties.isActivationEvent = 'true';
     const showNodeJsWarningKey = 'showNodeJsWarning';
     const showNodeJsWarning = !!getWorkspaceSetting<boolean>(showNodeJsWarningKey);
-    const binaries = binariesExist(nodeJsDependencyName);
+    await setNodeJsCommand();
+    const binaries = await binariesExist(nodeJsDependencyName);
     context.telemetry.properties.binariesExist = `${binaries}`;
 
     if (!binaries) {

--- a/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import axios from 'axios';
+import { EventEmitter } from 'events';
 import * as vscode from 'vscode';
 import {
   downloadAndExtractDependency,
+  downloadFileWithVerification,
+  DownloadIntegrityError,
   binariesExist,
   getLatestDotNetVersion,
   getLatestFunctionCoreToolsVersion,
@@ -16,9 +19,18 @@ import {
   getDependencyTimeout,
   installBinaries,
   useBinariesDependencies,
+  removeWithLockWait,
+  mkdirWithLockWait,
 } from '../binaries';
 import { ext } from '../../../extensionVariables';
-import { DependencyVersion, dotnetDependencyName, funcCoreToolsBinaryPathSettingKey, funcDependencyName } from '../../../constants';
+import {
+  DependencyVersion,
+  dotnetDependencyName,
+  funcCoreToolsBinaryPathSettingKey,
+  funcDependencyName,
+  nodeJsBinaryPathSettingKey,
+  nodeJsDependencyName,
+} from '../../../constants';
 import { validateAndInstallBinaries } from '../../commands/binaries/validateAndInstallBinaries';
 import { executeCommand } from '../funcCoreTools/cpUtils';
 import { getNpmCommand } from '../nodeJs/nodeJsVersion';
@@ -48,138 +60,9 @@ describe('binaries', () => {
       context = {
         telemetry: {
           properties: {},
+          measurements: {},
         },
       } as IActionContext;
-    });
-
-    it('should download and extract dependency', async () => {
-      const downloadUrl = 'https://example.com/dependency.zip';
-      const targetFolder = 'targetFolder';
-      const dependencyName = dotnetDependencyName;
-      const folderName = 'folderName';
-      const dotNetVersion = '6.0';
-
-      const writer = {
-        on: vi.fn((event: string, callback: () => void) => {
-          if (event === 'finish') {
-            callback();
-          }
-          return writer;
-        }),
-      } as any;
-
-      (axios.get as Mock).mockResolvedValue({
-        data: {
-          on: vi.fn(),
-          pipe: vi.fn().mockImplementation((writer) => {
-            return writer;
-          }),
-        },
-      });
-
-      (fs.createWriteStream as Mock).mockReturnValue(writer);
-
-      await downloadAndExtractDependency(context, downloadUrl, targetFolder, dependencyName, folderName, dotNetVersion);
-
-      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
-      expect(fs.chmodSync).toHaveBeenCalledWith(expect.any(String), 0o777);
-      expect(executeCommand).toHaveBeenCalledWith(ext.outputChannel, undefined, 'echo', `Downloading dependency from: ${downloadUrl}`);
-    });
-
-    it('rejects when the file writer fails while downloading a dependency', async () => {
-      const downloadUrl = 'https://example.com/dependency.zip';
-      const targetFolder = 'targetFolder';
-      const dependencyName = dotnetDependencyName;
-      const folderName = 'folderName';
-      const writerError = new Error('disk full');
-      const writer = {
-        on: vi.fn((event: string, callback: (error: Error) => void) => {
-          if (event === 'error') {
-            callback(writerError);
-          }
-          return writer;
-        }),
-      } as any;
-
-      (axios.get as Mock).mockResolvedValue({
-        data: {
-          on: vi.fn(),
-          pipe: vi.fn().mockImplementation((writer) => writer),
-        },
-      });
-
-      (fs.createWriteStream as Mock).mockReturnValue(writer);
-
-      await expect(downloadAndExtractDependency(context, downloadUrl, targetFolder, dependencyName, folderName)).rejects.toThrow(
-        'Error downloading and extracting the DotNetSDK zip file: disk full'
-      );
-      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('disk full'));
-      expect(context.telemetry.properties.error).toContain('disk full');
-    });
-
-    it('rejects when the readable download stream fails', async () => {
-      const downloadUrl = 'https://example.com/dependency.zip';
-      const targetFolder = 'targetFolder';
-      const dependencyName = dotnetDependencyName;
-      const folderName = 'folderName';
-      const streamError = new Error('connection reset');
-      const writer = {
-        on: vi.fn(),
-      } as any;
-
-      (axios.get as Mock).mockResolvedValue({
-        data: {
-          on: vi.fn((event: string, callback: (error: Error) => void) => {
-            if (event === 'error') {
-              callback(streamError);
-            }
-          }),
-          pipe: vi.fn().mockImplementation((writer) => writer),
-        },
-      });
-
-      (fs.createWriteStream as Mock).mockReturnValue(writer);
-
-      await expect(downloadAndExtractDependency(context, downloadUrl, targetFolder, dependencyName, folderName)).rejects.toThrow(
-        'Error downloading and extracting the DotNetSDK zip file: connection reset'
-      );
-      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('connection reset'));
-      expect(context.telemetry.properties.error).toContain('connection reset');
-    });
-
-    it('rejects when download cleanup fails after a file writer error', async () => {
-      const downloadUrl = 'https://example.com/dependency.zip';
-      const targetFolder = 'targetFolder';
-      const dependencyName = dotnetDependencyName;
-      const folderName = 'folderName';
-      const writerError = new Error('disk full');
-      const cleanupError = new Error('folder locked');
-      const writer = {
-        on: vi.fn((event: string, callback: (error: Error) => void) => {
-          if (event === 'error') {
-            callback(writerError);
-          }
-          return writer;
-        }),
-      } as any;
-
-      (axios.get as Mock).mockResolvedValue({
-        data: {
-          on: vi.fn(),
-          pipe: vi.fn().mockImplementation((writer) => writer),
-        },
-      });
-      (fs.createWriteStream as Mock).mockReturnValue(writer);
-      (fs.rmSync as Mock).mockImplementationOnce(() => {
-        throw cleanupError;
-      });
-
-      await expect(downloadAndExtractDependency(context, downloadUrl, targetFolder, dependencyName, folderName)).rejects.toThrow(
-        'Error downloading and extracting the DotNetSDK zip file: disk full'
-      );
-      expect(executeCommand).toHaveBeenCalledWith(ext.outputChannel, undefined, 'echo', expect.stringContaining('Failed to remove'));
-      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('disk full'));
-      expect(context.telemetry.properties.error).toContain('disk full');
     });
 
     it('should throw error when the compression file extension is not supported', async () => {
@@ -195,10 +78,177 @@ describe('binaries', () => {
     });
   });
 
+  describe('downloadFileWithVerification', () => {
+    let context: IActionContext;
+    const url = 'https://cdn.example.com/Microsoft.Azure.Functions.ExtensionBundle.Workflows.1.2.3_any-any.zip';
+    const destPath = '/tmp/dep.zip';
+    const dependencyName = 'TestDep';
+
+    beforeEach(() => {
+      context = {
+        telemetry: { properties: {}, measurements: {} },
+      } as IActionContext;
+      (fs.existsSync as Mock).mockReturnValue(false);
+    });
+
+    // Build a fake axios stream response. `chunks` are streamed in order;
+    // `headers` lets each test choose what the CDN reports.
+    function mockAxiosStream(chunks: string[], headers: Record<string, string>) {
+      const data = new EventEmitter() as EventEmitter & { pipe: (w: any) => any };
+      data.pipe = (writer: any) => {
+        // Schedule emission on the next microtask so test code can wire listeners.
+        setImmediate(() => {
+          for (const chunk of chunks) {
+            data.emit('data', Buffer.from(chunk));
+          }
+          writer.emit('finish');
+        });
+        return writer;
+      };
+      (axios.get as Mock).mockResolvedValueOnce({ headers, data });
+    }
+
+    function mockWriter() {
+      const writer = new EventEmitter() as EventEmitter & { write: Mock; end: Mock };
+      writer.write = vi.fn();
+      writer.end = vi.fn();
+      (fs.createWriteStream as Mock).mockReturnValueOnce(writer);
+      return writer;
+    }
+
+    it('verifies size and md5 from response headers on success', async () => {
+      mockWriter();
+      // MD5 of "hello world" in base64 = XrY7u+Ae7tCTyyK7j1rNww==
+      mockAxiosStream(['hello world'], {
+        'content-length': '11',
+        'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==',
+      });
+
+      const result = await downloadFileWithVerification(context, url, destPath, dependencyName);
+
+      expect(result.actualSize).toBe(11);
+      expect(result.expectedSize).toBe(11);
+      expect(result.expectedMd5).toBe('XrY7u+Ae7tCTyyK7j1rNww==');
+      expect(result.actualMd5).toBe('XrY7u+Ae7tCTyyK7j1rNww==');
+      expect(context.telemetry.properties[`${dependencyName}DownloadAttempts`]).toBe('1');
+      expect(context.telemetry.properties[`${dependencyName}Md5Match`]).toBe('true');
+    });
+
+    it('succeeds and reports skipped checks when headers are missing', async () => {
+      mockWriter();
+      mockAxiosStream(['abc'], {});
+
+      const result = await downloadFileWithVerification(context, url, destPath, dependencyName);
+
+      expect(result.expectedSize).toBeUndefined();
+      expect(result.expectedMd5).toBeUndefined();
+      expect(result.actualSize).toBe(3);
+      expect(context.telemetry.properties[`${dependencyName}Md5Match`]).toBe('skipped');
+      expect(context.telemetry.properties[`${dependencyName}ExpectedSize`]).toBe('unknown');
+    });
+
+    it('retries on size mismatch and ultimately fails with DownloadIntegrityError', async () => {
+      mockWriter();
+      mockAxiosStream(['short'], { 'content-length': '999', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+      mockWriter();
+      mockAxiosStream(['short'], { 'content-length': '999', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+      mockWriter();
+      mockAxiosStream(['short'], { 'content-length': '999', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+
+      await expect(downloadFileWithVerification(context, url, destPath, dependencyName, 3)).rejects.toBeInstanceOf(DownloadIntegrityError);
+      expect(axios.get).toHaveBeenCalledTimes(3);
+      expect(context.telemetry.properties[`${dependencyName}DownloadAttempts`]).toBe('3');
+    });
+
+    it('retries on md5 mismatch then succeeds on a later attempt', async () => {
+      // First attempt: corrupt body (md5 of 'corrupt' is not the expected one).
+      mockWriter();
+      mockAxiosStream(['corrupt'], { 'content-length': '11', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+      // Second attempt: matching body.
+      mockWriter();
+      mockAxiosStream(['hello world'], { 'content-length': '11', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+
+      const result = await downloadFileWithVerification(context, url, destPath, dependencyName, 3);
+
+      expect(result.actualSize).toBe(11);
+      expect(axios.get).toHaveBeenCalledTimes(2);
+      expect(context.telemetry.properties[`${dependencyName}DownloadAttempts`]).toBe('2');
+    }, 10000);
+
+    it('does not retry on 4xx HTTP errors', async () => {
+      const err = Object.assign(new Error('Not Found'), { response: { status: 404 } });
+      (axios.get as Mock).mockRejectedValueOnce(err);
+
+      await expect(downloadFileWithVerification(context, url, destPath, dependencyName, 3)).rejects.toBe(err);
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on 5xx HTTP errors', async () => {
+      const err5xx = Object.assign(new Error('Server Error'), { response: { status: 503 } });
+      (axios.get as Mock).mockRejectedValueOnce(err5xx);
+      mockWriter();
+      mockAxiosStream(['ok'], { 'content-length': '2' });
+
+      const result = await downloadFileWithVerification(context, url, destPath, dependencyName, 3);
+      expect(result.actualSize).toBe(2);
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    }, 10000);
+
+    it('requests identity encoding so Content-Length matches the bytes piped to disk', async () => {
+      mockWriter();
+      mockAxiosStream(['hello world'], { 'content-length': '11' });
+
+      await downloadFileWithVerification(context, url, destPath, dependencyName);
+
+      expect(axios.get).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          responseType: 'stream',
+          headers: expect.objectContaining({ 'Accept-Encoding': 'identity' }),
+          decompress: false,
+        })
+      );
+    });
+
+    it('tolerates Content-Encoding by skipping the size check (regression: dotnet-install.ps1 gzip)', async () => {
+      mockWriter();
+      // Server ignored our identity hint and gzipped anyway. Content-Length describes
+      // the compressed bytes (24942) but we record the decoded bytes piped to disk
+      // (76680). Previously this threw DownloadIntegrityError; now it succeeds.
+      const decoded = 'a'.repeat(76680);
+      mockAxiosStream([decoded], {
+        'content-encoding': 'gzip',
+        'content-length': '24942',
+      });
+
+      const result = await downloadFileWithVerification(context, url, destPath, dependencyName);
+
+      expect(result.actualSize).toBe(76680);
+      expect(context.telemetry.properties[`${dependencyName}DownloadAttempts`]).toBe('1');
+    });
+
+    it('still enforces size mismatches when no Content-Encoding is present', async () => {
+      mockWriter();
+      mockAxiosStream(['short'], { 'content-length': '999' });
+      mockWriter();
+      mockAxiosStream(['short'], { 'content-length': '999' });
+      mockWriter();
+      mockAxiosStream(['short'], { 'content-length': '999' });
+
+      await expect(downloadFileWithVerification(context, url, destPath, dependencyName, 3)).rejects.toBeInstanceOf(DownloadIntegrityError);
+      expect(axios.get).toHaveBeenCalledTimes(3);
+    }, 10000);
+  });
+
   describe('binariesExist', () => {
     beforeEach(() => {
       (getGlobalSetting as Mock).mockReturnValue('binariesLocation');
     });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     it('should return true if binaries exist', async () => {
       (fs.existsSync as Mock).mockReturnValue(true);
       const devContainerModule = await import('../devContainerUtils');
@@ -235,6 +285,49 @@ describe('binaries', () => {
 
       expect(result).toBe(false);
       expect(executeCommand).toHaveBeenCalledWith(ext.outputChannel, undefined, 'echo', `FuncCoreTools binary is missing: ${funcBinary}`);
+    });
+
+    it('should repair a stale Windows NodeJs binary path when node.exe exists', async () => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue(Platform.windows);
+      const nodeJsFolder = path.join('binariesLocation', nodeJsDependencyName);
+      const staleNodeBinary = path.join(nodeJsFolder, 'node');
+      const nodeExeBinary = path.join(nodeJsFolder, 'node.exe');
+      (fs.existsSync as Mock).mockImplementation((filePath: string) => filePath === nodeJsFolder || filePath === nodeExeBinary);
+      const devContainerModule = await import('../devContainerUtils');
+      vi.mocked(devContainerModule.isDevContainerWorkspace).mockResolvedValue(false);
+      (getGlobalSetting as Mock).mockImplementation((settingName?: string) =>
+        settingName === nodeJsBinaryPathSettingKey ? staleNodeBinary : 'binariesLocation'
+      );
+
+      const result = await binariesExist(nodeJsDependencyName);
+
+      expect(result).toBe(true);
+      expect(updateGlobalSetting).toHaveBeenCalledWith(nodeJsBinaryPathSettingKey, nodeExeBinary);
+      expect(executeCommand).toHaveBeenCalledWith(
+        ext.outputChannel,
+        undefined,
+        'echo',
+        `${nodeJsDependencyName} binary path updated: ${nodeExeBinary}`
+      );
+      expect(executeCommand).not.toHaveBeenCalledWith(ext.outputChannel, undefined, 'echo', `NodeJs binary is missing: ${staleNodeBinary}`);
+    });
+
+    it('should return false for a stale Windows NodeJs binary path when node.exe is also missing', async () => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue(Platform.windows);
+      const nodeJsFolder = path.join('binariesLocation', nodeJsDependencyName);
+      const staleNodeBinary = path.join(nodeJsFolder, 'node');
+      (fs.existsSync as Mock).mockImplementation((filePath: string) => filePath === nodeJsFolder);
+      const devContainerModule = await import('../devContainerUtils');
+      vi.mocked(devContainerModule.isDevContainerWorkspace).mockResolvedValue(false);
+      (getGlobalSetting as Mock).mockImplementation((settingName?: string) =>
+        settingName === nodeJsBinaryPathSettingKey ? staleNodeBinary : 'binariesLocation'
+      );
+
+      const result = await binariesExist(nodeJsDependencyName);
+
+      expect(result).toBe(false);
+      expect(updateGlobalSetting).not.toHaveBeenCalledWith(nodeJsBinaryPathSettingKey, expect.any(String));
+      expect(executeCommand).toHaveBeenCalledWith(ext.outputChannel, undefined, 'echo', `NodeJs binary is missing: ${staleNodeBinary}`);
     });
 
     it('should return false if useBinariesDependencies returns false', async () => {
@@ -588,6 +681,129 @@ describe('binaries', () => {
     });
   });
 
+  describe('removeWithLockWait', () => {
+    beforeEach(() => {
+      (fs as any).rmSync = vi.fn();
+      vi.mocked(fs.existsSync).mockReset();
+      vi.mocked(ext.outputChannel.appendLog).mockReset();
+    });
+
+    afterEach(() => {
+      delete (fs as any).rmSync;
+    });
+
+    it('returns immediately when the path does not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      await removeWithLockWait('C:/nope', 'TestDep', 1000);
+      expect((fs as any).rmSync).not.toHaveBeenCalled();
+    });
+
+    it('calls rmSync once when the directory is removable on the first attempt', async () => {
+      // exists -> true (so we try rmSync), then false (rmSync flushed).
+      vi.mocked(fs.existsSync).mockReturnValueOnce(true).mockReturnValueOnce(false);
+      (fs as any).rmSync.mockImplementation(() => undefined);
+      await removeWithLockWait('C:/dep', 'TestDep', 1000);
+      expect((fs as any).rmSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries when rmSync throws EPERM and eventually succeeds', async () => {
+      let calls = 0;
+      vi.mocked(fs.existsSync).mockImplementation(() => calls < 3); // true for first 3 checks, then false
+      (fs as any).rmSync.mockImplementation(() => {
+        calls += 1;
+        if (calls < 3) {
+          const err = new Error('EPERM') as Error & { code: string };
+          err.code = 'EPERM';
+          throw err;
+        }
+      });
+      await removeWithLockWait('C:/dep', 'TestDep', 5000);
+      expect((fs as any).rmSync).toHaveBeenCalledTimes(3);
+    });
+
+    it('throws after the budget elapses when rmSync keeps failing with EPERM', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs as any).rmSync.mockImplementation(() => {
+        const err = new Error('EPERM') as Error & { code: string };
+        err.code = 'EPERM';
+        throw err;
+      });
+      await expect(removeWithLockWait('C:/dep', 'TestDep', 600)).rejects.toThrow(/EPERM/);
+    });
+
+    it('throws immediately on a non-transient error (e.g. EINVAL)', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs as any).rmSync.mockImplementation(() => {
+        const err = new Error('EINVAL') as Error & { code: string };
+        err.code = 'EINVAL';
+        throw err;
+      });
+      await expect(removeWithLockWait('C:/dep', 'TestDep', 5000)).rejects.toThrow(/EINVAL/);
+      expect((fs as any).rmSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps waiting when rmSync silently leaves the directory in place (Windows pending-deletion)', async () => {
+      let existsCalls = 0;
+      // Stays true until the 5th existsSync call; rmSync always "succeeds" (returns undefined).
+      vi.mocked(fs.existsSync).mockImplementation(() => {
+        existsCalls += 1;
+        return existsCalls < 5;
+      });
+      (fs as any).rmSync.mockImplementation(() => undefined);
+      await removeWithLockWait('C:/dep', 'TestDep', 5000);
+      // rmSync attempted multiple times because each attempt found existsSync still true post-rm.
+      expect((fs as any).rmSync.mock.calls.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('mkdirWithLockWait', () => {
+    beforeEach(() => {
+      vi.mocked(fs.mkdirSync).mockReset();
+      vi.mocked(ext.outputChannel.appendLog).mockReset();
+    });
+
+    it('calls mkdirSync once on success', async () => {
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      await mkdirWithLockWait('C:/dep', 'TestDep', 1000);
+      expect(fs.mkdirSync).toHaveBeenCalledWith('C:/dep', { recursive: true });
+      expect(fs.mkdirSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on EPERM and ultimately resolves', async () => {
+      let calls = 0;
+      vi.mocked(fs.mkdirSync).mockImplementation(() => {
+        calls += 1;
+        if (calls < 3) {
+          const err = new Error('EPERM') as Error & { code: string };
+          err.code = 'EPERM';
+          throw err;
+        }
+        return undefined;
+      });
+      await mkdirWithLockWait('C:/dep', 'TestDep', 5000);
+      expect(calls).toBe(3);
+    });
+
+    it('throws after budget elapses when mkdirSync keeps failing', async () => {
+      vi.mocked(fs.mkdirSync).mockImplementation(() => {
+        const err = new Error('EPERM') as Error & { code: string };
+        err.code = 'EPERM';
+        throw err;
+      });
+      await expect(mkdirWithLockWait('C:/dep', 'TestDep', 600)).rejects.toThrow(/EPERM/);
+    });
+
+    it('throws immediately on a non-transient error', async () => {
+      vi.mocked(fs.mkdirSync).mockImplementation(() => {
+        const err = new Error('ENOSPC') as Error & { code: string };
+        err.code = 'ENOSPC';
+        throw err;
+      });
+      await expect(mkdirWithLockWait('C:/dep', 'TestDep', 5000)).rejects.toThrow(/ENOSPC/);
+      expect(fs.mkdirSync).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('useBinariesDependencies', () => {
     it('should return true if binaries dependencies are used', async () => {
       (getGlobalSetting as Mock).mockReturnValue(true);
@@ -627,6 +843,113 @@ describe('binaries', () => {
       const result = await useBinariesDependencies();
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe('verifyExtractedZip', () => {
+    const realFs = require('node:fs');
+    const os = require('os');
+    const pathMod = require('path');
+    const AdmZip = require('adm-zip');
+    let workDir: string;
+    let zipPath: string;
+    let extractDir: string;
+
+    beforeEach(() => {
+      // The global test-setup mocks fs.existsSync and fs.statSync to return undefined,
+      // which would make verifyExtractedZip see every file as missing. Re-route the
+      // sync filesystem calls to the real Node fs implementation for these tests.
+      (fs.existsSync as Mock).mockImplementation((p: string) => realFs.existsSync(p));
+      (fs.statSync as unknown as Mock) = vi.fn();
+      (fs.statSync as Mock).mockImplementation((p: string) => realFs.statSync(p));
+
+      workDir = realFs.mkdtempSync(pathMod.join(os.tmpdir(), 'verifyextract-'));
+      zipPath = pathMod.join(workDir, 'test.zip');
+      extractDir = pathMod.join(workDir, 'extracted');
+      realFs.mkdirSync(extractDir);
+
+      const zip = new AdmZip();
+      zip.addFile('a.txt', Buffer.from('hello'));
+      zip.addFile('sub/b.txt', Buffer.from('world!'));
+      zip.addFile('sub/c.bin', Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04]));
+      zip.writeZip(zipPath);
+    });
+
+    afterEach(() => {
+      try {
+        realFs.rmSync(workDir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    });
+
+    it('passes when every zip entry exists on disk with the expected size', async () => {
+      const { verifyExtractedZip } = await import('../binaries');
+      const zip = new AdmZip(zipPath);
+      zip.extractAllTo(extractDir, true, true);
+
+      expect(() => verifyExtractedZip(zip, extractDir)).not.toThrow();
+    });
+
+    it('throws BundleExtractionError(missing) when an extracted file is deleted', async () => {
+      const { verifyExtractedZip, BundleExtractionError } = await import('../binaries');
+      const zip = new AdmZip(zipPath);
+      zip.extractAllTo(extractDir, true, true);
+      realFs.rmSync(pathMod.join(extractDir, 'sub', 'b.txt'));
+
+      let caught: unknown;
+      try {
+        verifyExtractedZip(zip, extractDir);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(BundleExtractionError);
+      expect((caught as InstanceType<typeof BundleExtractionError>).kind).toBe('missing');
+      expect((caught as InstanceType<typeof BundleExtractionError>).entryName).toContain('b.txt');
+    });
+
+    it('throws BundleExtractionError(sizeMismatch) when an extracted file is truncated', async () => {
+      const { verifyExtractedZip, BundleExtractionError } = await import('../binaries');
+      const zip = new AdmZip(zipPath);
+      zip.extractAllTo(extractDir, true, true);
+      const target = pathMod.join(extractDir, 'sub', 'c.bin');
+      realFs.writeFileSync(target, Buffer.from([0x00])); // truncate from 5 bytes to 1
+
+      let caught: unknown;
+      try {
+        verifyExtractedZip(zip, extractDir);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(BundleExtractionError);
+      expect((caught as InstanceType<typeof BundleExtractionError>).kind).toBe('sizeMismatch');
+      expect((caught as InstanceType<typeof BundleExtractionError>).expectedSize).toBe(5);
+      expect((caught as InstanceType<typeof BundleExtractionError>).actualSize).toBe(1);
+    });
+
+    it('throws BundleExtractionError(missing) when extractDir is empty but the zip lists files', async () => {
+      const { verifyExtractedZip, BundleExtractionError } = await import('../binaries');
+      const zip = new AdmZip(zipPath);
+      // skip extractAllTo: simulate "extraction failed completely"
+
+      let caught: unknown;
+      try {
+        verifyExtractedZip(zip, extractDir);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(BundleExtractionError);
+      expect((caught as InstanceType<typeof BundleExtractionError>).kind).toBe('missing');
+    });
+
+    it('is a no-op for a zip that contains no file entries', async () => {
+      const { verifyExtractedZip } = await import('../binaries');
+      const emptyZipPath = pathMod.join(workDir, 'empty.zip');
+      const emptyZip = new AdmZip();
+      emptyZip.writeZip(emptyZipPath);
+      const zip = new AdmZip(emptyZipPath);
+
+      expect(() => verifyExtractedZip(zip, extractDir)).not.toThrow();
     });
   });
 });

--- a/apps/vs-code-designer/src/app/utils/__test__/bundleContentHash.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/bundleContentHash.test.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { computeBundleContentHash } from '../bundleFeed';
+import { bundleSourceMd5SidecarFile } from '../../../constants';
+
+// Override the global fs-extra mock from test-setup.ts with the real module so
+// these tests can actually create/read files on disk.
+vi.mock('fs-extra', async () => {
+  const actual = await vi.importActual<typeof import('fs-extra')>('fs-extra');
+  return actual;
+});
+
+// Resolve a real tmpdir without going through the globally-mocked `os` module.
+const realOs = (await vi.importActual<typeof import('os')>('os')) as typeof import('os');
+
+vi.mock('../../../extensionVariables', () => ({
+  ext: { outputChannel: { appendLog: vi.fn(), show: vi.fn() }, telemetryReporter: { sendTelemetryEvent: vi.fn() } },
+}));
+vi.mock('../../localize', () => ({ localize: vi.fn((_key: string, defaultValue: string) => defaultValue) }));
+
+describe('computeBundleContentHash', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fse.mkdtemp(path.join(realOs.tmpdir(), 'la-bundle-hash-'));
+  });
+
+  afterEach(async () => {
+    await fse.remove(tmpDir).catch(() => undefined);
+  });
+
+  it('returns undefined for a non-existent directory', async () => {
+    const result = await computeBundleContentHash(path.join(tmpDir, 'does-not-exist'));
+    expect(result).toBeUndefined();
+  });
+
+  it('is deterministic across repeated calls over the same tree', async () => {
+    await fse.outputFile(path.join(tmpDir, 'a.txt'), 'alpha');
+    await fse.outputFile(path.join(tmpDir, 'sub', 'b.bin'), Buffer.from([0, 1, 2, 3]));
+    const h1 = await computeBundleContentHash(tmpDir);
+    const h2 = await computeBundleContentHash(tmpDir);
+    expect(h1).toBeDefined();
+    expect(h1).toBe(h2);
+  });
+
+  it('matches the E2E preflight hash contract', async () => {
+    await fse.outputFile(path.join(tmpDir, 'a.txt'), 'alpha');
+    await fse.outputFile(path.join(tmpDir, 'sub', 'b.bin'), Buffer.from([0, 1, 2, 3]));
+    await fse.outputFile(path.join(tmpDir, bundleSourceMd5SidecarFile), JSON.stringify({ version: 1, sourceMd5: 'x', contentHash: 'y' }));
+
+    // Contract shared with run-e2e.js and bundleRepair.test.ts:
+    // sorted POSIX relative path, NUL, file size, NUL, file bytes, NUL;
+    // sidecar excluded; digest is base64 SHA-256.
+    await expect(computeBundleContentHash(tmpDir)).resolves.toBe('NCnH5Zy1riTeL6oGcO8/SmGZodVJojldZ8auMRwr2EM=');
+  });
+
+  it('changes when a single byte in a file is mutated', async () => {
+    await fse.outputFile(path.join(tmpDir, 'file.txt'), 'hello');
+    const before = await computeBundleContentHash(tmpDir);
+    await fse.outputFile(path.join(tmpDir, 'file.txt'), 'hellp'); // last char changed
+    const after = await computeBundleContentHash(tmpDir);
+    expect(before).not.toBe(after);
+  });
+
+  it('changes when a file is added', async () => {
+    await fse.outputFile(path.join(tmpDir, 'one.txt'), 'one');
+    const before = await computeBundleContentHash(tmpDir);
+    await fse.outputFile(path.join(tmpDir, 'two.txt'), 'two');
+    const after = await computeBundleContentHash(tmpDir);
+    expect(before).not.toBe(after);
+  });
+
+  it('changes when a file is removed', async () => {
+    await fse.outputFile(path.join(tmpDir, 'one.txt'), 'one');
+    await fse.outputFile(path.join(tmpDir, 'two.txt'), 'two');
+    const before = await computeBundleContentHash(tmpDir);
+    await fse.remove(path.join(tmpDir, 'two.txt'));
+    const after = await computeBundleContentHash(tmpDir);
+    expect(before).not.toBe(after);
+  });
+
+  it('excludes the sidecar file itself from the hash', async () => {
+    await fse.outputFile(path.join(tmpDir, 'a.txt'), 'alpha');
+    const without = await computeBundleContentHash(tmpDir);
+    await fse.outputFile(path.join(tmpDir, bundleSourceMd5SidecarFile), JSON.stringify({ version: 1, sourceMd5: 'x', contentHash: 'y' }));
+    const withSidecar = await computeBundleContentHash(tmpDir);
+    expect(without).toBe(withSidecar);
+  });
+
+  it('is path-sensitive: same bytes under different relative paths produce different hashes', async () => {
+    await fse.outputFile(path.join(tmpDir, 'a', 'file.txt'), 'same-bytes');
+    const h1 = await computeBundleContentHash(tmpDir);
+    await fse.remove(path.join(tmpDir, 'a'));
+    await fse.outputFile(path.join(tmpDir, 'b', 'file.txt'), 'same-bytes');
+    const h2 = await computeBundleContentHash(tmpDir);
+    expect(h1).not.toBe(h2);
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
@@ -5,17 +5,24 @@ import {
   getLatestVersionRange,
   addDefaultBundle,
   downloadExtensionBundle,
-  resetCachedBundleVersion
+  resetCachedBundleVersion,
+  isExtensionBundleDownloadInFlight,
+  waitForExtensionBundleReady,
+  getLastBundleInstallResult,
+  assertExtensionBundleOnDiskHealthy,
+  ensureExtensionBundleHealthy,
 } from '../bundleFeed';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as cp from 'child_process';
+import { Readable } from 'stream';
 import { extensionBundleId, defaultVersionRange, defaultExtensionBundlePathValue } from '../../../constants';
 import type { IHostJsonV2 } from '@microsoft/vscode-extension-logic-apps';
 import * as cpUtils from '../funcCoreTools/cpUtils';
 import * as feedModule from '../feed';
 import * as binariesModule from '../binaries';
+import { ext } from '../../../extensionVariables';
 
 // Mock fs-extra
 vi.mock('fs-extra', async (importOriginal) => {
@@ -24,9 +31,15 @@ vi.mock('fs-extra', async (importOriginal) => {
     ...(actual as object),
     readdir: vi.fn(),
     stat: vi.fn(),
+    lstat: vi.fn(),
     pathExists: vi.fn(),
     readdirSync: vi.fn(),
     statSync: vi.fn(),
+    readFile: vi.fn(),
+    createReadStream: vi.fn(),
+    outputFile: vi.fn().mockResolvedValue(undefined),
+    move: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -83,6 +96,15 @@ vi.mock('vscode', () => ({
       },
     ],
   },
+  window: {
+    // Invoke the task immediately so the wrapped download still runs and
+    // produces its side effects (mockedDownloadAndExtract calls, etc.).
+    withProgress: vi.fn(async (_opts: unknown, task: (...args: unknown[]) => Promise<unknown>) => task()),
+    showInformationMessage: vi.fn(),
+    showWarningMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+  },
+  ProgressLocation: { Notification: 15, SourceControl: 1, Window: 10 },
 }));
 
 // Mock feed module
@@ -95,9 +117,37 @@ vi.mock('../binaries', () => ({
   downloadAndExtractDependency: vi.fn(),
 }));
 
+// Mock integrity helpers (used by bundleFeed for HEAD-based hash verification)
+vi.mock('../integrity', () => ({
+  fetchExpectedMd5: vi.fn(),
+  isMissingPackageError: (error: unknown) => {
+    const status = (error as { response?: { status?: number } })?.response?.status;
+    if (typeof status === 'number') {
+      return status >= 400 && status < 500;
+    }
+    const code = (error as { code?: string })?.code;
+    if (typeof code === 'string') {
+      return code === 'ENOTFOUND' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'EAI_AGAIN' || code === 'ECONNRESET';
+    }
+    return false;
+  },
+}));
+
+// Mock vsCodeConfig/settings — bundleFeed reads experimental settings from here.
+vi.mock('../vsCodeConfig/settings', () => ({
+  getGlobalSetting: vi.fn().mockReturnValue(undefined),
+}));
+
 // Mock localSettings
 vi.mock('../appSettings/localSettings', () => ({
   getLocalSettingsJson: vi.fn().mockResolvedValue({}),
+}));
+
+// Mock the design-time launcher so we can observe the deferred post-install
+// restart fire AFTER `inFlightBundleWork` is cleared and the install result
+// is settled.
+vi.mock('../codeless/startDesignTimeApi', () => ({
+  startAllDesignTimeApis: vi.fn(),
 }));
 
 const mockedFse = vi.mocked(fse);
@@ -402,6 +452,7 @@ describe('getBundleVersionNumber', () => {
     const result = await getBundleVersionNumber();
 
     expect(result).toBe('2.1.0');
+    expect(ext.outputChannel.appendLog).toHaveBeenCalledWith('Current Logic Apps extension bundle version: 2.1.0');
     expect(mockedFse.readdir).toHaveBeenCalledWith(mockBundleFolder);
   });
 
@@ -583,27 +634,264 @@ describe('downloadExtensionBundle', () => {
     },
   });
 
-  beforeEach(() => {
+  // Helper: configure fs-extra so that the bundle versions in `localVersions` exist on disk
+  // and the sidecar contents (if provided) round-trip when readBundleSidecar reads them.
+  // `sidecarByVersion` keys are version strings; values are the publisher's MD5 to embed
+  // in the JSON sidecar's `sourceMd5` field. The sidecar's `contentHash` field is always
+  // set to the empty-tree hash (no files inside the version folder) so verifyLocalBundle's
+  // content-hash recompute returns the same value.
+  const EMPTY_TREE_HASH = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+  const buildSidecarJson = (sourceMd5: string, contentHash: string = EMPTY_TREE_HASH): string =>
+    JSON.stringify({ version: 1, sourceMd5, contentHash });
+  const setupHashableLocalDisk = (localVersion: string, fileContents = 'bundle-content') => {
+    const bundleDir = path.join(defaultExtensionBundlePathValue, localVersion);
+    const filePath = path.join(bundleDir, 'bin', 'bundle.dll');
+    const depsPath = path.join(bundleDir, 'bin', 'function.deps.json');
+    const depsContents = JSON.stringify({ targets: { bundle: { 'bundle/1.0.0': { runtime: { 'lib/netstandard2.0/bundle.dll': {} } } } } });
+
+    mockedFse.readdirSync.mockReturnValue([localVersion] as any);
+    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    mockedFse.pathExists.mockImplementation(((p: string) => {
+      if (typeof p === 'string' && p.endsWith('.bundle-source-md5')) {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(true);
+    }) as any);
+    mockedFse.readdir.mockImplementation(((p: string) => {
+      if (p === bundleDir) {
+        return Promise.resolve(['bin'] as any);
+      }
+      if (p === path.join(bundleDir, 'bin')) {
+        return Promise.resolve(['bundle.dll', 'function.deps.json'] as any);
+      }
+      return Promise.resolve([] as any);
+    }) as any);
+    mockedFse.lstat.mockImplementation(((p: string) =>
+      Promise.resolve({
+        isDirectory: () => p === path.join(bundleDir, 'bin'),
+        isFile: () => p === filePath || p === depsPath,
+      } as any)) as any);
+    mockedFse.stat.mockImplementation(((p: string) =>
+      Promise.resolve({
+        size: p === filePath ? Buffer.byteLength(fileContents) : p === depsPath ? Buffer.byteLength(depsContents) : 0,
+        isDirectory: () => p === bundleDir || p === path.join(bundleDir, 'bin'),
+        isFile: () => p === filePath || p === depsPath,
+      } as any)) as any);
+    mockedFse.readFile.mockImplementation(((p: string) => {
+      if (p === depsPath) {
+        return Promise.resolve(depsContents as any);
+      }
+      return Promise.resolve('' as any);
+    }) as any);
+    mockedFse.createReadStream.mockImplementation(((p: string) => {
+      if (p === filePath) {
+        return Readable.from([Buffer.from(fileContents)]) as any;
+      }
+      if (p === depsPath) {
+        return Readable.from([Buffer.from(depsContents)]) as any;
+      }
+      return Readable.from([]) as any;
+    }) as any);
+  };
+  const setupSingleFileLocalDisk = (localVersion: string, fileName = 'bundle.json') => {
+    const bundleDir = path.join(defaultExtensionBundlePathValue, localVersion);
+    const filePath = path.join(bundleDir, fileName);
+
+    mockedFse.readdirSync.mockReturnValue([localVersion] as any);
+    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    mockedFse.pathExists.mockImplementation(((p: string) => {
+      if (typeof p === 'string' && p.endsWith('.bundle-source-md5')) {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(p !== path.join(bundleDir, 'bin'));
+    }) as any);
+    mockedFse.readdir.mockImplementation(((p: string) => {
+      if (p === bundleDir) {
+        return Promise.resolve([fileName] as any);
+      }
+      return Promise.resolve([] as any);
+    }) as any);
+    mockedFse.lstat.mockImplementation(((p: string) =>
+      Promise.resolve({
+        isDirectory: () => false,
+        isFile: () => p === filePath,
+      } as any)) as any);
+    mockedFse.stat.mockImplementation(((p: string) =>
+      Promise.resolve({
+        size: p === filePath ? 2 : 0,
+        isDirectory: () => p === bundleDir,
+        isFile: () => p === filePath,
+      } as any)) as any);
+    mockedFse.createReadStream.mockImplementation(((p: string) => {
+      if (p === filePath) {
+        return Readable.from([Buffer.from('{}')]) as any;
+      }
+      return Readable.from([]) as any;
+    }) as any);
+  };
+  const setupBundleMissingRuntimeFile = (localVersion: string) => {
+    const bundleDir = path.join(defaultExtensionBundlePathValue, localVersion);
+    const binDir = path.join(bundleDir, 'bin');
+    const filePath = path.join(binDir, 'bundle.dll');
+    const depsPath = path.join(binDir, 'function.deps.json');
+    const depsContents = JSON.stringify({
+      targets: { bundle: { 'bundle/1.0.0': { runtime: { 'lib/netstandard2.0/bundle.dll': {}, 'lib/netstandard2.0/missing.dll': {} } } } },
+    });
+
+    mockedFse.readdirSync.mockReturnValue([localVersion] as any);
+    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    mockedFse.pathExists.mockImplementation(((p: string) => {
+      if (typeof p === 'string' && p.endsWith('.bundle-source-md5')) {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(p !== path.join(binDir, 'missing.dll'));
+    }) as any);
+    mockedFse.readdir.mockImplementation(((p: string) => {
+      if (p === bundleDir) {
+        return Promise.resolve(['bin'] as any);
+      }
+      if (p === binDir) {
+        return Promise.resolve(['bundle.dll', 'function.deps.json'] as any);
+      }
+      return Promise.resolve([] as any);
+    }) as any);
+    mockedFse.lstat.mockImplementation(((p: string) =>
+      Promise.resolve({
+        isDirectory: () => p === binDir,
+        isFile: () => p === filePath || p === depsPath,
+      } as any)) as any);
+    mockedFse.stat.mockImplementation(((p: string) =>
+      Promise.resolve({
+        size: p === filePath ? 2 : p === depsPath ? Buffer.byteLength(depsContents) : 0,
+        isDirectory: () => p === bundleDir || p === binDir,
+        isFile: () => p === filePath || p === depsPath,
+      } as any)) as any);
+    mockedFse.readFile.mockImplementation(((p: string) => {
+      if (p === depsPath) {
+        return Promise.resolve(depsContents as any);
+      }
+      return Promise.resolve('' as any);
+    }) as any);
+    mockedFse.createReadStream.mockImplementation(((p: string) => {
+      if (p === filePath) {
+        return Readable.from([Buffer.from('{}')]) as any;
+      }
+      if (p === depsPath) {
+        return Readable.from([Buffer.from(depsContents)]) as any;
+      }
+      return Readable.from([]) as any;
+    }) as any);
+  };
+  const setupRootFileWithEmptyBinLocalDisk = (localVersion: string) => {
+    const bundleDir = path.join(defaultExtensionBundlePathValue, localVersion);
+    const rootFilePath = path.join(bundleDir, 'bundle.json');
+    const binDir = path.join(bundleDir, 'bin');
+
+    mockedFse.readdirSync.mockReturnValue([localVersion] as any);
+    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    mockedFse.pathExists.mockImplementation(((p: string) => {
+      if (typeof p === 'string' && p.endsWith('.bundle-source-md5')) {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(true);
+    }) as any);
+    mockedFse.readdir.mockImplementation(((p: string) => {
+      if (p === bundleDir) {
+        return Promise.resolve(['bundle.json', 'bin'] as any);
+      }
+      if (p === binDir) {
+        return Promise.resolve([] as any);
+      }
+      return Promise.resolve([] as any);
+    }) as any);
+    mockedFse.lstat.mockImplementation(((p: string) =>
+      Promise.resolve({
+        isDirectory: () => p === binDir,
+        isFile: () => p === rootFilePath,
+      } as any)) as any);
+    mockedFse.stat.mockImplementation(((p: string) =>
+      Promise.resolve({
+        size: p === rootFilePath ? 2 : 0,
+        isDirectory: () => p === bundleDir || p === binDir,
+        isFile: () => p === rootFilePath,
+      } as any)) as any);
+    mockedFse.createReadStream.mockImplementation(((p: string) => {
+      if (p === rootFilePath) {
+        return Readable.from([Buffer.from('{}')]) as any;
+      }
+      return Readable.from([]) as any;
+    }) as any);
+  };
+  const setupLocalDisk = (
+    localVersions: string[],
+    sidecarByVersion: Record<string, string> = {},
+    options: { sidecarRaw?: Record<string, string>; sidecarContentHashOverride?: Record<string, string> } = {}
+  ) => {
+    mockedFse.readdirSync.mockReturnValue(localVersions as any);
+    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    // Async readdir is used by computeBundleContentHash's walk; return [] so it treats
+    // every version folder as an empty tree → content hash = EMPTY_TREE_HASH.
+    mockedFse.readdir.mockResolvedValue([] as any);
+    mockedFse.lstat.mockResolvedValue({ isDirectory: () => false, isFile: () => false } as any);
+    mockedFse.createReadStream.mockImplementation((() => Readable.from([])) as any);
+    mockedFse.pathExists.mockImplementation(((p: string) => {
+      // Default: bundle root and version folders exist; sidecar exists only when registered.
+      if (typeof p !== 'string') {
+        return Promise.resolve(true);
+      }
+      if (p.endsWith('.bundle-source-md5')) {
+        const inJson = Object.keys(sidecarByVersion).some((v) => p.includes(v));
+        const inRaw = Object.keys(options.sidecarRaw ?? {}).some((v) => p.includes(v));
+        return Promise.resolve(inJson || inRaw);
+      }
+      return Promise.resolve(true);
+    }) as any);
+    mockedFse.readFile.mockImplementation(((p: string) => {
+      if (typeof p !== 'string') {
+        return Promise.resolve('' as any);
+      }
+      const rawMatch = Object.entries(options.sidecarRaw ?? {}).find(([v]) => p.includes(v));
+      if (rawMatch) {
+        return Promise.resolve(rawMatch[1] as any);
+      }
+      const match = Object.entries(sidecarByVersion).find(([v]) => p.includes(v));
+      if (!match) {
+        return Promise.resolve('' as any);
+      }
+      const overrideHash = options.sidecarContentHashOverride?.[match[0]];
+      return Promise.resolve(buildSidecarJson(match[1], overrideHash ?? EMPTY_TREE_HASH) as any);
+    }) as any);
+  };
+
+  beforeEach(async () => {
     vi.clearAllMocks();
     // Reset environment variables
     delete process.env.AzureFunctionsJobHost_extensionBundle_version;
     delete process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+    // Default: experimental settings disabled
+    const settingsModule = await import('../vsCodeConfig/settings');
+    vi.mocked(settingsModule.getGlobalSetting).mockReturnValue(undefined);
+    // Default: HEAD request returns nothing — keeps tests that don't care about sidecar simple.
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue(undefined);
+    // Reset fs-extra mocks
+    mockedFse.readFile.mockReset();
+    mockedFse.outputFile.mockResolvedValue(undefined as any);
+    mockedFse.move.mockResolvedValue(undefined as any);
+    mockedFse.remove.mockResolvedValue(undefined as any);
   });
 
   it('should download newer version when feed has higher version than local', async () => {
     // Feed versions (simulating index.json format)
     const feedVersions = ['1.0.0', '1.1.0', '1.2.0', '1.3.0', '1.95.0'];
 
-    // Local version is 1.75.0
-    mockedFse.pathExists.mockResolvedValue(true as never);
-    mockedFse.readdirSync.mockReturnValue(['1.75.0'] as any);
-    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    setupLocalDisk(['1.75.0']);
 
     // Mock the feed to return the versions array
     mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
 
     // Mock download to succeed
-    mockedDownloadAndExtract.mockResolvedValue(undefined);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
 
     const context = createMockContext();
     const result = await downloadExtensionBundle(context as any);
@@ -622,36 +910,344 @@ describe('downloadExtensionBundle', () => {
     );
   });
 
-  it('should not download when local version is higher than feed versions', async () => {
-    // Feed only has older versions
+  it('should not download when local version is higher than feed versions and the on-disk sidecar matches the published MD5', async () => {
     const feedVersions = ['1.0.0', '1.1.0', '1.2.0'];
-
-    // Local version is already 1.75.0
-    mockedFse.pathExists.mockResolvedValue(true as never);
-    mockedFse.readdirSync.mockReturnValue(['1.75.0'] as any);
-    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    // Local version is already 1.75.0 with a valid sidecar.
+    const matchingMd5 = 'matching-md5-base64';
+    setupLocalDisk(['1.75.0'], { '1.75.0': matchingMd5 });
 
     mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue(matchingMd5);
 
     const context = createMockContext();
     const result = await downloadExtensionBundle(context as any);
 
-    // Should not download
     expect(result).toBe(false);
     expect(context.telemetry.properties.didUpdateExtensionBundle).toBe('false');
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('passed');
+    expect(context.telemetry.properties.extensionBundleVersionSource).toBe('localLatest');
     expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+  });
+
+  it('backfills sidecar metadata for a valid local bundle without re-downloading', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupHashableLocalDisk('1.95.0');
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('published-md5');
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(false);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarBackfilled');
+    expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+    expect(mockedFse.outputFile).toHaveBeenCalledWith(expect.stringContaining('.bundle-source-md5.'), expect.any(String), 'utf8');
+    expect(mockedFse.move).toHaveBeenCalledWith(
+      expect.stringContaining('.bundle-source-md5.'),
+      expect.stringContaining('.bundle-source-md5'),
+      { overwrite: true }
+    );
+    const payload = JSON.parse(mockedFse.outputFile.mock.calls[0]?.[1] as string);
+    expect(payload.sourceMd5).toBe('published-md5');
+    expect(payload.contentHash).toEqual(expect.any(String));
+  });
+
+  it('backfills content-hash-only sidecar metadata when CDN HEAD fails', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupHashableLocalDisk('1.95.0');
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockRejectedValue(new Error('network unavailable'));
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(false);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarBackfilled');
+    expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+    const payload = JSON.parse(mockedFse.outputFile.mock.calls[0]?.[1] as string);
+    expect(payload.sourceMd5).toBe('');
+    expect(payload.contentHash).toEqual(expect.any(String));
+  });
+
+  it('does not redownload a bundle whose existing sidecar was backfilled without source MD5', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupLocalDisk(['1.95.0'], { '1.95.0': '' });
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('published-md5');
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(false);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('passed');
+    expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+  });
+
+  it('should re-download when local version equals feed but the sidecar is missing and the bundle has no bin content', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupSingleFileLocalDisk('1.95.0');
+
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMissing');
+    expect(mockedDownloadAndExtract).toHaveBeenCalled();
+  });
+
+  it('should re-download when the sidecar is missing and the bundle manifest references a missing runtime file', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupBundleMissingRuntimeFile('1.95.0');
+
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMissing');
+    expect(mockedDownloadAndExtract).toHaveBeenCalled();
+  });
+
+  it('should re-download when a root file exists but the bundle bin folder is empty', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupRootFileWithEmptyBinLocalDisk('1.95.0');
+
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMissing');
+    expect(mockedDownloadAndExtract).toHaveBeenCalled();
+  });
+
+  it('falls back to redownload when sidecar backfill cannot write metadata', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupHashableLocalDisk('1.95.0');
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('published-md5');
+    mockedFse.move.mockRejectedValueOnce(new Error('sidecar locked'));
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMissing');
+    expect(mockedDownloadAndExtract).toHaveBeenCalled();
+  });
+
+  it('should re-download when local version equals feed but the sidecar is missing and the bundle has no content', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupLocalDisk(['1.95.0']); // no sidecar registered → readBundleSidecar returns undefined
+
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMissing');
+    expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('1.95.0'),
+      defaultExtensionBundlePathValue,
+      extensionBundleId,
+      '1.95.0'
+    );
+  });
+
+  it('should re-download when local version equals feed but the sidecar drifted from the published MD5', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupLocalDisk(['1.95.0'], { '1.95.0': 'old-md5' });
+
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('new-md5');
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMismatch');
+    expect(mockedDownloadAndExtract).toHaveBeenCalled();
+  });
+
+  it('should keep using local when the HEAD request fails', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupLocalDisk(['1.95.0'], { '1.95.0': 'some-md5' });
+
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockRejectedValue(new Error('network down'));
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(false);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('headRequestFailed');
+    expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+  });
+
+  it('shows a warning toast + progress notification when a corrupt local bundle is re-downloaded', async () => {
+    const vscode = await import('vscode');
+    const feedVersions = ['1.0.0', '1.95.0'];
+    // Local 1.95.0 with a sidecar that mismatches the CDN's published MD5.
+    setupLocalDisk(['1.95.0'], { '1.95.0': 'stale-on-disk-md5' });
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('fresh-cdn-md5');
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMismatch');
+    expect(vi.mocked(vscode.window.showWarningMessage)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(vscode.window.showWarningMessage).mock.calls[0]?.[0]).toMatch(/incomplete|checksum/i);
+    expect(vi.mocked(vscode.window.withProgress)).toHaveBeenCalled();
+    const progressTitle = (vi.mocked(vscode.window.withProgress).mock.calls[0]?.[0] as any)?.title ?? '';
+    expect(progressTitle).toMatch(/Re-downloading.*1\.95\.0/);
+    expect(vi.mocked(vscode.window.showInformationMessage)).toHaveBeenCalledWith(expect.stringMatching(/1\.95\.0.*ready/i));
+  });
+
+  it('shows a progress notification when a newer feed version is downloaded (no corruption warning)', async () => {
+    const vscode = await import('vscode');
+    setupLocalDisk(['1.75.0']);
+    mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(vi.mocked(vscode.window.showWarningMessage)).not.toHaveBeenCalled();
+    const progressTitle = (vi.mocked(vscode.window.withProgress).mock.calls[0]?.[0] as any)?.title ?? '';
+    expect(progressTitle).toMatch(/Downloading newer.*1\.95\.0/);
+    expect(vi.mocked(vscode.window.showInformationMessage)).toHaveBeenCalledWith(expect.stringMatching(/1\.95\.0.*ready/i));
+  });
+
+  // --- Phase 8: content-hash recompute ---
+
+  it('legacy bare-MD5 sidecar is treated as sidecarMissing (silent migration, no warning toast)', async () => {
+    const vscode = await import('vscode');
+    setupLocalDisk(['1.95.0'], {}, { sidecarRaw: { '1.95.0': 'legacy-bare-md5-string' } });
+    mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMissing');
+    // Migration path: silent — no warning toast for legacy users.
+    expect(vi.mocked(vscode.window.showWarningMessage)).not.toHaveBeenCalled();
+    expect(mockedDownloadAndExtract).toHaveBeenCalled();
+  });
+
+  it('JSON sidecar with wrong contentHash → contentMismatch + warning toast + redownload', async () => {
+    const vscode = await import('vscode');
+    setupLocalDisk(['1.95.0'], { '1.95.0': 'sourceMd5-ok' }, { sidecarContentHashOverride: { '1.95.0': 'wrong-content-hash' } });
+    mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('contentMismatch');
+    expect(vi.mocked(vscode.window.showWarningMessage)).toHaveBeenCalledTimes(1);
+    const progressTitle = (vi.mocked(vscode.window.withProgress).mock.calls[0]?.[0] as any)?.title ?? '';
+    expect(progressTitle).toMatch(/modified or corrupted/);
+    expect(mockedDownloadAndExtract).toHaveBeenCalled();
+  });
+
+  it('JSON sidecar with correct contentHash + matching CDN MD5 → passed (no download)', async () => {
+    const matchingMd5 = 'matching-md5';
+    setupLocalDisk(['1.95.0'], { '1.95.0': matchingMd5 });
+    mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue(matchingMd5);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(false);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('passed');
+    expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+  });
+
+  it('dedupes concurrent downloadExtensionBundle calls + waitForExtensionBundleReady blocks until done', async () => {
+    setupLocalDisk(['1.75.0']);
+    mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+    // Hold the download open so the second call has time to observe the in-flight state.
+    let releaseDownload: () => void = () => undefined;
+    const downloadGate = new Promise<void>((resolve) => {
+      releaseDownload = resolve;
+    });
+    mockedDownloadAndExtract.mockImplementation(async () => {
+      await downloadGate;
+      return { actualMd5: 'md5' } as any;
+    });
+
+    expect(isExtensionBundleDownloadInFlight()).toBe(false);
+
+    const context1 = createMockContext();
+    const context2 = createMockContext();
+    const first = downloadExtensionBundle(context1 as any);
+    // Yield so the first call records itself as in-flight before the second starts.
+    await Promise.resolve();
+    expect(isExtensionBundleDownloadInFlight()).toBe(true);
+
+    const second = downloadExtensionBundle(context2 as any);
+    const readyWait = waitForExtensionBundleReady();
+    let readyResolved = false;
+    readyWait.then(() => {
+      readyResolved = true;
+    });
+    // Give the event loop a tick to confirm the readyWait promise is still pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(readyResolved).toBe(false);
+
+    releaseDownload();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    await readyWait;
+
+    expect(firstResult).toBe(true);
+    // The deduped second call returns false (no new work) and doesn't fire another download.
+    expect(secondResult).toBe(false);
+    expect(mockedDownloadAndExtract).toHaveBeenCalledTimes(1);
+    expect(isExtensionBundleDownloadInFlight()).toBe(false);
+    expect(readyResolved).toBe(true);
   });
 
   it('should correctly identify the latest version from an unordered feed list', async () => {
     // Feed versions in random order
     const feedVersions = ['1.3.0', '1.95.0', '1.0.0', '1.50.0', '1.1.0'];
 
-    // No local versions
-    mockedFse.pathExists.mockResolvedValue(true as never);
-    mockedFse.readdirSync.mockReturnValue([] as any);
+    setupLocalDisk([]);
 
     mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
-    mockedDownloadAndExtract.mockResolvedValue(undefined);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
 
     const context = createMockContext();
     const result = await downloadExtensionBundle(context as any);
@@ -671,13 +1267,10 @@ describe('downloadExtensionBundle', () => {
     // Feed has 1.95.0
     const feedVersions = ['1.0.0', '1.95.0'];
 
-    // Multiple local versions, highest is 1.75.0
-    mockedFse.pathExists.mockResolvedValue(true as never);
-    mockedFse.readdirSync.mockReturnValue(['1.50.0', '1.75.0', '1.60.0'] as any);
-    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    setupLocalDisk(['1.50.0', '1.75.0', '1.60.0']);
 
     mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
-    mockedDownloadAndExtract.mockResolvedValue(undefined);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
 
     const context = createMockContext();
     const result = await downloadExtensionBundle(context as any);
@@ -691,5 +1284,781 @@ describe('downloadExtensionBundle', () => {
       extensionBundleId,
       '1.95.0'
     );
+  });
+
+  it('does not re-download when the env-var-pinned version is one of several local versions', async () => {
+    // Phase 5 bug fix: previously this used `semver.eq(envVarVer, latestLocalBundleVersion)`,
+    // which returned false when the pin was not the *highest* local version, causing a
+    // pointless redownload. Membership in localVersions is the right check.
+    const localSettingsMod = await import('../appSettings/localSettings');
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({
+      Values: { AzureFunctionsJobHost_extensionBundle_version: '1.50.0' },
+    } as any);
+    // Phase 14: pinned-version short-circuit now verifies the on-disk bundle
+    // before trusting it. Provide a sidecar so verifyLocalBundle returns 'passed'.
+    setupLocalDisk(['1.50.0', '1.60.0'], { '1.50.0': 'pinSourceMd5' });
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('pinSourceMd5');
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(false);
+    expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+    expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+    expect(context.telemetry.properties.extensionBundleVersionSource).toBe('envVar');
+    expect(context.telemetry.properties.didUpdateExtensionBundle).toBe('false');
+  });
+
+  it('downloads exactly the env-var-pinned version when not on disk', async () => {
+    const localSettingsMod = await import('../appSettings/localSettings');
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({
+      Values: { AzureFunctionsJobHost_extensionBundle_version: '1.50.0' },
+    } as any);
+    setupLocalDisk(['1.60.0']);
+    mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('1.50.0'),
+      defaultExtensionBundlePathValue,
+      extensionBundleId,
+      '1.50.0'
+    );
+  });
+
+  describe('experimental extension bundle', () => {
+    const setExperimentalSettings = async (values: { useExperimental?: boolean; sourceUri?: string; pinnedVersion?: string } = {}) => {
+      const settingsModule = await import('../vsCodeConfig/settings');
+      vi.mocked(settingsModule.getGlobalSetting).mockImplementation((key: string) => {
+        if (key === 'useExperimentalExtensionBundle') {
+          return values.useExperimental as any;
+        }
+        if (key === 'experimentalExtensionBundleSourceUri') {
+          return (values.sourceUri ?? '') as any;
+        }
+        if (key === 'experimentalExtensionBundleVersion') {
+          return (values.pinnedVersion ?? '') as any;
+        }
+        return undefined;
+      });
+    };
+
+    it('uses the pinned local version and never calls the public feed', async () => {
+      await setExperimentalSettings({ useExperimental: true, pinnedVersion: '1.21.0' });
+      // Phase 14: experimental pin short-circuit now verifies on disk.
+      setupLocalDisk(['1.21.0'], { '1.21.0': 'pinSourceMd5' });
+      const integrityModule = await import('../integrity');
+      vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('pinSourceMd5');
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(false);
+      expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+      expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalLocalPin');
+    });
+
+    it('downloads the pinned version from the experimental URI when missing on disk', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        pinnedVersion: '1.21.0-preview',
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk(['1.20.0']); // pin not on disk
+      // Source URI's index lists the pin.
+      mockedGetJsonFeed.mockResolvedValue(['1.10.0', '1.21.0-preview'] as any);
+      mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      // Index is probed against the experimental URI only — never the public CDN.
+      const indexCall = (mockedGetJsonFeed.mock.calls[0]?.[1] as string) ?? '';
+      expect(indexCall).toContain('https://private-cdn.example.com/public');
+      expect(mockedDownloadAndExtract).toHaveBeenCalledTimes(1);
+      expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('https://private-cdn.example.com/public'),
+        defaultExtensionBundlePathValue,
+        extensionBundleId,
+        '1.21.0-preview'
+      );
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalFirstDownload');
+      expect(context.telemetry.properties.experimentalSourceFallback).toBeUndefined();
+    });
+
+    it('falls back to the public CDN for the pin when source URI is empty and pin is not on disk', async () => {
+      // I3 in the plan: pin set, not on disk, no sourceUri → download `pin` from public CDN.
+      await setExperimentalSettings({ useExperimental: true, pinnedVersion: '1.21.0', sourceUri: '' });
+      setupLocalDisk(['1.20.0']); // pin not on disk
+      mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      // No index probe (no sourceUri to probe).
+      expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+      expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('cdn.functions.azure.com/public'),
+        defaultExtensionBundlePathValue,
+        extensionBundleId,
+        '1.21.0'
+      );
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalFirstDownload');
+    });
+
+    it('uses latest local without consulting the public feed when no pin is set', async () => {
+      await setExperimentalSettings({ useExperimental: true });
+      // Phase 14: experimental no-pin short-circuit now verifies on disk.
+      setupLocalDisk(['1.50.0', '1.75.0'], { '1.75.0': 'latestSourceMd5' });
+      const integrityModule = await import('../integrity');
+      vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('latestSourceMd5');
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(false);
+      expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+      expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalLocalLatest');
+    });
+
+    it('cold-starts from the experimental URI when nothing is on disk', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk([]);
+      mockedGetJsonFeed.mockResolvedValue(['1.10.0', '1.21.0-preview'] as any);
+      mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      // Should fetch the experimental index, not the public one.
+      const calledWith = (mockedGetJsonFeed.mock.calls[0]?.[1] as string) ?? '';
+      expect(calledWith).toContain('https://private-cdn.example.com/public');
+      expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('https://private-cdn.example.com/public'),
+        defaultExtensionBundlePathValue,
+        extensionBundleId,
+        '1.21.0-preview'
+      );
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalFirstDownload');
+    });
+
+    it('falls through to the public feed when toggle is on but no pin / no local / no source URI', async () => {
+      await setExperimentalSettings({ useExperimental: true });
+      setupLocalDisk([]);
+      mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      expect(context.telemetry.properties.experimentalFellThroughToPublic).toBe('true');
+      expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('1.95.0'),
+        defaultExtensionBundlePathValue,
+        extensionBundleId,
+        '1.95.0'
+      );
+    });
+
+    // ----- Phase 5 fallback tests -----
+
+    const make404 = () => {
+      const err: any = new Error('Request failed with status code 404');
+      err.response = { status: 404, headers: {}, data: '' };
+      err.isAxiosError = true;
+      return err;
+    };
+    const makeNetworkError = () => {
+      const err: any = new Error('getaddrinfo ENOTFOUND private-cdn.example.com');
+      err.code = 'ENOTFOUND';
+      err.isAxiosError = true;
+      return err;
+    };
+
+    it('falls back to the public CDN when the experimental URI returns 404 for the pinned zip', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        pinnedVersion: '1.21.0-preview',
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk(['1.20.0']);
+      // Index probe lists the pin so we proceed to download from the source.
+      mockedGetJsonFeed.mockResolvedValue(['1.21.0-preview'] as any);
+      // Source download 404s, public download succeeds.
+      mockedDownloadAndExtract.mockRejectedValueOnce(make404()).mockResolvedValueOnce({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      expect(mockedDownloadAndExtract).toHaveBeenCalledTimes(2);
+      const firstUrl = mockedDownloadAndExtract.mock.calls[0]?.[1] as string;
+      const secondUrl = mockedDownloadAndExtract.mock.calls[1]?.[1] as string;
+      expect(firstUrl).toContain('private-cdn.example.com');
+      expect(secondUrl).toContain('cdn.functions.azure.com/public');
+      expect(secondUrl).toContain('1.21.0-preview');
+      expect(context.telemetry.properties.experimentalSourceFallback).toBe('zip404');
+      expect(context.telemetry.properties.experimentalSourceFallbackTarget).toBe('public');
+    });
+
+    it('falls back to the public CDN when the experimental index does not list the pin', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        pinnedVersion: '1.21.0-preview',
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk(['1.20.0']);
+      // Index probe succeeds but pin is missing.
+      mockedGetJsonFeed.mockResolvedValue(['1.10.0', '1.20.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      // Only one download — straight to public, no source-zip attempt.
+      expect(mockedDownloadAndExtract).toHaveBeenCalledTimes(1);
+      const url = mockedDownloadAndExtract.mock.calls[0]?.[1] as string;
+      expect(url).toContain('cdn.functions.azure.com/public');
+      expect(url).toContain('1.21.0-preview');
+      expect(context.telemetry.properties.experimentalSourceFallback).toBe('pinNotInIndex');
+    });
+
+    it('falls back to the public feed when the experimental index returns 404 (cold start, no pin)', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk([]);
+      // First getJsonFeed call (experimental index) 404s, second call (public feed) succeeds.
+      mockedGetJsonFeed.mockRejectedValueOnce(make404()).mockResolvedValueOnce(['1.0.0', '1.95.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      expect(context.telemetry.properties.experimentalSourceFallback).toBe('index404');
+      expect(context.telemetry.properties.experimentalFellThroughToPublic).toBe('true');
+      const url = mockedDownloadAndExtract.mock.calls.at(-1)?.[1] as string;
+      expect(url).toContain('cdn.functions.azure.com/public');
+      expect(url).toContain('1.95.0');
+    });
+
+    it('falls back to the public feed on a network error to the experimental URI (cold start, no pin)', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk([]);
+      mockedGetJsonFeed.mockRejectedValueOnce(makeNetworkError()).mockResolvedValueOnce(['1.0.0', '1.95.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      expect(context.telemetry.properties.experimentalSourceFallback).toBe('networkError');
+      expect(context.telemetry.properties.experimentalFellThroughToPublic).toBe('true');
+    });
+
+    it('throws when both the experimental URI and the public CDN 404 for the pinned version', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        pinnedVersion: '9.9.9-bogus',
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk(['1.20.0']);
+      mockedGetJsonFeed.mockResolvedValue(['9.9.9-bogus'] as any);
+      mockedDownloadAndExtract.mockRejectedValueOnce(make404()).mockRejectedValueOnce(make404());
+
+      const context = createMockContext();
+      // Phase 12+: `downloadExtensionBundleCore` now re-throws on failure so
+      // the outer wrapper records `lastBundleInstallResult = 'failed'` and
+      // downstream consumers (validateAndInstallBinaries, startDesignTimeApi)
+      // can refuse to spawn func.exe. The test originally asserted a swallow
+      // returning `false`; that silently let func start against a missing
+      // bundle.
+      await expect(downloadExtensionBundle(context as any)).rejects.toThrow();
+      expect(mockedDownloadAndExtract).toHaveBeenCalledTimes(2);
+      expect(getLastBundleInstallResult()).toBe('failed');
+    });
+
+    it('does not honor the source URI when the master toggle is off', async () => {
+      await setExperimentalSettings({
+        useExperimental: false,
+        sourceUri: 'https://private-cdn.example.com/public',
+        pinnedVersion: '1.21.0-preview',
+      });
+      setupLocalDisk(['1.20.0']);
+      mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      // Public CDN, public latest — toggle off means experimental settings are ignored.
+      const url = mockedDownloadAndExtract.mock.calls[0]?.[1] as string;
+      expect(url).toContain('cdn.functions.azure.com/public');
+      expect(url).toContain('1.95.0');
+      expect(url).not.toContain('private-cdn.example.com');
+      expect(url).not.toContain('1.21.0-preview');
+    });
+  });
+
+  describe('deferred post-install design-time restart', () => {
+    it('fires startAllDesignTimeApis after the install settles when an update happened', async () => {
+      const startApiModule = await import('../codeless/startDesignTimeApi');
+      const mockedStart = vi.mocked(startApiModule.startAllDesignTimeApis);
+      let inFlightWhenCalled: boolean | undefined;
+      let lastResultWhenCalled: ReturnType<typeof getLastBundleInstallResult> | undefined;
+      mockedStart.mockImplementation(async () => {
+        inFlightWhenCalled = isExtensionBundleDownloadInFlight();
+        lastResultWhenCalled = getLastBundleInstallResult();
+      });
+
+      setupLocalDisk(['1.75.0']);
+      mockedGetJsonFeed.mockResolvedValue(['1.95.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue({ actualMd5: 'md5' } as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+      expect(result).toBe(true);
+
+      // Restart is fire-and-forget — yield to the microtask queue so the IIFE runs.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockedStart).toHaveBeenCalledTimes(1);
+      expect(inFlightWhenCalled).toBe(false);
+      expect(lastResultWhenCalled).toBe('ok');
+    });
+
+    it('does NOT fire startAllDesignTimeApis when the download throws', async () => {
+      const startApiModule = await import('../codeless/startDesignTimeApi');
+      const mockedStart = vi.mocked(startApiModule.startAllDesignTimeApis);
+      mockedStart.mockResolvedValue(undefined as any);
+
+      setupLocalDisk(['1.75.0']);
+      mockedGetJsonFeed.mockResolvedValue(['1.95.0'] as any);
+      mockedDownloadAndExtract.mockRejectedValue(new Error('boom'));
+
+      const context = createMockContext();
+      await expect(downloadExtensionBundle(context as any)).rejects.toThrow();
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockedStart).not.toHaveBeenCalled();
+      expect(getLastBundleInstallResult()).toBe('failed');
+    });
+  });
+});
+
+describe('getExtensionBundleBaseUrl', () => {
+  let getExtensionBundleBaseUrl: typeof import('../bundleFeed').getExtensionBundleBaseUrl;
+  let settingsModule: typeof import('../vsCodeConfig/settings');
+  let localSettingsMod: typeof import('../appSettings/localSettings');
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    delete process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+    ({ getExtensionBundleBaseUrl } = await import('../bundleFeed'));
+    settingsModule = await import('../vsCodeConfig/settings');
+    localSettingsMod = await import('../appSettings/localSettings');
+    vi.mocked(settingsModule.getGlobalSetting).mockReturnValue(undefined);
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({} as any);
+  });
+
+  const ctx = () => ({
+    telemetry: { properties: {} as Record<string, string>, measurements: {} as Record<string, number> },
+  });
+
+  it('uses local.settings.json over everything else', async () => {
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({
+      Values: { FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI: 'https://from-local-settings' },
+    } as any);
+    process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI = 'https://from-env';
+    vi.mocked(settingsModule.getGlobalSetting).mockImplementation((key: string) =>
+      key === 'useExperimentalExtensionBundle'
+        ? (true as any)
+        : key === 'experimentalExtensionBundleSourceUri'
+          ? ('https://from-vscode' as any)
+          : undefined
+    );
+
+    const c = ctx();
+    const result = await getExtensionBundleBaseUrl(c as any);
+    expect(result.baseUrl).toBe('https://from-local-settings');
+    expect(result.source).toBe('localSettings');
+    expect(c.telemetry.properties.extensionBundleBaseUrlSource).toBe('localSettings');
+  });
+
+  it('uses process.env when local.settings.json is empty', async () => {
+    process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI = 'https://from-env';
+    const result = await getExtensionBundleBaseUrl(ctx() as any);
+    expect(result.baseUrl).toBe('https://from-env');
+    expect(result.source).toBe('envVar');
+  });
+
+  it('uses experimental setting when toggle is on and the higher-precedence sources are empty', async () => {
+    vi.mocked(settingsModule.getGlobalSetting).mockImplementation((key: string) =>
+      key === 'useExperimentalExtensionBundle'
+        ? (true as any)
+        : key === 'experimentalExtensionBundleSourceUri'
+          ? ('https://from-vscode' as any)
+          : undefined
+    );
+    const result = await getExtensionBundleBaseUrl(ctx() as any);
+    expect(result.baseUrl).toBe('https://from-vscode');
+    expect(result.source).toBe('experimentalSetting');
+    expect(result.isExperimental).toBe(true);
+  });
+
+  it('falls back to the public CDN when nothing is configured', async () => {
+    const result = await getExtensionBundleBaseUrl(ctx() as any);
+    expect(result.baseUrl).toBe('https://cdn.functions.azure.com/public');
+    expect(result.source).toBe('default');
+  });
+});
+
+describe('assertExtensionBundleOnDiskHealthy', () => {
+  const EMPTY_TREE_HASH = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+  const sidecarJson = (sourceMd5: string, contentHash: string) => JSON.stringify({ version: 1, sourceMd5, contentHash });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fse.readFile).mockReset();
+    vi.mocked(fse.outputFile).mockResolvedValue(undefined as any);
+  });
+
+  it('returns ok when sidecar contentHash matches the recomputed on-disk hash', async () => {
+    vi.mocked(fse.readdirSync).mockReturnValue(['1.50.0'] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    vi.mocked(fse.readFile).mockResolvedValue(sidecarJson('anyMd5', EMPTY_TREE_HASH) as any);
+
+    const result = await assertExtensionBundleOnDiskHealthy();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.version).toBe('1.50.0');
+    }
+  });
+
+  it('returns contentMismatch when the recomputed hash does not match the sidecar', async () => {
+    vi.mocked(fse.readdirSync).mockReturnValue(['1.50.0'] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    // Sidecar claims a different hash than what computeBundleContentHash would
+    // return for an empty tree.
+    vi.mocked(fse.readFile).mockResolvedValue(sidecarJson('anyMd5', 'TOTALLY-DIFFERENT-HASH') as any);
+
+    const result = await assertExtensionBundleOnDiskHealthy();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('contentMismatch');
+      expect(result.version).toBe('1.50.0');
+    }
+  });
+
+  it('returns sidecarMissing when no sidecar exists', async () => {
+    vi.mocked(fse.readdirSync).mockReturnValue(['1.50.0'] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    // pathExists returns true for bundle dir, false for sidecar file.
+    vi.mocked(fse.pathExists).mockImplementation(((p: string) => {
+      if (typeof p === 'string' && p.endsWith('.bundle-source-md5')) {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(true);
+    }) as any);
+
+    const result = await assertExtensionBundleOnDiskHealthy();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('sidecarMissing');
+    }
+  });
+
+  it('returns noBundle when no local bundle version exists', async () => {
+    vi.mocked(fse.readdirSync).mockReturnValue([] as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    const result = await assertExtensionBundleOnDiskHealthy();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('noBundle');
+    }
+  });
+});
+
+describe('ensureExtensionBundleHealthy repair gate', () => {
+  const EMPTY_TREE_HASH = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+  const sidecarJson = (sourceMd5: string, contentHash: string) => JSON.stringify({ version: 1, sourceMd5, contentHash });
+
+  const ctx = () => ({
+    telemetry: { properties: {} as Record<string, string>, measurements: {} as Record<string, number> },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCachedBundleVersion();
+    vi.mocked(fse.readFile).mockReset();
+    vi.mocked(fse.outputFile).mockResolvedValue(undefined as any);
+  });
+
+  it('passes through when on-disk health check returns ok', async () => {
+    vi.mocked(fse.readdirSync).mockReturnValue(['1.50.0'] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    vi.mocked(fse.readFile).mockResolvedValue(sidecarJson('md5', EMPTY_TREE_HASH) as any);
+
+    await expect(ensureExtensionBundleHealthy(ctx() as any)).resolves.toBeUndefined();
+    expect(ext.outputChannel.appendLog).toHaveBeenCalledWith('Logic Apps extension bundle 1.50.0 on-disk integrity check passed.');
+    expect(vi.mocked(binariesModule.downloadAndExtractDependency)).not.toHaveBeenCalled();
+  });
+
+  it('triggers a repair download when on-disk health check fails', async () => {
+    let callIdx = 0;
+    vi.mocked(fse.readdirSync).mockReturnValue(['1.50.0'] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    // 1st read (initial assertExtensionBundleOnDiskHealthy): WRONG → mismatch.
+    // 2nd read (downloadExtensionBundle default-flow verifyLocalBundle): WRONG → triggers download.
+    // 3rd+ reads (post-repair re-check): CORRECT.
+    vi.mocked(fse.readFile).mockImplementation((async () => {
+      callIdx++;
+      return callIdx <= 2 ? sidecarJson('md5', 'WRONG') : sidecarJson('md5', EMPTY_TREE_HASH);
+    }) as any);
+    vi.mocked(feedModule.getJsonFeed).mockResolvedValue(['1.50.0'] as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('md5');
+    vi.mocked(binariesModule.downloadAndExtractDependency).mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    await expect(ensureExtensionBundleHealthy(ctx() as any)).resolves.toBeUndefined();
+    expect(vi.mocked(binariesModule.downloadAndExtractDependency)).toHaveBeenCalled();
+  });
+
+  it('repairs instead of backfilling when the strict on-disk health gate lacks a sidecar', async () => {
+    const localVersion = '1.50.0';
+    const bundleDir = path.join(defaultExtensionBundlePathValue, localVersion);
+    const filePath = path.join(bundleDir, 'bin', 'bundle.dll');
+    const depsPath = path.join(bundleDir, 'bin', 'function.deps.json');
+    const depsContents = JSON.stringify({ targets: { bundle: { 'bundle/1.0.0': { runtime: { 'lib/netstandard2.0/bundle.dll': {} } } } } });
+    let sidecarExists = false;
+    let sidecarPayload = '';
+
+    vi.mocked(fse.readdirSync).mockReturnValue([localVersion] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockImplementation(((p: string) => {
+      if (typeof p === 'string' && p.endsWith('.bundle-source-md5')) {
+        return Promise.resolve(sidecarExists);
+      }
+      return Promise.resolve(true);
+    }) as any);
+    vi.mocked(fse.readdir).mockImplementation(((p: string) => {
+      if (p === bundleDir) {
+        return Promise.resolve(['bin'] as any);
+      }
+      if (p === path.join(bundleDir, 'bin')) {
+        return Promise.resolve(['bundle.dll', 'function.deps.json'] as any);
+      }
+      return Promise.resolve([] as any);
+    }) as any);
+    vi.mocked(fse.lstat).mockImplementation(((p: string) =>
+      Promise.resolve({
+        isDirectory: () => p === path.join(bundleDir, 'bin'),
+        isFile: () => p === filePath || p === depsPath,
+      } as any)) as any);
+    vi.mocked(fse.stat).mockImplementation(((p: string) =>
+      Promise.resolve({
+        size: p === filePath ? Buffer.byteLength('bundle-content') : p === depsPath ? Buffer.byteLength(depsContents) : 0,
+        isDirectory: () => p === bundleDir || p === path.join(bundleDir, 'bin'),
+        isFile: () => p === filePath || p === depsPath,
+      } as any)) as any);
+    vi.mocked(fse.createReadStream).mockImplementation(((p: string) => {
+      if (p === filePath) {
+        return Readable.from([Buffer.from('bundle-content')]) as any;
+      }
+      if (p === depsPath) {
+        return Readable.from([Buffer.from(depsContents)]) as any;
+      }
+      return Readable.from([]) as any;
+    }) as any);
+    vi.mocked(fse.readFile).mockImplementation(((p: string) => {
+      if (p === depsPath) {
+        return Promise.resolve(depsContents as any);
+      }
+      return Promise.resolve(sidecarPayload as any);
+    }) as any);
+    vi.mocked(fse.outputFile).mockImplementation((async (_p: string, payload: string) => {
+      sidecarPayload = payload;
+    }) as any);
+    vi.mocked(fse.move).mockImplementation((async () => {
+      sidecarExists = true;
+    }) as any);
+    vi.mocked(feedModule.getJsonFeed).mockResolvedValue([localVersion] as any);
+    vi.mocked(binariesModule.downloadAndExtractDependency).mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    await expect(ensureExtensionBundleHealthy(ctx() as any)).resolves.toBeUndefined();
+
+    expect(vi.mocked(binariesModule.downloadAndExtractDependency)).toHaveBeenCalled();
+  });
+
+  it('throws when repair download fails and on-disk health still bad', async () => {
+    vi.mocked(fse.readdirSync).mockReturnValue(['1.50.0'] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    vi.mocked(fse.readFile).mockResolvedValue(sidecarJson('md5', 'WRONG') as any);
+    vi.mocked(feedModule.getJsonFeed).mockResolvedValue(['1.50.0'] as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('md5');
+    vi.mocked(binariesModule.downloadAndExtractDependency).mockRejectedValue(new Error('CDN down'));
+
+    await expect(ensureExtensionBundleHealthy(ctx() as any)).rejects.toThrow(/Logic Apps extension bundle is not installed correctly/);
+  });
+
+  it('downloads and verifies the bundle when required mode starts with no local bundle', async () => {
+    let readdirSyncCalls = 0;
+    vi.mocked(fse.readdirSync).mockImplementation((() => {
+      readdirSyncCalls++;
+      return readdirSyncCalls <= 2 ? [] : ['1.50.0'];
+    }) as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    vi.mocked(fse.readFile).mockResolvedValue(sidecarJson('md5', EMPTY_TREE_HASH) as any);
+    vi.mocked(feedModule.getJsonFeed).mockResolvedValue(['1.50.0'] as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('md5');
+    vi.mocked(binariesModule.downloadAndExtractDependency).mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    await expect(ensureExtensionBundleHealthy(ctx() as any, { requireInstalled: true })).resolves.toBeUndefined();
+
+    expect(vi.mocked(binariesModule.downloadAndExtractDependency)).toHaveBeenCalled();
+  });
+
+  it('rejects required mode when bundle install does not leave a sidecar', async () => {
+    let readdirSyncCalls = 0;
+    vi.mocked(fse.readdirSync).mockImplementation((() => {
+      readdirSyncCalls++;
+      return readdirSyncCalls <= 2 ? [] : ['1.50.0'];
+    }) as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockImplementation(((p: string) => Promise.resolve(!p.endsWith('.bundle-source-md5'))) as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    vi.mocked(feedModule.getJsonFeed).mockResolvedValue(['1.50.0'] as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('md5');
+    vi.mocked(binariesModule.downloadAndExtractDependency).mockResolvedValue({ actualMd5: 'md5' } as any);
+
+    await expect(ensureExtensionBundleHealthy(ctx() as any, { requireInstalled: true })).rejects.toThrow(
+      /on-disk integrity still failed: sidecarMissing/
+    );
+  });
+});
+
+describe('short-circuit verification (envVar / experimental pins)', () => {
+  const sidecarJson = (sourceMd5: string, contentHash: string) => JSON.stringify({ version: 1, sourceMd5, contentHash });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    resetCachedBundleVersion();
+    delete process.env.AzureFunctionsJobHost_extensionBundle_version;
+    const settingsMod = await import('../vsCodeConfig/settings');
+    vi.mocked(settingsMod.getGlobalSetting).mockReturnValue(undefined);
+    const localSettingsMod = await import('../appSettings/localSettings');
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({} as any);
+    vi.mocked(fse.readFile).mockReset();
+    vi.mocked(fse.outputFile).mockResolvedValue(undefined as any);
+  });
+
+  it('env-var pin: re-downloads when on-disk content hash drifts', async () => {
+    const localSettingsMod = await import('../appSettings/localSettings');
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({
+      Values: { AzureFunctionsJobHost_extensionBundle_version: '1.50.0' },
+    } as any);
+    vi.mocked(fse.readdirSync).mockReturnValue(['1.50.0'] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    // Sidecar says contentHash X, recompute returns empty-tree hash ≠ X.
+    vi.mocked(fse.readFile).mockResolvedValue(sidecarJson('md5', 'STALE') as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('md5');
+    vi.mocked(binariesModule.downloadAndExtractDependency).mockResolvedValue(undefined as any);
+
+    const context = { telemetry: { properties: {} as any, measurements: {} as any } };
+    await expect(downloadExtensionBundle(context as any)).rejects.toThrow(/no source MD5 was available/);
+    expect(vi.mocked(binariesModule.downloadAndExtractDependency)).toHaveBeenCalled();
+  });
+
+  it('experimental pin: re-downloads when on-disk content hash drifts', async () => {
+    const settingsMod = await import('../vsCodeConfig/settings');
+    vi.mocked(settingsMod.getGlobalSetting).mockImplementation((key: string) => {
+      if (key === 'useExperimentalExtensionBundle') {
+        return true as any;
+      }
+      if (key === 'experimentalExtensionBundlePinnedVersion') {
+        return '1.50.0' as any;
+      }
+      return undefined as any;
+    });
+    vi.mocked(fse.readdirSync).mockReturnValue(['1.50.0'] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    vi.mocked(fse.readFile).mockResolvedValue(sidecarJson('md5', 'STALE') as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('md5');
+    vi.mocked(binariesModule.downloadAndExtractDependency).mockResolvedValue(undefined as any);
+
+    const context = { telemetry: { properties: {} as any, measurements: {} as any } };
+    await expect(downloadExtensionBundle(context as any)).rejects.toThrow(/no source MD5 was available/);
+    expect(vi.mocked(binariesModule.downloadAndExtractDependency)).toHaveBeenCalled();
+  });
+
+  it('experimental no-pin local latest: re-downloads when on-disk content hash drifts', async () => {
+    const settingsMod = await import('../vsCodeConfig/settings');
+    vi.mocked(settingsMod.getGlobalSetting).mockImplementation((key: string) => {
+      if (key === 'useExperimentalExtensionBundle') {
+        return true as any;
+      }
+      return undefined as any;
+    });
+    vi.mocked(fse.readdirSync).mockReturnValue(['1.50.0'] as any);
+    vi.mocked(fse.statSync).mockReturnValue({ isDirectory: () => true } as any);
+    vi.mocked(fse.pathExists).mockResolvedValue(true as any);
+    vi.mocked(fse.readdir).mockResolvedValue([] as any);
+    vi.mocked(fse.readFile).mockResolvedValue(sidecarJson('md5', 'STALE') as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('md5');
+    vi.mocked(binariesModule.downloadAndExtractDependency).mockResolvedValue(undefined as any);
+
+    const context = { telemetry: { properties: {} as any, measurements: {} as any } };
+    await expect(downloadExtensionBundle(context as any)).rejects.toThrow(/no source MD5 was available/);
+    expect(vi.mocked(binariesModule.downloadAndExtractDependency)).toHaveBeenCalled();
   });
 });

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -24,12 +24,14 @@ import { executeCommand } from './funcCoreTools/cpUtils';
 import { getNpmCommand } from './nodeJs/nodeJsVersion';
 import { getGlobalSetting, getWorkspaceSetting, updateGlobalSetting } from './vsCodeConfig/settings';
 import { onboardBinaries, useBinariesDependencies } from './runtimeDependencies';
+import { type DownloadAttemptResult, downloadFileWithVerification as downloadFileWithVerificationCore } from './integrity';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { Platform, type IGitHubReleaseInfo } from '@microsoft/vscode-extension-logic-apps';
 import axios from 'axios';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as cp from 'child_process';
 import * as semver from 'semver';
 import * as vscode from 'vscode';
 
@@ -39,6 +41,8 @@ import { setFunctionsCommand } from './funcCoreTools/funcVersion';
 import { startAllDesignTimeApis, stopAllDesignTimeApis } from './codeless/startDesignTimeApi';
 
 export { useBinariesDependencies } from './runtimeDependencies';
+export { DownloadIntegrityError } from './integrity';
+export type { DownloadAttemptResult } from './integrity';
 
 /**
  * Download and Extracts dependency zip.
@@ -56,7 +60,7 @@ export async function downloadAndExtractDependency(
   dependencyName: string,
   folderName?: string,
   dotNetVersion?: string
-): Promise<void> {
+): Promise<DownloadAttemptResult | undefined> {
   folderName = folderName || dependencyName;
   const tempFolderPath = path.join(os.tmpdir(), defaultLogicAppsFolder, folderName);
   targetFolder = path.join(targetFolder, folderName);
@@ -69,95 +73,188 @@ export async function downloadAndExtractDependency(
   const dependencyFilePath = path.join(tempFolderPath, `${dependencyName}${dependencyFileExtension}`);
 
   executeCommand(ext.outputChannel, undefined, 'echo', `Downloading dependency from: ${downloadUrl}`);
+  fs.mkdirSync(tempFolderPath, { recursive: true });
+  fs.chmodSync(tempFolderPath, 0o777);
 
-  const response = await axios.get(downloadUrl, { responseType: 'stream' });
-  await new Promise<void>((resolve, reject) => {
-    const rejectDownload = async (error: Error) => {
-      const errorMessage = `Error downloading and extracting the ${dependencyName} zip file: ${error.message}`;
-      vscode.window.showErrorMessage(errorMessage);
-      context.telemetry.properties.error = errorMessage;
-
-      try {
+  let integrityResult: DownloadAttemptResult | undefined;
+  try {
+    integrityResult = await downloadFileWithVerification(context, downloadUrl, dependencyFilePath, dependencyName);
+  } catch (error) {
+    const errorMessage = `Error downloading the ${dependencyName} file: ${error instanceof Error ? error.message : String(error)}`;
+    vscode.window.showErrorMessage(errorMessage);
+    context.telemetry.properties.error = errorMessage;
+    // Clean up partials before bailing.
+    try {
+      if (fs.existsSync(tempFolderPath)) {
+        fs.rmSync(tempFolderPath, { recursive: true, force: true });
+      }
+      if (fs.existsSync(targetFolder)) {
         fs.rmSync(targetFolder, { recursive: true, force: true });
-        await executeCommand(ext.outputChannel, undefined, 'echo', `[ExtractError]: Removed ${targetFolder}`);
-      } catch (cleanupError) {
-        try {
-          await executeCommand(
+      }
+    } catch {
+      // Best-effort cleanup; ignore secondary errors.
+    }
+    throw error;
+  }
+
+  executeCommand(ext.outputChannel, undefined, 'echo', `Successfully downloaded ${dependencyName} dependency.`);
+  fs.chmodSync(dependencyFilePath, 0o777);
+
+  try {
+    // Extract to targetFolder
+    if (dependencyName === dotnetDependencyName) {
+      const version = dotNetVersion ?? semver.major(DependencyVersion.dotnet8);
+      if (process.platform === Platform.windows) {
+        await executeCommand(
+          ext.outputChannel,
+          undefined,
+          'powershell -ExecutionPolicy Bypass -File',
+          dependencyFilePath,
+          '-InstallDir',
+          targetFolder,
+          '-Channel',
+          `${version}.0`
+        );
+      } else {
+        await executeCommand(ext.outputChannel, undefined, dependencyFilePath, '-InstallDir', targetFolder, '-Channel', `${version}.0`);
+      }
+    } else {
+      if (dependencyName === funcDependencyName || dependencyName === extensionBundleId) {
+        // Await actual process exit (not just SIGTERM) so our own func.exe
+        // releases its handles on the bundle dir before we try to delete it.
+        // Without this, the immediately-following rmSync can leave the dir
+        // in a Windows pending-deletion state and mkdir then EPERMs.
+        await stopAllDesignTimeApisAndWait();
+      }
+      try {
+        await extractDependency(dependencyFilePath, targetFolder, dependencyName);
+      } catch (firstError) {
+        const lockLike = isTransientLockError(firstError) || firstError instanceof BundleExtractionError;
+        if (!lockLike) {
+          throw firstError;
+        }
+        // Likely an orphan func.exe holding the bundle directory open. Offer
+        // to terminate orphan processes and retry once. If the user declines
+        // or no orphans are found, propagate the original error.
+        const terminated = await offerToTerminateOrphanFuncProcesses(dependencyName);
+        if (!terminated) {
+          throw firstError;
+        }
+        ext.outputChannel.appendLog(`Retrying ${dependencyName} install after terminating orphan func.exe processes.`);
+        await extractDependency(dependencyFilePath, targetFolder, dependencyName);
+      }
+      ext.outputChannel.appendLog(localize('successInstall', 'Successfully installed {0}', dependencyName));
+      if (dependencyName === funcDependencyName) {
+        // Add execute permissions for func and gozip binaries
+        if (process.platform !== Platform.windows) {
+          fs.chmodSync(`${targetFolder}/func`, 0o755);
+          fs.chmodSync(`${targetFolder}/gozip`, 0o755);
+          fs.chmodSync(`${targetFolder}/in-proc8/func`, 0o755);
+          fs.chmodSync(`${targetFolder}/in-proc6/func`, 0o755);
+        }
+        await setFunctionsCommand();
+        await startAllDesignTimeApis();
+      }
+      // NB: when dependencyName === extensionBundleId we intentionally do NOT
+      // restart design-time here. The bundle download flow defers the restart
+      // until after the full install is verified (sidecar written + install
+      // marked 'ok' + in-flight promise cleared) so the design-time host
+      // doesn't spawn against a bundle that's still mid-install. See the
+      // restart hook in `downloadExtensionBundle`'s finally block in
+      // `bundleFeed.ts`.
+    }
+  } catch (error) {
+    // Extraction (or verification) failed. Do NOT delete targetFolder: on
+    // Windows the most common cause is EPERM/EBUSY from another process
+    // (typically an orphan func.exe from a previous session) holding bundle
+    // DLLs open. Deleting the folder is impossible while it's locked, and
+    // leaving the user with NO bundle is strictly worse than leaving them
+    // with the partial one they already had. The Phase 8 sidecar/content-hash
+    // check will detect the bad state on the next activation and trigger
+    // another re-download, which can succeed once the lock holder exits.
+    const lockHint =
+      isTransientLockError(error) || error instanceof BundleExtractionError
+        ? ` Another process (often an orphan func.exe from a prior session) may be holding files in ${targetFolder}. Close all VS Code windows running Logic Apps, kill any leftover func.exe processes, and reload to retry.`
+        : '';
+    const baseMessage =
+      error instanceof BundleExtractionError
+        ? `Extension bundle ${dependencyName} extraction was incomplete (${error.kind}${
+            error.entryName ? `: ${error.entryName}` : ''
+          }) at ${targetFolder}.${lockHint}`
+        : `Failed to install ${dependencyName} after download at ${targetFolder}: ${
+            error instanceof Error ? error.message : String(error)
+          }.${lockHint}`;
+    ext.outputChannel.appendLog(baseMessage);
+    vscode.window.showErrorMessage(
+      localize(
+        'bundleInstallFailed',
+        'Logic Apps extension bundle {0} could not be installed at {1}. Another process may be holding the folder. Close other VS Code windows and any running func.exe processes, then reload this window to retry.',
+        dependencyName,
+        targetFolder
+      )
+    );
+    context.telemetry.properties.extractError = error instanceof Error ? error.message : String(error);
+    throw error;
+  } finally {
+    // remove the temp folder.
+    if (fs.existsSync(tempFolderPath)) {
+      fs.rmSync(tempFolderPath, { recursive: true, force: true });
+      executeCommand(ext.outputChannel, undefined, 'echo', `Removed ${tempFolderPath}`);
+    }
+  }
+
+  return integrityResult;
+}
+
+/**
+ * Streams a file from `url` to `destPath`, verifying integrity against
+ * `Content-Length` and `Content-MD5` response headers when present.
+ *
+ * Thin wrapper that adds extension-host telemetry + log lines on top of the
+ * vscode-free implementation in `./integrity`.
+ */
+export async function downloadFileWithVerification(
+  context: IActionContext,
+  url: string,
+  destPath: string,
+  dependencyName: string,
+  maxAttempts?: number
+): Promise<DownloadAttemptResult> {
+  let attemptsUsed = 0;
+  try {
+    const result = await downloadFileWithVerificationCore(url, destPath, {
+      maxAttempts,
+      hooks: {
+        onSuccess: (attempt, attemptResult, durationMs) => {
+          attemptsUsed = attempt;
+          context.telemetry.properties[`${dependencyName}DownloadAttempts`] = String(attempt);
+          context.telemetry.properties[`${dependencyName}ExpectedSize`] =
+            attemptResult.expectedSize === undefined ? 'unknown' : String(attemptResult.expectedSize);
+          context.telemetry.properties[`${dependencyName}ActualSize`] = String(attemptResult.actualSize);
+          context.telemetry.properties[`${dependencyName}Md5Match`] = attemptResult.expectedMd5 ? 'true' : 'skipped';
+          context.telemetry.measurements ??= {};
+          context.telemetry.measurements[`${dependencyName}DownloadDurationMs`] = durationMs;
+        },
+        onAttempt: (attempt, error, willRetry) => {
+          attemptsUsed = attempt;
+          executeCommand(
             ext.outputChannel,
             undefined,
             'echo',
-            `[ExtractError]: Failed to remove ${targetFolder}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+            `Download attempt ${attempt} for ${dependencyName} failed: ${
+              error instanceof Error ? error.message : String(error)
+            }${willRetry ? ' — retrying.' : ''}`
           );
-        } catch {
-          // Keep rejection behavior deterministic even if cleanup logging fails.
-        }
-      } finally {
-        reject(new Error(errorMessage));
-      }
-    };
-
-    executeCommand(ext.outputChannel, undefined, 'echo', `Creating temporary folder... ${tempFolderPath}`);
-    fs.mkdirSync(tempFolderPath, { recursive: true });
-    fs.chmodSync(tempFolderPath, 0o777);
-
-    const writer = fs.createWriteStream(dependencyFilePath);
-    response.data.on?.('error', rejectDownload);
-    response.data.pipe(writer);
-
-    writer.on('finish', async () => {
-      try {
-        executeCommand(ext.outputChannel, undefined, 'echo', `Successfully downloaded ${dependencyName} dependency.`);
-        fs.chmodSync(dependencyFilePath, 0o777);
-
-        // Extract to targetFolder
-        if (dependencyName === dotnetDependencyName) {
-          const version = dotNetVersion ?? semver.major(DependencyVersion.dotnet8);
-          if (process.platform === Platform.windows) {
-            await executeCommand(
-              ext.outputChannel,
-              undefined,
-              'powershell -ExecutionPolicy Bypass -File',
-              dependencyFilePath,
-              '-InstallDir',
-              targetFolder,
-              '-Channel',
-              `${version}.0`
-            );
-          } else {
-            await executeCommand(ext.outputChannel, undefined, dependencyFilePath, '-InstallDir', targetFolder, '-Channel', `${version}.0`);
-          }
-        } else {
-          if (dependencyName === funcDependencyName || dependencyName === extensionBundleId) {
-            stopAllDesignTimeApis();
-          }
-          await extractDependency(dependencyFilePath, targetFolder, dependencyName);
-          vscode.window.showInformationMessage(localize('successInstall', `Successfully installed ${dependencyName}`));
-          if (dependencyName === funcDependencyName) {
-            // Add execute permissions for func and gozip binaries
-            if (process.platform !== Platform.windows) {
-              fs.chmodSync(`${targetFolder}/func`, 0o755);
-              fs.chmodSync(`${targetFolder}/gozip`, 0o755);
-              fs.chmodSync(`${targetFolder}/in-proc8/func`, 0o755);
-              fs.chmodSync(`${targetFolder}/in-proc6/func`, 0o755);
-            }
-            await setFunctionsCommand();
-            await startAllDesignTimeApis();
-          } else if (dependencyName === extensionBundleId) {
-            await startAllDesignTimeApis();
-          }
-        }
-        // remove the temp folder.
-        fs.rmSync(tempFolderPath, { recursive: true });
-        executeCommand(ext.outputChannel, undefined, 'echo', `Removed ${tempFolderPath}`);
-        resolve();
-      } catch (error) {
-        reject(error);
-      }
+        },
+      },
     });
-    writer.on('error', async (error) => {
-      await rejectDownload(error);
-    });
-  });
+    return result;
+  } catch (error) {
+    if (attemptsUsed > 0) {
+      context.telemetry.properties[`${dependencyName}DownloadAttempts`] = String(attemptsUsed);
+    }
+    throw error;
+  }
 }
 
 const getFunctionCoreToolVersionFromGithub = async (context: IActionContext, majorVersion: string): Promise<string> => {
@@ -338,11 +435,40 @@ export async function binariesExist(dependencyName: string): Promise<boolean> {
 
   executeCommand(ext.outputChannel, undefined, 'echo', `${dependencyName} Binaries: ${binariesPath}`);
   if (expectedBinaryPath && !fs.existsSync(expectedBinaryPath)) {
+    if (await tryRepairWindowsNodeJsBinaryPath(dependencyName, binariesPath, expectedBinaryPath)) {
+      return true;
+    }
+
     executeCommand(ext.outputChannel, undefined, 'echo', `${dependencyName} binary is missing: ${expectedBinaryPath}`);
     return false;
   }
 
   return binariesExist;
+}
+
+async function tryRepairWindowsNodeJsBinaryPath(
+  dependencyName: string,
+  binariesPath: string,
+  expectedBinaryPath: string
+): Promise<boolean> {
+  if (dependencyName !== nodeJsDependencyName || process.platform !== Platform.windows) {
+    return false;
+  }
+
+  const nodeCommand = DependencyDefaultPath.node;
+  const staleNodePath = path.join(binariesPath, nodeCommand);
+  if (path.normalize(expectedBinaryPath).toLowerCase() !== path.normalize(staleNodePath).toLowerCase()) {
+    return false;
+  }
+
+  const nodeExePath = path.join(binariesPath, `${nodeCommand}.exe`);
+  if (!fs.existsSync(nodeExePath)) {
+    return false;
+  }
+
+  await updateGlobalSetting<string>(nodeJsBinaryPathSettingKey, nodeExePath);
+  executeCommand(ext.outputChannel, undefined, 'echo', `${nodeJsDependencyName} binary path updated: ${nodeExePath}`);
+  return true;
 }
 
 async function readJsonFromUrl(url: string): Promise<any> {
@@ -393,23 +519,505 @@ function cleanDirectory(targetFolder: string): void {
   }
 }
 
-async function extractDependency(dependencyFilePath: string, targetFolder: string, dependencyName: string): Promise<void> {
-  // Clear targetFolder's contents without deleting the folder itself
-  // TODO(aeldridge): It is possible there is a lock on a file in targetFolder, should be handled.
-  cleanDirectory(targetFolder);
-  await executeCommand(ext.outputChannel, undefined, 'echo', `Extracting ${dependencyFilePath}`);
-  try {
-    if (dependencyFilePath.endsWith('.zip')) {
-      const zip = new AdmZip(dependencyFilePath);
-      zip.extractAllTo(targetFolder, /* overwrite */ true, /* Permissions */ true);
-    } else {
-      await executeCommand(ext.outputChannel, undefined, 'tar', '-xzvf', dependencyFilePath, '-C', targetFolder);
+/**
+ * Maximum number of times to attempt extracting a dependency archive before
+ * giving up and propagating the error to the caller. The retry is in place to
+ * absorb transient Windows file-system errors (EBUSY/EPERM from antivirus or
+ * Windows search indexer) and partial-extract verification failures.
+ */
+const MAX_EXTRACT_ATTEMPTS = 2;
+
+/**
+ * Delay between extract attempts.
+ */
+const EXTRACT_RETRY_DELAY_MS = 750;
+
+/**
+ * Discriminator for the kinds of post-extract verification failures we surface
+ * to callers. Use this to distinguish "the zip extracted, but the resulting
+ * tree is wrong" from a download integrity error or a generic I/O error.
+ */
+export type BundleExtractionFailureKind = 'missing' | 'sizeMismatch' | 'empty';
+
+/**
+ * Thrown when the on-disk extracted bundle does not match the archive's
+ * central directory. Triggers a retry inside `extractDependency` and, on the
+ * final attempt, propagates so the caller can drop the partial tree and
+ * re-download.
+ */
+export class BundleExtractionError extends Error {
+  public readonly kind: BundleExtractionFailureKind;
+  public readonly entryName?: string;
+  public readonly expectedSize?: number;
+  public readonly actualSize?: number;
+
+  constructor(kind: BundleExtractionFailureKind, entryName?: string, expectedSize?: number, actualSize?: number) {
+    let message: string;
+    switch (kind) {
+      case 'missing':
+        message = `Extracted bundle is missing expected file: ${entryName}`;
+        break;
+      case 'sizeMismatch':
+        message = `Extracted bundle file ${entryName} is ${actualSize ?? '?'} bytes, expected ${expectedSize ?? '?'}`;
+        break;
+      default:
+        message = 'Extracted bundle is empty (zip listed entries but none reached disk)';
+        break;
     }
-    extractContainerFolder(targetFolder);
-    await executeCommand(ext.outputChannel, undefined, 'echo', `Extraction ${dependencyName} successfully completed.`);
-  } catch (error) {
-    throw new Error(`Error extracting ${dependencyName}: ${error}`);
+    super(message);
+    this.name = 'BundleExtractionError';
+    this.kind = kind;
+    this.entryName = entryName;
+    this.expectedSize = expectedSize;
+    this.actualSize = actualSize;
   }
+}
+
+function isTransientLockError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const code = (error as { code?: string }).code;
+  return code === 'EBUSY' || code === 'EPERM' || code === 'EACCES';
+}
+
+/**
+ * Wall-clock budget we'll wait for a Windows file lock to release before
+ * giving up and failing the install. 30s is generous but reflects what we
+ * actually see: a dying `func.exe` plus a Defender scan plus a pending
+ * `rmSync` flush can easily eat 5–15s on a slow profile, and failing fast
+ * leaves the user with a broken bundle until they reload.
+ */
+const LOCK_WAIT_BUDGET_MS = 30_000;
+
+/**
+ * How often to retry the locked filesystem operation. Tight at first (most
+ * locks clear in <1s) — the wall-clock budget caps total wait time.
+ */
+const LOCK_WAIT_POLL_MS = 250;
+
+/**
+ * How often to surface "still waiting" progress to the user during a long
+ * lock wait so it's clear we're not hung.
+ */
+const LOCK_WAIT_LOG_INTERVAL_MS = 5_000;
+
+/**
+ * After this much persistent locking, offer the orphan-`func.exe` prompt
+ * once. We don't offer it immediately because most locks clear within the
+ * first second on their own and surfacing a modal-ish prompt every install
+ * would be noisy.
+ */
+const LOCK_WAIT_ORPHAN_PROMPT_AFTER_MS = 5_000;
+
+/**
+ * Max time to wait for our own design-time `func.exe` processes to fully
+ * exit after `stopAllDesignTimeApis()`. Short by design — these are our
+ * processes and SIGTERM/SIGKILL should land within a couple of seconds.
+ */
+const DESIGN_TIME_EXIT_TIMEOUT_MS = 5_000;
+
+/**
+ * Returns true when a process with the given PID is still running. Uses
+ * `process.kill(pid, 0)`, a no-op signal that throws ESRCH when the process
+ * is gone. Works on Windows and POSIX.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    // ESRCH = no such process. EPERM means we don't have permission to
+    // signal, but the process exists → treat as alive.
+    if (code === 'EPERM') {
+      return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Polls until every PID in `pids` has exited, or `timeoutMs` elapses.
+ * Best-effort: never throws, just returns when done. Designed for the
+ * window after `stopAllDesignTimeApis()` where our own `func.exe` is
+ * draining file handles.
+ */
+async function waitForFuncProcessExit(pids: readonly number[], timeoutMs: number): Promise<void> {
+  if (pids.length === 0) {
+    return;
+  }
+  const deadline = Date.now() + timeoutMs;
+  let remaining = pids.filter((pid) => isProcessAlive(pid));
+  while (remaining.length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, LOCK_WAIT_POLL_MS));
+    remaining = remaining.filter((pid) => isProcessAlive(pid));
+  }
+  if (remaining.length > 0 && ext.outputChannel) {
+    ext.outputChannel.appendLog(
+      `Some design-time func.exe process(es) still alive after ${timeoutMs}ms wait: PID(s) ${remaining.join(', ')}. Proceeding anyway.`
+    );
+  }
+}
+
+/**
+ * Stops all tracked design-time hosts and waits for the underlying
+ * `func.exe` processes to actually exit before returning. The plain
+ * `stopAllDesignTimeApis()` is fire-and-forget — control returns while
+ * Windows is still flushing the file handles those processes held, which
+ * leaves the bundle directory in a locked / pending-deletion state when we
+ * try to extract immediately after.
+ */
+async function stopAllDesignTimeApisAndWait(timeoutMs: number = DESIGN_TIME_EXIT_TIMEOUT_MS): Promise<void> {
+  const trackedBefore = Array.from(getTrackedFuncPids());
+  stopAllDesignTimeApis();
+  if (trackedBefore.length === 0) {
+    return;
+  }
+  await waitForFuncProcessExit(trackedBefore, timeoutMs);
+}
+
+/**
+ * Result classification for the inner attempt of a lock-wait helper.
+ */
+type LockWaitAttempt = { ok: true } | { ok: false; error: unknown; retry: boolean };
+
+/**
+ * Generic retry loop used by `removeWithLockWait` and `mkdirWithLockWait`.
+ * Polls `attempt` until success or `budgetMs` elapses. Logs progress every
+ * ~5s and offers the orphan-`func.exe` prompt once after ~5s of persistent
+ * locking. On budget exhaustion, throws the last seen error.
+ */
+async function withLockWait(
+  opLabel: string,
+  targetPath: string,
+  dependencyName: string,
+  budgetMs: number,
+  attempt: () => LockWaitAttempt
+): Promise<void> {
+  const start = Date.now();
+  const deadline = start + budgetMs;
+  let lastProgressLog = start;
+  let orphanPromptOffered = false;
+  let lastError: unknown;
+
+  while (true) {
+    const result = attempt();
+    if (result.ok) {
+      const waited = Date.now() - start;
+      if (waited >= LOCK_WAIT_LOG_INTERVAL_MS && ext.outputChannel) {
+        ext.outputChannel.appendLog(
+          `${opLabel} ${targetPath} succeeded after waiting ${(waited / 1000).toFixed(1)}s for the lock to release.`
+        );
+      }
+      return;
+    }
+    const failure = result as { ok: false; error: unknown; retry: boolean };
+    lastError = failure.error;
+    if (!failure.retry) {
+      throw lastError;
+    }
+    const now = Date.now();
+    if (now >= deadline) {
+      throw lastError;
+    }
+    if (now - lastProgressLog >= LOCK_WAIT_LOG_INTERVAL_MS && ext.outputChannel) {
+      const waited = ((now - start) / 1000).toFixed(1);
+      const remaining = ((deadline - now) / 1000).toFixed(1);
+      const code = (lastError as { code?: string })?.code ?? 'lock';
+      ext.outputChannel.appendLog(
+        `Still waiting on ${dependencyName} (${code}) to ${opLabel.toLowerCase()} ${targetPath}: ${waited}s elapsed, up to ${remaining}s remaining.`
+      );
+      lastProgressLog = now;
+    }
+    if (!orphanPromptOffered && now - start >= LOCK_WAIT_ORPHAN_PROMPT_AFTER_MS) {
+      orphanPromptOffered = true;
+      // Best-effort — even if the user cancels we keep waiting for the
+      // budget to elapse, since some lock holders (Defender, indexer) clear
+      // on their own and there's no point bailing early.
+      try {
+        await offerToTerminateOrphanFuncProcesses(dependencyName);
+      } catch (promptErr) {
+        if (ext.outputChannel) {
+          ext.outputChannel.appendLog(
+            `Orphan func.exe prompt failed during ${opLabel.toLowerCase()} wait: ${promptErr instanceof Error ? promptErr.message : String(promptErr)}`
+          );
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, LOCK_WAIT_POLL_MS));
+  }
+}
+
+/**
+ * Removes `targetPath` recursively, retrying for up to `budgetMs` on
+ * transient Windows lock errors (EPERM/EBUSY/EACCES). Returns silently
+ * when the path doesn't exist.
+ *
+ * Why: on Windows, `fs.rmSync(force: true)` may "succeed" while silently
+ * skipping locked files — leaving the directory in a pending-deletion state
+ * that makes the immediately-following `mkdirSync` throw EPERM. This helper
+ * keeps retrying until the path is genuinely gone (or budget exhausted).
+ */
+export async function removeWithLockWait(
+  targetPath: string,
+  dependencyName: string,
+  budgetMs: number = LOCK_WAIT_BUDGET_MS
+): Promise<void> {
+  await withLockWait('Remove', targetPath, dependencyName, budgetMs, () => {
+    if (!fs.existsSync(targetPath)) {
+      return { ok: true };
+    }
+    try {
+      fs.rmSync(targetPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    } catch (error) {
+      return { ok: false, error, retry: isTransientLockError(error) };
+    }
+    // Even after rmSync returns success, Windows may have left the dir in
+    // place because some files are still locked. Treat lingering existence
+    // as a transient lock and keep waiting.
+    if (fs.existsSync(targetPath)) {
+      return {
+        ok: false,
+        error: Object.assign(new Error(`Path ${targetPath} still exists after rmSync (locked files held by another process).`), {
+          code: 'EBUSY',
+        }),
+        retry: true,
+      };
+    }
+    return { ok: true };
+  });
+}
+
+/**
+ * Creates `targetPath` (recursive), retrying for up to `budgetMs` on
+ * transient Windows lock errors. The common case this exists for: we just
+ * `rmSync`'d the same path and Windows hasn't finished flushing the
+ * deletion, so `mkdirSync` returns EPERM until the FS catches up.
+ */
+export async function mkdirWithLockWait(targetPath: string, dependencyName: string, budgetMs: number = LOCK_WAIT_BUDGET_MS): Promise<void> {
+  await withLockWait('Mkdir', targetPath, dependencyName, budgetMs, () => {
+    try {
+      fs.mkdirSync(targetPath, { recursive: true });
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error, retry: isTransientLockError(error) };
+    }
+  });
+}
+
+/**
+ * Enumerates all running `func.exe` processes on Windows via `tasklist`.
+ * Returns an empty array on non-Windows or if `tasklist` fails.
+ */
+async function listFuncExePidsWindows(): Promise<number[]> {
+  if (process.platform !== Platform.windows) {
+    return [];
+  }
+  return new Promise<number[]>((resolve) => {
+    cp.exec('tasklist /FI "IMAGENAME eq func.exe" /FO CSV /NH', (error, stdout) => {
+      if (error) {
+        resolve([]);
+        return;
+      }
+      const pids: number[] = [];
+      for (const line of stdout.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        // CSV: "func.exe","12345","Console","1","12,345 K"
+        const fields = trimmed.split(',').map((s) => s.replace(/^"|"$/g, '').trim());
+        if (fields[0]?.toLowerCase() === 'func.exe') {
+          const pid = Number.parseInt(fields[1], 10);
+          if (!Number.isNaN(pid)) {
+            pids.push(pid);
+          }
+        }
+      }
+      resolve(pids);
+    });
+  });
+}
+
+/**
+ * Returns the set of `func.exe` PIDs the extension knows about — i.e. the
+ * design-time hosts it spawned and tracks in `ext.designTimeInstances`.
+ * Anything not in this set is an orphan from a prior session.
+ */
+function getTrackedFuncPids(): Set<number> {
+  const known = new Set<number>();
+  for (const inst of ext.designTimeInstances.values()) {
+    if (!inst) {
+      continue;
+    }
+    if (inst.childFuncPid !== undefined && inst.childFuncPid !== null) {
+      const pid = Number(inst.childFuncPid);
+      if (!Number.isNaN(pid)) {
+        known.add(pid);
+      }
+    }
+    const directPid = inst.process?.pid;
+    if (typeof directPid === 'number') {
+      known.add(directPid);
+    }
+  }
+  return known;
+}
+
+/**
+ * Detects orphan `func.exe` processes (not tracked by this extension session)
+ * that are likely holding files in the bundle install directory. If any are
+ * found, prompts the user to terminate them. Returns true if at least one
+ * orphan was killed (caller should retry the operation).
+ *
+ * No-op on non-Windows since the EPERM/EBUSY scenarios reported by users are
+ * Windows-specific.
+ */
+async function offerToTerminateOrphanFuncProcesses(dependencyName: string): Promise<boolean> {
+  if (process.platform !== Platform.windows) {
+    return false;
+  }
+  const allFuncPids = await listFuncExePidsWindows();
+  if (allFuncPids.length === 0) {
+    return false;
+  }
+  const tracked = getTrackedFuncPids();
+  const orphans = allFuncPids.filter((pid) => !tracked.has(pid));
+  if (orphans.length === 0) {
+    return false;
+  }
+  ext.outputChannel.appendLog(
+    `Detected ${orphans.length} orphan func.exe process(es) not managed by this VS Code session (PID${
+      orphans.length > 1 ? 's' : ''
+    } ${orphans.join(', ')}). These may be locking the ${dependencyName} install directory.`
+  );
+  const terminateLabel = localize('terminateOrphanFuncBtn', 'Terminate {0} process(es)', orphans.length);
+  const choice = await vscode.window.showWarningMessage(
+    localize(
+      'orphanFuncDetected',
+      'Logic Apps detected {0} leftover func.exe process(es) from a previous session that may be blocking the {1} update. Terminate them now to unblock the install?',
+      orphans.length,
+      dependencyName
+    ),
+    { modal: false },
+    terminateLabel
+  );
+  if (choice !== terminateLabel) {
+    ext.outputChannel.appendLog('User declined to terminate orphan func.exe processes.');
+    return false;
+  }
+  let killed = 0;
+  for (const pid of orphans) {
+    try {
+      process.kill(pid);
+      killed++;
+    } catch (killErr) {
+      ext.outputChannel.appendLog(
+        `Could not terminate func.exe PID ${pid}: ${killErr instanceof Error ? killErr.message : String(killErr)}`
+      );
+    }
+  }
+  ext.outputChannel.appendLog(`Terminated ${killed}/${orphans.length} orphan func.exe process(es).`);
+  if (killed > 0) {
+    // Give Windows a beat to release file handles before any retry.
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+  }
+  return killed > 0;
+}
+
+/**
+ * Verifies every file entry in the zip's central directory exists on disk at
+ * `targetFolder` with the size the archive claims it should have. Must be
+ * called before `extractContainerFolder` (which may rename a single root
+ * directory away, breaking the entry-name → on-disk-path mapping).
+ *
+ * Throws `BundleExtractionError` on the first mismatch.
+ */
+export function verifyExtractedZip(zip: AdmZip, targetFolder: string): void {
+  const fileEntries = zip.getEntries().filter((entry) => !entry.isDirectory);
+  if (fileEntries.length === 0) {
+    return;
+  }
+  let verified = 0;
+  for (const entry of fileEntries) {
+    const onDisk = path.join(targetFolder, entry.entryName);
+    if (!fs.existsSync(onDisk)) {
+      throw new BundleExtractionError('missing', entry.entryName);
+    }
+    const stat = fs.statSync(onDisk);
+    if (stat.size !== entry.header.size) {
+      throw new BundleExtractionError('sizeMismatch', entry.entryName, entry.header.size, stat.size);
+    }
+    verified++;
+  }
+  if (verified === 0) {
+    throw new BundleExtractionError('empty');
+  }
+}
+
+async function extractDependency(dependencyFilePath: string, targetFolder: string, dependencyName: string): Promise<void> {
+  // Delete the existing target folder before extraction so we start from a
+  // truly empty state. This is critical when replacing a corrupt bundle: the
+  // old files (which may be stale, partial, or from a different version) must
+  // be gone before AdmZip writes the new ones, because AdmZip's overwrite
+  // mode does NOT delete files that are absent from the new zip.
+  //
+  // On Windows the delete + recreate pair is racy when something else (a
+  // recently-stopped func.exe, Defender, the search indexer) is still
+  // draining handles. Both helpers wait up to 30s for the lock to clear and
+  // log progress every ~5s so the user sees we're working, not stuck.
+  if (fs.existsSync(targetFolder)) {
+    ext.outputChannel.appendLog(`Removing existing ${dependencyName} install at ${targetFolder} before re-extracting.`);
+    await removeWithLockWait(targetFolder, dependencyName);
+  }
+  await mkdirWithLockWait(targetFolder, dependencyName);
+  try {
+    fs.chmodSync(targetFolder, 0o777);
+  } catch {
+    // Permission tweak is best-effort.
+  }
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_EXTRACT_ATTEMPTS; attempt++) {
+    try {
+      if (attempt > 1) {
+        // Clear the failed partial extract before retrying.
+        cleanDirectory(targetFolder);
+      }
+      ext.outputChannel.appendLog(`Extracting ${dependencyFilePath} (attempt ${attempt}/${MAX_EXTRACT_ATTEMPTS})`);
+      if (dependencyFilePath.endsWith('.zip')) {
+        const zip = new AdmZip(dependencyFilePath);
+        zip.extractAllTo(targetFolder, /* overwrite */ true, /* Permissions */ true);
+        // Verify before extractContainerFolder rewrites paths.
+        verifyExtractedZip(zip, targetFolder);
+      } else {
+        await executeCommand(ext.outputChannel, undefined, 'tar', '-xzvf', dependencyFilePath, '-C', targetFolder);
+      }
+      extractContainerFolder(targetFolder);
+      await executeCommand(ext.outputChannel, undefined, 'echo', `Extraction ${dependencyName} successfully completed.`);
+      return;
+    } catch (error) {
+      lastError = error;
+      const isLastAttempt = attempt === MAX_EXTRACT_ATTEMPTS;
+      const isRetryable = error instanceof BundleExtractionError || isTransientLockError(error);
+      if (isLastAttempt || !isRetryable) {
+        break;
+      }
+      const reason =
+        error instanceof BundleExtractionError
+          ? `verification failed (${error.kind}${error.entryName ? `: ${error.entryName}` : ''})`
+          : `transient lock (${(error as { code?: string }).code ?? 'unknown'})`;
+      ext.outputChannel.appendLog(
+        `Extraction attempt ${attempt} for ${dependencyName} failed (${reason}); retrying in ${EXTRACT_RETRY_DELAY_MS}ms.`
+      );
+      await new Promise((resolve) => setTimeout(resolve, EXTRACT_RETRY_DELAY_MS));
+    }
+  }
+  if (lastError instanceof BundleExtractionError) {
+    throw lastError;
+  }
+  throw new Error(`Error extracting ${dependencyName}: ${lastError}`);
 }
 
 /**

--- a/apps/vs-code-designer/src/app/utils/bundleFeed.ts
+++ b/apps/vs-code-designer/src/app/utils/bundleFeed.ts
@@ -2,20 +2,108 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { defaultVersionRange, extensionBundleId, localSettingsFileName, defaultExtensionBundlePathValue } from '../../constants';
+import {
+  defaultVersionRange,
+  extensionBundleId,
+  localSettingsFileName,
+  defaultExtensionBundlePathValue,
+  bundleSourceMd5SidecarFile,
+  useExperimentalExtensionBundleSettingKey,
+  experimentalExtensionBundleSourceUriSettingKey,
+  experimentalExtensionBundleVersionSettingKey,
+} from '../../constants';
 import { getLocalSettingsJson } from './appSettings/localSettings';
 import { downloadAndExtractDependency } from './binaries';
+import { fetchExpectedMd5, isMissingPackageError } from './integrity';
 import { getJsonFeed } from './feed';
+import { getGlobalSetting } from './vsCodeConfig/settings';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { IBundleDependencyFeed, IBundleMetadata, IHostJsonV2 } from '@microsoft/vscode-extension-logic-apps';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import * as path from 'path';
 import * as semver from 'semver';
 import * as vscode from 'vscode';
 import { localize } from '../../localize';
 import { ext } from '../../extensionVariables';
+import { createHash } from 'crypto';
 import { getFunctionsCommand } from './funcCoreTools/funcVersion';
 import * as fse from 'fs-extra';
 import { executeCommand } from './funcCoreTools/cpUtils';
+
+const PUBLIC_BUNDLE_BASE_URL = 'https://cdn.functions.azure.com/public';
+
+export type BundleBaseUrlSource = 'localSettings' | 'envVar' | 'experimentalSetting' | 'default';
+export type BundleVersionSource =
+  | 'envVar'
+  | 'experimentalLocalPin'
+  | 'experimentalFirstDownload'
+  | 'experimentalLocalLatest'
+  | 'publicFeedLatest'
+  | 'localLatest';
+
+/**
+ * Why the extension fell back from the configured experimental source URI to
+ * the public CDN. Recorded only when a fallback actually fired.
+ */
+export type ExperimentalSourceFallbackReason = 'pinNotInIndex' | 'zip404' | 'index404' | 'networkError' | 'integrityFailure';
+
+interface ExtensionBundleBaseUrlResult {
+  baseUrl: string;
+  source: BundleBaseUrlSource;
+  isExperimental: boolean;
+  experimentalSourceUri: string;
+  experimentalPinnedVersion: string;
+}
+
+/**
+ * Resolves the base URL used for fetching the extension bundle index, dependency feed,
+ * and zip — plus the experimental settings that may alter version-selection behavior.
+ *
+ * Precedence (highest → lowest):
+ *   1. Workspace `local.settings.json` value `FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI`.
+ *   2. `process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI`.
+ *   3. VS Code experimental setting `experimentalExtensionBundleSourceUri` (only when
+ *      `useExperimentalExtensionBundle` is `true` and the URI is non-empty).
+ *   4. Default public CDN.
+ */
+export async function getExtensionBundleBaseUrl(context: IActionContext): Promise<ExtensionBundleBaseUrlResult> {
+  const projectPath: string | undefined = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
+  let localSettingsUri: string | undefined;
+  if (projectPath) {
+    try {
+      localSettingsUri = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
+        ?.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+    } catch {
+      // Missing/invalid local.settings.json is fine; fall through to other sources.
+    }
+  }
+
+  const envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+  const isExperimental = getGlobalSetting<boolean>(useExperimentalExtensionBundleSettingKey) === true;
+  const experimentalSourceUri = (getGlobalSetting<string>(experimentalExtensionBundleSourceUriSettingKey) ?? '').trim();
+  const experimentalPinnedVersion = (getGlobalSetting<string>(experimentalExtensionBundleVersionSettingKey) ?? '').trim();
+
+  let baseUrl: string;
+  let source: BundleBaseUrlSource;
+  if (localSettingsUri && localSettingsUri.length > 0) {
+    baseUrl = localSettingsUri;
+    source = 'localSettings';
+  } else if (envVarUri && envVarUri.length > 0) {
+    baseUrl = envVarUri;
+    source = 'envVar';
+  } else if (isExperimental && experimentalSourceUri.length > 0) {
+    baseUrl = experimentalSourceUri;
+    source = 'experimentalSetting';
+  } else {
+    baseUrl = PUBLIC_BUNDLE_BASE_URL;
+    source = 'default';
+  }
+
+  context.telemetry.properties.extensionBundleBaseUrlSource = source;
+  context.telemetry.properties.useExperimentalExtensionBundle = String(isExperimental);
+
+  return { baseUrl, source, isExperimental, experimentalSourceUri, experimentalPinnedVersion };
+}
 
 /**
  * Gets Workflow bundle extension feed.
@@ -23,10 +111,8 @@ import { executeCommand } from './funcCoreTools/cpUtils';
  * @returns {Promise<string[]>} Returns array of available bundle versions.
  */
 async function getWorkflowBundleFeed(context: IActionContext): Promise<string[]> {
-  const envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  const baseUrl: string = envVarUri || 'https://cdn.functions.azure.com/public';
+  const { baseUrl } = await getExtensionBundleBaseUrl(context);
   const url = `${baseUrl}/ExtensionBundles/${extensionBundleId}/index.json`;
-
   return getJsonFeed(context, url);
 }
 
@@ -41,14 +127,7 @@ async function getBundleDependencyFeed(
   bundleMetadata: IBundleMetadata | undefined
 ): Promise<IBundleDependencyFeed> {
   const bundleId: string = (bundleMetadata && bundleMetadata?.id) || extensionBundleId;
-  const projectPath: string | undefined = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
-  let envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  if (projectPath) {
-    envVarUri = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
-      ?.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  }
-
-  const baseUrl: string = envVarUri || 'https://cdn.functions.azure.com/public';
+  const { baseUrl } = await getExtensionBundleBaseUrl(context);
   const url = `${baseUrl}/ExtensionBundles/${bundleId}/dependency.json`;
   return getJsonFeed(context, url);
 }
@@ -83,22 +162,226 @@ export function addDefaultBundle(hostJson: IHostJsonV2): void {
 }
 
 /**
- * Gets bundle extension zip. Microsoft.Azure.Functions.ExtensionBundle.Workflows.<version>.
- * @param {IActionContext} context - Command context.
- * @param {string} extensionVersion - Bundle Extension Version.
- * @returns {string} Returns bundle extension zip url.
+ * Builds the URL to the bundle's zip on the configured base URL.
  */
-async function getExtensionBundleZip(context: IActionContext, extensionVersion: string): Promise<string> {
-  let envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  const projectPath: string | undefined = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
-  if (projectPath) {
-    envVarUri = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
-      ?.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  }
-  const baseUrl: string = envVarUri || 'https://cdn.functions.azure.com/public';
-  const url = `${baseUrl}/ExtensionBundles/${extensionBundleId}/${extensionVersion}/${extensionBundleId}.${extensionVersion}_any-any.zip`;
+function buildExtensionBundleZipUrl(baseUrl: string, extensionVersion: string): string {
+  return `${baseUrl}/ExtensionBundles/${extensionBundleId}/${extensionVersion}/${extensionBundleId}.${extensionVersion}_any-any.zip`;
+}
 
-  return url;
+/**
+ * Returns the absolute path of the on-disk MD5 sidecar for a given bundle version.
+ * The sidecar is written by `downloadExtensionBundle` after a successful download
+ * so subsequent startups can confirm the bundle still matches the publisher's
+ * `Content-MD5` header without re-downloading.
+ */
+/**
+ * Sidecar shape persisted next to the extracted bundle:
+ *  - `sourceMd5` is the MD5 of the downloaded zip (matches what the CDN publishes
+ *    as `Content-MD5` on a HEAD of the zip URL), used to detect CDN-side republish.
+ *  - `contentHash` is a deterministic sha256 over the extracted file tree, recomputed
+ *    on every activation to detect post-download mutation (manual edits, disk bit-rot,
+ *    AV restore, partial overwrite, etc.).
+ *
+ * The sidecar is NOT a snapshot of the bundle's state — it is a tiny *expected* value
+ * that we compare against a freshly-computed `actual`. A corrupted sidecar produces a
+ * false-positive mismatch (we redownload), which is harmless. Both fields are present
+ * iff the bundle was downloaded by this version of the extension.
+ */
+interface BundleSidecar {
+  version: number;
+  sourceMd5: string;
+  contentHash: string;
+}
+
+const SIDECAR_FORMAT_VERSION = 1;
+
+function getBundleSidecarPath(version: string): string {
+  return path.join(defaultExtensionBundlePathValue, version, bundleSourceMd5SidecarFile);
+}
+
+async function readBundleSidecar(version: string): Promise<BundleSidecar | undefined> {
+  const sidecarPath = getBundleSidecarPath(version);
+  try {
+    if (!(await fse.pathExists(sidecarPath))) {
+      return undefined;
+    }
+    const raw = (await fse.readFile(sidecarPath, 'utf8')).trim();
+    if (raw.length === 0) {
+      return undefined;
+    }
+    // Lenient: legacy bare-MD5 sidecars (no JSON braces) and JSON missing the
+    // contentHash field both fall through to undefined, forcing a one-time
+    // migration redownload to upgrade the format.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return undefined;
+    }
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof (parsed as Record<string, unknown>).sourceMd5 === 'string' &&
+      typeof (parsed as Record<string, unknown>).contentHash === 'string' &&
+      typeof (parsed as Record<string, unknown>).version === 'number'
+    ) {
+      const obj = parsed as Record<string, unknown>;
+      return {
+        version: obj.version as number,
+        sourceMd5: obj.sourceMd5 as string,
+        contentHash: obj.contentHash as string,
+      };
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeBundleSidecar(version: string, sourceMd5: string, contentHash: string): Promise<void> {
+  const sidecarPath = getBundleSidecarPath(version);
+  const tempSidecarPath = `${sidecarPath}.${process.pid}.${Date.now()}.tmp`;
+  const payload: BundleSidecar = { version: SIDECAR_FORMAT_VERSION, sourceMd5, contentHash };
+  try {
+    await fse.outputFile(tempSidecarPath, JSON.stringify(payload), 'utf8');
+    await fse.move(tempSidecarPath, sidecarPath, { overwrite: true });
+  } catch (writeError) {
+    await fse.remove(tempSidecarPath).catch(() => undefined);
+    const message = localize(
+      'bundleSidecarWriteFailed',
+      'Failed to write extension-bundle MD5 sidecar at "{0}": {1}',
+      sidecarPath,
+      String(writeError)
+    );
+    ext.outputChannel?.appendLog(message);
+    throw new Error(message);
+  }
+}
+
+async function hasRequiredBundleContent(bundleDir: string): Promise<boolean> {
+  if (!(await fse.pathExists(bundleDir))) {
+    return false;
+  }
+
+  const binDir = path.join(bundleDir, 'bin');
+  const depsPath = path.join(binDir, 'function.deps.json');
+  if (!(await fse.pathExists(depsPath))) {
+    return false;
+  }
+
+  let parsedDeps: unknown;
+  try {
+    parsedDeps = JSON.parse(await fse.readFile(depsPath, 'utf8'));
+  } catch {
+    return false;
+  }
+
+  const requiredRuntimeFiles = new Set<string>();
+  const targets = (parsedDeps as { targets?: unknown })?.targets;
+  if (typeof targets === 'object' && targets !== null) {
+    for (const target of Object.values(targets as Record<string, unknown>)) {
+      if (typeof target !== 'object' || target === null) {
+        continue;
+      }
+      for (const dependency of Object.values(target as Record<string, unknown>)) {
+        const runtime = (dependency as { runtime?: unknown })?.runtime;
+        if (typeof runtime !== 'object' || runtime === null) {
+          continue;
+        }
+        for (const relPath of Object.keys(runtime as Record<string, unknown>)) {
+          requiredRuntimeFiles.add(relPath);
+        }
+      }
+    }
+  }
+
+  if (requiredRuntimeFiles.size === 0) {
+    return false;
+  }
+
+  const normalizedBinDir = path.normalize(binDir);
+  for (const relPath of requiredRuntimeFiles) {
+    const candidates = [
+      path.normalize(path.join(binDir, ...relPath.split('/'))),
+      path.normalize(path.join(binDir, path.basename(relPath))),
+    ];
+    const hasRuntimeFile = await candidates.reduce(async (previous, candidate) => {
+      if (await previous) {
+        return true;
+      }
+      if (!candidate.startsWith(`${normalizedBinDir}${path.sep}`)) {
+        return false;
+      }
+      return (await fse.pathExists(candidate)) && (await fse.stat(candidate)).isFile();
+    }, Promise.resolve(false));
+
+    if (!hasRuntimeFile) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Deterministic streaming sha256 over every regular file in `bundleDir`.
+ *
+ * - Sorts entries by POSIX-normalized relative path so the hash is stable across
+ *   filesystems / OSes.
+ * - Skips the sidecar file itself (otherwise writing the sidecar would invalidate
+ *   the hash we just computed).
+ * - For each entry we feed `<relPath>\0<size>\0<file-bytes>\0` so renames and
+ *   truncations both shift the hash.
+ *
+ * Returns the base64 digest, or `undefined` if `bundleDir` doesn't exist.
+ */
+export async function computeBundleContentHash(bundleDir: string): Promise<string | undefined> {
+  if (!(await fse.pathExists(bundleDir))) {
+    return undefined;
+  }
+  const entries: string[] = [];
+  const walk = async (dir: string): Promise<void> => {
+    const items = await fse.readdir(dir);
+    for (const item of items) {
+      const abs = path.join(dir, item);
+      const stat = await fse.lstat(abs);
+      if (stat.isDirectory()) {
+        await walk(abs);
+      } else if (stat.isFile()) {
+        const rel = path.relative(bundleDir, abs).split(path.sep).join('/');
+        if (rel === bundleSourceMd5SidecarFile) {
+          continue;
+        }
+        entries.push(rel);
+      }
+    }
+  };
+  await walk(bundleDir);
+  entries.sort();
+
+  const hash = createHash('sha256');
+  for (const rel of entries) {
+    const abs = path.join(bundleDir, ...rel.split('/'));
+    const stat = await fse.stat(abs);
+    hash.update(rel);
+    hash.update('\0');
+    hash.update(String(stat.size));
+    hash.update('\0');
+    await new Promise<void>((resolve, reject) => {
+      const stream = fse.createReadStream(abs);
+      stream.on('data', (chunk: Buffer | string) => {
+        if (typeof chunk === 'string') {
+          hash.update(chunk);
+        } else {
+          hash.update(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+        }
+      });
+      stream.on('error', reject);
+      stream.on('end', () => resolve());
+    });
+    hash.update('\0');
+  }
+  return hash.digest('base64');
 }
 
 /**
@@ -121,48 +404,942 @@ async function getExtensionBundleVersionFolders(directoryPath: string): Promise<
   return folders;
 }
 
+function pickLatestVersion(versions: string[]): string {
+  let latest = '0.0.0';
+  for (const v of versions) {
+    if (semver.valid(v) && semver.gt(v, latest)) {
+      latest = v;
+    }
+  }
+  return latest;
+}
+
+/**
+ * Downloads the bundle zip from the resolved base URL and writes the sidecar
+ * (source MD5 from the download + a fresh content-hash of the extracted tree).
+ * Used both for the standard "feed wins" path and for the experimental cold-start path.
+ */
+async function downloadBundleAndWriteSidecar(context: IActionContext, baseUrl: string, version: string): Promise<void> {
+  const zipUrl = buildExtensionBundleZipUrl(baseUrl, version);
+  const result = await downloadAndExtractDependency(context, zipUrl, defaultExtensionBundlePathValue, extensionBundleId, version);
+  if (!result?.actualMd5) {
+    throw new Error(`Bundle ${version} was downloaded but no source MD5 was available. Refusing to install without a sidecar.`);
+  }
+  const bundleDir = path.join(defaultExtensionBundlePathValue, version);
+  const contentHash = await computeBundleContentHash(bundleDir);
+  if (!contentHash) {
+    // No files were hashed — the extracted bundle directory is empty. Refuse to
+    // bless this state with a sidecar, otherwise the next activation would treat
+    // the partial install as "good" and never re-download.
+    throw new Error(`Bundle ${version} was downloaded but the extracted directory at ${bundleDir} is empty. Refusing to write sidecar.`);
+  }
+  await writeBundleSidecar(version, result.actualMd5, contentHash);
+}
+
+/**
+ * Same as `downloadBundleAndWriteSidecar` but returns `undefined` when the
+ * configured CDN doesn't have the package (HTTP 404 / network failure) so
+ * callers can fall back to a different source. Genuine integrity failures
+ * (corrupt bytes despite valid headers) still throw — those should not be
+ * silently retried against another CDN.
+ */
+async function tryDownloadBundleAndWriteSidecar(
+  context: IActionContext,
+  baseUrl: string,
+  version: string
+): Promise<{ ok: true } | { ok: false; reason: ExperimentalSourceFallbackReason; error: unknown }> {
+  try {
+    await downloadBundleAndWriteSidecar(context, baseUrl, version);
+    return { ok: true };
+  } catch (error) {
+    if (isMissingPackageError(error)) {
+      const status = (error as { response?: { status?: number } })?.response?.status;
+      const reason: ExperimentalSourceFallbackReason = typeof status === 'number' && status === 404 ? 'zip404' : 'networkError';
+      return { ok: false, reason, error };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Fetches the index.json for the given (experimental) base URL. Returns the
+ * version array on success, `undefined` on 404 / network error so the caller
+ * can fall back. Other errors (e.g. malformed JSON) propagate.
+ */
+async function tryFetchSourceIndex(
+  context: IActionContext,
+  baseUrl: string
+): Promise<{ ok: true; versions: string[] } | { ok: false; reason: ExperimentalSourceFallbackReason; error: unknown }> {
+  const url = `${baseUrl}/ExtensionBundles/${extensionBundleId}/index.json`;
+  try {
+    const versions: string[] = await getJsonFeed(context, url);
+    return { ok: true, versions };
+  } catch (error) {
+    if (isMissingPackageError(error)) {
+      const status = (error as { response?: { status?: number } })?.response?.status;
+      const reason: ExperimentalSourceFallbackReason = typeof status === 'number' && status === 404 ? 'index404' : 'networkError';
+      return { ok: false, reason, error };
+    }
+    throw error;
+  }
+}
+
+function logExperimentalFallback(context: IActionContext, reason: ExperimentalSourceFallbackReason, detail: string, error?: unknown): void {
+  context.telemetry.properties.experimentalSourceFallback = reason;
+  context.telemetry.properties.experimentalSourceFallbackTarget = 'public';
+  if (ext.outputChannel) {
+    const message = error instanceof Error ? `${detail} (${error.message})` : detail;
+    ext.outputChannel.appendLog(
+      localize(
+        'experimentalSourceFallback',
+        'Experimental extension-bundle source could not deliver ({0}); falling back to public CDN. {1}',
+        reason,
+        message
+      )
+    );
+  }
+}
+
+/**
+ * Why we're about to (re)download a bundle — drives the user-facing
+ * notification copy so the user understands *why* something is being
+ * downloaded, not just *that* it is.
+ */
+type DownloadReason =
+  | 'newerVersion'
+  | 'sidecarMissing'
+  | 'sidecarMismatch'
+  | 'contentMismatch'
+  | 'experimentalPin'
+  | 'experimentalLatest'
+  | 'envVarPin'
+  | 'envVarRepair'
+  | 'experimentalPinRepair'
+  | 'experimentalLocalLatestRepair'
+  | 'fallbackPublic';
+
+function describeSource(baseUrl: string): string {
+  if (baseUrl.startsWith(PUBLIC_BUNDLE_BASE_URL)) {
+    return localize('bundleSourcePublic', 'public Azure CDN');
+  }
+  return baseUrl;
+}
+
+function buildProgressTitle(version: string, reason: DownloadReason, baseUrl: string): string {
+  const source = describeSource(baseUrl);
+  switch (reason) {
+    case 'sidecarMissing':
+      // First-run-after-upgrade case (no `.bundle-source-md5` yet) — the
+      // bundle isn't necessarily corrupt, just unverifiable, so we phrase
+      // the toast as "couldn't be verified" rather than "incomplete".
+      return localize(
+        'bundleProgressRedownloadUnverified',
+        'Re-downloading Logic Apps extension bundle {0} from {1} (local copy could not be verified)…',
+        version,
+        source
+      );
+    case 'sidecarMismatch':
+      return localize(
+        'bundleProgressRedownload',
+        'Re-downloading Logic Apps extension bundle {0} from {1} (local copy was incomplete)…',
+        version,
+        source
+      );
+    case 'contentMismatch':
+      return localize(
+        'bundleProgressCorruption',
+        'Re-downloading Logic Apps extension bundle {0} from {1} — files on disk were modified or corrupted…',
+        version,
+        source
+      );
+    case 'newerVersion':
+      return localize('bundleProgressNewer', 'Downloading newer Logic Apps extension bundle {0} from {1}…', version, source);
+    case 'experimentalPin':
+      return localize('bundleProgressPin', 'Downloading pinned Logic Apps extension bundle {0} from {1}…', version, source);
+    case 'experimentalLatest':
+      return localize(
+        'bundleProgressExperimental',
+        'Downloading Logic Apps extension bundle {0} from experimental source {1}…',
+        version,
+        source
+      );
+    case 'envVarPin':
+      return localize(
+        'bundleProgressEnvVar',
+        'Downloading Logic Apps extension bundle {0} pinned by host.json/env from {1}…',
+        version,
+        source
+      );
+    case 'envVarRepair':
+      return localize(
+        'bundleProgressEnvVarRepair',
+        'Re-downloading pinned Logic Apps extension bundle {0} from {1} — on-disk integrity check failed…',
+        version,
+        source
+      );
+    case 'experimentalPinRepair':
+      return localize(
+        'bundleProgressExperimentalPinRepair',
+        'Re-downloading experimental pinned Logic Apps extension bundle {0} from {1} — on-disk integrity check failed…',
+        version,
+        source
+      );
+    case 'experimentalLocalLatestRepair':
+      return localize(
+        'bundleProgressExperimentalLatestRepair',
+        'Re-downloading Logic Apps extension bundle {0} (experimental local latest) from {1} — on-disk integrity check failed…',
+        version,
+        source
+      );
+    case 'fallbackPublic':
+      return localize(
+        'bundleProgressFallback',
+        'Experimental source could not deliver Logic Apps extension bundle {0}; downloading from public Azure CDN…',
+        version
+      );
+    default:
+      return localize('bundleProgressGeneric', 'Downloading Logic Apps extension bundle {0}…', version);
+  }
+}
+
+/**
+ * Surfaces a one-time warning toast when we detect that the local copy of
+ * the bundle is corrupt / incomplete. We always follow it with the actual
+ * download (which the user also sees via the progress notification), so
+ * the warning is informational only — no buttons.
+ */
+function notifyCorruptionDetected(version: string, source: string): void {
+  vscode.window.showWarningMessage(
+    localize(
+      'bundleCorruptionDetected',
+      'Logic Apps extension bundle {0} on disk is incomplete or its checksum no longer matches {1}. Re-downloading.',
+      version,
+      source
+    )
+  );
+}
+
+/**
+ * Wraps `downloadBundleAndWriteSidecar` in a `withProgress` notification and
+ * shows a success toast so the user can see what's happening rather than
+ * silently waiting on activation.
+ *
+ * Tests stub `vscode.window.withProgress` to immediately invoke its task, so
+ * this stays unit-testable.
+ */
+async function downloadBundleWithProgress(
+  context: IActionContext,
+  baseUrl: string,
+  version: string,
+  reason: DownloadReason
+): Promise<void> {
+  const title = buildProgressTitle(version, reason, baseUrl);
+  if (ext.outputChannel) {
+    ext.outputChannel.appendLog(title);
+  }
+  await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title, cancellable: false }, async () => {
+    await downloadBundleAndWriteSidecar(context, baseUrl, version);
+  });
+  vscode.window.showInformationMessage(localize('bundleDownloadReady', 'Logic Apps extension bundle {0} is ready.', version));
+}
+
+/**
+ * Progress-wrapped variant of `tryDownloadBundleAndWriteSidecar` for the
+ * experimental → public fallback chain. Behaves identically to the bare
+ * helper but surfaces a progress notification during the attempt.
+ */
+async function tryDownloadBundleWithProgress(
+  context: IActionContext,
+  baseUrl: string,
+  version: string,
+  reason: DownloadReason
+): Promise<{ ok: true } | { ok: false; reason: ExperimentalSourceFallbackReason; error: unknown }> {
+  const title = buildProgressTitle(version, reason, baseUrl);
+  if (ext.outputChannel) {
+    ext.outputChannel.appendLog(title);
+  }
+  let outcome: { ok: true } | { ok: false; reason: ExperimentalSourceFallbackReason; error: unknown } = { ok: true };
+  await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title, cancellable: false }, async () => {
+    outcome = await tryDownloadBundleAndWriteSidecar(context, baseUrl, version);
+  });
+  if (outcome.ok) {
+    vscode.window.showInformationMessage(localize('bundleDownloadReady', 'Logic Apps extension bundle {0} is ready.', version));
+  }
+  return outcome;
+}
+
+/**
+ * Verifies the on-disk bundle:
+ *   1. Sidecar present and parseable (else `sidecarMissing` — also fires for
+ *      legacy bare-MD5 sidecars to drive one-time migration).
+ *   2. Recompute the extracted tree's content hash and compare to the sidecar's
+ *      `contentHash` — catches post-download mutation (manual edits, bit-rot,
+ *      AV restore, partial overwrite). On mismatch: `contentMismatch`.
+ *   3. HEAD the public CDN for the zip's `Content-MD5` and compare to the
+ *      sidecar's `sourceMd5` — catches publisher republish under same version.
+ *      On mismatch: `sidecarMismatch`. HEAD failure → `headRequestFailed`
+ *      (treated as passed by the caller so CDN flakes don't punish offline users).
+ */
+async function verifyLocalBundle(
+  context: IActionContext,
+  publicBaseUrl: string,
+  localVersion: string,
+  options: { allowSidecarBackfill?: boolean } = {}
+): Promise<'passed' | 'sidecarBackfilled' | 'sidecarMissing' | 'contentMismatch' | 'sidecarMismatch' | 'headRequestFailed'> {
+  const sidecar = await readBundleSidecar(localVersion);
+  if (!sidecar) {
+    if (options.allowSidecarBackfill !== false) {
+      const backfilled = await tryBackfillBundleSidecar(context, publicBaseUrl, localVersion);
+      if (backfilled) {
+        return 'sidecarBackfilled';
+      }
+    }
+    return 'sidecarMissing';
+  }
+
+  const bundleDir = path.join(defaultExtensionBundlePathValue, localVersion);
+  const actualContentHash = await computeBundleContentHash(bundleDir);
+  if (!actualContentHash || actualContentHash !== sidecar.contentHash) {
+    if (ext.outputChannel) {
+      ext.outputChannel.appendLog(
+        localize(
+          'bundleContentHashMismatch',
+          'Logic Apps extension bundle {0} content hash mismatch (expected {1}, got {2}).',
+          localVersion,
+          sidecar.contentHash,
+          actualContentHash ?? '<missing>'
+        )
+      );
+    }
+    return 'contentMismatch';
+  }
+
+  const headUrl = buildExtensionBundleZipUrl(publicBaseUrl, localVersion);
+  let publishedMd5: string | undefined;
+  try {
+    publishedMd5 = await fetchExpectedMd5(headUrl);
+  } catch (error) {
+    if (ext.outputChannel) {
+      ext.outputChannel.appendLog(
+        localize(
+          'bundleHashHeadFailed',
+          'Failed to verify extension-bundle MD5 against {0}: {1}',
+          headUrl,
+          error instanceof Error ? error.message : String(error)
+        )
+      );
+    }
+    context.telemetry.properties.bundleHashHeadError = error instanceof Error ? error.message : String(error);
+    return 'headRequestFailed';
+  }
+
+  if (!publishedMd5) {
+    return 'passed';
+  }
+  if (!sidecar.sourceMd5) {
+    return 'passed';
+  }
+  return publishedMd5 === sidecar.sourceMd5 ? 'passed' : 'sidecarMismatch';
+}
+
+async function tryBackfillBundleSidecar(context: IActionContext, publicBaseUrl: string, localVersion: string): Promise<boolean> {
+  const bundleDir = path.join(defaultExtensionBundlePathValue, localVersion);
+  if (!(await hasRequiredBundleContent(bundleDir))) {
+    ext.outputChannel?.appendLog(
+      `Logic Apps extension bundle ${localVersion} is missing sidecar metadata, but the extracted bundle folder is incomplete. Re-downloading.`
+    );
+    return false;
+  }
+
+  const actualContentHash = await computeBundleContentHash(bundleDir);
+  if (!actualContentHash) {
+    return false;
+  }
+
+  const headUrl = buildExtensionBundleZipUrl(publicBaseUrl, localVersion);
+  let publishedMd5: string | undefined;
+  try {
+    publishedMd5 = await fetchExpectedMd5(headUrl);
+  } catch (error) {
+    ext.outputChannel?.appendLog(
+      localize(
+        'bundleBackfillHashHeadFailed',
+        'Failed to backfill extension-bundle sidecar from {0}: {1}',
+        headUrl,
+        error instanceof Error ? error.message : String(error)
+      )
+    );
+    context.telemetry.properties.bundleBackfillHeadError = error instanceof Error ? error.message : String(error);
+    publishedMd5 = '';
+  }
+
+  if (!publishedMd5) {
+    ext.outputChannel?.appendLog(
+      `Logic Apps extension bundle ${localVersion} is missing sidecar metadata, and the bundle source did not publish Content-MD5. Backfilling content hash only.`
+    );
+  }
+
+  try {
+    await writeBundleSidecar(localVersion, publishedMd5 ?? '', actualContentHash);
+  } catch {
+    return false;
+  }
+  ext.outputChannel?.appendLog(`Logic Apps extension bundle ${localVersion} sidecar metadata backfilled from existing install.`);
+  return true;
+}
+
+type LocalBundleVerificationResult = Awaited<ReturnType<typeof verifyLocalBundle>>;
+type RepairableLocalBundleFailure = Extract<LocalBundleVerificationResult, 'sidecarMissing' | 'sidecarMismatch' | 'contentMismatch'>;
+
+function requiresBundleRepair(hashCheck: LocalBundleVerificationResult): hashCheck is RepairableLocalBundleFailure {
+  return hashCheck === 'sidecarMissing' || hashCheck === 'sidecarMismatch' || hashCheck === 'contentMismatch';
+}
+
+function notifyCorruptionIfNeeded(hashCheck: RepairableLocalBundleFailure, version: string, baseUrl: string): void {
+  // sidecarMissing fires on first-run-after-upgrade for legacy bare-MD5
+  // sidecars; keep that path quieter to avoid alarming users during migration.
+  if (hashCheck !== 'sidecarMissing') {
+    notifyCorruptionDetected(version, describeSource(baseUrl));
+  }
+}
+
+/**
+ * Tracks any in-flight `downloadExtensionBundle` so other parts of the
+ * extension (e.g. `startDesignTimeApi` which spawns `func.exe` against the
+ * extracted bundle folder) can `await waitForExtensionBundleReady()` and
+ * avoid racing against an active re-extract — which on Windows can lock the
+ * bundle folder, kill the design-time host, and leave the user with a half-
+ * extracted bundle until the next activation.
+ *
+ * Activation itself fires `downloadExtensionBundle` without awaiting so the
+ * UI stays responsive; this gives any code path that *does* depend on the
+ * extracted bundle a way to block on completion when needed. Stays a noop
+ * (resolved promise) when no download is in flight.
+ */
+let inFlightBundleWork: Promise<void> | undefined;
+
+/**
+ * Outcome of the most recent extension-bundle install attempt this session.
+ * `'unknown'` until `downloadExtensionBundle` has finished at least once.
+ * `'failed'` when extraction/install threw (e.g. EPERM from a locked dir),
+ * so callers can refuse to proceed with downstream work that requires a
+ * known-healthy bundle (design-time host startup, dependency validation).
+ */
+export type BundleInstallResult = 'unknown' | 'ok' | 'failed';
+let lastBundleInstallResult: BundleInstallResult = 'unknown';
+let lastBundleInstallError: Error | undefined;
+
+export function getLastBundleInstallResult(): BundleInstallResult {
+  return lastBundleInstallResult;
+}
+
+export function getLastBundleInstallError(): Error | undefined {
+  return lastBundleInstallError;
+}
+
+/**
+ * Tracks call-stacks that are currently *inside* `downloadExtensionBundle`.
+ * Anything awaited from within that scope — most importantly the post-extract
+ * `startAllDesignTimeApis` call that itself awaits `waitForExtensionBundleReady`
+ * — must NOT block on `inFlightBundleWork`, or we self-deadlock: the in-flight
+ * promise is resolved in `downloadExtensionBundle`'s `finally`, which can only
+ * run once the awaited restart finishes.
+ */
+const bundleDownloadScope = new AsyncLocalStorage<true>();
+
+export function waitForExtensionBundleReady(): Promise<void> {
+  // Re-entrant call from within the download's own post-extract hook —
+  // returning the in-flight promise here would deadlock. The caller is by
+  // definition already running because the bundle is on disk.
+  if (bundleDownloadScope.getStore() === true) {
+    return Promise.resolve();
+  }
+  return inFlightBundleWork ?? Promise.resolve();
+}
+
+export function isExtensionBundleDownloadInFlight(): boolean {
+  return inFlightBundleWork !== undefined;
+}
+
+/**
+ * True iff the current async call stack is *inside* a `downloadExtensionBundle`
+ * invocation (set by AsyncLocalStorage). Callers that gate on bundle health
+ * (e.g. the design-time-host launcher) use this to suppress the misleading
+ * "Waiting for bundle…" log when the call originates from the download's own
+ * post-extract hook — the bundle is on disk by then, so there's nothing to
+ * wait for and the message is just noise.
+ */
+export function isInsideBundleDownloadScope(): boolean {
+  return bundleDownloadScope.getStore() === true;
+}
+
+/**
+ * Pure on-disk health check for the installed extension bundle. Reads the
+ * sidecar, recomputes the content hash of the extracted tree from disk, and
+ * compares them. Has NO side effects — no downloads, no writes — so it's
+ * safe to call from any number of places (gate, scheduled re-check, etc.).
+ *
+ * Returns `{ ok: true, version }` when the latest local bundle's recomputed
+ * content hash matches the sidecar's stored value. Otherwise returns
+ * `{ ok: false, reason, version?, detail? }` so the caller can decide
+ * whether to repair, warn, or fail.
+ *
+ * Why this exists: prior to Phase 14 we trusted the sidecar's `contentHash`
+ * field as proof the on-disk tree was intact, but a user manually deleting
+ * a subfolder (e.g. `bin/.../PowerShell`) leaves the sidecar untouched while
+ * the tree is corrupt. `ensureExtensionBundleHealthy` now uses this helper
+ * to proactively detect that drift and force a synchronous repair download.
+ */
+export type BundleOnDiskHealthResult =
+  | { ok: true; version: string }
+  | {
+      ok: false;
+      reason: 'noBundle' | 'sidecarMissing' | 'sidecarUnreadable' | 'emptyBundleDir' | 'contentMismatch';
+      version?: string;
+      detail?: string;
+    };
+
+type BundleOnDiskHealthFailure = Extract<BundleOnDiskHealthResult, { ok: false }>;
+
+function formatBundleHealthFailure(failure: BundleOnDiskHealthFailure): string {
+  return failure.detail ? `${failure.reason} (${failure.detail})` : failure.reason;
+}
+
+function throwBundleHealthError(prefix: string, failure: BundleOnDiskHealthFailure): never {
+  throw new Error(
+    `Logic Apps extension bundle is not installed correctly. ${prefix}: ${formatBundleHealthFailure(failure)}. Close other VS Code windows running Logic Apps, terminate any leftover func.exe processes, and reload this window to retry.`
+  );
+}
+
+export async function assertExtensionBundleOnDiskHealthy(version?: string): Promise<BundleOnDiskHealthResult> {
+  let targetVersion = version;
+  if (!targetVersion) {
+    const localVersions = await getExtensionBundleVersionFolders(defaultExtensionBundlePathValue);
+    const latest = pickLatestVersion(localVersions);
+    if (latest === '0.0.0') {
+      return { ok: false, reason: 'noBundle' };
+    }
+    targetVersion = latest;
+  }
+  const bundleDir = path.join(defaultExtensionBundlePathValue, targetVersion);
+  if (!(await fse.pathExists(bundleDir))) {
+    return { ok: false, reason: 'noBundle', version: targetVersion };
+  }
+  const sidecar = await readBundleSidecar(targetVersion);
+  if (!sidecar) {
+    return { ok: false, reason: 'sidecarMissing', version: targetVersion };
+  }
+  if (!sidecar.contentHash) {
+    return { ok: false, reason: 'sidecarUnreadable', version: targetVersion, detail: 'sidecar missing contentHash field' };
+  }
+  const actualHash = await computeBundleContentHash(bundleDir);
+  if (!actualHash) {
+    return { ok: false, reason: 'emptyBundleDir', version: targetVersion };
+  }
+  if (actualHash !== sidecar.contentHash) {
+    return {
+      ok: false,
+      reason: 'contentMismatch',
+      version: targetVersion,
+      detail: `expected ${sidecar.contentHash}, got ${actualHash}`,
+    };
+  }
+  return { ok: true, version: targetVersion };
+}
+
+/**
+ * Awaits any in-flight bundle work and throws if the most recent install
+ * attempt failed. Callers that must not proceed without a healthy bundle
+ * (e.g. design-time host startup, runtime dependency validation) should
+ * call this rather than the lower-level `waitForExtensionBundleReady`.
+ *
+ * Phase 14: when a context is supplied this also proactively re-checks the
+ * on-disk bundle (see `assertExtensionBundleOnDiskHealthy`). If the disk
+ * has drifted from the sidecar (user deleted a subfolder, AV restored a
+ * stale copy, etc.) we kick off a synchronous repair download, then
+ * re-check. If repair still fails the function throws so the dependency
+ * validation refuses to mark the runtime "successfully installed" and the
+ * design-time host never spawns against a corrupt bundle.
+ *
+ * Callers without a context (legacy) still get the old await-only behavior.
+ */
+interface EnsureExtensionBundleHealthyOptions {
+  requireInstalled?: boolean;
+}
+
+interface DownloadExtensionBundleOptions {
+  allowSidecarBackfill?: boolean;
+}
+
+export async function ensureExtensionBundleHealthy(
+  context?: IActionContext,
+  options: EnsureExtensionBundleHealthyOptions = {}
+): Promise<void> {
+  await waitForExtensionBundleReady();
+  if (lastBundleInstallResult === 'failed') {
+    const cause = lastBundleInstallError?.message ?? 'unknown error';
+    throw new Error(
+      `Logic Apps extension bundle is not installed correctly. Last install attempt failed: ${cause}. Close other VS Code windows running Logic Apps, terminate any leftover func.exe processes, and reload this window to retry.`
+    );
+  }
+
+  if (!context) {
+    return;
+  }
+
+  const initialHealth = await assertExtensionBundleOnDiskHealthy();
+  if (initialHealth.ok) {
+    ext.outputChannel?.appendLog(`Logic Apps extension bundle ${initialHealth.version} on-disk integrity check passed.`);
+    return;
+  }
+  const initialFailure = initialHealth as Extract<BundleOnDiskHealthResult, { ok: false }>;
+
+  // No bundle at all and no in-flight install — let the caller's normal
+  // path (downloadExtensionBundle from main.ts:157) handle first-run
+  // bootstrap. We don't want to race that on a fresh install.
+  if (initialFailure.reason === 'noBundle' && lastBundleInstallResult === 'unknown') {
+    if (!options.requireInstalled || !context) {
+      return;
+    }
+    ext.outputChannel?.appendLog('Logic Apps extension bundle is not installed. Downloading before dependency validation can complete.');
+    await downloadExtensionBundle(context, { allowSidecarBackfill: false });
+    const postInstallHealth = await assertExtensionBundleOnDiskHealthy();
+    if (postInstallHealth.ok) {
+      return;
+    }
+    throwBundleHealthError('Install completed but on-disk integrity still failed', postInstallHealth as BundleOnDiskHealthFailure);
+  }
+
+  const versionLabel = initialFailure.version ? ` ${initialFailure.version}` : '';
+  const reasonLabel = formatBundleHealthFailure(initialFailure);
+  ext.outputChannel?.appendLog(
+    `Logic Apps extension bundle${versionLabel} on-disk integrity check failed: ${reasonLabel}. Attempting repair.`
+  );
+
+  if (context.telemetry?.properties) {
+    context.telemetry.properties.bundleOnDiskHealthCheck = initialFailure.reason;
+  }
+
+  try {
+    await downloadExtensionBundle(context, { allowSidecarBackfill: false });
+  } catch (repairError) {
+    const cause = repairError instanceof Error ? repairError.message : String(repairError);
+    throw new Error(
+      `Logic Apps extension bundle is not installed correctly. Repair attempt failed: ${cause}. Close other VS Code windows running Logic Apps, terminate any leftover func.exe processes, and reload this window to retry.`
+    );
+  }
+
+  const postRepairHealth = await assertExtensionBundleOnDiskHealthy();
+  if (postRepairHealth.ok) {
+    return;
+  }
+  throwBundleHealthError('Repair completed but on-disk integrity still failed', postRepairHealth as BundleOnDiskHealthFailure);
+}
+
 /**
  * Download Microsoft.Azure.Functions.ExtensionBundle.Workflows.<version>
  * Destination: C:\Users\<USERHOME>\.azure-functions-core-tools\Functions\ExtensionBundles\<version>
  * @param {IActionContext} context - Command context.
  * @returns {Promise<bool>} A boolean indicating whether the bundle was updated.
  */
-export async function downloadExtensionBundle(context: IActionContext): Promise<boolean> {
+export async function downloadExtensionBundle(context: IActionContext, options: DownloadExtensionBundleOptions = {}): Promise<boolean> {
+  // Dedupe concurrent calls: if a download is already in flight, await it
+  // instead of kicking off a parallel attempt that would race for the same
+  // extraction directory.
+  if (inFlightBundleWork) {
+    await inFlightBundleWork;
+    return false;
+  }
+  let resolveInFlight: (() => void) | undefined;
+  inFlightBundleWork = new Promise<void>((resolve) => {
+    resolveInFlight = resolve;
+  });
+  let installSucceededAndChanged = false;
   try {
-    const downloadExtensionBundleStartTime = Date.now();
+    // Mark this whole call-stack as "inside the bundle download". Any nested
+    // `waitForExtensionBundleReady()` will short-circuit instead of awaiting
+    // the in-flight promise we own.
+    const result = await bundleDownloadScope.run(true, () => downloadExtensionBundleCore(context, options));
+    lastBundleInstallResult = 'ok';
+    lastBundleInstallError = undefined;
+    installSucceededAndChanged = result;
+    return result;
+  } catch (error) {
+    lastBundleInstallResult = 'failed';
+    lastBundleInstallError = error instanceof Error ? error : new Error(String(error));
+    throw error;
+  } finally {
+    inFlightBundleWork = undefined;
+    resolveInFlight?.();
+    // Defer the post-install design-time restart until AFTER both the
+    // in-flight promise is cleared AND `lastBundleInstallResult` is settled.
+    // Earlier this restart fired from inside `downloadAndExtractDependency`
+    // — while the install was still mid-flight and not yet verified — which
+    // caused the design-time launcher to log a misleading "Waiting for
+    // bundle download to complete…" line and then immediately spawn
+    // `func.exe` (short-circuiting via `bundleDownloadScope`). With the
+    // restart hoisted out here, `startDesignTimeApi` sees a clean
+    // `lastBundleInstallResult === 'ok'` and an idle `inFlightBundleWork`.
+    if (installSucceededAndChanged) {
+      // Dynamic import to dodge the circular dependency between this module
+      // and `startDesignTimeApi.ts` (which imports `waitForExtensionBundleReady`).
+      // Fire-and-forget — we don't block the caller of `downloadExtensionBundle`
+      // on the restart; failures are surfaced through the output channel.
+      const restartPromise = (async () => {
+        try {
+          const { startAllDesignTimeApis } = await import('./codeless/startDesignTimeApi');
+          await startAllDesignTimeApis();
+        } catch (restartError) {
+          ext.outputChannel?.appendLog(
+            `Post-bundle-install design-time restart failed: ${restartError instanceof Error ? restartError.message : String(restartError)}`
+          );
+        }
+      })();
+      restartPromise.catch(() => undefined);
+    }
+  }
+}
+
+async function downloadExtensionBundleCore(context: IActionContext, options: DownloadExtensionBundleOptions): Promise<boolean> {
+  const downloadExtensionBundleStartTime = Date.now();
+  try {
     let envVarVer: string | undefined = process.env.AzureFunctionsJobHost_extensionBundle_version;
     const projectPath: string | undefined = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
     if (projectPath) {
-      envVarVer = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
-        ?.AzureFunctionsJobHost_extensionBundle_version;
+      try {
+        envVarVer = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
+          ?.AzureFunctionsJobHost_extensionBundle_version;
+      } catch {
+        // ignore
+      }
     }
 
-    // Check for latest version at directory.
-    let latestLocalBundleVersion = '1.0.0';
     const localVersions = await getExtensionBundleVersionFolders(defaultExtensionBundlePathValue);
-    for (const localVersion of localVersions) {
-      latestLocalBundleVersion = semver.gt(latestLocalBundleVersion, localVersion) ? latestLocalBundleVersion : localVersion;
-    }
+    const latestLocalBundleVersion = pickLatestVersion(localVersions);
+    const baseUrlInfo = await getExtensionBundleBaseUrl(context);
 
     context.telemetry.properties.envVariableExtensionBundleVersion = envVarVer;
+
+    // 1. Pinned via env / local.settings.json.
+    //    Use a *membership* test against the full set of local versions, not
+    //    equality with `latestLocalBundleVersion`. The runtime is happy with
+    //    any matching cached version, so re-downloading just because a newer
+    //    version also happens to be on disk is wasteful — and it's the
+    //    "later version present locally wouldn't be used" complaint.
     if (envVarVer) {
-      if (semver.eq(envVarVer, latestLocalBundleVersion)) {
+      context.telemetry.properties.extensionBundleVersionSource = 'envVar';
+      if (semver.valid(envVarVer) && localVersions.some((v) => v === envVarVer)) {
+        // Verify the on-disk bundle for the pinned version. Without this,
+        // a corrupt local copy would silently satisfy the env-var pin and
+        // we'd never repair it.
+        const hashCheck = await verifyLocalBundle(context, baseUrlInfo.baseUrl, envVarVer, options);
+        context.telemetry.properties.localBundleHashCheck = hashCheck;
+        if (requiresBundleRepair(hashCheck)) {
+          notifyCorruptionIfNeeded(hashCheck, envVarVer, baseUrlInfo.baseUrl);
+          await downloadBundleWithProgress(context, baseUrlInfo.baseUrl, envVarVer, 'envVarRepair');
+          context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+          context.telemetry.properties.didUpdateExtensionBundle = 'true';
+          return true;
+        }
+        ext.defaultBundleVersion = envVarVer;
+        ext.latestBundleVersion = envVarVer;
+        context.telemetry.properties.didUpdateExtensionBundle = 'false';
         return false;
       }
-
-      const extensionBundleUrl = await getExtensionBundleZip(context, envVarVer);
-      await downloadAndExtractDependency(context, extensionBundleUrl, defaultExtensionBundlePathValue, extensionBundleId, envVarVer);
+      await downloadBundleWithProgress(context, baseUrlInfo.baseUrl, envVarVer, 'envVarPin');
       context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
       context.telemetry.properties.didUpdateExtensionBundle = 'true';
       return true;
     }
 
-    // Check the latest from feed.
-    let latestFeedBundleVersion = '1.0.0';
-    const feedVersions: string[] = await getWorkflowBundleFeed(context);
-    for (const bundleVersion of feedVersions) {
-      latestFeedBundleVersion = semver.gt(latestFeedBundleVersion, bundleVersion) ? latestFeedBundleVersion : bundleVersion;
+    // 2. Experimental toggle on. Never consults the public CDN's *latest*
+    //    feed for version selection — but if the configured private source
+    //    cannot deliver the package AND we have no usable local copy, we
+    //    fall back to downloading from the public CDN as a last resort so
+    //    the dev isn't left with a non-running environment.
+    if (baseUrlInfo.isExperimental) {
+      const pin = baseUrlInfo.experimentalPinnedVersion;
+
+      if (pin && pin.length > 0) {
+        const pinIsLocal = localVersions.some((v) => v === pin);
+        if (pinIsLocal) {
+          // Verify before trusting the local pin. The experimental URI is
+          // the publisher of record for hash verification here.
+          const verifyBaseUrl = baseUrlInfo.experimentalSourceUri.length > 0 ? baseUrlInfo.experimentalSourceUri : PUBLIC_BUNDLE_BASE_URL;
+          const hashCheck = await verifyLocalBundle(context, verifyBaseUrl, pin, options);
+          context.telemetry.properties.localBundleHashCheck = hashCheck;
+          if (requiresBundleRepair(hashCheck)) {
+            notifyCorruptionIfNeeded(hashCheck, pin, verifyBaseUrl);
+            // Prefer the experimental source for the repair if configured.
+            if (baseUrlInfo.experimentalSourceUri.length > 0) {
+              const repair = await tryDownloadBundleWithProgress(context, baseUrlInfo.experimentalSourceUri, pin, 'experimentalPinRepair');
+              if (repair.ok === true) {
+                ext.defaultBundleVersion = pin;
+                ext.latestBundleVersion = pin;
+                context.telemetry.properties.extensionBundleVersionSource = 'experimentalPinRepair';
+                context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+                context.telemetry.properties.didUpdateExtensionBundle = 'true';
+                return true;
+              }
+              logExperimentalFallback(context, repair.reason, `Repair of pin ${pin} from experimental source failed.`, repair.error);
+            }
+            await downloadBundleWithProgress(context, PUBLIC_BUNDLE_BASE_URL, pin, 'experimentalPinRepair');
+            ext.defaultBundleVersion = pin;
+            ext.latestBundleVersion = pin;
+            context.telemetry.properties.extensionBundleVersionSource = 'experimentalPinRepair';
+            context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+            context.telemetry.properties.didUpdateExtensionBundle = 'true';
+            return true;
+          }
+          ext.defaultBundleVersion = pin;
+          ext.latestBundleVersion = pin;
+          context.telemetry.properties.extensionBundleVersionSource = 'experimentalLocalPin';
+          context.telemetry.properties.didUpdateExtensionBundle = 'false';
+          return false;
+        }
+
+        // Pin not on disk: try the configured experimental source URI first
+        // (if any), then fall back to the public CDN for the same pin.
+        if (baseUrlInfo.experimentalSourceUri.length > 0) {
+          // Optionally probe the source's index first — this lets us
+          // distinguish "private CDN doesn't have this pin" from "private
+          // CDN is fine but the zip URL was momentarily unreachable" so the
+          // telemetry reason is accurate.
+          const indexProbe = await tryFetchSourceIndex(context, baseUrlInfo.experimentalSourceUri);
+          if (indexProbe.ok === true && indexProbe.versions.includes(pin)) {
+            const result = await tryDownloadBundleWithProgress(context, baseUrlInfo.experimentalSourceUri, pin, 'experimentalPin');
+            if (result.ok === true) {
+              ext.defaultBundleVersion = pin;
+              ext.latestBundleVersion = pin;
+              context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
+              context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+              context.telemetry.properties.didUpdateExtensionBundle = 'true';
+              return true;
+            }
+            logExperimentalFallback(
+              context,
+              result.reason,
+              `Pin ${pin} listed in experimental index but its zip could not be downloaded.`,
+              result.error
+            );
+          } else if (indexProbe.ok === true) {
+            logExperimentalFallback(context, 'pinNotInIndex', `Pin ${pin} is not present in the experimental source index.`);
+          } else {
+            logExperimentalFallback(context, indexProbe.reason, 'Could not read the experimental source index.', indexProbe.error);
+          }
+        }
+
+        // Fallback: download the pin from the public CDN.
+        await downloadBundleWithProgress(context, PUBLIC_BUNDLE_BASE_URL, pin, 'fallbackPublic');
+        ext.defaultBundleVersion = pin;
+        ext.latestBundleVersion = pin;
+        context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
+        context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+        context.telemetry.properties.didUpdateExtensionBundle = 'true';
+        return true;
+      }
+
+      if (latestLocalBundleVersion !== '0.0.0') {
+        // Verify on disk before trusting the cached experimental local latest.
+        const verifyBaseUrl = baseUrlInfo.experimentalSourceUri.length > 0 ? baseUrlInfo.experimentalSourceUri : PUBLIC_BUNDLE_BASE_URL;
+        const hashCheck = await verifyLocalBundle(context, verifyBaseUrl, latestLocalBundleVersion, options);
+        context.telemetry.properties.localBundleHashCheck = hashCheck;
+        if (requiresBundleRepair(hashCheck)) {
+          notifyCorruptionIfNeeded(hashCheck, latestLocalBundleVersion, verifyBaseUrl);
+          if (baseUrlInfo.experimentalSourceUri.length > 0) {
+            const repair = await tryDownloadBundleWithProgress(
+              context,
+              baseUrlInfo.experimentalSourceUri,
+              latestLocalBundleVersion,
+              'experimentalLocalLatestRepair'
+            );
+            if (repair.ok === true) {
+              ext.defaultBundleVersion = latestLocalBundleVersion;
+              ext.latestBundleVersion = latestLocalBundleVersion;
+              context.telemetry.properties.extensionBundleVersionSource = 'experimentalLocalLatestRepair';
+              context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+              context.telemetry.properties.didUpdateExtensionBundle = 'true';
+              return true;
+            }
+            logExperimentalFallback(
+              context,
+              repair.reason,
+              `Repair of local latest ${latestLocalBundleVersion} from experimental source failed.`,
+              repair.error
+            );
+          }
+          await downloadBundleWithProgress(context, PUBLIC_BUNDLE_BASE_URL, latestLocalBundleVersion, 'experimentalLocalLatestRepair');
+          ext.defaultBundleVersion = latestLocalBundleVersion;
+          ext.latestBundleVersion = latestLocalBundleVersion;
+          context.telemetry.properties.extensionBundleVersionSource = 'experimentalLocalLatestRepair';
+          context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+          context.telemetry.properties.didUpdateExtensionBundle = 'true';
+          return true;
+        }
+        ext.defaultBundleVersion = latestLocalBundleVersion;
+        ext.latestBundleVersion = latestLocalBundleVersion;
+        context.telemetry.properties.extensionBundleVersionSource = 'experimentalLocalLatest';
+        context.telemetry.properties.didUpdateExtensionBundle = 'false';
+        return false;
+      }
+
+      // No pin, no local copy — try the experimental source URI for its
+      // latest. If that fails (404 / network error / empty index), fall
+      // through to the public-CDN default flow below.
+      if (baseUrlInfo.experimentalSourceUri.length > 0) {
+        const indexProbe = await tryFetchSourceIndex(context, baseUrlInfo.experimentalSourceUri);
+        if (indexProbe.ok === true) {
+          const experimentalLatest = pickLatestVersion(indexProbe.versions);
+          if (experimentalLatest !== '0.0.0') {
+            const result = await tryDownloadBundleWithProgress(
+              context,
+              baseUrlInfo.experimentalSourceUri,
+              experimentalLatest,
+              'experimentalLatest'
+            );
+            if (result.ok === true) {
+              ext.defaultBundleVersion = experimentalLatest;
+              ext.latestBundleVersion = experimentalLatest;
+              context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
+              context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+              context.telemetry.properties.didUpdateExtensionBundle = 'true';
+              return true;
+            }
+            logExperimentalFallback(
+              context,
+              result.reason,
+              `Latest ${experimentalLatest} from experimental source failed to download.`,
+              result.error
+            );
+          } else {
+            logExperimentalFallback(context, 'index404', 'Experimental source index returned no versions.');
+          }
+        } else {
+          logExperimentalFallback(context, indexProbe.reason, 'Could not read the experimental source index.', indexProbe.error);
+        }
+      }
+      // Toggle is on but no pin, no local, and the experimental URI either
+      // wasn't set or couldn't deliver — fall through to public-feed flow
+      // so the dev isn't dead-in-the-water.
+      context.telemetry.properties.experimentalFellThroughToPublic = 'true';
     }
+
+    // 3. Default flow: use latest local if intact; otherwise re-download from CDN.
+    //    If we got here via the experimental fall-through, force the public CDN —
+    //    using the (broken) experimental baseUrl would defeat the whole point of
+    //    the fallback.
+    const fellThroughFromExperimental = baseUrlInfo.isExperimental;
+    const effectiveBaseUrl = fellThroughFromExperimental ? PUBLIC_BUNDLE_BASE_URL : baseUrlInfo.baseUrl;
+
+    let latestFeedBundleVersion = '0.0.0';
+    let feedVersions: string[];
+    if (fellThroughFromExperimental) {
+      const publicIndexUrl = `${PUBLIC_BUNDLE_BASE_URL}/ExtensionBundles/${extensionBundleId}/index.json`;
+      feedVersions = await getJsonFeed(context, publicIndexUrl);
+    } else {
+      feedVersions = await getWorkflowBundleFeed(context);
+    }
+    latestFeedBundleVersion = pickLatestVersion(feedVersions);
 
     context.telemetry.properties.latestBundleVersion = semver.gt(latestFeedBundleVersion, latestLocalBundleVersion)
       ? latestFeedBundleVersion
@@ -172,27 +1349,52 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
     ext.latestBundleVersion = context.telemetry.properties.latestBundleVersion;
 
     if (semver.gt(latestFeedBundleVersion, latestLocalBundleVersion)) {
-      const extensionBundleUrl = await getExtensionBundleZip(context, latestFeedBundleVersion);
-      await downloadAndExtractDependency(
-        context,
-        extensionBundleUrl,
-        defaultExtensionBundlePathValue,
-        extensionBundleId,
-        latestFeedBundleVersion
-      );
-
+      await downloadBundleWithProgress(context, effectiveBaseUrl, latestFeedBundleVersion, 'newerVersion');
+      context.telemetry.properties.extensionBundleVersionSource = 'publicFeedLatest';
+      context.telemetry.properties.localBundleHashCheck = 'skipped';
       context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
       context.telemetry.properties.didUpdateExtensionBundle = 'true';
       return true;
     }
 
+    // Local is at least as new as the feed — verify the on-disk bundle's source MD5
+    // and re-download if it's missing or has drifted (e.g. CDN republished the same version).
+    if (latestLocalBundleVersion !== '0.0.0') {
+      const hashCheck = await verifyLocalBundle(context, effectiveBaseUrl, latestLocalBundleVersion, options);
+      context.telemetry.properties.localBundleHashCheck = hashCheck;
+      if (requiresBundleRepair(hashCheck)) {
+        // Surface a one-shot warning so the user understands *why* we're
+        // suddenly downloading on what looks like a steady-state activation.
+        // sidecarMissing fires on first-run-after-upgrade for legacy bare-MD5
+        // sidecars; keep that path quieter (no toast) to avoid alarming users
+        // during the one-time migration.
+        notifyCorruptionIfNeeded(hashCheck, latestLocalBundleVersion, effectiveBaseUrl);
+        await downloadBundleWithProgress(context, effectiveBaseUrl, latestLocalBundleVersion, hashCheck);
+        context.telemetry.properties.extensionBundleVersionSource = 'publicFeedLatest';
+        context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+        context.telemetry.properties.didUpdateExtensionBundle = 'true';
+        return true;
+      }
+    } else {
+      context.telemetry.properties.localBundleHashCheck = 'skipped';
+    }
+
+    context.telemetry.properties.extensionBundleVersionSource = 'localLatest';
     context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
     context.telemetry.properties.didUpdateExtensionBundle = 'false';
     return false;
   } catch (error) {
-    const errorMessage = `Error downloading and extracting the Logic Apps Standard extension bundle: ${error.message}`;
+    const errorMessage = `Error downloading and extracting the Logic Apps Standard extension bundle: ${error instanceof Error ? error.message : String(error)}`;
     context.telemetry.properties.errorMessage = errorMessage;
-    return false;
+    if (ext.outputChannel) {
+      ext.outputChannel.appendLog(errorMessage);
+    }
+    // Re-throw so the outer `downloadExtensionBundle` wrapper sets
+    // `lastBundleInstallResult = 'failed'`. Without this, downstream callers
+    // (validateAndInstallBinaries, startDesignTimeApi) see the install as
+    // healthy and proceed to spawn func.exe against a missing/corrupt bundle,
+    // producing the silent "No job functions found" failure mode.
+    throw error instanceof Error ? error : new Error(errorMessage);
   }
 }
 
@@ -264,6 +1466,12 @@ let cachedBundleVersion: string | null = null;
 
 export function resetCachedBundleVersion(): void {
   cachedBundleVersion = null;
+  // Phase 14: also reset bundle install state so tests that intentionally fail
+  // an install (e.g. mockRejectedValue) don't poison subsequent tests with a
+  // stale `lastBundleInstallResult === 'failed'`.
+  lastBundleInstallResult = 'unknown';
+  lastBundleInstallError = undefined;
+  inFlightBundleWork = undefined;
 }
 
 /**
@@ -300,6 +1508,7 @@ export async function getBundleVersionNumber(workingDirectory?: string): Promise
 
   // Cache the result
   cachedBundleVersion = bundleVersionNumber;
+  ext.outputChannel?.appendLog(`Current Logic Apps extension bundle version: ${bundleVersionNumber}`);
   return bundleVersionNumber;
 }
 

--- a/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/startDesignTimeApi.ts
@@ -54,6 +54,12 @@ import { findChildProcess } from '../../commands/pickFuncProcess';
 import find_process from 'find-process';
 import { getChildProcessesWithScript } from '../findChildProcess/findChildProcess';
 import { isCodefulProject } from '../codeful';
+import {
+  ensureExtensionBundleHealthy,
+  isExtensionBundleDownloadInFlight,
+  isInsideBundleDownloadScope,
+  waitForExtensionBundleReady,
+} from '../bundleFeed';
 
 const maxDesignTimeValidationRestarts = 1;
 
@@ -294,6 +300,32 @@ export async function startDesignTimeApi(projectPath: string): Promise<void> {
               designTimeInst.port
             )
           );
+
+          // If activation triggered a bundle (re)download (newer version, corruption
+          // detected, sidecar missing/drifted), wait for it to finish before spawning
+          // func.exe. Launching while the extension bundle is being re-extracted can
+          // lock the bundle folder on Windows and leave the design-time host pointing
+          // at a half-extracted bundle.
+          //
+          // When this call originates from inside `downloadExtensionBundle` itself
+          // (the post-install restart hook), `isInsideBundleDownloadScope()` is true
+          // and there is nothing to wait for — the bundle is on disk by then.
+          // Suppress the misleading "Waiting…" log in that case.
+          if (isExtensionBundleDownloadInFlight() && !isInsideBundleDownloadScope()) {
+            ext.outputChannel.appendLog(
+              localize(
+                'waitingForBundleReady',
+                'Waiting for Logic Apps extension bundle download to complete before starting design-time host for project "{0}"…',
+                projectPath
+              )
+            );
+            await waitForExtensionBundleReady();
+          }
+          // Refuse to spawn func.exe if the most recent bundle install attempt
+          // failed. Without a healthy bundle, func reports "No job functions
+          // found" and unhealthy storage forever — surfacing a clear, actionable
+          // error here is strictly better than letting the host start broken.
+          await ensureExtensionBundleHealthy(actionContext);
 
           startDesignTimeProcess(ext.outputChannel, cwd, getFunctionsCommand(), 'host', 'start', portArgs);
           await waitForDesignTimeStartUp(actionContext, projectPath, url, true);

--- a/apps/vs-code-designer/src/app/utils/integrity.ts
+++ b/apps/vs-code-designer/src/app/utils/integrity.ts
@@ -1,0 +1,235 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * vscode-free integrity helpers. Importable from both the extension host
+ * (binaries.ts) and from ExTester / Mocha tests that cannot pull in the
+ * `vscode` module.
+ */
+import axios from 'axios';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+
+/**
+ * Error thrown when a downloaded file fails integrity verification
+ * (size or MD5 mismatch against the response headers).
+ */
+export class DownloadIntegrityError extends Error {
+  constructor(
+    public readonly url: string,
+    public readonly reason: 'size' | 'md5',
+    public readonly expected: string,
+    public readonly actual: string
+  ) {
+    super(`Download integrity check failed for ${url}: ${reason} mismatch (expected ${expected}, got ${actual}).`);
+    this.name = 'DownloadIntegrityError';
+  }
+}
+
+export interface DownloadAttemptResult {
+  expectedSize?: number;
+  actualSize: number;
+  expectedMd5?: string;
+  actualMd5: string;
+}
+
+export const DEFAULT_DOWNLOAD_MAX_ATTEMPTS = 3;
+
+/**
+ * Optional callbacks the extension host plugs in so log + telemetry stays in
+ * its own layer; in tests we leave these undefined.
+ */
+export interface DownloadHooks {
+  onAttempt?: (attempt: number, error: unknown, willRetry: boolean) => void;
+  onSuccess?: (attempt: number, result: DownloadAttemptResult, durationMs: number) => void;
+}
+
+/**
+ * Streams a file from `url` to `destPath`, verifying integrity against
+ * `Content-Length` and `Content-MD5` response headers when present.
+ *
+ * Azure Blob Storage (which backs cdn.functions.azure.com) sets both headers
+ * on upload, so this catches CDN-edge truncation/corruption end-to-end without
+ * any publishing-pipeline changes.
+ *
+ * Retries on network errors and integrity failures with exponential backoff.
+ */
+export async function downloadFileWithVerification(
+  url: string,
+  destPath: string,
+  options: { maxAttempts?: number; hooks?: DownloadHooks } = {}
+): Promise<DownloadAttemptResult> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_DOWNLOAD_MAX_ATTEMPTS;
+  const hooks = options.hooks ?? {};
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const attemptStart = Date.now();
+    try {
+      const result = await downloadFileAttempt(url, destPath);
+      hooks.onSuccess?.(attempt, result, Date.now() - attemptStart);
+      return result;
+    } catch (error) {
+      lastError = error;
+      try {
+        if (fs.existsSync(destPath)) {
+          fs.rmSync(destPath, { force: true });
+        }
+      } catch {
+        // best-effort cleanup
+      }
+
+      const isRetryable = isRetryableDownloadError(error);
+      const willRetry = isRetryable && attempt < maxAttempts;
+      hooks.onAttempt?.(attempt, error, willRetry);
+
+      if (!willRetry) {
+        throw error;
+      }
+      await delay(1000 * 2 ** (attempt - 1));
+    }
+  }
+  throw lastError;
+}
+
+function downloadFileAttempt(url: string, destPath: string): Promise<DownloadAttemptResult> {
+  return new Promise<DownloadAttemptResult>((resolve, reject) => {
+    axios
+      .get(url, {
+        responseType: 'stream',
+        // Force identity so Content-Length describes the bytes we actually
+        // pipe to disk. Without this, axios negotiates gzip/br and
+        // auto-decompresses the stream, leaving Content-Length pointing at the
+        // compressed size — which would cause spurious size mismatches against
+        // the decoded byte count we measure (e.g. dot.net/v1/dotnet-install.ps1).
+        headers: { 'Accept-Encoding': 'identity' },
+        decompress: false,
+      })
+      .then((response) => {
+        const headers = response.headers ?? {};
+        const contentEncodingRaw = headers['content-encoding'] ?? headers['Content-Encoding'];
+        const contentEncoding = typeof contentEncodingRaw === 'string' ? contentEncodingRaw.trim().toLowerCase() : '';
+        const responseIsEncoded = contentEncoding.length > 0 && contentEncoding !== 'identity';
+        const contentLengthRaw = headers['content-length'] ?? headers['Content-Length'];
+        const parsedSize = contentLengthRaw === undefined ? Number.NaN : Number.parseInt(String(contentLengthRaw), 10);
+        // Coerce non-finite / zero / negative values to undefined so callers
+        // (and telemetry) can reliably distinguish "unknown size" from a real
+        // byte count, and so we don't ship literal "NaN" strings via
+        // String(expectedSize) into Application Insights.
+        const expectedSize = Number.isFinite(parsedSize) && parsedSize > 0 ? parsedSize : undefined;
+        const expectedMd5Raw = headers['content-md5'] ?? headers['Content-MD5'];
+        const expectedMd5 = typeof expectedMd5Raw === 'string' && expectedMd5Raw.length > 0 ? expectedMd5Raw : undefined;
+
+        const writer = fs.createWriteStream(destPath);
+        const hash = createHash('md5');
+        let actualSize = 0;
+        let settled = false;
+
+        const settle = (fn: () => void) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          fn();
+        };
+
+        response.data.on('data', (chunk: Buffer) => {
+          actualSize += chunk.length;
+          hash.update(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+        });
+        response.data.on('error', (err: Error) => settle(() => reject(err)));
+        writer.on('error', (err: Error) => settle(() => reject(err)));
+        writer.on('finish', () =>
+          settle(() => {
+            // If the server ignored our identity hint and gzipped/br-encoded
+            // the body anyway, Content-Length describes the compressed bytes
+            // and is meaningless next to the byte count we recorded (which
+            // for `decompress: false` is the compressed stream too — but
+            // skipping the size check here keeps us safe regardless of which
+            // layer ends up decoding). MD5 is still checked when present.
+            if (!responseIsEncoded && expectedSize !== undefined && actualSize !== expectedSize) {
+              reject(new DownloadIntegrityError(url, 'size', String(expectedSize), String(actualSize)));
+              return;
+            }
+            const actualMd5 = hash.digest('base64');
+            if (expectedMd5 && actualMd5 !== expectedMd5) {
+              reject(new DownloadIntegrityError(url, 'md5', expectedMd5, actualMd5));
+              return;
+            }
+            resolve({ expectedSize, actualSize, expectedMd5, actualMd5 });
+          })
+        );
+
+        response.data.pipe(writer);
+      })
+      .catch((err) => reject(err));
+  });
+}
+
+export function isRetryableDownloadError(error: unknown): boolean {
+  if (error instanceof DownloadIntegrityError) {
+    return true;
+  }
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  if (typeof status === 'number') {
+    return status >= 500 && status < 600;
+  }
+  return true;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Timeout (ms) for the HEAD request issued by `fetchExpectedMd5`. Activation
+ * waits on this synchronously when verifying an installed bundle, so a stalled
+ * connection (flaky network, captive portal, mis-configured proxy) must not
+ * be allowed to hang VS Code indefinitely — the caller falls back to the
+ * cached bundle when the CDN cannot be reached promptly.
+ */
+const FETCH_EXPECTED_MD5_TIMEOUT_MS = 30_000;
+
+/**
+ * Issues a HEAD request against `url` and returns the published `Content-MD5`
+ * (base64) value, if any. Returns `undefined` when the header is missing.
+ * Throws when the request itself fails so callers can decide whether to
+ * fall back gracefully.
+ */
+export async function fetchExpectedMd5(url: string): Promise<string | undefined> {
+  const response = await axios.head(url, {
+    headers: { 'Accept-Encoding': 'identity' },
+    timeout: FETCH_EXPECTED_MD5_TIMEOUT_MS,
+  });
+  const headers = response.headers ?? {};
+  const expectedMd5Raw = headers['content-md5'] ?? headers['Content-MD5'];
+  if (typeof expectedMd5Raw === 'string' && expectedMd5Raw.length > 0) {
+    return expectedMd5Raw;
+  }
+  return undefined;
+}
+
+/**
+ * Returns true for errors that indicate "the configured CDN does not have the
+ * package right now" — HTTP 404 / 4xx, plus the common Node network failure
+ * codes (no DNS, refused connection, timeout). Genuine integrity failures
+ * (corrupt bytes returned with the right size/headers) and 5xx errors are NOT
+ * "missing package" — they're transient or actively wrong, and the caller
+ * should retry / surface them rather than silently fall back.
+ */
+export function isMissingPackageError(error: unknown): boolean {
+  if (error instanceof DownloadIntegrityError) {
+    return false;
+  }
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  if (typeof status === 'number') {
+    return status >= 400 && status < 500;
+  }
+  const code = (error as { code?: string })?.code;
+  if (typeof code === 'string') {
+    return code === 'ENOTFOUND' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'EAI_AGAIN' || code === 'ECONNRESET';
+  }
+  return false;
+}

--- a/apps/vs-code-designer/src/app/utils/nodeJs/__test__/nodeJsVersion.test.ts
+++ b/apps/vs-code-designer/src/app/utils/nodeJs/__test__/nodeJsVersion.test.ts
@@ -168,7 +168,7 @@ describe('nodeJsVersion - cross-platform binary path resolution', () => {
 
       await setNodeJsCommand();
 
-      expect(updateGlobalSetting).toHaveBeenCalledWith('nodeJsBinaryPath', path.join(NODE_DIR, 'node'));
+      expect(updateGlobalSetting).toHaveBeenCalledWith('nodeJsBinaryPath', path.join(NODE_DIR, 'node.exe'));
       expect(fs.chmodSync).not.toHaveBeenCalled();
       expect(fs.readdirSync).not.toHaveBeenCalled();
     });

--- a/apps/vs-code-designer/src/app/utils/nodeJs/nodeJsVersion.ts
+++ b/apps/vs-code-designer/src/app/utils/nodeJs/nodeJsVersion.ts
@@ -72,7 +72,7 @@ export async function setNodeJsCommand(): Promise<void> {
     if (binariesExist) {
       // windows the executable is at root folder, linux & macos its in <node-v*>/bin
       if (process.platform === Platform.windows) {
-        command = path.join(nodeJsBinariesPath, ext.nodeJsCliPath);
+        command = path.join(nodeJsBinariesPath, `${ext.nodeJsCliPath}.exe`);
       } else {
         const nodeSubFolder = getNodeSubFolder(nodeJsBinariesPath);
         if (nodeSubFolder) {

--- a/apps/vs-code-designer/src/app/utils/runtimeDependencies.ts
+++ b/apps/vs-code-designer/src/app/utils/runtimeDependencies.ts
@@ -10,6 +10,7 @@ import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microso
 import * as vscode from 'vscode';
 import { getGlobalSetting } from './vsCodeConfig/settings';
 import { isDevContainerWorkspace } from './devContainerUtils';
+import { shouldRequireStrictDependencyValidation } from './strictDependencyValidation';
 
 export const useBinariesDependencies = async (): Promise<boolean> => {
   const isDevContainer = await isDevContainerWorkspace();
@@ -21,15 +22,24 @@ export const useBinariesDependencies = async (): Promise<boolean> => {
   return !!binariesInstallation;
 };
 
+async function validateRuntimeDependencies(actionContext: IActionContext, activateContext: IActionContext): Promise<void> {
+  await runWithDurationTelemetry(actionContext, extensionCommand.validateAndInstallBinaries, async () => {
+    const binariesInstallation = await useBinariesDependencies();
+    if (binariesInstallation) {
+      activateContext.telemetry.properties.lastStep = extensionCommand.validateAndInstallBinaries;
+      await validateAndInstallBinaries(actionContext);
+      await validateTasksJson(actionContext, vscode.workspace.workspaceFolders);
+    }
+  });
+}
+
 export const onboardBinaries = async (activateContext: IActionContext) => {
+  if (shouldRequireStrictDependencyValidation()) {
+    await validateRuntimeDependencies(activateContext, activateContext);
+    return;
+  }
+
   await callWithTelemetryAndErrorHandling(extensionCommand.validateAndInstallBinaries, async (actionContext: IActionContext) => {
-    await runWithDurationTelemetry(actionContext, extensionCommand.validateAndInstallBinaries, async () => {
-      const binariesInstallation = await useBinariesDependencies();
-      if (binariesInstallation) {
-        activateContext.telemetry.properties.lastStep = extensionCommand.validateAndInstallBinaries;
-        await validateAndInstallBinaries(actionContext);
-        await validateTasksJson(actionContext, vscode.workspace.workspaceFolders);
-      }
-    });
+    await validateRuntimeDependencies(actionContext, activateContext);
   });
 };

--- a/apps/vs-code-designer/src/app/utils/strictDependencyValidation.ts
+++ b/apps/vs-code-designer/src/app/utils/strictDependencyValidation.ts
@@ -1,0 +1,8 @@
+import { e2eStrictDependencyValidationSettingKey } from '../../constants';
+import { getGlobalSetting } from './vsCodeConfig/settings';
+
+export function shouldRequireStrictDependencyValidation(): boolean {
+  return (
+    process.env.LA_E2E_STRICT_DEPENDENCY_VALIDATION === '1' || getGlobalSetting<boolean>(e2eStrictDependencyValidationSettingKey) === true
+  );
+}

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -282,6 +282,10 @@ export const dotNetBinaryPathSettingKey = 'dotnetBinaryPath';
 export const nodeJsBinaryPathSettingKey = 'nodeJsBinaryPath';
 export const funcCoreToolsBinaryPathSettingKey = 'funcCoreToolsBinaryPath';
 export const dependencyTimeoutSettingKey = 'dependencyTimeout';
+export const e2eStrictDependencyValidationSettingKey = 'e2eStrictDependencyValidation';
+export const useExperimentalExtensionBundleSettingKey = 'useExperimentalExtensionBundle';
+export const experimentalExtensionBundleSourceUriSettingKey = 'experimentalExtensionBundleSourceUri';
+export const experimentalExtensionBundleVersionSettingKey = 'experimentalExtensionBundleVersion';
 export const unitTestExplorer = 'unitTestExplorer';
 export const verifyConnectionKeysSetting = 'verifyConnectionKeys';
 export const useSmbDeployment = 'useSmbDeploymentForHybrid';
@@ -290,6 +294,7 @@ export const onStartLanguageServer = 'onStartLanguageServer';
 // host.json
 export const extensionBundleId = 'Microsoft.Azure.Functions.ExtensionBundle.Workflows';
 export const targetBundleKey = 'FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI';
+export const bundleSourceMd5SidecarFile = '.bundle-source-md5';
 
 // local.settings.json
 export const localEmulatorConnectionString = 'UseDevelopmentStorage=true';

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -15,6 +15,7 @@ import {
   updateLogicAppsContext,
 } from './app/utils/extension';
 import { registerFuncHostTaskEvents } from './app/utils/funcCoreTools/funcHostTask';
+import { shouldRequireStrictDependencyValidation } from './app/utils/strictDependencyValidation';
 import { verifyVSCodeConfigOnActivate } from './app/utils/vsCodeConfig/verifyVSCodeConfigOnActivate';
 import { extensionCommand, logicAppFilter } from './constants';
 import { ext } from './extensionVariables';
@@ -151,7 +152,20 @@ export async function activate(context: vscode.ExtensionContext) {
       await convertToWorkspace(activateContext);
     }
 
-    downloadExtensionBundle(activateContext);
+    if (shouldRequireStrictDependencyValidation()) {
+      await downloadExtensionBundle(activateContext);
+    } else {
+      // Intentionally not awaited so activation stays snappy. Downstream code
+      // that depends on the extracted bundle (startDesignTimeApi) calls
+      // waitForExtensionBundleReady() to block on the in-flight work and avoid
+      // racing the re-extract — which on Windows can lock the bundle folder and
+      // leave the design-time host pointing at a half-extracted bundle.
+      downloadExtensionBundle(activateContext).catch((error) => {
+        ext.outputChannel?.appendLog(
+          `Background extension-bundle download failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      });
+    }
     promptParameterizeConnections(activateContext, false);
     verifyLocalConnectionKeys(activateContext);
     await startOnboarding(activateContext);

--- a/apps/vs-code-designer/src/onboarding.ts
+++ b/apps/vs-code-designer/src/onboarding.ts
@@ -13,6 +13,7 @@ import {
 import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
 import { isDevContainerWorkspace } from './app/utils/devContainerUtils';
 import { ext } from './extensionVariables';
+import { shouldRequireStrictDependencyValidation } from './app/utils/strictDependencyValidation';
 
 /**
  * Start onboarding experience prompting inputs for user.
@@ -23,11 +24,19 @@ import { ext } from './extensionVariables';
 export const startOnboarding = async (activateContext: IActionContext) => {
   const isDevContainer = await isDevContainerWorkspace();
   activateContext.telemetry.properties.isDevContainer = String(isDevContainer);
+  const requireStrictDependencyValidation = shouldRequireStrictDependencyValidation();
 
   if (isDevContainer) {
     activateContext.telemetry.properties.skippedDependencyOnboarding = 'true';
     activateContext.telemetry.properties.skippedDependencyOnboardingReason = 'devContainer';
     ext.outputChannel.appendLog('Devcontainer workspace detected. Skipping dependency onboarding and auto-starting design time APIs.');
+  } else if (requireStrictDependencyValidation) {
+    const binariesInstallStartTime = Date.now();
+    await runWithDurationTelemetry(activateContext, autoRuntimeDependenciesValidationAndInstallationSetting, async () => {
+      activateContext.telemetry.properties.lastStep = autoRuntimeDependenciesValidationAndInstallationSetting;
+      await installBinaries(activateContext);
+    });
+    activateContext.telemetry.measurements.binariesInstallDuration = Date.now() - binariesInstallStartTime;
   } else {
     await callWithTelemetryAndErrorHandling(
       autoRuntimeDependenciesValidationAndInstallationSetting,

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -994,6 +994,11 @@
             "description": "Enable automatic validation and installation for runtime dependencies at the configured path.",
             "default": true
           },
+          "azureLogicAppsStandard.e2eStrictDependencyValidation": {
+            "type": "boolean",
+            "description": "Fail dependency and extension-bundle validation instead of showing success-shaped UI fallbacks. Intended for automated VS Code E2E setup only.",
+            "default": false
+          },
           "azureLogicAppsStandard.showAutoStartAzuriteWarning": {
             "type": "boolean",
             "description": "Show a warning asking if user's would like to configure Azurite auto start.",
@@ -1037,6 +1042,21 @@
             "type": "string",
             "default": "",
             "markdownDescription": "Absolute path to the .nupkg file."
+          },
+          "azureLogicAppsStandard.useExperimentalExtensionBundle": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Experimental master opt-in. When enabled, the Logic Apps extension bundle is sourced from local disk first, then from `#azureLogicAppsStandard.experimentalExtensionBundleSourceUri#` if configured. The public CDN's *latest* feed is **not** consulted for version selection while this is on. If the configured private source cannot deliver the requested package and no usable local copy exists, the extension automatically falls back to a single download from the public CDN so the environment stays runnable. **The other two `experimental*` settings have no effect while this is `false`.** Use this to test preview bundles that have not yet been published to `cdn.functions.azure.com`."
+          },
+          "azureLogicAppsStandard.experimentalExtensionBundleSourceUri": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Experimental: alternative base URL for the Logic Apps extension bundle (mirrors the shape of `FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI`, e.g. `https://my-private-cdn/public`). **Only honored when `#azureLogicAppsStandard.useExperimentalExtensionBundle#` is `true`.** If the configured URL cannot deliver the requested bundle (HTTP 404, unreachable, or missing version), the extension automatically falls back to the public Azure CDN to avoid leaving you with a broken environment; check the output channel for the `experimentalSourceFallback` reason."
+          },
+          "azureLogicAppsStandard.experimentalExtensionBundleVersion": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Experimental: optional pinned version (for example `1.21.0-preview`). **Only honored when `#azureLogicAppsStandard.useExperimentalExtensionBundle#` is `true`.** While set, no 'latest' feed is consulted; the version is fetched from the configured source URL with the same public-CDN fallback as `#azureLogicAppsStandard.experimentalExtensionBundleSourceUri#`. If empty, the highest local version is used."
           }
         }
       }


### PR DESCRIPTION
Cherry-pick of #9289's predecessor — **#9294 fix(vscode): Guard against bundle download corruption** — into `hotfix/v5.961`.

**Source PR:** Azure/LogicAppsUX#9294
**Source commit:** `4fb46025c19936049f5174ec83fdb4d6b613ad5d`
**Target branch:** `hotfix/v5.961`

## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

`Microsoft.Azure.Functions.ExtensionBundle.Workflows` is downloaded from a CDN at extension activation. When the CDN occasionally returns a truncated zip, the extension cached the partial file and failed later in opaque ways. There was also no way to test against an unreleased bundle locally, no fallback when a private/experimental CDN was misconfigured, and no user-visible signal during activation downloads.

This PR adds end-to-end integrity verification (size + MD5), opt-in experimental bundle settings with a public-CDN safety net, and `withProgress` notifications so the user sees what is happening (and why a redownload is occurring).

## Impact of Change
- **Users**: Bundles are verified against `Content-Length` and `Content-MD5` on download, and against an MD5 sidecar on every activation. Corrupt local copies are detected and replaced automatically. Users see a progress notification during downloads and a warning toast immediately before a corruption-triggered redownload, so silent activation hangs are gone. Three new VS Code settings (`useExperimentalExtensionBundle`, `experimentalExtensionBundleSourceUri`, `experimentalExtensionBundleVersion`) let users point at unreleased bundle builds without losing the public-CDN safety net. Bundles are now verified and repaired automatically for users.
- **Developers**: New `downloadFileWithVerification`, `verifyLocalBundleHash`, `fetchExpectedMd5`, and `isMissingPackageError` helpers in `integrity.ts`. `bundleFeed.ts` gains a `DownloadReason`-driven `withProgress` wrapper used at every download call site, plus a private-to-public CDN fallback chain that only triggers on "package missing" errors (4xx / DNS), never on integrity failures. New E2E phase `bundleintegrityonly` exercised via `run-e2e.js`.
- **System**: One extra HEAD request per activation to validate the local sidecar. No change to the public CDN contract. The MD5 sidecar lives next to the bundle so a manually-deleted bundle directory self-heals.

## Test Plan
- [x] Unit tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: VS Code extension host (Windows), public Azure CDN, simulated experimental source override. 66 bundleFeed unit tests + 1065 vscode-designer extension-unit tests passing. New `bundleintegrityonly` live E2E phase 4/4 passing.

## Contributors


## Screenshots/Videos

