### PR TITLE
feat(vscode): workflow/webview validation and E2E launcher migration (#9289) [hotfix/v5.970]

### DIFF
--- a/.github/agents/customer-repro-tester.agent.md
+++ b/.github/agents/customer-repro-tester.agent.md
@@ -12,7 +12,7 @@ Your job is to turn customer reports into safe, actionable repro evidence:
 - parse symptoms, expected behavior, actual behavior, host surface, SKU, workflow kind, versions, settings, screenshots, logs, and sanitized artifacts;
 - remove or reject secrets, tenant IDs, subscription IDs, connection strings, tokens, personal data, and raw customer payloads;
 - choose the cheapest reliable repro method: manual, unit, React unit, Playwright E2E, VS Code ExTester E2E, or live-service-only investigation;
-- use Playwright for browser/standalone/portal-like flows and VS Code ExTester through `run-e2e.js` for VS Code extension/webview flows;
+- use Playwright for browser/standalone/portal-like flows and VS Code ExTester through `run-e2e.ts` for VS Code extension/webview flows;
 - produce a repro report with steps, expected/actual behavior, evidence, likely owner, regression recommendation, and privacy notes.
 
 Do not use live Azure/ARM/customer-tenant resources without explicit user approval.

--- a/.github/agents/test.agent.md
+++ b/.github/agents/test.agent.md
@@ -13,7 +13,7 @@ Own test strategy and coverage quality:
 - map behavior changes and PR comments to meaningful assertions;
 - reuse existing helpers, mocks, and fixtures;
 - avoid weakening assertions to hide product bugs;
-- for VS Code E2E, ensure tests are wired through `apps/vs-code-designer/src/test/ui/run-e2e.js` and follow `apps/vs-code-designer/src/test/ui/SKILL.md`;
+- for VS Code E2E, ensure tests are wired through `apps/vs-code-designer/src/test/ui/run-e2e.ts` and follow `apps/vs-code-designer/src/test/ui/SKILL.md`;
 - provide a coverage verdict before final status when tests are part of the plan.
 
 Do not write production feature code unless explicitly asked. Coordinate with the owning domain agent for product changes.

--- a/.github/agents/vscode-test-specialist.agent.md
+++ b/.github/agents/vscode-test-specialist.agent.md
@@ -5,7 +5,7 @@ description: Specialist for VS Code extension unit tests and ExTester UI E2E tes
 
 You are the LogicAppsUX VS Code test specialist.
 
-Use `.squad/agents/vscode-test-specialist/charter.md` as your detailed charter. Read `.squad/playbooks/vscode-testing.md`, `.squad/knowledge/vscode-e2e-testing.md`, `apps/vs-code-designer/src/test/ui/SKILL.md`, and `apps/vs-code-designer/src/test/ui/run-e2e.js` before editing VS Code UI E2E tests.
+Use `.squad/agents/vscode-test-specialist/charter.md` as your detailed charter. Read `.squad/playbooks/vscode-testing.md`, `.squad/knowledge/vscode-e2e-testing.md`, `apps/vs-code-designer/src/test/ui/SKILL.md`, and `apps/vs-code-designer/src/test/ui/run-e2e.ts` before editing VS Code UI E2E tests.
 
 Focus on deterministic VS Code tests:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,7 +64,7 @@ pnpm run vscode:designer:e2e:headless # Headless mode
 ```bash
 cd apps/vs-code-designer
 npx tsup --config tsup.e2e.test.config.ts
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 
 # Run specific phases via E2E_MODE env var
 E2E_MODE="createonly"    # Phase 4.1: workspace creation
@@ -82,7 +82,7 @@ Key knowledge files for E2E tests:
 - `apps/vs-code-designer/src/test/ui/SKILL.md` — Complete learning document (700+ lines)
 - `apps/vs-code-designer/src/test/ui/designerHelpers.ts` — Shared designer test helpers
 - `apps/vs-code-designer/src/test/ui/runHelpers.ts` — Shared debug/run test helpers
-- `apps/vs-code-designer/src/test/ui/run-e2e.js` — Test launcher (7 phases)
+- `apps/vs-code-designer/src/test/ui/run-e2e.ts` — Test launcher (7 phases)
 
 ### Code Quality
 ```bash
@@ -368,3 +368,4 @@ Each package has detailed guidance in `docs/ai-setup/packages/<name>.md`. Read t
 ## Squad Agents
 
 This repo uses Squad for AI agent specialization. See `.squad/README.md` for the team roster and `.squad/routing.md` for work dispatch.
+

--- a/.github/instructions/vs-code-designer.instructions.md
+++ b/.github/instructions/vs-code-designer.instructions.md
@@ -98,10 +98,10 @@ Run Phase 4.2 only (requires workspaces from a prior Phase 4.1 run):
 cd apps/vs-code-designer
 npx tsup --config tsup.e2e.test.config.ts
 $env:E2E_MODE = "designeronly"
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 ```
 
-Key files: `designerActions.test.ts`, `run-e2e.js`, `SKILL.md` (detailed learning document)
+Key files: `designerActions.test.ts`, `run-e2e.ts`, `SKILL.md` (detailed learning document)
 
 ## Configuration
 
@@ -178,7 +178,7 @@ Each test runs in its own fresh VS Code session to avoid workspace-switch conten
 
 11. **Only use built-in operations (Request, Response) for reliable tests**: Connector operations (Compose) may not appear if the design-time API hasn't loaded the catalog.
 
-12. **Always run tests automatically after creating or modifying them**: After writing or editing any test file, immediately: lint (`npx biome check --write`), build (`npx tsup`), and run (`node src/test/ui/run-e2e.js`) — don't wait for the user to ask. Report pass/fail results with any failure details.
+12. **Always run tests automatically after creating or modifying them**: After writing or editing any test file, immediately: lint (`npx biome check --write`), build (`npx tsup`), and run (`node out/test/run-e2e.js`) — don't wait for the user to ask. Report pass/fail results with any failure details.
 
 ### Running Tests
 
@@ -201,7 +201,7 @@ $env:E2E_MODE = "independentonly"         # 4.0 + 4.8b + 4.11 — no Phase 4.1 d
 $env:E2E_MODE = "createplusdesigner"      # 4.1 → 4.2, 4.7
 $env:E2E_MODE = "createplusnewtests"      # 4.1 → 4.3, 4.4, 4.5, 4.6
 $env:E2E_MODE = "createplusconversion"    # 4.1 → 4.8a, 4.8c, 4.8d, 4.8e
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 ```
 
 The four `createplus*` / `independentonly` modes are how `.github/workflows/vscode-e2e.yml` shards the suite across parallel runners. `full` remains the single-runner debug fallback.
@@ -239,3 +239,4 @@ Do NOT stop after pushing and tell the user "I'll wait" — proactively check an
 ## Graphify
 
 Read `apps/vs-code-designer/src/graphify-out/GRAPH_REPORT.md` for structural context (god nodes, communities, surprising connections).
+

--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           export PATH="$(dirname $(which node)):/usr/local/bin:/usr/bin:/bin:$PATH"
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
-            node apps/vs-code-designer/src/test/ui/run-e2e.js
+            node apps/vs-code-designer/out/test/run-e2e.js
         env:
           LA_E2E_SCENARIO: p41a-fixtures
           LA_E2E_STRICT_DEPENDENCY_VALIDATION: '1'
@@ -493,7 +493,7 @@ jobs:
           export PATH="$(dirname $(which node)):/usr/local/bin:/usr/bin:/bin:$PATH"
           echo "PATH=$PATH"
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
-            node apps/vs-code-designer/src/test/ui/run-e2e.js
+            node apps/vs-code-designer/out/test/run-e2e.js
         env:
           # Per-scenario matrix: each shard runs exactly one scenarios[] entry.
           LA_E2E_SCENARIO: ${{ matrix.scenario }}
@@ -601,7 +601,7 @@ jobs:
           export PATH="$(dirname $(which node)):/usr/local/bin:/usr/bin:/bin:$PATH"
           echo "PATH=$PATH"
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
-            node apps/vs-code-designer/src/test/ui/run-e2e.js
+            node apps/vs-code-designer/out/test/run-e2e.js
         env:
           LA_E2E_SCENARIO: p40-nonlogicapp
           E2E_VSCODE_VERSION: ${{ matrix.vscode-version }}
@@ -643,3 +643,4 @@ jobs:
             exit 1
           fi
           echo "All vscode-e2e jobs passed."
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ pnpm run vscode:designer:e2e:headless # Headless mode
 ```bash
 cd apps/vs-code-designer
 npx tsup --config tsup.e2e.test.config.ts
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 
 # Run specific phases via E2E_MODE env var
 E2E_MODE="createonly"    # Phase 4.1: workspace creation
@@ -86,7 +86,7 @@ Key knowledge files for E2E tests:
 - `apps/vs-code-designer/src/test/ui/SKILL.md` — Complete learning document (700+ lines)
 - `apps/vs-code-designer/src/test/ui/designerHelpers.ts` — Shared designer test helpers
 - `apps/vs-code-designer/src/test/ui/runHelpers.ts` — Shared debug/run test helpers
-- `apps/vs-code-designer/src/test/ui/run-e2e.js` — Test launcher (7 phases)
+- `apps/vs-code-designer/src/test/ui/run-e2e.ts` — Test launcher (7 phases)
 
 ### Code Quality
 ```bash
@@ -372,3 +372,4 @@ Each package has detailed guidance in `docs/ai-setup/packages/<name>.md`. Read t
 ## Squad Agents
 
 This repo uses Squad for AI agent specialization. See `.squad/README.md` for the team roster and `.squad/routing.md` for work dispatch.
+

--- a/apps/vs-code-designer/CLAUDE.md
+++ b/apps/vs-code-designer/CLAUDE.md
@@ -98,10 +98,10 @@ Run Phase 4.2 only (requires workspaces from a prior Phase 4.1 run):
 cd apps/vs-code-designer
 npx tsup --config tsup.e2e.test.config.ts
 $env:E2E_MODE = "designeronly"
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 ```
 
-Key files: `designerActions.test.ts`, `run-e2e.js`, `SKILL.md` (detailed learning document)
+Key files: `designerActions.test.ts`, `run-e2e.ts`, `SKILL.md` (detailed learning document)
 
 ## Configuration
 
@@ -178,7 +178,7 @@ Each test runs in its own fresh VS Code session to avoid workspace-switch conten
 
 11. **Only use built-in operations (Request, Response) for reliable tests**: Connector operations (Compose) may not appear if the design-time API hasn't loaded the catalog.
 
-12. **Always run tests automatically after creating or modifying them**: After writing or editing any test file, immediately: lint (`npx biome check --write`), build (`npx tsup`), and run (`node src/test/ui/run-e2e.js`) — don't wait for the user to ask. Report pass/fail results with any failure details.
+12. **Always run tests automatically after creating or modifying them**: After writing or editing any test file, immediately: lint (`npx biome check --write`), build (`npx tsup`), and run (`node out/test/run-e2e.js`) — don't wait for the user to ask. Report pass/fail results with any failure details.
 
 ### Running Tests
 
@@ -201,7 +201,7 @@ $env:E2E_MODE = "independentonly"         # 4.0 + 4.8b + 4.11 — no Phase 4.1 d
 $env:E2E_MODE = "createplusdesigner"      # 4.1 → 4.2, 4.7
 $env:E2E_MODE = "createplusnewtests"      # 4.1 → 4.3, 4.4, 4.5, 4.6
 $env:E2E_MODE = "createplusconversion"    # 4.1 → 4.8a, 4.8c, 4.8d, 4.8e
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 ```
 
 The four `createplus*` / `independentonly` modes are how `.github/workflows/vscode-e2e.yml` shards the suite across parallel runners. `full` remains the single-runner debug fallback.
@@ -239,3 +239,4 @@ Do NOT stop after pushing and tell the user "I'll wait" — proactively check an
 ## Graphify
 
 Read `apps/vs-code-designer/src/graphify-out/GRAPH_REPORT.md` for structural context (god nodes, communities, surprising connections).
+

--- a/apps/vs-code-designer/package.json
+++ b/apps/vs-code-designer/package.json
@@ -71,7 +71,7 @@
     "test:e2e-cli": "vscode-test",
     "test:e2e-cli:compile": "tsc -p ./tsconfig.e2e.json",
     "pretest:e2e-cli": "pnpm run test:e2e-cli:compile",
-    "vscode:designer:e2e:ui": "cd ../.. && pnpm run build:extension && cd apps/vs-code-designer && pnpm run build:ui && node src/test/ui/run-e2e.js",
-    "vscode:designer:e2e:headless": "cd ../.. && pnpm run build:extension && cd apps/vs-code-designer && pnpm run build:ui && node src/test/ui/run-e2e.js"
+    "vscode:designer:e2e:ui": "cd ../.. && pnpm run build:extension && cd apps/vs-code-designer && pnpm run build:ui && node out/test/run-e2e.js",
+    "vscode:designer:e2e:headless": "cd ../.. && pnpm run build:extension && cd apps/vs-code-designer && pnpm run build:ui && node out/test/run-e2e.js"
   }
 }

--- a/apps/vs-code-designer/src/app/commands/createWorkflow/__test__/createWorkflow.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createWorkflow/__test__/createWorkflow.test.ts
@@ -194,7 +194,6 @@ describe('createWorkflow', () => {
 
       expect(createLogicAppWorkflow).toHaveBeenCalledWith(context, data, 'D:\\repoA\\SharedProject');
     });
-
     it('throws when webview sends unrecognized project name', async () => {
       const folder = { name: 'ProjectA', uri: { fsPath: 'D:\\workspace\\ProjectA' }, index: 0 } as vscode.WorkspaceFolder;
       (vscode.workspace as any).workspaceFolders = [folder];

--- a/apps/vs-code-designer/src/app/utils/languageServerProtocol.ts
+++ b/apps/vs-code-designer/src/app/utils/languageServerProtocol.ts
@@ -3,13 +3,12 @@ import path from 'path';
 import * as fse from 'fs-extra';
 import { assetsFolderName, lspDirectory } from '../../constants';
 import { ext } from '../../extensionVariables';
+import { lspSdkHashMarkerName, lspServerDirectoryName, lspServerHashMarkerName } from './languageServerProtocolConstants';
 import { ensureRuntimeDependenciesPath } from './runtimeDependenciesPath';
 import AdmZip from 'adm-zip';
 import { createHash } from 'crypto';
 
-const lspServerDirectoryName = 'LSPServer';
-const lspServerHashMarkerName = '.lspserver-hash';
-const lspSdkHashMarkerName = '.lspsdk-hash';
+export { lspSdkHashMarkerName, lspServerDirectoryName, lspServerHashMarkerName };
 const lockedFileErrorCodes = new Set(['EBUSY', 'EPERM']);
 const lockedFileRetryDelayMs = 2000;
 const lockedFileRetryAttempts = 3;

--- a/apps/vs-code-designer/src/app/utils/languageServerProtocolConstants.ts
+++ b/apps/vs-code-designer/src/app/utils/languageServerProtocolConstants.ts
@@ -1,0 +1,3 @@
+export const lspServerDirectoryName = 'LSPServer';
+export const lspServerHashMarkerName = '.lspserver-hash';
+export const lspSdkHashMarkerName = '.lspsdk-hash';

--- a/apps/vs-code-designer/src/test/ui/SKILL.md
+++ b/apps/vs-code-designer/src/test/ui/SKILL.md
@@ -20,7 +20,7 @@ These are the rules whose violation has caused entire test suites to be rewritte
 
 For any test that touches debug, the design-time API, the language server, the overview page, or anything that runs after a workspace opens:
 
-1. Create the workspace via the real **Create Workspace** webview in one `run-e2e.js` phase.
+1. Create the workspace via the real **Create Workspace** webview in one `run-e2e.ts` phase.
 2. After it generates the `.code-workspace`, end that VS Code session.
 3. Open a fresh phase with the generated `.code-workspace` as the `resources` argument.
 4. Wait for design-time startup evidence (e.g., `workflow-designtime/`) before any debug or designer assertion.
@@ -31,7 +31,7 @@ For any test that touches debug, the design-time API, the language server, the o
 - Pure non-Logic-App smoke tests (e.g., `nonLogicAppStartup.test.ts`).
 - Standalone-runner unit tests that explicitly do not start VS Code.
 
-**Anti-precedents in this repo**: `createLegacyProjectFixture` in `run-e2e.js` exists because it predates this rule, and the former `createCodefulProjectFixture` was deleted after Phase 4.10 moved to Create Workspace + reopen. **Do not use synthetic helpers as templates for new tests.**
+**Anti-precedents in this repo**: `createLegacyProjectFixture` in `run-e2e.ts` exists because it predates this rule, and the former `createCodefulProjectFixture` was deleted after Phase 4.10 moved to Create Workspace + reopen. **Do not use synthetic helpers as templates for new tests.**
 
 **If the wizard helper does not yet support your project type**, the correct fix is to extend `createWorkspace.test.ts`'s helper to support the new `appType`, not to synthesize a fixture. The extension already supports codeful project creation via `CreateLogicAppWorkspace.ts` -> `createCodefulWorkflowFile`, and the E2E helper now exposes that flow for Phase 4.10.
 
@@ -69,7 +69,7 @@ Run `npx biome check --write <files>` and `npx tsup --config tsup.e2e.test.confi
 | `src/test/ui/designerActions.test.ts` | Designer full lifecycle tests (~2647 lines). Phase 4.2 |
 | `src/test/ui/designerOpen.test.ts` | Designer open tests (~1100 lines). Deprecated — Phase 4.2 now uses `designerActions.test.ts` only |
 | `src/test/ui/workspaceManifest.ts` | Shared manifest types and utilities (~110 lines) |
-| `src/test/ui/run-e2e.js` | Launcher script (~695 lines). Orchestrates ExTester programmatically. Plain JS (no compilation needed) |
+| `src/test/ui/run-e2e.ts` | Launcher script (~2600 lines). Orchestrates ExTester programmatically. Compiled by tsup to `out/test/run-e2e.js` |
 | `src/test/ui/run-clean.ps1` | PowerShell helper to kill stuck processes, compile, and run |
 | `src/test/ui/smoke.test.ts` | Extension smoke tests |
 | `src/test/ui/commands.test.ts` | Logic Apps command tests |
@@ -95,17 +95,17 @@ cd apps/vs-code-designer
 npx tsup --config tsup.e2e.test.config.ts
 
 # 3. Run all tests (Phase 4.0+)
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 
 # 4. Run only Phase 4.2 (designer tests) using existing workspaces
 $env:E2E_MODE="designeronly"    # PowerShell
 export E2E_MODE=designeronly    # bash
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 
 # 5. Run only the plain-folder startup regression test
 $env:E2E_MODE="nonlogicappstartup"  # PowerShell
 export E2E_MODE=nonlogicappstartup  # bash
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 
 # Or use the PowerShell helper (kills stuck processes first):
 powershell -ExecutionPolicy Bypass -File src/test/ui/run-clean.ps1
@@ -115,7 +115,7 @@ powershell -ExecutionPolicy Bypass -File src/test/ui/run-clean.ps1
 
 ```bash
 pnpm run build:ui       # Compiles test TypeScript via tsup → CJS
-pnpm run test:ui        # Runs node src/test/ui/run-e2e.js
+pnpm run test:ui        # Runs node out/test/run-e2e.js
 ```
 
 ### E2E_MODE Environment Variable
@@ -132,7 +132,7 @@ pnpm run test:ui        # Runs node src/test/ui/run-e2e.js
 **NOTE**: When running from a background terminal, run from `apps/vs-code-designer`:
 ```bash
 cd apps/vs-code-designer
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 ```
 
 ## 4. Architecture
@@ -197,7 +197,7 @@ The Compose action parameter panel uses a Lexical contenteditable editor, not a 
 
 ### Operational guidance from this session
 
-- If Phase 4.2 reports missing workspace paths, re-run full `run-e2e.js` (without `E2E_MODE`) to regenerate fresh Phase 4.1 outputs before retrying designer tests.
+- If Phase 4.2 reports missing workspace paths, re-run full `run-e2e.ts` (without `E2E_MODE`) to regenerate fresh Phase 4.1 outputs before retrying designer tests.
 - If settings cleanup encounters file locks, clear stale VS Code test processes and retry with the existing cleanup fallback (`settings/User` deletion path).
 - Use actions-only runs while iterating on discovery panel selectors, then promote to full Phase 4.2 once stable.
 
@@ -223,7 +223,7 @@ VS Code will auto-update our old-versioned extension (`5.110.0`) from the market
   "update.mode": "none"
 }
 ```
-And `run-e2e.js` removes any stale auto-updated versions of our extension on startup.
+And `run-e2e.ts` removes any stale auto-updated versions of our extension on startup.
 
 ### Test-Extensions Directory Structure
 
@@ -243,12 +243,12 @@ dist/test-extensions/
 ### Issue: `.obsolete` file blocks extension loading
 **Symptom**: Extension host log shows no activation for our extension. Commands don't appear in palette.
 **Cause**: VS Code writes `{"ms-azuretools.vscode-azurelogicapps-5.110.0":true}` to `.obsolete` in the extensions dir.
-**Fix**: Delete `.obsolete` after copying extension. Already handled in `run-e2e.js`.
+**Fix**: Delete `.obsolete` after copying extension. Already handled in `run-e2e.ts`.
 
 ### Issue: Extension auto-updated from marketplace
 **Symptom**: 5 command palette picks instead of expected 2-3. Errors reference `5.230.15/main.js` instead of `5.110.0`.
 **Cause**: VS Code downloads newer version from marketplace, creating duplicate extension.
-**Fix**: Set `extensions.autoUpdate: false` in VS Code settings. Remove stale versions in `run-e2e.js`.
+**Fix**: Set `extensions.autoUpdate: false` in VS Code settings. Remove stale versions in `run-e2e.ts`.
 
 ### Issue: Wrong webview opened ("Create Workspace From Package")
 **Symptom**: Webview shows "Package path" input. Tab title includes "From Package". Tests can't find expected fields.
@@ -377,7 +377,7 @@ await input.setText('logic app workspace');    // ❌ switches to file search
 **Symptom**: `E2E_MODE=designeronly` tests fail with "Missing workspace directories" for several workspace types.
 **Cause**: The `after()` hook in `designerOpen.test.ts` calls `cleanupAllWorkspaces()` which deletes workspace directories. If Phase 4.2 is re-run after cleanup, the workspaces no longer exist.
 **Impact**: Tests 1, 2, 6-9 fail in Phase 4.2 (workspace structure verification).
-**Fix**: Always run Phase 4.1 (createWorkspace) before Phase 4.2 to ensure fresh workspaces. The `run-e2e.js` script does this automatically when `E2E_MODE` is not set.
+**Fix**: Always run Phase 4.1 (createWorkspace) before Phase 4.2 to ensure fresh workspaces. The `run-e2e.ts` script does this automatically when `E2E_MODE` is not set.
 
 ### Issue: `openFileInEditor()` via Quick Open is unreliable
 **Symptom**: "Failed to open workflow.json" errors when using the old `InputBox`-based Quick Open approach.
@@ -654,7 +654,7 @@ They are independent. The CLI tests (`src/test/e2e/`) use `@vscode/test-cli` and
 ```json
 // In apps/vs-code-designer/package.json:
 "build:ui": "npx tsup --config tsup.e2e.test.config.ts",
-"test:ui": "node src/test/ui/run-e2e.js"
+"test:ui": "node out/test/run-e2e.js"
 ```
 
 **Note**: The build was migrated from `tsc` to `tsup` for CJS output compatibility with ExTester/Mocha. The `tsup.e2e.test.config.ts` file compiles all `src/test/ui/*.test.ts` to `out/test/*.test.js` in CommonJS format.
@@ -758,7 +758,7 @@ Remove-Item -Recurse -Force out/test -ErrorAction SilentlyContinue
 - **Phase separation (4.1 / 4.2)**: Allows re-running designer tests without re-creating workspaces
 - **tsup for test compilation**: Reliable CJS output; `tsc` had inconsistent module format issues
 - **Workspace manifest**: Single source of truth for workspace paths, prevents hardcoded path drift
-- **`run-e2e.js` as orchestrator**: Plain JS (no compile step needed), handles extension copying, dependency installation, process cleanup, and test execution in one script
+- **`run-e2e.ts` as orchestrator**: Plain JS (no compile step needed), handles extension copying, dependency installation, process cleanup, and test execution in one script
 - **Multi-layered process cleanup**: 6 fallback strategies for EBUSY errors; always succeeds eventually
 - **2 focused tests instead of 15+ scattered tests**: Reduced from 15+ tests (23 min, 20% pass rate) to 2 comprehensive end-to-end tests (5 min, ~80% pass rate). Each test covers the complete lifecycle.
 - **`assert.ok()` at every step**: Each step has a clear assertion with a descriptive message. No more swallowed errors in try/catch blocks.
@@ -774,7 +774,7 @@ Remove-Item -Recurse -Force out/test -ErrorAction SilentlyContinue
 
 ### VS Code Settings Required for Testing
 
-The `run-e2e.js` script generates these settings for the test VS Code instance:
+The `run-e2e.ts` script generates these settings for the test VS Code instance:
 
 ```json
 {
@@ -866,3 +866,4 @@ Always:
 ### Anti-precedent flag
 
 Synthetic codeful Phase 4.10 fixtures are prohibited by Rule 1 and D-001. Keep Phase 4.10 on the real Create Workspace + fresh reopen pattern; if the codeful wizard flow changes, update `createWorkspace.test.ts` helpers rather than writing project files directly to disk.
+

--- a/apps/vs-code-designer/src/test/ui/createWorkspace.behavior.test.ts
+++ b/apps/vs-code-designer/src/test/ui/createWorkspace.behavior.test.ts
@@ -893,9 +893,97 @@ describe('Create Workspace Tests', function () {
 
       await assertNextButtonDisabled(driver);
 
-      await clearAndType(wfNameInput, uniqueName('validwf'));
+      await clearAndType(wfNameInput, 'la-trigger-github');
+      await assertNoValidationMessage(driver, 'Workflow name must start with a letter and can only contain letters, digits');
+
       await captureScreenshot(driver, 'validWfSep-passed');
-      console.log('[validWfSep] PASSED');
+      console.log('[validWfSep] PASSED: invalid separators rejected and "la-trigger-github" accepted');
+    });
+
+    it('should show reserved name error for workflow name "Artifacts"', async () => {
+      const wfNameInput = await findInputByLabel(driver, 'Workflow name');
+      await clearAndType(wfNameInput, 'Artifacts');
+
+      await findValidationMessage(driver, 'reserved and cannot be used');
+      console.log('[validWfReserved] Error shown for "Artifacts"');
+
+      await assertNextButtonDisabled(driver);
+
+      // Restore valid value
+      await clearAndType(wfNameInput, uniqueName('validwf'));
+      await captureScreenshot(driver, 'validWfReserved-artifacts-passed');
+      console.log('[validWfReserved] PASSED: "Artifacts" blocked as reserved');
+    });
+
+    it('should show reserved name error for workflow name "lib"', async () => {
+      const wfNameInput = await findInputByLabel(driver, 'Workflow name');
+      await clearAndType(wfNameInput, 'lib');
+
+      await findValidationMessage(driver, 'reserved and cannot be used');
+      console.log('[validWfReservedLib] Error shown for "lib"');
+
+      await assertNextButtonDisabled(driver);
+
+      // Restore valid value
+      await clearAndType(wfNameInput, uniqueName('validwf'));
+      await captureScreenshot(driver, 'validWfReserved-lib-passed');
+      console.log('[validWfReservedLib] PASSED: "lib" blocked as reserved');
+    });
+
+    it('should show reserved name error case-insensitively for workflow name', async () => {
+      const wfNameInput = await findInputByLabel(driver, 'Workflow name');
+
+      // 'artifacts' (lowercase of 'Artifacts')
+      await clearAndType(wfNameInput, 'artifacts');
+      await findValidationMessage(driver, 'reserved and cannot be used');
+      console.log('[validWfReservedCase] Error shown for "artifacts" (lowercase)');
+
+      // 'ARTIFACTS' (uppercase)
+      await clearAndType(wfNameInput, 'ARTIFACTS');
+      await findValidationMessage(driver, 'reserved and cannot be used');
+      console.log('[validWfReservedCase] Error shown for "ARTIFACTS" (uppercase)');
+
+      await assertNextButtonDisabled(driver);
+
+      // Restore valid value
+      await clearAndType(wfNameInput, uniqueName('validwf'));
+      await assertNoValidationMessage(driver, 'reserved and cannot be used');
+      await captureScreenshot(driver, 'validWfReserved-case-passed');
+      console.log('[validWfReservedCase] PASSED: case-insensitive reserved name check works');
+    });
+
+    it('should show reserved name error for workflow name "workflow-designtime"', async () => {
+      const wfNameInput = await findInputByLabel(driver, 'Workflow name');
+      await clearAndType(wfNameInput, 'workflow-designtime');
+
+      await findValidationMessage(driver, 'reserved and cannot be used');
+      console.log('[validWfReservedDesigntime] Error shown for "workflow-designtime"');
+
+      await assertNextButtonDisabled(driver);
+
+      // Restore valid value
+      await clearAndType(wfNameInput, uniqueName('validwf'));
+      await captureScreenshot(driver, 'validWfReserved-designtime-passed');
+      console.log('[validWfReservedDesigntime] PASSED: "workflow-designtime" blocked as reserved');
+    });
+
+    it('should clear reserved name error when valid workflow name is typed', async () => {
+      const wfNameInput = await findInputByLabel(driver, 'Workflow name');
+
+      // Start with reserved name
+      await clearAndType(wfNameInput, 'custom');
+      await findValidationMessage(driver, 'reserved and cannot be used');
+      console.log('[validWfReservedClear] Error shown for "custom"');
+
+      await assertNextButtonDisabled(driver);
+
+      // Type a valid name
+      await clearAndType(wfNameInput, uniqueName('validwf'));
+      await assertNoValidationMessage(driver, 'reserved and cannot be used');
+      console.log('[validWfReservedClear] Error cleared after typing valid name');
+
+      await captureScreenshot(driver, 'validWfReserved-clear-passed');
+      console.log('[validWfReservedClear] PASSED: reserved error clears when valid name typed');
     });
 
     // -----------------------------------------------------------------------

--- a/apps/vs-code-designer/src/test/ui/designerHelpers.ts
+++ b/apps/vs-code-designer/src/test/ui/designerHelpers.ts
@@ -69,6 +69,7 @@ import {
   waitForQuickInputAndType,
 } from './helpers';
 import type { WorkspaceManifestEntry } from './workspaceManifest';
+import { isExecutableFile } from './runtimeBinaryCheck';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -141,14 +142,7 @@ function ensureRuntimeDependencyExecutablePermissions(): void {
   }
 }
 
-function isExecutableFile(filePath: string): boolean {
-  try {
-    fs.accessSync(filePath, process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
+// isExecutableFile is imported from ./runtimeBinaryCheck (shared with run-e2e.ts)
 
 function getFuncCoreToolsCandidatePaths(): string[] {
   const executableName = process.platform === 'win32' ? 'func.exe' : 'func';
@@ -158,6 +152,7 @@ function getFuncCoreToolsCandidatePaths(): string[] {
     path.join(funcToolsRoot, 'in-proc8', executableName),
     path.join(funcToolsRoot, 'in-proc6', executableName),
   ];
+  const executableNames = new Set([executableName]);
 
   const directoriesToScan = [funcToolsRoot];
   for (const directory of directoriesToScan) {
@@ -168,7 +163,7 @@ function getFuncCoreToolsCandidatePaths(): string[] {
       const entryPath = path.join(directory, entry.name);
       if (entry.isDirectory()) {
         directoriesToScan.push(entryPath);
-      } else if (entry.name === executableName) {
+      } else if (executableNames.has(entry.name)) {
         candidates.push(entryPath);
       }
     }
@@ -179,17 +174,25 @@ function getFuncCoreToolsCandidatePaths(): string[] {
 
 function getFuncCoreToolsPath(): string {
   const candidates = getFuncCoreToolsCandidatePaths();
+  // All candidates are already func binaries (getFuncCoreToolsCandidatePaths only matches executableNames)
   return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[0];
 }
 
 function assertFuncCoreToolsExecutable(context: string): void {
-  const funcBinaryPath = getFuncCoreToolsPath();
   ensureRuntimeDependencyExecutablePermissions();
-  if (!fs.existsSync(funcBinaryPath)) {
+  const funcBinaryPath = getFuncCoreToolsPath();
+  // Multiple existing candidates are expected: FuncCoreTools installs copies under
+  // in-proc8/, in-proc6/, etc. for different .NET versions. We validate ALL of them
+  // have execute permissions since the extension picks one at runtime based on project config.
+  const existingCandidates = getFuncCoreToolsCandidatePaths().filter((candidate) => fs.existsSync(candidate));
+  if (existingCandidates.length === 0) {
     throw new Error(`[depValidation] func binary not found after ${context}: ${funcBinaryPath}`);
   }
-  if (!isExecutableFile(funcBinaryPath)) {
-    throw new Error(`[depValidation] func binary exists but is not executable after ${context}: ${funcBinaryPath}`);
+
+  for (const candidate of existingCandidates) {
+    if (!isExecutableFile(candidate)) {
+      throw new Error(`[depValidation] FuncCoreTools binary exists but is not executable after ${context}: ${candidate}`);
+    }
   }
 }
 

--- a/apps/vs-code-designer/src/test/ui/helpers.ts
+++ b/apps/vs-code-designer/src/test/ui/helpers.ts
@@ -1054,7 +1054,7 @@ export async function openFolderInSession(driver: WebDriver, folderPath: string)
   // Pre-flight: wait until the workbench is interactable. Without this the
   // first retry attempt almost always fails with ElementNotInteractableError
   // and wastes ~13 s before the second attempt succeeds.
-  await waitForWorkbenchReady(driver, 15_000);
+  await waitForWorkbenchReady(driver, 20_000);
 
   // Aggressively dismiss ALL blocking UI before opening command palette.
   // On CI, dialogs like "C# Dev Kit Sign In" appear and block keyboard input.
@@ -1088,45 +1088,85 @@ export async function openFolderInSession(driver: WebDriver, folderPath: string)
       }
       await sleep(500);
 
+      // Click the workbench area to ensure VS Code has keyboard focus.
+      // On CI runners, focus can be lost to notification toasts or other OS
+      // windows, causing Ctrl+Shift+P to never reach the editor.
+      try {
+        const workbench = await driver.findElement(By.css('.monaco-workbench'));
+        await driver.actions().move({ origin: workbench, x: 100, y: 100 }).click().perform();
+        await sleep(300);
+      } catch {
+        /* best-effort focus — proceed regardless */
+      }
+
       // Use Ctrl+Shift+P (more reliable than F1 when dialogs are present)
       await driver.actions().keyDown(Key.CONTROL).keyDown(Key.SHIFT).sendKeys('p').keyUp(Key.SHIFT).keyUp(Key.CONTROL).perform();
-      await sleep(1000);
 
-      const cmdInput = await driver.findElement(By.css('.quick-input-box input'));
+      // Wait for the command palette input to become interactive (not just present in DOM).
+      // This replaces a fixed 1s sleep that was too short on cold CI runners.
+      const cmdInput = await driver.wait(
+        until.elementIsEnabled(await waitForElement(driver, '.quick-input-box input', 5000)),
+        5000,
+        '[openFolderInSession] Command palette input not interactive within 5s'
+      );
+
       await cmdInput.sendKeys(Key.chord(Key.CONTROL, 'a'));
       await cmdInput.sendKeys('> File: Open Folder...');
-      await sleep(1000);
+
+      // Wait for the filtered command list to appear before pressing Enter.
+      await driver
+        .wait(
+          async () => {
+            const rows = await driver.findElements(By.css('.quick-input-list .monaco-list-row'));
+            return rows.length > 0;
+          },
+          5000,
+          '[openFolderInSession] Command list did not populate within 5s'
+        )
+        .catch(() => {
+          /* proceed anyway — the command may still work */
+        });
+      await sleep(300);
 
       // Press Enter to execute the command
       await cmdInput.sendKeys(Key.ENTER);
-      await sleep(2000);
 
-      // The simple dialog input should appear. Type the path.
-      // ExTester sets files.simpleDialog.enable=true.
-      const dialogInput = await driver.findElement(By.css('.quick-input-box input'));
+      // Wait for the simple file dialog input to appear (ExTester sets
+      // files.simpleDialog.enable=true so this is a quick-input, not native OS dialog).
+      const dialogInput = await driver.wait(
+        until.elementIsEnabled(await waitForElement(driver, '.quick-input-box input', 8000)),
+        5000,
+        '[openFolderInSession] File dialog input not interactive within 5s'
+      );
+
       await dialogInput.sendKeys(Key.chord(Key.CONTROL, 'a'));
       await dialogInput.sendKeys(folderPath);
-      await sleep(500);
+      await sleep(300);
       await dialogInput.sendKeys(Key.ENTER);
-      await sleep(5000);
 
-      // Check if folder opened by looking at the title
-      const title = await driver.getTitle().catch(() => '');
-      console.log(`[openFolderInSession] VS Code title: "${title}"`);
-
-      if (title !== 'Visual Studio Code') {
-        console.log('[openFolderInSession] Folder opened successfully');
-        return;
-      }
-
-      // Also check Explorer rows
-      const rows = await driver
-        .executeScript<number>(
-          'return document.querySelectorAll(".explorer-viewlet .monaco-list-row, .explorer-folders-view .monaco-list-row").length'
+      // Wait for the folder to open — poll title and Explorer for up to 10s
+      const folderOpened = await driver
+        .wait(
+          async () => {
+            const title = await driver.getTitle().catch(() => '');
+            if (title !== 'Visual Studio Code' && title !== '') {
+              return true;
+            }
+            const rows = await driver
+              .executeScript<number>(
+                'return document.querySelectorAll(".explorer-viewlet .monaco-list-row, .explorer-folders-view .monaco-list-row").length'
+              )
+              .catch(() => 0);
+            return rows > 0;
+          },
+          10_000,
+          '[openFolderInSession] Folder did not open within 10s'
         )
-        .catch(() => 0);
-      if (rows > 0) {
-        console.log(`[openFolderInSession] Folder opened (${rows} Explorer rows)`);
+        .catch(() => false);
+
+      if (folderOpened) {
+        const title = await driver.getTitle().catch(() => '');
+        console.log(`[openFolderInSession] Folder opened successfully (title: "${title}")`);
         return;
       }
 
@@ -1142,4 +1182,13 @@ export async function openFolderInSession(driver: WebDriver, folderPath: string)
     }
   }
   console.log('[openFolderInSession] All attempts exhausted');
+}
+
+/**
+ * Wait for an element to appear in the DOM (polling until present).
+ * Unlike `driver.findElement`, this won't throw immediately if the element
+ * doesn't exist yet — it retries until the timeout expires.
+ */
+async function waitForElement(driver: WebDriver, cssSelector: string, timeoutMs: number): Promise<WebElement> {
+  return driver.wait(until.elementLocated(By.css(cssSelector)), timeoutMs);
 }

--- a/apps/vs-code-designer/src/test/ui/lspSdkExtractionEperm.test.ts
+++ b/apps/vs-code-designer/src/test/ui/lspSdkExtractionEperm.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="mocha" />
+
+import * as assert from 'assert';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { NotificationType, VSBrowser, Workbench } from 'vscode-extension-tester';
+import { sleep, waitForQuickInputReady } from './helpers';
+
+const validateDependenciesCommand = 'Azure Logic Apps: Validate and install dependency binaries';
+
+describe('LSP SDK extraction EPERM repro', function () {
+  this.timeout(180000);
+
+  let workbench: Workbench;
+  let depsRoot: string;
+  let principal: string;
+  let aclDenied = false;
+
+  before(async function () {
+    if (process.platform !== 'win32') {
+      this.skip();
+    }
+
+    depsRoot = process.env.LA_E2E_LSP_EPERM_DEPS_ROOT ?? '';
+    assert.ok(depsRoot, 'LA_E2E_LSP_EPERM_DEPS_ROOT must be set by E2E_MODE=lspeperm');
+    assert.ok(fs.existsSync(depsRoot), `Isolated dependency root must exist: ${depsRoot}`);
+
+    const userName = process.env.USERNAME;
+    const userDomain = process.env.USERDOMAIN;
+    assert.ok(userName, 'USERNAME must be set for icacls ACL mutation');
+    principal = userDomain ? `${userDomain}\\${userName}` : userName;
+
+    workbench = new Workbench();
+    await VSBrowser.instance.driver.sleep(3000);
+  });
+
+  afterEach(() => {
+    restoreCreateDirectoryPermission();
+  });
+
+  it('reproduces real Windows EPERM when LSPServer cannot be created', async () => {
+    const lspServerPath = path.join(depsRoot, 'LSPServer');
+    const lspServerDllPath = path.join(lspServerPath, 'SdkLspServer.dll');
+    fs.rmSync(lspServerPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
+    fs.rmSync(path.join(depsRoot, '.lspserver-hash'), { force: true });
+
+    denyCreateDirectoryPermission();
+
+    await waitForQuickInputReady(workbench, VSBrowser.instance.driver);
+    await workbench.executeCommand(validateDependenciesCommand);
+
+    await waitForDependencyFailureNotification();
+
+    assert.ok(!fs.existsSync(lspServerDllPath), `LSP server DLL should not exist while directory creation is denied: ${lspServerDllPath}`);
+  });
+
+  function denyCreateDirectoryPermission(): void {
+    execFileSync('icacls', [depsRoot, '/deny', `${principal}:(AD)`], { stdio: 'pipe' });
+    aclDenied = true;
+    assertDirectoryCreationDenied();
+  }
+
+  function restoreCreateDirectoryPermission(): void {
+    if (!aclDenied) {
+      return;
+    }
+
+    try {
+      execFileSync('icacls', [depsRoot, '/remove:d', principal], { stdio: 'pipe' });
+    } finally {
+      aclDenied = false;
+    }
+  }
+
+  function assertDirectoryCreationDenied(): void {
+    const probePath = path.join(depsRoot, `acl-probe-${Date.now()}`);
+    try {
+      fs.mkdirSync(probePath);
+      fs.rmSync(probePath, { recursive: true, force: true });
+      assert.fail(`Expected create-directory permission to be denied under ${depsRoot}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      assert.match(message, /EPERM|EACCES|permission|access/i, `Expected ACL denial, got: ${message}`);
+    }
+  }
+
+  async function waitForDependencyFailureNotification(): Promise<void> {
+    const deadline = Date.now() + 120000;
+    let lastNotificationText = '';
+    while (Date.now() < deadline) {
+      const notifications = await workbench.getNotifications().catch(() => []);
+      for (const notification of notifications) {
+        const [type, message] = await Promise.all([
+          notification.getType().catch(() => undefined),
+          notification.getMessage().catch(() => ''),
+        ]);
+        if (message) {
+          lastNotificationText = message;
+        }
+        if (type === NotificationType.Error && /Error extracting LSP server:.*EPERM.*LSPServer/i.test(message)) {
+          console.log(`[lspeperm] Observed dependency failure notification: ${message}`);
+          return;
+        }
+      }
+      await sleep(1000);
+    }
+
+    assert.fail(`Timed out waiting for dependency failure notification. Last notification: ${lastNotificationText || '<none>'}`);
+  }
+});

--- a/apps/vs-code-designer/src/test/ui/multipleDesigners.test.ts
+++ b/apps/vs-code-designer/src/test/ui/multipleDesigners.test.ts
@@ -602,11 +602,30 @@ async function clickEnabledButtonByText(driver: WebDriver, buttonTexts: string[]
   return false;
 }
 
-async function fillCreateWorkflowWebview(driver: WebDriver, newWorkflowName: string): Promise<boolean> {
+async function fillCreateWorkflowWebview(driver: WebDriver, newWorkflowName: string, expectedProjectName?: string): Promise<boolean> {
   let webview: WebView | undefined;
   try {
     webview = await switchToWebviewFrame(driver);
     console.log('[multiDesigner] Create workflow webview opened');
+
+    // Verify the Project dropdown is visible and has the expected project pre-selected
+    // (this validates our multi-root project dropdown fix)
+    const projectDropdown = await findDropdownByLabel(driver, 'Project').catch(() => null);
+    if (projectDropdown) {
+      console.log('[multiDesigner] Project dropdown is visible');
+      const dropdownText = await projectDropdown.getText().catch(() => '');
+      console.log(`[multiDesigner] Project dropdown value: "${dropdownText}"`);
+      if (expectedProjectName) {
+        assert.ok(
+          dropdownText.includes(expectedProjectName),
+          `Expected project dropdown to contain "${expectedProjectName}", got "${dropdownText}"`
+        );
+        console.log(`[multiDesigner] ✓ Project dropdown pre-selected: "${expectedProjectName}"`);
+      }
+    } else {
+      // Single-project workspaces may not show the dropdown (only 1 project auto-selected)
+      console.log('[multiDesigner] No Project dropdown visible (likely single-project workspace, auto-selected)');
+    }
 
     const nameInput = await findInputByLabel(driver, 'Workflow name');
     await clearAndType(nameInput, newWorkflowName);
@@ -685,7 +704,7 @@ async function addWorkflowViaRightClick(driver: WebDriver, appFolderName: string
 
           // Current product flow opens the Create workflow webview. Older
           // builds used Quick Input, so keep that path as fallback only.
-          if (await fillCreateWorkflowWebview(driver, newWorkflowName)) {
+          if (await fillCreateWorkflowWebview(driver, newWorkflowName, appFolderName)) {
             console.log(`[multiDesigner] Submitted Create workflow webview for "${newWorkflowName}"`);
             return true;
           }

--- a/apps/vs-code-designer/src/test/ui/run-clean.ps1
+++ b/apps/vs-code-designer/src/test/ui/run-clean.ps1
@@ -29,7 +29,7 @@ Get-ChildItem $extDir -Directory -ErrorAction SilentlyContinue | Where-Object {
 # Run the E2E tests, capturing output to a log file
 Write-Host "`n=== Running E2E tests ==="
 $logFile = Join-Path $appDir "out\test\e2e-results.log"
-node src/test/ui/run-e2e.js 2>&1 | Tee-Object -FilePath $logFile
+node out/test/run-e2e.js 2>&1 | Tee-Object -FilePath $logFile
 
 Write-Host "`n=== Test run complete ==="
 Write-Host "Results saved to: $logFile"

--- a/apps/vs-code-designer/src/test/ui/run-e2e.ts
+++ b/apps/vs-code-designer/src/test/ui/run-e2e.ts
@@ -13,15 +13,102 @@
  * isolated directory.
  */
 
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
-const crypto = require('crypto');
-const { exec, execSync } = require('child_process');
-const { ExTester } = require('vscode-extension-tester');
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as crypto from 'crypto';
+import { exec, execSync } from 'child_process';
+import { ExTester } from 'vscode-extension-tester';
+import { isExecutableFile } from './runtimeBinaryCheck';
+import { lspDirectory } from '../../constants';
+import { lspServerDirectoryName, lspServerHashMarkerName, lspSdkHashMarkerName } from '../../app/utils/languageServerProtocolConstants';
 
-const projectDir = path.resolve(__dirname, '..', '..', '..');
+type BundleFileEntry = { relPath: string; fullPath: string };
+type ExtensionBundleState = { version: string; bundleDir: string; sidecarPath: string };
+type BundleSidecar = { sourceMd5: string; contentHash: string };
+type InstallResult = { dep: string; success: boolean };
+type RuntimeDependencyPaths = {
+  depsRoot: string;
+  funcToolsDir: string;
+  funcExecutableCandidates: string[];
+  dotnetSdkDir: string;
+  nodeJsDir: string;
+  funcBinary: string;
+  dotnetBinary: string;
+  nodeBinary: string;
+};
+type TestSettingsOptions = {
+  validateDependencies?: boolean;
+  autoStartDesignTime?: boolean;
+  includeRuntimeDependencyPaths?: boolean;
+  runtimeDependenciesPathOverride?: string;
+  useExperimentalBundle?: boolean;
+  experimentalBundleSourceUri?: string;
+  experimentalBundleVersion?: string;
+};
+type ScenarioSettings = Omit<TestSettingsOptions, 'validateDependencies'> & {
+  validateDependencies?: boolean | 'auto';
+};
+type WorkspaceSpec =
+  | 'plain-folder'
+  | 'self-creates'
+  | 'self-contained'
+  | 'manifest-multi'
+  | {
+      appType?: string;
+      wfType?: string;
+      use?: 'wsDir' | 'appDir';
+    };
+type ManifestEntry = {
+  label?: string;
+  appType?: string;
+  wfType?: string;
+  wsFilePath?: string;
+  wsDir?: string;
+  appDir?: string;
+  wfName?: string;
+  [key: string]: unknown;
+};
+type CodefulWorkspaceEntry = ManifestEntry & {
+  label: string;
+  appType: string;
+  wsFilePath: string;
+  appDir: string;
+  wfName: string;
+};
+type CodefulDebugWorkspaces = { modern: CodefulWorkspaceEntry; legacy: CodefulWorkspaceEntry };
+type WorkspaceSelection = { resources: string[]; legacyDir?: string };
+type Scenario = {
+  id: string;
+  testFile: string | string[];
+  workspaceSpec: WorkspaceSpec;
+  settings?: ScenarioSettings;
+  monolithic?: boolean;
+  env?: Record<string, string>;
+};
+type PhaseRunOptions = {
+  vscodeVersion: string;
+  settings: string;
+  cleanup: boolean;
+  offline: boolean;
+  resources: string[];
+};
+type ExtensionJsonEntry = {
+  identifier: { id: string };
+  version: string;
+  location: { $mid: number; path: string; scheme: 'file' };
+  relativeLocation: string;
+  metadata: { installedTimestamp: number; source: 'gallery' };
+};
+type EnvOverride = { key: string; prev: string | undefined };
+
+const getErrorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+const projectDir = fs.existsSync(path.join(__dirname, '..', '..', 'package.json'))
+  ? path.resolve(__dirname, '..', '..')
+  : path.resolve(__dirname, '..', '..', '..');
 const distDir = path.join(projectDir, 'dist');
+const sourceUiTestDir = path.join(projectDir, 'src', 'test', 'ui');
 
 /**
  * Pinned VS Code version for test stability.
@@ -33,8 +120,7 @@ const DEFAULT_VSCODE_VERSION = '1.108.0';
 const VSCODE_VERSION_SOURCE = process.env.E2E_VSCODE_VERSION ? 'E2E_VSCODE_VERSION' : process.env.CODE_VERSION ? 'CODE_VERSION' : 'default';
 if (process.env.E2E_VSCODE_VERSION && process.env.CODE_VERSION && process.env.E2E_VSCODE_VERSION !== process.env.CODE_VERSION) {
   throw new Error(
-    `E2E_VSCODE_VERSION (${process.env.E2E_VSCODE_VERSION}) and CODE_VERSION (${process.env.CODE_VERSION}) disagree. ` +
-      'Set only one VS Code version override for run-e2e.js.'
+    `E2E_VSCODE_VERSION (${process.env.E2E_VSCODE_VERSION}) and CODE_VERSION (${process.env.CODE_VERSION}) disagree. Set only one VS Code version override for run-e2e.js.`
   );
 }
 const VSCODE_VERSION = process.env.E2E_VSCODE_VERSION || process.env.CODE_VERSION || DEFAULT_VSCODE_VERSION;
@@ -44,13 +130,30 @@ const EXTENSION_BUNDLE_ID = 'Microsoft.Azure.Functions.ExtensionBundle.Workflows
 const EXTENSION_BUNDLE_ROOT = path.join(os.homedir(), '.azure-functions-core-tools', 'Functions', 'ExtensionBundles', EXTENSION_BUNDLE_ID);
 const BUNDLE_SIDECAR_FILE = '.bundle-source-md5';
 
+/**
+ * LSP-related artifact names that must be removed when preparing an isolated
+ * dependency root for the EPERM repro test. This forces the extension to
+ * re-extract the LSP server/SDK during the test.
+ *
+ * Source of truth: languageServerProtocol.ts and constants.ts
+ */
+const LSP_STALE_ARTIFACT_NAMES = [
+  lspServerDirectoryName,
+  lspServerHashMarkerName,
+  lspDirectory,
+  lspSdkHashMarkerName,
+  '.lspserver-version',
+  '.lspserver-path',
+  '.lspsdk-version',
+];
+
 // Store test-extensions in test-resources/ (alongside VS Code download) rather
 // than dist/ — tsup's `clean: true` wipes dist/ on every build:extension, which
 // would destroy cached marketplace extension installs.
 const extDir = path.join(os.tmpdir(), 'test-resources', 'test-extensions');
 const testGlob = path.resolve(projectDir, 'out', 'test', '*.js').replace(/\\/g, '/');
 
-function compareSemverDesc(a, b) {
+function compareSemverDesc(a: string, b: string): number {
   const pa = a.split('.').map((part) => Number.parseInt(part, 10));
   const pb = b.split('.').map((part) => Number.parseInt(part, 10));
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
@@ -62,7 +165,7 @@ function compareSemverDesc(a, b) {
   return 0;
 }
 
-function findLatestExtensionBundle() {
+function findLatestExtensionBundle(): ExtensionBundleState | undefined {
   if (!fs.existsSync(EXTENSION_BUNDLE_ROOT)) {
     return undefined;
   }
@@ -85,11 +188,14 @@ function findLatestExtensionBundle() {
   };
 }
 
-function listBundleFiles(bundleDir) {
-  const files = [];
+function listBundleFiles(bundleDir: string): BundleFileEntry[] {
+  const files: BundleFileEntry[] = [];
   const stack = [bundleDir];
   while (stack.length > 0) {
     const current = stack.pop();
+    if (!current) {
+      continue;
+    }
     for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
       const fullPath = path.join(current, entry.name);
       const relPath = path.relative(bundleDir, fullPath).split(path.sep).join('/');
@@ -107,7 +213,7 @@ function listBundleFiles(bundleDir) {
   return files;
 }
 
-function computeBundleContentHash(bundleDir, files) {
+function computeBundleContentHash(bundleDir: string, files: BundleFileEntry[]): string {
   const hash = crypto.createHash('sha256');
   const nul = Buffer.from([0]);
   for (const file of files) {
@@ -122,7 +228,7 @@ function computeBundleContentHash(bundleDir, files) {
   return hash.digest('base64');
 }
 
-function verifyLogicAppsExtensionBundle(label) {
+function verifyLogicAppsExtensionBundle(label: string): ExtensionBundleState {
   const state = findLatestExtensionBundle();
   if (!state) {
     throw new Error(`[${label}] Logic Apps extension bundle root is missing or has no version folders: ${EXTENSION_BUNDLE_ROOT}`);
@@ -131,11 +237,11 @@ function verifyLogicAppsExtensionBundle(label) {
     throw new Error(`[${label}] Logic Apps extension bundle sidecar is missing: ${state.sidecarPath}`);
   }
 
-  let sidecar;
+  let sidecar: BundleSidecar;
   try {
     sidecar = JSON.parse(fs.readFileSync(state.sidecarPath, 'utf8'));
-  } catch (error) {
-    throw new Error(`[${label}] Logic Apps extension bundle sidecar is not valid JSON: ${error.message}`);
+  } catch (error: any) {
+    throw new Error(`[${label}] Logic Apps extension bundle sidecar is not valid JSON: ${getErrorMessage(error)}`);
   }
   if (!sidecar || typeof sidecar.sourceMd5 !== 'string' || typeof sidecar.contentHash !== 'string') {
     throw new Error(`[${label}] Logic Apps extension bundle sidecar is missing sourceMd5/contentHash: ${state.sidecarPath}`);
@@ -157,7 +263,7 @@ function verifyLogicAppsExtensionBundle(label) {
   return state;
 }
 
-function pruneUnhealthyLogicAppsExtensionBundles(label) {
+function pruneUnhealthyLogicAppsExtensionBundles(label: string): void {
   if (!fs.existsSync(EXTENSION_BUNDLE_ROOT)) {
     return;
   }
@@ -187,14 +293,14 @@ function pruneUnhealthyLogicAppsExtensionBundles(label) {
         console.log(`[${label}] Removing bundle ${version}: invalid sidecar/content hash`);
         fs.rmSync(bundleDir, { recursive: true, force: true });
       }
-    } catch (error) {
-      console.log(`[${label}] Removing bundle ${version}: health check failed (${error.message})`);
+    } catch (error: any) {
+      console.log(`[${label}] Removing bundle ${version}: health check failed (${getErrorMessage(error)})`);
       fs.rmSync(bundleDir, { recursive: true, force: true });
     }
   }
 }
 
-function createExTester() {
+function createExTester(): ExTester {
   return new ExTester(
     undefined, // storageFolder — use default (os.tmpdir()/test-resources)
     undefined, // releaseType — Stable
@@ -205,13 +311,15 @@ function createExTester() {
 /**
  * Recursively copy a directory, skipping test-extensions itself to avoid infinite recursion.
  */
-function copyDirSync(src, dest, skipDir) {
+function copyDirSync(src: string, dest: string, skipDir?: string): void {
   fs.mkdirSync(dest, { recursive: true });
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
     // Skip the test-extensions directory itself to avoid infinite recursion
-    if (skipDir && path.resolve(srcPath) === path.resolve(skipDir)) continue;
+    if (skipDir && path.resolve(srcPath) === path.resolve(skipDir)) {
+      continue;
+    }
     if (entry.isDirectory()) {
       copyDirSync(srcPath, destPath);
     } else {
@@ -220,8 +328,8 @@ function copyDirSync(src, dest, skipDir) {
   }
 }
 
-async function withDownloadRetry(label, action) {
-  let lastError;
+async function withDownloadRetry(label: string, action: () => Promise<void>): Promise<void> {
+  let lastError: unknown;
   for (let attempt = 1; attempt <= DOWNLOAD_RETRY_ATTEMPTS; attempt++) {
     try {
       if (attempt > 1) {
@@ -229,9 +337,9 @@ async function withDownloadRetry(label, action) {
       }
       await action();
       return;
-    } catch (error) {
+    } catch (error: any) {
       lastError = error;
-      const message = error?.message || String(error);
+      const message = getErrorMessage(error);
       console.log(`  ${label} attempt ${attempt}/${DOWNLOAD_RETRY_ATTEMPTS} failed: ${message}`);
       if (attempt < DOWNLOAD_RETRY_ATTEMPTS) {
         await new Promise((resolve) => setTimeout(resolve, attempt * 10_000));
@@ -241,15 +349,15 @@ async function withDownloadRetry(label, action) {
   throw lastError;
 }
 
-function installExtensionWithCli(cliBase, dep, label = dep) {
-  return new Promise((resolve) => {
+function installExtensionWithCli(cliBase: string, dep: string, label: string = dep): Promise<InstallResult> {
+  return new Promise<InstallResult>((resolve) => {
     const command = `${cliBase} --force --install-extension "${dep}" --extensions-dir="${extDir}"`;
     const startTime = Date.now();
-    exec(command, { timeout: 300000 }, (error, stdout, stderr) => {
+    exec(command, { timeout: 300000 }, (error: Error | null, stdout: string, stderr: string) => {
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
       if (error) {
         const output = `${stdout || ''}\n${stderr || ''}`.trim().slice(-1000);
-        console.warn(`  ⚠ ${label} failed (${elapsed}s): ${error.message}${output ? `\n${output}` : ''}`);
+        console.warn(`  ⚠ ${label} failed (${elapsed}s): ${getErrorMessage(error)}${output ? `\n${output}` : ''}`);
         resolve({ dep, success: false });
       } else {
         console.log(`  ✓ ${label} installed (${elapsed}s)`);
@@ -259,7 +367,7 @@ function installExtensionWithCli(cliBase, dep, label = dep) {
   });
 }
 
-function findNestedWindowsCliPath(codeFolder) {
+function findNestedWindowsCliPath(codeFolder: string): string | undefined {
   if (process.platform !== 'win32') {
     return undefined;
   }
@@ -282,7 +390,7 @@ function findNestedWindowsCliPath(codeFolder) {
   return undefined;
 }
 
-function preflightVSCodeCli(extest) {
+function preflightVSCodeCli(extest: ExTester): void {
   const codeFolder = extest.code.getCodeFolder();
   const cliPath = extest.code.getCliPath();
   const executablePath = extest.code.executablePath;
@@ -295,23 +403,21 @@ function preflightVSCodeCli(extest) {
   if (!fs.existsSync(cliPath)) {
     const nestedHint = nestedCliPath ? ` Found nested Windows CLI at ${nestedCliPath}, but ExTester resolved ${cliPath}.` : '';
     throw new Error(
-      `VS Code CLI not found at ${cliPath}.${nestedHint} ` +
-        `Clear ${codeFolder} and rerun, or update vscode-extension-tester if the VS Code archive layout changed.`
+      `VS Code CLI not found at ${cliPath}.${nestedHint} Clear ${codeFolder} and rerun, or update vscode-extension-tester if the VS Code archive layout changed.`
     );
   }
 
-  let output;
+  let output: string;
   try {
     output = execSync(`${extest.code.getCliInitCommand()} -v`, {
       encoding: 'utf8',
       env: extest.code.env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-  } catch (error) {
+  } catch (error: any) {
     const nestedHint = nestedCliPath ? ` Nested Windows CLI candidate: ${nestedCliPath}.` : '';
     throw new Error(
-      `VS Code CLI preflight failed for ${cliPath}.${nestedHint} ` +
-        `Clear ${codeFolder} and rerun, or update vscode-extension-tester if the VS Code archive layout changed.\n${error.message}`
+      `VS Code CLI preflight failed for ${cliPath}.${nestedHint} Clear ${codeFolder} and rerun, or update vscode-extension-tester if the VS Code archive layout changed.\n${getErrorMessage(error)}`
     );
   }
 
@@ -325,7 +431,7 @@ function preflightVSCodeCli(extest) {
   console.log(`  ✓ VS Code CLI preflight: ${actualVersion} (${cliPath})`);
 }
 
-async function downloadExTesterAssets() {
+async function downloadExTesterAssets(): Promise<void> {
   await withDownloadRetry(`download VS Code ${VSCODE_VERSION}`, async () => {
     const downloadTester = createExTester();
     await downloadTester.downloadCode(VSCODE_VERSION);
@@ -340,12 +446,16 @@ async function downloadExTesterAssets() {
  * This is needed after parallel marketplace installs, which may race on
  * concurrent writes to extensions.json, corrupting or losing entries.
  */
-function rebuildExtensionsJson(extensionsDir) {
-  const entries = [];
+function rebuildExtensionsJson(extensionsDir: string): void {
+  const entries: ExtensionJsonEntry[] = [];
   for (const entry of fs.readdirSync(extensionsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
+    if (!entry.isDirectory()) {
+      continue;
+    }
     const pkgPath = path.join(extensionsDir, entry.name, 'package.json');
-    if (!fs.existsSync(pkgPath)) continue;
+    if (!fs.existsSync(pkgPath)) {
+      continue;
+    }
     try {
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
       const id = `${pkg.publisher}.${pkg.name}`;
@@ -383,8 +493,8 @@ function rebuildExtensionsJson(extensionsDir) {
  * `la-e2e.startDebug`, `la-e2e.stopDebug`, and `la-e2e.recorderPing`
  * commands used by Phase 4.10.
  */
-function installCodefulTaskRecorderExtension(extDir) {
-  const recorderSrc = path.join(__dirname, 'codefulTaskRecorderExtension');
+function installCodefulTaskRecorderExtension(extDir: string): string {
+  const recorderSrc = path.join(sourceUiTestDir, 'codefulTaskRecorderExtension');
   if (!fs.existsSync(path.join(recorderSrc, 'package.json'))) {
     throw new Error(`Recorder extension source missing at ${recorderSrc}`);
   }
@@ -429,7 +539,7 @@ function installCodefulTaskRecorderExtension(extDir) {
  * Build a synthetic "legacy" project fixture for the legacy/standard
  * non-Logic-App regression tests.
  */
-function createLegacyProjectFixture(label) {
+function createLegacyProjectFixture(label: string): string {
   const legacyRoot = fs.mkdtempSync(path.join(os.tmpdir(), `la-e2e-${label}-`));
   const legacyDir = path.join(legacyRoot, 'legacy-project');
   const legacyWfDir = path.join(legacyDir, 'testworkflow');
@@ -478,8 +588,8 @@ function createLegacyProjectFixture(label) {
  * Run async tasks with a concurrency limit.
  * Returns results in the same order as the input tasks.
  */
-async function parallelLimit(taskFns, limit) {
-  const results = new Array(taskFns.length);
+async function parallelLimit<T>(taskFns: Array<() => Promise<T>>, limit: number): Promise<T[]> {
+  const results: T[] = new Array(taskFns.length);
   let nextIndex = 0;
 
   async function runNext() {
@@ -489,7 +599,7 @@ async function parallelLimit(taskFns, limit) {
     }
   }
 
-  const workers = [];
+  const workers: Promise<void>[] = [];
   for (let w = 0; w < Math.min(limit, taskFns.length); w++) {
     workers.push(runNext());
   }
@@ -497,14 +607,14 @@ async function parallelLimit(taskFns, limit) {
   return results;
 }
 
-async function main() {
+async function main(): Promise<void> {
   // Fast path: bundleintegrityonly is a pure-Node Mocha probe that needs
   // neither the built extension (dist/package.json) nor ExTester / VS Code.
   // Short-circuit before any of those checks so the phase can run on a
   // fresh checkout (or any shard) without first running the extension build.
   const earlyMode = (process.env.E2E_MODE || 'full').toLowerCase();
   if (earlyMode === 'bundleintegrityonly') {
-    const outTestDir = path.resolve(__dirname, '..', '..', '..', 'out', 'test');
+    const outTestDir = path.join(projectDir, 'out', 'test');
     const file = path.join(outTestDir, 'bundleCdnHealth.test.js').replace(/\\/g, '/');
     if (!fs.existsSync(file)) {
       console.error(`\n✖ Compiled test not found: ${file}\n  Run: npx tsup --config tsup.e2e.test.config.ts`);
@@ -518,14 +628,12 @@ async function main() {
     const Mocha = require('mocha');
     const mocha = new Mocha({ color: true, timeout: 60_000, reporter: 'spec' });
     mocha.addFile(file);
-    const exit = await new Promise((resolve) => {
+    const exit = await new Promise<number>((resolve) => {
       mocha.run((failures) => resolve(failures > 0 ? 1 : 0));
     });
     console.log(`\n=== bundleintegrityonly exit code: ${exit} ===`);
     process.exit(exit);
   }
-
-  const { ExTester } = require('vscode-extension-tester');
 
   // ------------------------------------------------------------------
   // D-001 pre-flight: enforce that *.fixtures.test.ts files do not write
@@ -533,11 +641,13 @@ async function main() {
   // This guard is a cheap grep — it runs before any build/test work so
   // a violating PR fails fast on its very first CI run.
   // ------------------------------------------------------------------
-  const uiTestDir = path.resolve(__dirname);
+  const uiTestDir = sourceUiTestDir;
   const fixturesGuardPattern = /fs\s*\.\s*writeFile|outputJson/;
-  const fixturesGuardViolations = [];
+  const fixturesGuardViolations: string[] = [];
   for (const fname of fs.readdirSync(uiTestDir)) {
-    if (!fname.endsWith('.fixtures.test.ts')) continue;
+    if (!fname.endsWith('.fixtures.test.ts')) {
+      continue;
+    }
     const filePath = path.join(uiTestDir, fname);
     const contents = fs.readFileSync(filePath, 'utf8');
     if (fixturesGuardPattern.test(contents)) {
@@ -546,9 +656,7 @@ async function main() {
   }
   if (fixturesGuardViolations.length > 0) {
     console.error(
-      '\n✖ D-001 lint guard FAILED: *.fixtures.test.ts files must not call fs.writeFile* or outputJson*.\n' +
-        '  Fixture workspaces must be produced by the Create Workspace wizard, not synthesized on disk.\n' +
-        `  Violating files: ${fixturesGuardViolations.join(', ')}`
+      `\n✖ D-001 lint guard FAILED: *.fixtures.test.ts files must not call fs.writeFile* or outputJson*.\n  Fixture workspaces must be produced by the Create Workspace wizard, not synthesized on disk.\n  Violating files: ${fixturesGuardViolations.join(', ')}`
     );
     process.exit(2);
   }
@@ -556,12 +664,11 @@ async function main() {
 
   // Read extension metadata from dist/package.json
   const pkgJson = JSON.parse(fs.readFileSync(path.join(distDir, 'package.json'), 'utf8'));
-  const extDeps = pkgJson.extensionDependencies || [];
+  const extDeps: string[] = pkgJson.extensionDependencies || [];
   const devContainersDependency = 'ms-vscode-remote.remote-containers';
   if (extDeps.some((dep) => dep.toLowerCase() === devContainersDependency)) {
     throw new Error(
-      `${devContainersDependency} must not be listed in extensionDependencies. ` +
-        'It causes VS Code to install/start Dev Containers for users who only installed Azure Logic Apps.'
+      `${devContainersDependency} must not be listed in extensionDependencies. It causes VS Code to install/start Dev Containers for users who only installed Azure Logic Apps.`
     );
   }
   const requiredE2ePrereqs = ['ms-dotnettools.csdevkit'];
@@ -592,7 +699,7 @@ async function main() {
   // run VS Code CLI --install-extension sequentially. Parallel CLI installs
   // race on shared extension/cache directories and can leave VS Code with
   // partially extracted dependencies even when a follow-up retry succeeds.
-  const getExtensionEntries = (extensionId) => {
+  const getExtensionEntries = (extensionId: string): string[] => {
     if (!fs.existsSync(extDir)) {
       return [];
     }
@@ -605,7 +712,7 @@ async function main() {
     });
   };
 
-  const readExtensionId = (entry) => {
+  const readExtensionId = (entry: string): string | undefined => {
     const pkgPath = path.join(extDir, entry, 'package.json');
     if (!fs.existsSync(pkgPath)) {
       return undefined;
@@ -618,12 +725,12 @@ async function main() {
     }
   };
 
-  const findValidInstalledExtension = (extensionId) => {
+  const findValidInstalledExtension = (extensionId: string): string | undefined => {
     const depLower = extensionId.toLowerCase();
     return getExtensionEntries(extensionId).find((entry) => readExtensionId(entry) === depLower);
   };
 
-  const removeInvalidExtensionEntries = (extensionId) => {
+  const removeInvalidExtensionEntries = (extensionId: string): void => {
     for (const entry of getExtensionEntries(extensionId)) {
       if (readExtensionId(entry) !== extensionId.toLowerCase()) {
         console.log(`  Removing invalid cached dependency: ${entry}`);
@@ -635,7 +742,7 @@ async function main() {
   if (extDeps.length > 0) {
     console.log(`\n=== Step 2: Install ${extDeps.length} extension dependencies ===`);
 
-    const depsToInstall = [];
+    const depsToInstall: string[] = [];
     for (const dep of extDeps) {
       removeInvalidExtensionEntries(dep);
       const alreadyInstalled = !!findValidInstalledExtension(dep);
@@ -706,7 +813,7 @@ async function main() {
 
   // Step 3: Copy our built extension into test-extensions as an "installed" extension
   // Skip the copy if dist/main.js hasn't changed (compare mtime for a fast-path).
-  console.log(`\n=== Step 3: Install our extension from dist/ ===`);
+  console.log('\n=== Step 3: Install our extension from dist/ ===');
   const pkgId = `${pkgJson.publisher}.${pkgJson.name}`.toLowerCase();
 
   const srcMainJs = path.join(distDir, 'main.js');
@@ -717,7 +824,7 @@ async function main() {
     const srcMtime = fs.statSync(srcMainJs).mtimeMs;
     const destMtime = fs.statSync(destMainJs).mtimeMs;
     if (srcMtime === destMtime) {
-      console.log(`  ✓ dist/main.js unchanged (mtime match), skipping copy`);
+      console.log('  ✓ dist/main.js unchanged (mtime match), skipping copy');
       needsCopy = false;
     } else {
       console.log(`  dist/main.js changed (src=${new Date(srcMtime).toISOString()}, dest=${new Date(destMtime).toISOString()})`);
@@ -747,7 +854,7 @@ async function main() {
       fs.utimesSync(destMainJs, srcStat.atime, srcStat.mtime);
     }
 
-    console.log(`  ✓ Extension installed in test-extensions`);
+    console.log('  ✓ Extension installed in test-extensions');
   }
 
   // Verify the copied extension has the necessary files
@@ -761,14 +868,14 @@ async function main() {
     console.error(`  ✗ ERROR: main.js not found at ${copiedMain}`);
     process.exit(1);
   }
-  console.log(`  ✓ Verified: package.json and main.js present`);
+  console.log('  ✓ Verified: package.json and main.js present');
 
   // CRITICAL: Remove .obsolete file — VS Code uses this to skip loading extensions.
   // Previous test runs or ExTester's cleanup step may have marked our extension
   // as obsolete, causing VS Code to refuse to load it even though the directory exists.
   const obsoleteFile = path.join(extDir, '.obsolete');
   if (fs.existsSync(obsoleteFile)) {
-    console.log(`  Removing .obsolete file (was blocking extension loading)`);
+    console.log('  Removing .obsolete file (was blocking extension loading)');
     fs.rmSync(obsoleteFile);
   }
 
@@ -776,11 +883,11 @@ async function main() {
   // Marketplace-installed extensions get entries automatically, but our manually
   // copied extension needs to be added explicitly.
   const extensionsJsonPath = path.join(extDir, 'extensions.json');
-  let extensionsJson = [];
+  let extensionsJson: ExtensionJsonEntry[] = [];
   if (fs.existsSync(extensionsJsonPath)) {
     try {
       extensionsJson = JSON.parse(fs.readFileSync(extensionsJsonPath, 'utf8'));
-    } catch (e) {
+    } catch {
       extensionsJson = [];
     }
   }
@@ -805,13 +912,17 @@ async function main() {
     },
   });
   fs.writeFileSync(extensionsJsonPath, JSON.stringify(extensionsJson));
-  console.log(`  ✓ Registered in extensions.json`);
+  console.log('  ✓ Registered in extensions.json');
 
   // List all extensions that will be loaded
   console.log('\n=== Extensions in test-extensions/ ===');
   for (const entry of fs.readdirSync(extDir)) {
-    if (entry === 'extensions.json') continue;
-    if (entry === '.obsolete') continue;
+    if (entry === 'extensions.json') {
+      continue;
+    }
+    if (entry === '.obsolete') {
+      continue;
+    }
     console.log(`  ${entry}`);
   }
 
@@ -819,7 +930,9 @@ async function main() {
   // auto-downloaded from the marketplace in a previous run.
   // Only keep our exact version. Also clean up duplicate dependency versions.
   for (const entry of fs.readdirSync(extDir)) {
-    if (entry === 'extensions.json' || entry === '.obsolete') continue;
+    if (entry === 'extensions.json' || entry === '.obsolete') {
+      continue;
+    }
     if (entry.toLowerCase().startsWith(pkgId) && entry !== extDirName) {
       const fullPath = path.join(extDir, entry);
       console.log(`  Removing stale auto-updated version: ${entry}`);
@@ -828,13 +941,17 @@ async function main() {
   }
 
   // Clean up duplicate versions of dependency extensions (keep newest)
-  const depVersions = {};
+  const depVersions: Record<string, string[]> = {};
   for (const entry of fs.readdirSync(extDir)) {
-    if (entry === 'extensions.json' || entry === '.obsolete') continue;
+    if (entry === 'extensions.json' || entry === '.obsolete') {
+      continue;
+    }
     const match = entry.match(/^(.+?)-(\d+\.\d+\.\d+.*)$/);
     if (match) {
       const baseName = match[1].toLowerCase();
-      if (!depVersions[baseName]) depVersions[baseName] = [];
+      if (!depVersions[baseName]) {
+        depVersions[baseName] = [];
+      }
       depVersions[baseName].push(entry);
     }
   }
@@ -902,8 +1019,10 @@ async function main() {
       for (const line of lines) {
         const match = line.match(/,(\d+)\s*$/);
         if (match) {
-          const pid = parseInt(match[1], 10);
-          if (pid === process.pid) continue;
+          const pid = Number.parseInt(match[1], 10);
+          if (pid === process.pid) {
+            continue;
+          }
           console.log(`  Killing leftover test process PID ${pid}`);
           try {
             execSync(`taskkill /F /T /PID ${pid}`, { timeout: 5000, stdio: 'pipe' });
@@ -917,8 +1036,8 @@ async function main() {
       console.log(`  Killed ${killed} processes, waiting for handles to release...`);
       await new Promise((r) => setTimeout(r, 5000));
     }
-  } catch (e) {
-    console.warn(`  Warning: Could not check for leftover processes: ${e.message}`);
+  } catch (e: any) {
+    console.warn(`  Warning: Could not check for leftover processes: ${getErrorMessage(e)}`);
   }
 
   // Clean stale settings/cache from previous test runs to avoid EPERM/EBUSY errors.
@@ -936,8 +1055,8 @@ async function main() {
         cleaned = true;
         console.log(`  ✓ Settings dir cleaned (attempt ${attempt + 1})`);
         break;
-      } catch (e) {
-        console.warn(`  Cleanup attempt ${attempt + 1}/5 failed: ${e.message}`);
+      } catch (e: any) {
+        console.warn(`  Cleanup attempt ${attempt + 1}/5 failed: ${getErrorMessage(e)}`);
         if (attempt < 4) {
           await new Promise((r) => setTimeout(r, 3000));
         }
@@ -951,33 +1070,33 @@ async function main() {
       if (fs.existsSync(userDir)) {
         try {
           fs.rmSync(userDir, { recursive: true, force: true });
-          console.log(`  ✓ Deleted settings/User — ExTester will skip cleanup of locked log files`);
+          console.log('  ✓ Deleted settings/User — ExTester will skip cleanup of locked log files');
           cleaned = true;
-        } catch (e3) {
-          console.warn(`  Could not delete settings/User: ${e3.message}`);
+        } catch (e3: any) {
+          console.warn(`  Could not delete settings/User: ${getErrorMessage(e3)}`);
         }
       } else {
-        console.log(`  settings/User does not exist — ExTester will skip cleanup (OK)`);
+        console.log('  settings/User does not exist — ExTester will skip cleanup (OK)');
         cleaned = true;
       }
     }
 
     if (!cleaned) {
       // Last resort: try renaming
-      const staleDir = settingsDir + '-stale-' + Date.now();
+      const staleDir = `${settingsDir}-stale-${Date.now()}`;
       try {
         fs.renameSync(settingsDir, staleDir);
         console.log(`  Renamed stale settings dir to: ${path.basename(staleDir)}`);
-      } catch (e2) {
-        console.warn(`  Warning: Could not rename settings dir either: ${e2.message}`);
-        console.warn(`  ExTester may fail with EBUSY — consider restarting VS Code and trying again`);
+      } catch (e2: any) {
+        console.warn(`  Warning: Could not rename settings dir either: ${getErrorMessage(e2)}`);
+        console.warn('  ExTester may fail with EBUSY — consider restarting VS Code and trying again');
       }
     }
   }
 
   // Resolve the auto-downloaded runtime dependency paths so the extension can
   // find func, dotnet, and node without relying on PATH or re-downloading.
-  const resolveNodeBinDir = (depsRoot) => {
+  const resolveNodeBinDir = (depsRoot: string): string => {
     const nodeJsRoot = path.join(depsRoot, 'NodeJs');
     if (process.platform === 'win32') {
       return nodeJsRoot;
@@ -1003,22 +1122,23 @@ async function main() {
     return nodeJsRoot;
   };
 
-  const getRuntimeDependencyPaths = () => {
-    const depsRoot = path.join(os.homedir(), '.azurelogicapps', 'dependencies');
+  const getRuntimeDependencyPaths = (depsRootOverride?: string): RuntimeDependencyPaths => {
+    const depsRoot = depsRootOverride || path.join(os.homedir(), '.azurelogicapps', 'dependencies');
     const nodeJsDir = resolveNodeBinDir(depsRoot);
     const funcToolsDir = path.join(depsRoot, 'FuncCoreTools');
     const funcExecutable = process.platform === 'win32' ? 'func.exe' : 'func';
-    const nodeExecutable = process.platform === 'win32' ? 'node.exe' : 'node';
     const dotnetExecutable = process.platform === 'win32' ? 'dotnet.exe' : 'dotnet';
-    const funcBinaryCandidates = [
+    const nodeExecutable = process.platform === 'win32' ? 'node.exe' : 'node';
+    const funcExecutableCandidates = [
       path.join(funcToolsDir, funcExecutable),
       path.join(funcToolsDir, 'in-proc8', funcExecutable),
       path.join(funcToolsDir, 'in-proc6', funcExecutable),
     ];
-    const funcBinary = funcBinaryCandidates.find((candidate) => fs.existsSync(candidate)) || funcBinaryCandidates[0];
+    const funcBinary = funcExecutableCandidates.find((candidate) => fs.existsSync(candidate)) || funcExecutableCandidates[0];
     return {
       depsRoot,
       funcToolsDir,
+      funcExecutableCandidates,
       dotnetSdkDir: path.join(depsRoot, 'DotNetSDK'),
       nodeJsDir,
       funcBinary,
@@ -1027,13 +1147,83 @@ async function main() {
     };
   };
 
-  const runtimeDependenciesReady = () => {
-    const { funcBinary, dotnetBinary, nodeBinary } = getRuntimeDependencyPaths();
-    return [funcBinary, dotnetBinary, nodeBinary].every((binaryPath) => fs.existsSync(binaryPath));
+  const runtimePermissionStatus = (binaryPath: string): string => {
+    if (!fs.existsSync(binaryPath)) {
+      return 'missing';
+    }
+    const mode = process.platform === 'win32' ? 'n/a' : `0${(fs.statSync(binaryPath).mode & 0o777).toString(8)}`;
+    return `${isExecutableFile(binaryPath) ? 'executable' : 'not-executable'} mode=${mode}`;
   };
-  const shouldValidateRuntimeDependencies = () => !runtimeDependenciesReady();
 
-  const pruneInvalidRuntimeDependencyRoots = (label) => {
+  const logRuntimeDependencyPermissions = (label: string, depsRootOverride?: string): void => {
+    const { funcBinary, dotnetBinary, nodeBinary, funcExecutableCandidates } = getRuntimeDependencyPaths(depsRootOverride);
+    const candidates = [funcBinary, dotnetBinary, nodeBinary, ...funcExecutableCandidates];
+    for (const candidate of [...new Set(candidates)]) {
+      console.log(`  [${label}] runtime binary ${candidate}: ${runtimePermissionStatus(candidate)}`);
+    }
+  };
+
+  const repairRuntimeDependencyExecutablePermissions = (label: string, failOnExistingNonExecutable = false): void => {
+    if (process.platform !== 'linux' && process.platform !== 'darwin') {
+      return;
+    }
+
+    const { funcBinary, dotnetBinary, nodeBinary, funcToolsDir, funcExecutableCandidates } = getRuntimeDependencyPaths();
+    const { execSync } = require('child_process');
+    const candidates = [funcBinary, dotnetBinary, nodeBinary, ...funcExecutableCandidates];
+    let fixedAny = false;
+    for (const bin of [...new Set(candidates)]) {
+      if (!fs.existsSync(bin)) {
+        continue;
+      }
+      try {
+        execSync(`chmod +x "${bin}"`, { stdio: 'ignore' });
+        fixedAny = true;
+      } catch (error: any) {
+        console.log(`  [${label}] failed to chmod runtime binary ${bin}: ${getErrorMessage(error)}`);
+      }
+    }
+
+    if (fs.existsSync(funcToolsDir)) {
+      try {
+        execSync(`chmod -R +x "${funcToolsDir}"`, { stdio: 'ignore' });
+        fixedAny = true;
+      } catch (error: any) {
+        console.log(`  [${label}] failed to chmod FuncCoreTools directory ${funcToolsDir}: ${getErrorMessage(error)}`);
+      }
+    }
+
+    if (fixedAny) {
+      console.log(`  [${label}] Fixed execute permissions on runtime binaries`);
+    }
+    logRuntimeDependencyPermissions(label);
+
+    if (failOnExistingNonExecutable) {
+      const brokenCandidates = [...new Set(funcExecutableCandidates)]
+        .filter((candidate) => fs.existsSync(candidate))
+        .filter((candidate) => !isExecutableFile(candidate));
+      if (brokenCandidates.length > 0) {
+        throw new Error(`[${label}] FuncCoreTools binaries exist but are not executable: ${brokenCandidates.join(', ')}`);
+      }
+    }
+  };
+
+  const runtimeDependenciesReady = (): boolean => {
+    const { funcBinary, dotnetBinary, nodeBinary, funcExecutableCandidates } = getRuntimeDependencyPaths();
+    const requiredBinariesReady = [funcBinary, dotnetBinary, nodeBinary].every(
+      (binaryPath) => fs.existsSync(binaryPath) && isExecutableFile(binaryPath)
+    );
+    const existingFuncToolsExecutable = funcExecutableCandidates
+      .filter((binaryPath) => fs.existsSync(binaryPath))
+      .every((binaryPath) => isExecutableFile(binaryPath));
+    return requiredBinariesReady && existingFuncToolsExecutable;
+  };
+  const shouldValidateRuntimeDependencies = (): boolean => {
+    repairRuntimeDependencyExecutablePermissions('runtime dependency readiness', true);
+    return !runtimeDependenciesReady();
+  };
+
+  const pruneInvalidRuntimeDependencyRoots = (label: string): void => {
     const { depsRoot, funcToolsDir, dotnetSdkDir, nodeJsDir, funcBinary, dotnetBinary, nodeBinary } = getRuntimeDependencyPaths();
     const dependencyRoots = [
       { label: 'NodeJs', root: path.join(depsRoot, 'NodeJs'), probes: [nodeBinary] },
@@ -1067,10 +1257,11 @@ async function main() {
     validateDependencies = false,
     autoStartDesignTime = true,
     includeRuntimeDependencyPaths = true,
+    runtimeDependenciesPathOverride,
     useExperimentalBundle = false,
     experimentalBundleSourceUri = '',
     experimentalBundleVersion = '',
-  } = {}) => {
+  }: TestSettingsOptions = {}): void => {
     const settings = {
       'extensions.autoUpdate': false,
       'extensions.autoCheckUpdates': false,
@@ -1109,6 +1300,8 @@ async function main() {
       // the generated task chain has started instead of waiting the default
       // 60 s. Other phases never reach pickProcess so this is harmless.
       'azureLogicAppsStandard.pickProcessTimeout': 15,
+      // Keep dependency validation non-interactive in explicit command tests.
+      'azureLogicAppsStandard.showNodeJsWarning': false,
       // Experimental-bundle opt-ins. Off by default for every phase so the
       // standard CDN flow continues to be tested. The bundleintegrityonly
       // phase or any future phase that wants to test a private bundle can
@@ -1118,7 +1311,7 @@ async function main() {
       'azureLogicAppsStandard.experimentalExtensionBundleVersion': experimentalBundleVersion,
     };
     if (includeRuntimeDependencyPaths) {
-      const { depsRoot, funcBinary, dotnetBinary, nodeBinary } = getRuntimeDependencyPaths();
+      const { depsRoot, funcBinary, dotnetBinary, nodeBinary } = getRuntimeDependencyPaths(runtimeDependenciesPathOverride);
       Object.assign(settings, {
         // Point to auto-downloaded runtime binaries so the extension can start
         // the design-time API process (func host start) without relying on PATH.
@@ -1132,6 +1325,9 @@ async function main() {
     console.log(
       `  Settings: validateDependencies=${validateDependencies}, autoStartDesignTime=${autoStartDesignTime}, includeRuntimeDependencyPaths=${includeRuntimeDependencyPaths}`
     );
+    if (runtimeDependenciesPathOverride) {
+      console.log(`  Settings dependency path override: ${runtimeDependenciesPathOverride}`);
+    }
   };
 
   // Write initial settings — keep dependency validation ON for all phases.
@@ -1180,6 +1376,7 @@ async function main() {
   const testFile = (name) => path.join(outTestDir, name).replace(/\\/g, '/');
 
   const phase0Files = [testFile('nonLogicAppStartup.test.js')];
+  const lspEpermFiles = [testFile('lspSdkExtractionEperm.test.js')];
 
   const phase1Files = [testFile('basic.test.js'), testFile('commands.test.js'), testFile('createWorkspace.behavior.test.js')];
   // Phase 4.1a (NEW Step 2): fast fixtures-only wizard run that writes the manifest
@@ -1250,7 +1447,7 @@ async function main() {
   //   monolithic    — true when the scenario runs multiple test files
   //                   in a single VS Code session (currently 4.1, 4.7).
   // ------------------------------------------------------------------
-  const scenarios = [
+  const scenarios: Scenario[] = [
     // Independent / no-workspace scenarios
     {
       id: 'p40-nonlogicapp',
@@ -1421,7 +1618,7 @@ async function main() {
   // switchToWebviewFrame, openFolderInSession, waitForWorkbenchReady). All CI-dependent
   // runtime-gated waits use a 90s minimum deadline per the VS Code E2E reliability playbook.
 
-  const runOptions = {
+  const runOptions: PhaseRunOptions = {
     vscodeVersion: VSCODE_VERSION,
     settings: settingsFile,
     cleanup: false,
@@ -1429,7 +1626,7 @@ async function main() {
     resources: [],
   };
 
-  const prepareFreshSession = async (label) => {
+  const prepareFreshSession = async (label: string): Promise<void> => {
     const settingsDir = path.join(require('os').tmpdir(), 'test-resources', 'settings');
     const userDir = path.join(settingsDir, 'User');
 
@@ -1529,8 +1726,8 @@ async function main() {
       try {
         fs.rmSync(userDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
         console.log(`  [${label}] ✓ Deleted settings/User`);
-      } catch (e) {
-        console.warn(`  [${label}] Could not delete settings/User: ${e.message}`);
+      } catch (e: any) {
+        console.warn(`  [${label}] Could not delete settings/User: ${getErrorMessage(e)}`);
         console.warn(`  [${label}] Proceeding anyway — ExTester will create fresh settings`);
       }
     } else {
@@ -1541,32 +1738,10 @@ async function main() {
     // The extension's download/extract process doesn't set chmod +x on Linux,
     // causing "/bin/sh: 1: .../func: Permission denied" when the extension
     // tries to run `func host start` to start the design-time API.
-    if (process.platform === 'linux' || process.platform === 'darwin') {
-      const { execSync } = require('child_process');
-      const { funcBinary, dotnetBinary, nodeBinary, funcToolsDir } = getRuntimeDependencyPaths();
-      for (const bin of [funcBinary, dotnetBinary, nodeBinary]) {
-        if (fs.existsSync(bin)) {
-          try {
-            execSync(`chmod +x "${bin}"`, { stdio: 'ignore' });
-          } catch {
-            /* ignore */
-          }
-        }
-      }
-      // Also chmod the entire FuncCoreTools directory — it contains sub-binaries
-      // (e.g., gozip, func) that all need execute permission.
-      if (fs.existsSync(funcToolsDir)) {
-        try {
-          execSync(`chmod -R +x "${funcToolsDir}"`, { stdio: 'ignore' });
-          console.log(`  [${label}] ✓ Fixed execute permissions on runtime binaries`);
-        } catch {
-          /* ignore */
-        }
-      }
-    }
+    repairRuntimeDependencyExecutablePermissions(label, true);
   };
 
-  const runPhase = async (phaseName, files, optionsOverride = {}) => {
+  const runPhase = async (phaseName: string, files: string[], optionsOverride: Partial<PhaseRunOptions> = {}): Promise<number> => {
     const phaseRunOptions = {
       ...runOptions,
       ...optionsOverride,
@@ -1609,10 +1784,46 @@ async function main() {
     return code;
   };
 
+  const prepareLspEpermDependencyRoot = (): string => {
+    if (process.platform !== 'win32') {
+      throw new Error('The LSP EPERM repro uses Windows ACLs and can only run on Windows.');
+    }
+
+    const source = getRuntimeDependencyPaths();
+    const requiredSourceDirs = [
+      ['NodeJs', source.nodeJsDir],
+      ['FuncCoreTools', source.funcToolsDir],
+      ['DotNetSDK', source.dotnetSdkDir],
+    ];
+    const missing = requiredSourceDirs.filter(([, dir]) => !fs.existsSync(dir)).map(([name, dir]) => `${name}: ${dir}`);
+    if (missing.length > 0) {
+      throw new Error(
+        `E2E_MODE=lspeperm requires existing runtime dependencies before cloning an isolated dependency root. Run a normal dependency-validation E2E phase first. Missing: ${missing.join(', ')}`
+      );
+    }
+
+    const depsRoot = path.join(os.tmpdir(), 'la-e2e-test', 'lsp-eperm-dependencies');
+    fs.rmSync(depsRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
+    fs.mkdirSync(depsRoot, { recursive: true });
+
+    for (const [name, sourceDir] of requiredSourceDirs) {
+      fs.cpSync(sourceDir, path.join(depsRoot, name), { recursive: true });
+    }
+
+    for (const artifactName of LSP_STALE_ARTIFACT_NAMES) {
+      fs.rmSync(path.join(depsRoot, artifactName), { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
+    }
+
+    process.env.LA_E2E_LSP_EPERM_DEPS_ROOT = depsRoot;
+    console.log(`  Prepared isolated LSP EPERM dependency root: ${depsRoot}`);
+    logRuntimeDependencyPermissions('lspeperm isolated root', depsRoot);
+    return depsRoot;
+  };
+
   // Runs Mocha against compiled test files directly, without spawning a VS Code
   // session. Used for the bundle CDN integrity probe, which is a pure Node
   // test (HTTP HEAD + small download) and does not need ExTester.
-  const runMochaPhase = async (phaseName, files) => {
+  const runMochaPhase = async (phaseName: string, files: string[]): Promise<number> => {
     console.log(`\n=== ${phaseName} (Mocha-only, no VS Code) ===`);
     console.log(`  Files: ${files.join(', ')}`);
     for (const file of files) {
@@ -1628,7 +1839,7 @@ async function main() {
     for (const file of files) {
       mocha.addFile(file);
     }
-    return await new Promise((resolve) => {
+    return await new Promise<number>((resolve) => {
       mocha.run((failures) => {
         const code = failures > 0 ? 1 : 0;
         console.log(`  ${phaseName} exit code: ${code}`);
@@ -1637,7 +1848,7 @@ async function main() {
     });
   };
 
-  const configureCodefulRecorderEnvironment = () => {
+  const configureCodefulRecorderEnvironment = (): void => {
     const eventsFile = path.join(os.tmpdir(), 'la-e2e-test', 'codeful-events.jsonl');
     const triggerDir = path.join(os.tmpdir(), 'la-e2e-test', 'triggers');
     fs.mkdirSync(path.dirname(eventsFile), { recursive: true });
@@ -1661,13 +1872,13 @@ async function main() {
     console.log(`  Trigger dir:  ${triggerDir}`);
   };
 
-  const loadCodefulDebugWorkspaces = () => {
+  const loadCodefulDebugWorkspaces = (): CodefulDebugWorkspaces => {
     const manifestPath = path.join(os.tmpdir(), 'la-e2e-test', 'created-workspaces.json');
     if (!fs.existsSync(manifestPath)) {
       throw new Error(`Codeful debug manifest not found: ${manifestPath}`);
     }
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    const codefulEntries = manifest.filter((entry) => entry.appType === 'codeful');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ManifestEntry[];
+    const codefulEntries = manifest.filter((entry) => entry.appType === 'codeful') as CodefulWorkspaceEntry[];
     const modern = codefulEntries.find((entry) => /modern/i.test(entry.label)) || codefulEntries[0];
     const legacy = codefulEntries.find((entry) => /legacy/i.test(entry.label)) || codefulEntries[1];
     for (const [variant, entry] of [
@@ -1686,7 +1897,7 @@ async function main() {
     return { modern, legacy };
   };
 
-  const patchLegacyCodefulCsproj = (entry) => {
+  const patchLegacyCodefulCsproj = (entry: CodefulWorkspaceEntry): void => {
     const csprojFiles = fs.readdirSync(entry.appDir).filter((name) => name.endsWith('.csproj'));
     if (csprojFiles.length !== 1) {
       throw new Error(`Expected exactly one codeful .csproj in ${entry.appDir}, found ${csprojFiles.length}: ${csprojFiles.join(', ')}`);
@@ -1709,7 +1920,7 @@ async function main() {
     console.log(`  Patched legacy codeful targets AfterTargets=Publish in ${csprojPath}`);
   };
 
-  const patchGeneratedCodefulProjectForDebugGuard = (entry, variant) => {
+  const patchGeneratedCodefulProjectForDebugGuard = (entry: CodefulWorkspaceEntry, variant: string): void => {
     const workflowFile = path.join(entry.appDir, `${entry.wfName}.cs`);
     const programFile = path.join(entry.appDir, 'Program.cs');
 
@@ -1782,14 +1993,14 @@ namespace ${namespaceName}
     console.log(`  Patched ${variant} generated codeful workflow to built-in HTTP trigger + Response: ${workflowFile}`);
   };
 
-  const removeDesignTimeEvidence = async (entry, variant) => {
+  const removeDesignTimeEvidence = async (entry: CodefulWorkspaceEntry, variant: string): Promise<void> => {
     const designTimeDir = path.join(entry.appDir, 'workflow-designtime');
     for (let attempt = 1; attempt <= 6; attempt++) {
       try {
         fs.rmSync(designTimeDir, { recursive: true, force: true });
         console.log(`  Removed stale ${variant} design-time evidence: ${designTimeDir}`);
         return;
-      } catch (err) {
+      } catch (err: any) {
         const message = err instanceof Error ? err.message : String(err);
         if (attempt === 6 && !/EBUSY|EPERM|resource busy|locked/i.test(message)) {
           throw err;
@@ -1806,7 +2017,7 @@ namespace ${namespaceName}
     }
   };
 
-  const runCodefulDebugPhases = async (labelPrefix) => {
+  const runCodefulDebugPhases = async (labelPrefix: string): Promise<number> => {
     writeTestSettings({ validateDependencies: true, autoStartDesignTime: true });
     process.env.LA_E2E_CODEFUL_CREATE_ONLY = '1';
     await prepareFreshSession(`${labelPrefix}-phase10a-create`);
@@ -1850,12 +2061,12 @@ namespace ${namespaceName}
   };
 
   try {
-    const getPhase2Resources = () => {
+    const getPhase2Resources = (): string[] => {
       const manifestPath = path.join(require('os').tmpdir(), 'la-e2e-test', 'created-workspaces.json');
-      let phase2Resources = [];
+      let phase2Resources: string[] = [];
       if (fs.existsSync(manifestPath)) {
         try {
-          const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ManifestEntry[];
           // Use the same fallback order as the test files:
           // prefer standard+Stateful, then any standard, then first entry
           const preferred =
@@ -1868,8 +2079,8 @@ namespace ${namespaceName}
           } else {
             console.warn('  Could not find a valid directory in manifest for phase 2 startup resource');
           }
-        } catch (e) {
-          console.warn(`  Failed to parse manifest for phase 2 startup resource: ${e.message}`);
+        } catch (e: any) {
+          console.warn(`  Failed to parse manifest for phase 2 startup resource: ${getErrorMessage(e)}`);
         }
       } else {
         console.warn(`  Manifest not found for phase 2 startup resource: ${manifestPath}`);
@@ -1877,22 +2088,22 @@ namespace ${namespaceName}
       return phase2Resources;
     };
 
-    const getStandardStatelessResources = () => {
+    const getStandardStatelessResources = (): string[] => {
       const manifestPath = path.join(require('os').tmpdir(), 'la-e2e-test', 'created-workspaces.json');
       if (!fs.existsSync(manifestPath)) {
         console.warn(`  Manifest not found for stateless startup resource: ${manifestPath}`);
         return [];
       }
       try {
-        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ManifestEntry[];
         const preferred = manifest.find((e) => e.appType === 'standard' && e.wfType === 'Stateless');
         if (preferred?.wsFilePath && fs.existsSync(preferred.wsFilePath)) {
           console.log(`  Using stateless startup workspace: ${preferred.wsFilePath}`);
           return [preferred.wsFilePath];
         }
         console.warn('  Could not find Standard + Stateless workspace in manifest for stateless startup resource');
-      } catch (e) {
-        console.warn(`  Failed to parse manifest for stateless startup resource: ${e.message}`);
+      } catch (e: any) {
+        console.warn(`  Failed to parse manifest for stateless startup resource: ${getErrorMessage(e)}`);
       }
       return [];
     };
@@ -1924,7 +2135,7 @@ namespace ${namespaceName}
     //
     // Returns { resources, legacyDir? }. `legacyDir` is set only for
     // 'self-contained' so runScenarioPhases can wire up the env var.
-    const selectWorkspaceForSpec = (spec, scenarioId) => {
+    const selectWorkspaceForSpec = (spec: WorkspaceSpec, scenarioId: string): WorkspaceSelection => {
       if (spec === 'plain-folder' || spec === 'self-creates') {
         return { resources: [] };
       }
@@ -1937,8 +2148,8 @@ namespace ${namespaceName}
       if (fs.existsSync(manifestPath)) {
         try {
           manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-        } catch (e) {
-          console.warn(`  [${scenarioId}] Failed to parse manifest: ${e.message}`);
+        } catch (e: any) {
+          console.warn(`  [${scenarioId}] Failed to parse manifest: ${getErrorMessage(e)}`);
         }
       } else {
         console.warn(`  [${scenarioId}] Manifest not found: ${manifestPath}`);
@@ -1946,7 +2157,9 @@ namespace ${namespaceName}
       if (spec === 'manifest-multi') {
         // Mirrors getPhase2Resources() — returns the preferred standard
         // workspace; the test itself walks the manifest for the rest.
-        if (!manifest) return { resources: [] };
+        if (!manifest) {
+          return { resources: [] };
+        }
         const preferred =
           manifest.find((e) => e.appType === 'standard' && e.wfType === 'Stateful') ||
           manifest.find((e) => e.appType === 'standard') ||
@@ -1957,11 +2170,13 @@ namespace ${namespaceName}
         return { resources: [] };
       }
       if (spec && typeof spec === 'object') {
-        if (!manifest) return { resources: [] };
+        if (!manifest) {
+          return { resources: [] };
+        }
         const { appType, wfType, use } = spec;
         const entry =
           manifest.find((e) => (!appType || e.appType === appType) && (!wfType || e.wfType === wfType)) ||
-          (!wfType ? manifest.find((e) => !appType || e.appType === appType) : undefined) ||
+          (wfType ? undefined : manifest.find((e) => !appType || e.appType === appType)) ||
           (!appType && !wfType ? manifest[0] : undefined);
         if (!entry) {
           console.warn(`  [${scenarioId}] No manifest entry matched ${JSON.stringify(spec)}`);
@@ -1992,19 +2207,19 @@ namespace ${namespaceName}
     //   6. Collect exit codes; every scenario contributes to the aggregate.
     //
     // Returns the aggregate exit code.
-    const runScenarioPhases = async (scenarioList /* , opts */) => {
-      const exits = [];
+    const runScenarioPhases = async (scenarioList: Scenario[] /* , opts */): Promise<number> => {
+      const exits: number[] = [];
       for (const scenario of scenarioList) {
         const { id, testFile: files, workspaceSpec, settings = {}, monolithic, env: scenarioEnv } = scenario;
-        const resolvedSettings = { ...settings };
+        const resolvedSettings: ScenarioSettings = { ...settings };
         if (resolvedSettings.validateDependencies === 'auto') {
           resolvedSettings.validateDependencies = shouldValidateRuntimeDependencies();
         }
-        writeTestSettings(resolvedSettings);
+        writeTestSettings(resolvedSettings as TestSettingsOptions);
 
         // Apply per-scenario env overrides (e.g. LA_E2E_SHAPE for parameterized
         // shape-specific shards). Captured here so we can restore afterward.
-        const envOverridesApplied = [];
+        const envOverridesApplied: EnvOverride[] = [];
         if (scenarioEnv && typeof scenarioEnv === 'object') {
           for (const [key, value] of Object.entries(scenarioEnv)) {
             envOverridesApplied.push({ key, prev: process.env[key] });
@@ -2132,6 +2347,24 @@ namespace ${namespaceName}
       process.exit(startupExit);
     }
 
+    if (e2eMode === 'lspeperm') {
+      if (process.platform !== 'win32') {
+        console.log('E2E_MODE=lspeperm is Windows-only because it uses icacls ACL mutation; skipping on this platform.');
+        process.exit(0);
+      }
+
+      await downloadExTesterAssets();
+      const lspEpermDepsRoot = prepareLspEpermDependencyRoot();
+      writeTestSettings({
+        validateDependencies: false,
+        autoStartDesignTime: false,
+        runtimeDependenciesPathOverride: lspEpermDepsRoot,
+      });
+      await prepareFreshSession('lspeperm-only');
+      const lspEpermExit = await runPhase('Manual: LSP SDK EPERM repro', lspEpermFiles);
+      process.exit(lspEpermExit);
+    }
+
     if (e2eMode === 'designeronly') {
       // Ensure VS Code and ChromeDriver are downloaded
       await downloadExTesterAssets();
@@ -2150,7 +2383,7 @@ namespace ${namespaceName}
       await downloadExTesterAssets();
       writeTestSettings({ validateDependencies: shouldValidateRuntimeDependencies(), autoStartDesignTime: true });
       const wsResources = getPhase2Resources();
-      const exits = [];
+      const exits: number[] = [];
 
       await prepareFreshSession('phase3-only');
       exits.push(await runPhase('Phase 4.3: inlineJavascript', phase3Files, { resources: wsResources }));
@@ -2179,7 +2412,7 @@ namespace ${namespaceName}
       // fully activates and detects legacy projects / shows conversion dialog.
       writeTestSettings({ validateDependencies: true, autoStartDesignTime: false });
       const wsResources = getPhase2Resources();
-      const exits = [];
+      const exits: number[] = [];
 
       // Phase 4.8a: Open workspace DIR (not .code-workspace), click No
       // Startup resource = workspace directory (the folder containing .code-workspace)
@@ -2187,9 +2420,11 @@ namespace ${namespaceName}
         const manifestPath = path.join(require('os').tmpdir(), 'la-e2e-test', 'created-workspaces.json');
         if (fs.existsSync(manifestPath)) {
           try {
-            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ManifestEntry[];
             const preferred = manifest.find((e) => e.appType === 'standard' && e.wfType === 'Stateful') || manifest[0];
-            if (preferred?.wsDir && fs.existsSync(preferred.wsDir)) return [preferred.wsDir];
+            if (preferred?.wsDir && fs.existsSync(preferred.wsDir)) {
+              return [preferred.wsDir];
+            }
           } catch {
             /* ignore */
           }
@@ -2237,9 +2472,11 @@ namespace ${namespaceName}
         const manifestPath = path.join(require('os').tmpdir(), 'la-e2e-test', 'created-workspaces.json');
         if (fs.existsSync(manifestPath)) {
           try {
-            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ManifestEntry[];
             const preferred = manifest.find((e) => e.appType === 'standard' && e.wfType === 'Stateful') || manifest[0];
-            if (preferred?.appDir && fs.existsSync(preferred.appDir)) return [preferred.appDir];
+            if (preferred?.appDir && fs.existsSync(preferred.appDir)) {
+              return [preferred.appDir];
+            }
           } catch {
             /* ignore */
           }
@@ -2301,7 +2538,7 @@ namespace ${namespaceName}
 
     if (e2eMode === 'independentonly') {
       await downloadExTesterAssets();
-      const exits = [];
+      const exits: number[] = [];
 
       // Phase 4.0: nonLogicAppStartup — plain folder, no Logic App context.
       writeTestSettings({ validateDependencies: false, autoStartDesignTime: false, includeRuntimeDependencyPaths: false });
@@ -2328,7 +2565,7 @@ namespace ${namespaceName}
 
     if (e2eMode === 'createplusdesigner') {
       await downloadExTesterAssets();
-      const exits = [];
+      const exits: number[] = [];
 
       // Phase 4.1: createWorkspace — needed to produce the manifest consumed
       // by Phase 4.2 and Phase 4.7 (dataMapper.test.ts asserts the manifest
@@ -2369,7 +2606,7 @@ namespace ${namespaceName}
 
     if (e2eMode === 'createplusnewtests') {
       await downloadExTesterAssets();
-      const exits = [];
+      const exits: number[] = [];
 
       writeTestSettings({ validateDependencies: true, autoStartDesignTime: true });
       await prepareFreshSession('phase1-shard');
@@ -2403,7 +2640,7 @@ namespace ${namespaceName}
 
     if (e2eMode === 'createplusconversion') {
       await downloadExTesterAssets();
-      const exits = [];
+      const exits: number[] = [];
 
       writeTestSettings({ validateDependencies: true, autoStartDesignTime: true });
       await prepareFreshSession('phase1-shard');
@@ -2411,14 +2648,14 @@ namespace ${namespaceName}
 
       const wsResources = getPhase2Resources();
       const manifestPath = path.join(require('os').tmpdir(), 'la-e2e-test', 'created-workspaces.json');
-      const readManifest = () => {
+      const readManifest = (): ManifestEntry[] | null => {
         try {
           return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
         } catch {
           return null;
         }
       };
-      const findPreferred = (m) =>
+      const findPreferred = (m: ManifestEntry[] | null): ManifestEntry | undefined =>
         m && (m.find((e) => e.appType === 'standard' && e.wfType === 'Stateful') || m.find((e) => e.appType === 'standard'));
 
       const wsDir = (() => {
@@ -2565,7 +2802,9 @@ namespace ${namespaceName}
       await new Promise((resolve) => setTimeout(resolve, 3000));
       await prepareFreshSession('phase8a');
       phase8aExit = await runPhase('Phase 4.8a: conversionNo', phase8aFiles, { resources: wsDir });
-      if (phase8aExit !== 0) console.log(`\n⚠ Phase 4.8a exited with code ${phase8aExit} — continuing`);
+      if (phase8aExit !== 0) {
+        console.log(`\n⚠ Phase 4.8a exited with code ${phase8aExit} — continuing`);
+      }
     }
 
     // Phase 4.8b: Open legacy project, create workspace dialog
@@ -2578,7 +2817,9 @@ namespace ${namespaceName}
     await prepareFreshSession('phase8b');
     process.env.LA_E2E_LEGACY_PROJECT_DIR = legacyDir;
     phase8bExit = await runPhase('Phase 4.8b: conversionCreate', phase8bFiles, { resources: [legacyDir] });
-    if (phase8bExit !== 0) console.log(`\n⚠ Phase 4.8b exited with code ${phase8bExit} — continuing`);
+    if (phase8bExit !== 0) {
+      console.log(`\n⚠ Phase 4.8b exited with code ${phase8bExit} — continuing`);
+    }
 
     // Phase 4.8c: Multiple designers + add workflow
     // Re-enable full design-time — this test needs the designer to open.
@@ -2586,7 +2827,9 @@ namespace ${namespaceName}
     await new Promise((resolve) => setTimeout(resolve, 3000));
     await prepareFreshSession('phase8c');
     const phase8cExit = await runPhase('Phase 4.8c: multipleDesigners', phase8cFiles, { resources: phase2Resources });
-    if (phase8cExit !== 0) console.log(`\n⚠ Phase 4.8c exited with code ${phase8cExit} — continuing`);
+    if (phase8cExit !== 0) {
+      console.log(`\n⚠ Phase 4.8c exited with code ${phase8cExit} — continuing`);
+    }
 
     // Phase 4.8d: Open workspace dir, click Yes (may reload VS Code)
     // Restore conversion settings — design-time not needed, but validation must stay ON.
@@ -2596,7 +2839,9 @@ namespace ${namespaceName}
       await new Promise((resolve) => setTimeout(resolve, 3000));
       await prepareFreshSession('phase8d');
       phase8dExit = await runPhase('Phase 4.8d: conversionYes', phase8dFiles, { resources: wsDir });
-      if (phase8dExit !== 0) console.log(`\n⚠ Phase 4.8d exited with code ${phase8dExit} — continuing`);
+      if (phase8dExit !== 0) {
+        console.log(`\n⚠ Phase 4.8d exited with code ${phase8dExit} — continuing`);
+      }
     } else {
       console.error('  No workspace directory found for phase 4.8d — failing strict conversionYes gate');
       phase8dExit = 1;
@@ -2619,7 +2864,9 @@ namespace ${namespaceName}
       await new Promise((resolve) => setTimeout(resolve, 3000));
       await prepareFreshSession('phase8e');
       phase8eExit = await runPhase('Phase 4.8e: conversionSubfolder', phase8eFiles, { resources: appDir });
-      if (phase8eExit !== 0) console.log(`\n⚠ Phase 4.8e exited with code ${phase8eExit} — continuing`);
+      if (phase8eExit !== 0) {
+        console.log(`\n⚠ Phase 4.8e exited with code ${phase8eExit} — continuing`);
+      }
     }
 
     // Phase 4.10: D-001-compliant codeful debug F5 task pattern regression guard.
@@ -2629,10 +2876,12 @@ namespace ${namespaceName}
     let phase10Exit = 0;
     try {
       phase10Exit = await runCodefulDebugPhases('phase10');
-      if (phase10Exit !== 0) console.log(`\n⚠ Phase 4.10 exited with code ${phase10Exit} — continuing`);
-    } catch (err) {
+      if (phase10Exit !== 0) {
+        console.log(`\n⚠ Phase 4.10 exited with code ${phase10Exit} — continuing`);
+      }
+    } catch (err: any) {
       phase10Exit = 1;
-      console.log(`\n⚠ Phase 4.10 setup error: ${err.message || err} — continuing`);
+      console.log(`\n⚠ Phase 4.10 setup error: ${getErrorMessage(err)} — continuing`);
     }
 
     // Exit with worst exit code from all phases.
@@ -2655,8 +2904,8 @@ namespace ${namespaceName}
       `\n=== Final results: 4.0=${phase0Exit}, 4.1=${phase1Exit}, 4.2=${phase2Exit}, 4.3=${phase3Exit}, 4.4=${phase4Exit}, 4.5=${phase5Exit}, 4.7=${phase7Exit}, 4.8a=${phase8aExit}, 4.8b=${phase8bExit}, 4.8c=${phase8cExit}, 4.8d=${phase8dExit}, 4.8e=${phase8eExit}, 4.10=${phase10Exit} → exit ${finalExit} ===`
     );
     process.exit(finalExit);
-  } catch (err) {
-    console.error(`\n✗ ExTester error: ${err.message || err}`);
+  } catch (err: any) {
+    console.error(`\n✗ ExTester error: ${getErrorMessage(err)}`);
     process.exit(1);
   }
 }

--- a/apps/vs-code-designer/src/test/ui/runHelpers.ts
+++ b/apps/vs-code-designer/src/test/ui/runHelpers.ts
@@ -25,9 +25,36 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as http from 'http';
 import * as https from 'https';
+import * as os from 'os';
 import * as path from 'path';
 import { type Workbench, WebView, By, type WebDriver, VSBrowser, Key, EditorView, BottomBarPanel } from 'vscode-extension-tester';
 import { sleep, captureScreenshot, dismissAllDialogs, clearBlockingUI, focusEditor } from './helpers';
+
+// Uses the default dependency path (~/.azurelogicapps/dependencies) since E2E tests
+// always configure autoRuntimeDependenciesPath to this default via run-e2e.js settings injection.
+function getFuncCoreToolsDiagnosticPaths(): string[] {
+  const funcToolsRoot = path.join(os.homedir(), '.azurelogicapps', 'dependencies', 'FuncCoreTools');
+  const funcExecutable = process.platform === 'win32' ? 'func.exe' : 'func';
+  return [
+    path.join(funcToolsRoot, funcExecutable),
+    path.join(funcToolsRoot, 'in-proc8', funcExecutable),
+    path.join(funcToolsRoot, 'in-proc6', funcExecutable),
+  ];
+}
+
+function getExecutableDiagnostic(filePath: string): string {
+  if (!fs.existsSync(filePath)) {
+    return 'missing';
+  }
+
+  const mode = process.platform === 'win32' ? 'n/a' : `0${(fs.statSync(filePath).mode & 0o777).toString(8)}`;
+  try {
+    fs.accessSync(filePath, process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK);
+    return `executable mode=${mode}`;
+  } catch {
+    return `not-executable mode=${mode}`;
+  }
+}
 
 // ===========================================================================
 // Port management helpers
@@ -662,6 +689,16 @@ export async function waitForRuntimeReady(
     console.log(`[waitForRuntimeReady][diag] Running processes:\n${output}`);
   } catch (e: any) {
     console.log(`[waitForRuntimeReady][diag] Process inventory failed: ${e?.message ?? e}`);
+  }
+
+  // Dump C2 — managed FuncCoreTools executable permissions. p43 failures can
+  // start the top-level wrapper but fail when it dispatches in-proc8/func.
+  try {
+    for (const funcToolsPath of getFuncCoreToolsDiagnosticPaths()) {
+      console.log(`[waitForRuntimeReady][diag] FuncCoreTools permission ${funcToolsPath}: ${getExecutableDiagnostic(funcToolsPath)}`);
+    }
+  } catch (e: any) {
+    console.log(`[waitForRuntimeReady][diag] FuncCoreTools permission dump failed: ${e?.message ?? e}`);
   }
 
   // Dump D — Structured final gate state (single grep-friendly line)

--- a/apps/vs-code-designer/src/test/ui/runtimeBinaryCheck.ts
+++ b/apps/vs-code-designer/src/test/ui/runtimeBinaryCheck.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared dependency-validation utilities used by both:
+ * - run-e2e.ts (E2E launcher, compiled by tsup)
+ * - designerHelpers.ts (ExTester test helpers, compiled by tsup)
+ *
+ * This module avoids duplication of the executable-check logic across contexts.
+ */
+
+import * as fs from 'fs';
+
+/**
+ * Returns the appropriate fs.access mode for checking runtime binary executability.
+ *
+ * On Windows, there is no execute-permission concept at the filesystem level;
+ * executability is determined by file extension (.exe, .cmd, etc.).
+ * Node.js docs: "On Windows, fs.access() does not fully support X_OK,
+ * which is treated as F_OK." So we use F_OK explicitly to be honest that
+ * we are only verifying the file exists (which, combined with .exe extension,
+ * means it is executable).
+ *
+ * On Unix (Linux/macOS), X_OK checks the actual execute permission bit.
+ */
+export function runtimeExecutableAccessMode(): number {
+  return process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK;
+}
+
+/**
+ * Checks whether a file exists and is executable on the current platform.
+ */
+export function isExecutableFile(filePath: string): boolean {
+  try {
+    fs.accessSync(filePath, runtimeExecutableAccessMode());
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/vs-code-react/src/app/createWorkflow/createWorkflowSetup.tsx
+++ b/apps/vs-code-react/src/app/createWorkflow/createWorkflowSetup.tsx
@@ -4,12 +4,56 @@
  *--------------------------------------------------------------------------------------------*/
 import { useCreateWorkspaceStyles } from '../createWorkspace/createWorkspaceStyles';
 import { WorkflowTypeStep } from '../createWorkspace/steps/workflowTypeStep';
+import { Dropdown, Field, Label, Option, Text } from '@fluentui/react-components';
+import type { DropdownProps } from '@fluentui/react-components';
+import { useSelector, useDispatch } from 'react-redux';
+import type { RootState } from '../../state/store';
+import { setLogicAppName, setLogicAppType } from '../../state/createWorkspaceSlice';
+import type { AvailableProject } from '../../state/createWorkspaceSlice';
+import { ProjectType } from '@microsoft/vscode-extension-logic-apps';
+
+const SELECT_PROJECT_PLACEHOLDER = 'Select Project';
 
 export const CreateWorkflowSetup = () => {
   const styles = useCreateWorkspaceStyles();
+  const dispatch = useDispatch();
+  const { logicAppName, availableProjects } = useSelector((state: RootState) => state.createWorkspace);
+
+  const handleProjectChange: DropdownProps['onOptionSelect'] = (_event, data) => {
+    if (data.optionValue) {
+      const selected = availableProjects.find((p: AvailableProject) => p.name === data.optionValue);
+      dispatch(setLogicAppName(data.optionValue));
+      if (selected) {
+        dispatch(setLogicAppType(selected.isCodeful ? ProjectType.codeful : ''));
+      }
+    }
+  };
+
+  const showProjectDropdown = availableProjects.length > 0;
 
   return (
     <div className={styles.formSection}>
+      {showProjectDropdown && (
+        <>
+          <Text className={styles.sectionTitle}>Project</Text>
+          <Field required>
+            <Label required>Project</Label>
+            <Dropdown
+              value={logicAppName || ''}
+              selectedOptions={logicAppName ? [logicAppName] : []}
+              onOptionSelect={handleProjectChange}
+              placeholder={SELECT_PROJECT_PLACEHOLDER}
+              className={styles.inputControl}
+            >
+              {availableProjects.map((project: AvailableProject) => (
+                <Option value={project.name} key={project.name} text={project.name}>
+                  {project.name}
+                </Option>
+              ))}
+            </Dropdown>
+          </Field>
+        </>
+      )}
       <WorkflowTypeStep />
     </div>
   );

--- a/apps/vs-code-react/src/app/createWorkspace/__test__/createWorkspace.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/__test__/createWorkspace.test.tsx
@@ -43,7 +43,7 @@ vi.mock('react-router-dom', () => ({
   useOutletContext: vi.fn(),
 }));
 
-import { CreateWorkspace, CreateWorkspaceFromPackage, CreateWorkspaceStructure, CreateLogicApp } from '../createWorkspace';
+import { CreateWorkspace, CreateWorkspaceFromPackage, CreateWorkspaceStructure, CreateLogicApp, CreateWorkflow } from '../createWorkspace';
 
 const setTestCreateWorkspaceState = 'test/setCreateWorkspaceState';
 
@@ -67,6 +67,7 @@ const createDefaultState = (overrides: Partial<CreateWorkspaceState> = {}): Crea
     isComplete: false,
     workspaceFileJson: '',
     logicAppsWithoutCustomCode: undefined,
+    existingFolders: [],
     flowType: 'createWorkspace',
     pathValidationResults: { '/home/user/projects': true },
     packageValidationResults: {},
@@ -76,6 +77,7 @@ const createDefaultState = (overrides: Partial<CreateWorkspaceState> = {}): Crea
     separator: '/',
     platform: null,
     isDevContainerProject: false,
+    availableProjects: [],
     ...overrides,
   };
 };
@@ -236,6 +238,59 @@ describe('CreateWorkspace', () => {
       expect(nextButton).toBeDisabled();
     });
 
+    it('should disable Next when the workspace folder already exists', () => {
+      renderWithStore({
+        flowType: 'createWorkspace',
+        workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
+        pathValidationResults: { '/valid/path': true },
+        workspaceName: 'existing-ws',
+        workspaceExistenceResults: {
+          '/valid/path/existing-ws': true,
+        },
+        currentStep: 0,
+      });
+      const buttons = screen.getAllByRole('button');
+      const nextButton = buttons.find((b) => b.textContent?.includes('Next'));
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('should disable Next when the workspace file already exists', () => {
+      renderWithStore({
+        flowType: 'createWorkspace',
+        workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
+        pathValidationResults: { '/valid/path': true },
+        workspaceName: 'existing-ws',
+        workspaceExistenceResults: {
+          '/valid/path/existing-ws': false,
+          '/valid/path/existing-ws/existing-ws.code-workspace': true,
+        },
+        currentStep: 0,
+      });
+      const buttons = screen.getAllByRole('button');
+      const nextButton = buttons.find((b) => b.textContent?.includes('Next'));
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('should disable Next while workspace existence validation is pending', () => {
+      renderWithStore({
+        flowType: 'createWorkspace',
+        workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
+        pathValidationResults: { '/valid/path': true },
+        workspaceName: 'pending-ws',
+        logicAppType: ProjectType.logicApp,
+        logicAppName: 'valid-app',
+        workflowType: 'Stateful-Codeless',
+        workflowName: 'valid-workflow',
+        workspaceExistenceResults: {
+          '/valid/path/pending-ws': false,
+        },
+        currentStep: 0,
+      });
+      const buttons = screen.getAllByRole('button');
+      const nextButton = buttons.find((b) => b.textContent?.includes('Next'));
+      expect(nextButton).toBeDisabled();
+    });
+
     it('should disable Next when logic app name is empty for createWorkspace', () => {
       renderWithStore({
         flowType: 'createWorkspace',
@@ -253,6 +308,10 @@ describe('CreateWorkspace', () => {
         workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
         pathValidationResults: { '/valid/path': true },
         workspaceName: 'valid-name',
+        workspaceExistenceResults: {
+          '/valid/path/valid-name': false,
+          '/valid/path/valid-name/valid-name.code-workspace': false,
+        },
         logicAppType: ProjectType.logicApp,
         logicAppName: 'valid-app',
         workflowType: 'Stateful-Codeless',
@@ -271,6 +330,10 @@ describe('CreateWorkspace', () => {
           workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
           pathValidationResults: { '/valid/path': true },
           workspaceName: 'valid-name',
+          workspaceExistenceResults: {
+            '/valid/path/valid-name': false,
+            '/valid/path/valid-name/valid-name.code-workspace': false,
+          },
           logicAppType: '',
           logicAppName: '',
           currentStep: 0,
@@ -486,6 +549,10 @@ describe('CreateWorkspace', () => {
         workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
         pathValidationResults: { '/valid/path': true },
         workspaceName: 'valid-name',
+        workspaceExistenceResults: {
+          '/valid/path/valid-name': false,
+          '/valid/path/valid-name/valid-name.code-workspace': false,
+        },
         logicAppType: ProjectType.logicApp,
         logicAppName: 'valid-app',
         workflowType: 'Stateful-Codeless',
@@ -496,11 +563,12 @@ describe('CreateWorkspace', () => {
       const buttons = screen.getAllByRole('button');
       const nextButton = buttons.find((b) => b.textContent?.includes('Next'));
 
-      if (nextButton && !nextButton.hasAttribute('disabled')) {
-        fireEvent.click(nextButton);
-        const state = store.getState().createWorkspace;
-        expect(state.currentStep).toBe(1);
-      }
+      expect(nextButton).toBeDefined();
+      expect(nextButton?.hasAttribute('disabled')).toBe(false);
+
+      fireEvent.click(nextButton as HTMLElement);
+      const state = store.getState().createWorkspace;
+      expect(state.currentStep).toBe(1);
     });
 
     it('should enable Next button for custom code with dotted namespace', () => {
@@ -509,6 +577,10 @@ describe('CreateWorkspace', () => {
         workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
         pathValidationResults: { '/valid/path': true },
         workspaceName: 'valid-name',
+        workspaceExistenceResults: {
+          '/valid/path/valid-name': false,
+          '/valid/path/valid-name/valid-name.code-workspace': false,
+        },
         logicAppType: ProjectType.customCode,
         logicAppName: 'valid-app',
         workflowType: 'Stateful-Codeless',
@@ -579,5 +651,95 @@ describe('Flow type wrapper components', () => {
 
     const state = store.getState().createWorkspace;
     expect(state.flowType).toBe('createLogicApp');
+  });
+});
+
+describe('CreateLogicApp state preservation (resetState race condition)', () => {
+  it('should preserve existingFolders after mount when initializeProject has populated them', () => {
+    const store = configureStore({
+      reducer: { createWorkspace: createWorkspaceSlice.reducer },
+    });
+
+    // Simulate initializeProject being dispatched (as extension host sends initialize_frame)
+    act(() => {
+      store.dispatch(
+        createWorkspaceSlice.actions.initializeProject({
+          workspaceFileJson: { folders: [{ name: 'TestApp', path: './TestApp' }] },
+          logicAppsWithoutCustomCode: [],
+          existingFolders: ['TestApp', 'CustomCodeProject', '.vscode'],
+        })
+      );
+    });
+
+    // Verify state has existingFolders before mount
+    expect(store.getState().createWorkspace.existingFolders).toEqual(['TestApp', 'CustomCodeProject', '.vscode']);
+
+    // Mount CreateLogicApp — this previously called resetState which wiped existingFolders
+    render(
+      <Provider store={store}>
+        <CreateLogicApp />
+      </Provider>
+    );
+
+    // After mount, existingFolders must still be preserved
+    const stateAfterMount = store.getState().createWorkspace;
+    expect(stateAfterMount.existingFolders).toEqual(['TestApp', 'CustomCodeProject', '.vscode']);
+    expect(stateAfterMount.flowType).toBe('createLogicApp');
+  });
+
+  it('should preserve workspaceFileJson after mount when initializeProject has populated it', () => {
+    const store = configureStore({
+      reducer: { createWorkspace: createWorkspaceSlice.reducer },
+    });
+
+    const workspaceFileJson = { folders: [{ name: 'MyApp', path: './MyApp' }] };
+
+    act(() => {
+      store.dispatch(
+        createWorkspaceSlice.actions.initializeProject({
+          workspaceFileJson,
+          logicAppsWithoutCustomCode: [{ label: 'MyApp' }],
+          existingFolders: ['MyApp'],
+        })
+      );
+    });
+
+    render(
+      <Provider store={store}>
+        <CreateLogicApp />
+      </Provider>
+    );
+
+    const stateAfterMount = store.getState().createWorkspace;
+    expect(stateAfterMount.workspaceFileJson).toEqual(workspaceFileJson);
+    expect(stateAfterMount.logicAppsWithoutCustomCode).toEqual([{ label: 'MyApp' }]);
+  });
+
+  it('should not interfere with CreateWorkflow preserving availableProjects', () => {
+    const store = configureStore({
+      reducer: { createWorkspace: createWorkspaceSlice.reducer },
+    });
+
+    const availableProjects = [
+      { name: 'Project1', path: '/workspace/Project1', isCodeful: false, existingWorkflows: ['workflow-a'] },
+      { name: 'Project2', path: '/workspace/Project2', isCodeful: true, existingWorkflows: [] },
+    ];
+
+    act(() => {
+      store.dispatch(createWorkspaceSlice.actions.initializeWorkspace({ availableProjects }));
+    });
+
+    expect(store.getState().createWorkspace.availableProjects).toEqual(availableProjects);
+
+    // Dynamically import CreateWorkflow
+    render(
+      <Provider store={store}>
+        <CreateWorkflow />
+      </Provider>
+    );
+
+    const stateAfterMount = store.getState().createWorkspace;
+    expect(stateAfterMount.availableProjects).toEqual(availableProjects);
+    expect(stateAfterMount.flowType).toBe('createWorkflow');
   });
 });

--- a/apps/vs-code-react/src/app/createWorkspace/createWorkspace.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/createWorkspace.tsx
@@ -58,8 +58,10 @@ const CreateWorkspaceInternal = () => {
     workspaceExistenceResults,
     packageValidationResults,
     logicAppsWithoutCustomCode,
+    existingFolders,
     separator,
     isDevContainerProject,
+    availableProjects,
   } = createWorkspaceState;
 
   // Calculate total steps - always 2: Setup and Review + Create
@@ -149,9 +151,24 @@ const CreateWorkspaceInternal = () => {
     STEP_REVIEW_CREATE: intlText.REVIEW_CREATE_LABEL,
   };
 
-  // Helper function to check if a name already exists in workspace folders
+  // Helper function to check if a name already exists in workspace folders or on disk
   const isNameAlreadyInWorkspace = (name: string) => {
-    return workspaceFileJson?.folders && workspaceFileJson.folders.some((folder: { name: string }) => folder.name === name);
+    if (workspaceFileJson?.folders && workspaceFileJson.folders.some((folder: { name: string }) => folder.name === name)) {
+      return true;
+    }
+    // Also check actual directories on disk (case-insensitive) — catches C# project folders etc.
+    return existingFolders.some((folder: string) => folder.toLowerCase() === name.trim().toLowerCase());
+  };
+
+  const getWorkspaceExistencePaths = () => {
+    const workspaceFolder = `${workspaceProjectPath.fsPath}${separator}${workspaceName}`;
+    const workspaceFile = `${workspaceFolder}${separator}${workspaceName}.code-workspace`;
+    return { workspaceFolder, workspaceFile };
+  };
+
+  const isWorkspaceNameAvailable = () => {
+    const { workspaceFolder, workspaceFile } = getWorkspaceExistencePaths();
+    return workspaceExistenceResults[workspaceFolder] === false && workspaceExistenceResults[workspaceFile] === false;
   };
 
   // Helper function to validate logic app name with support for existing logic apps
@@ -170,6 +187,15 @@ const CreateWorkspaceInternal = () => {
 
     // Check for workspace folder collision (only if not using existing logic app)
     return !isNameAlreadyInWorkspace(name.trim());
+  };
+
+  // Helper to check if a workflow name already exists in the selected project
+  const isWorkflowNameTakenInProject = (name: string) => {
+    const selectedProject = (availableProjects || []).find((p) => p.name === logicAppName);
+    if (!selectedProject?.existingWorkflows) {
+      return false;
+    }
+    return selectedProject.existingWorkflows.some((w) => w.toLowerCase() === name.toLowerCase());
   };
 
   const canProceed = () => {
@@ -195,9 +221,7 @@ const CreateWorkspaceInternal = () => {
 
         // Workspace name validation (not needed for createLogicApp)
         if (requirements.needsWorkspaceName) {
-          const workspaceFolder = `${workspaceProjectPath.fsPath}${separator}${workspaceName}`;
-          const workspaceNameValid =
-            workspaceName.trim() !== '' && nameValidation.test(workspaceName.trim()) && workspaceExistenceResults[workspaceFolder] !== true;
+          const workspaceNameValid = workspaceName.trim() !== '' && nameValidation.test(workspaceName.trim()) && isWorkspaceNameAvailable();
           if (!workspaceNameValid) {
             return false;
           }
@@ -213,10 +237,16 @@ const CreateWorkspaceInternal = () => {
 
         // Logic app name validation
         if (requirements.needsLogicAppName) {
-          const logicAppNameValid =
-            flowType === FLOW_TYPES.CREATE_LOGIC_APP
-              ? validateLogicAppNameForNavigation(logicAppName)
-              : logicAppName.trim() !== '' && nameValidation.test(logicAppName.trim()) && !isNameAlreadyInWorkspace(logicAppName.trim());
+          let logicAppNameValid: boolean;
+          if (flowType === FLOW_TYPES.CREATE_LOGIC_APP) {
+            logicAppNameValid = validateLogicAppNameForNavigation(logicAppName);
+          } else if (flowType === FLOW_TYPES.CREATE_WORKFLOW) {
+            // For createWorkflow, logicAppName is a pre-existing project selected from a dropdown
+            logicAppNameValid = logicAppName.trim() !== '';
+          } else {
+            logicAppNameValid =
+              logicAppName.trim() !== '' && nameValidation.test(logicAppName.trim()) && !isNameAlreadyInWorkspace(logicAppName.trim());
+          }
           if (!logicAppNameValid) {
             return false;
           }
@@ -241,7 +271,10 @@ const CreateWorkspaceInternal = () => {
             // For other flows, always validate workflow fields
             const workflowTypeValid = workflowType !== '';
             const workflowNameValid =
-              workflowName.trim() !== '' && nameValidation.test(workflowName.trim()) && !isNameAlreadyInWorkspace(workflowName.trim());
+              workflowName.trim() !== '' &&
+              nameValidation.test(workflowName.trim()) &&
+              !isNameAlreadyInWorkspace(workflowName.trim()) &&
+              !isWorkflowNameTakenInProject(workflowName.trim());
             if (!workflowTypeValid || !workflowNameValid) {
               return false;
             }
@@ -299,9 +332,7 @@ const CreateWorkspaceInternal = () => {
         // For convertToWorkspace, only validate workspace path and name
         if (flowType === FLOW_TYPES.CONVERT_TO_WORKSPACE) {
           const workspacePathValid = workspaceProjectPath.fsPath !== '' && pathValidationResults[workspaceProjectPath.fsPath] === true;
-          const workspaceFolder = `${workspaceProjectPath.fsPath}${separator}${workspaceName}`;
-          const workspaceNameValid =
-            workspaceName.trim() !== '' && nameValidation.test(workspaceName.trim()) && workspaceExistenceResults[workspaceFolder] !== true;
+          const workspaceNameValid = workspaceName.trim() !== '' && nameValidation.test(workspaceName.trim()) && isWorkspaceNameAvailable();
           return workspacePathValid && workspaceNameValid;
         }
 
@@ -309,9 +340,8 @@ const CreateWorkspaceInternal = () => {
         const workspacePathValid = requirements.needsWorkspacePath
           ? workspaceProjectPath.fsPath !== '' && pathValidationResults[workspaceProjectPath.fsPath] === true
           : true;
-        const workspaceFolder = `${workspaceProjectPath.fsPath}${separator}${workspaceName}`;
         const workspaceNameValid = requirements.needsWorkspaceName
-          ? workspaceName.trim() !== '' && nameValidation.test(workspaceName.trim()) && workspaceExistenceResults[workspaceFolder] !== true
+          ? workspaceName.trim() !== '' && nameValidation.test(workspaceName.trim()) && isWorkspaceNameAvailable()
           : true;
         const logicAppTypeValid = requirements.needsLogicAppType ? logicAppType !== '' : true;
         const logicAppNameValid = requirements.needsLogicAppName
@@ -319,7 +349,10 @@ const CreateWorkspaceInternal = () => {
           : true;
         const workflowTypeValid = requirements.needsWorkflowFields ? workflowType !== '' : true;
         const workflowNameValid = requirements.needsWorkflowFields
-          ? workflowName.trim() !== '' && nameValidation.test(workflowName.trim()) && !isNameAlreadyInWorkspace(workflowName.trim())
+          ? workflowName.trim() !== '' &&
+            nameValidation.test(workflowName.trim()) &&
+            !isNameAlreadyInWorkspace(workflowName.trim()) &&
+            !isWorkflowNameTakenInProject(workflowName.trim())
           : true;
 
         const baseFieldsValid =
@@ -727,7 +760,9 @@ export const CreateLogicApp = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(resetState(undefined));
+    // Only set the flow type — do NOT call resetState here.
+    // The webview is always created fresh (new panel) so state starts from initialState.
+    // Calling resetState races with initializeProject and can wipe existingFolders/workspaceFileJson.
     dispatch(setFlowType(FLOW_TYPES.CREATE_LOGIC_APP));
   }, [dispatch]);
 
@@ -738,7 +773,9 @@ export const CreateWorkflow = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(resetState({ preserveLogicAppData: true }));
+    // Only set the flow type — do NOT call resetState here.
+    // The webview is always created fresh (new panel) so state starts from initialState.
+    // Calling resetState races with initializeWorkspace and can wipe availableProjects.
     dispatch(setFlowType(FLOW_TYPES.CREATE_WORKFLOW));
   }, [dispatch]);
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/dotNetFrameworkStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/dotNetFrameworkStep.test.tsx
@@ -38,6 +38,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     isComplete: false,
     workspaceFileJson: '',
     logicAppsWithoutCustomCode: undefined,
+    existingFolders: [],
     flowType: 'createWorkspace',
     pathValidationResults: {},
     packageValidationResults: {},
@@ -47,6 +48,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     separator: '/',
     platform: null,
     isDevContainerProject: false,
+    availableProjects: [],
     ...overrides,
   };
 
@@ -69,6 +71,15 @@ const renderWithStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
         <DotNetFrameworkStep />
       </Provider>
     ),
+  };
+};
+
+const getCustomCodeInputs = () => {
+  const textboxes = screen.getAllByRole('textbox');
+  return {
+    folderInput: textboxes[0],
+    namespaceInput: textboxes[1],
+    functionNameInput: textboxes[2],
   };
 };
 
@@ -173,6 +184,57 @@ describe('DotNetFrameworkStep', () => {
 
       const state = store.getState().createWorkspace;
       expect(state.targetFramework).toBe('net10.0');
+    });
+  });
+
+  describe('field validation messages', () => {
+    it('shows the function folder validation message for invalid folder names', () => {
+      renderWithStore({ logicAppType: ProjectType.customCode });
+      const { folderInput } = getCustomCodeInputs();
+
+      fireEvent.change(folderInput, { target: { value: '1folder' } });
+
+      expect(
+        screen.getByText('Function folder name must start with a letter and can only contain letters, digits, "_" and "-".')
+      ).toBeInTheDocument();
+    });
+
+    it('allows valid hyphenated function folder names', () => {
+      renderWithStore({ logicAppType: ProjectType.customCode });
+      const { folderInput } = getCustomCodeInputs();
+
+      fireEvent.change(folderInput, { target: { value: 'func-folder_01' } });
+
+      expect(
+        screen.queryByText('Function folder name must start with a letter and can only contain letters, digits, "_" and "-".')
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows the function folder same-as-logic-app message', () => {
+      renderWithStore({ logicAppType: ProjectType.customCode, logicAppName: 'LogicApp' });
+      const { folderInput } = getCustomCodeInputs();
+
+      fireEvent.change(folderInput, { target: { value: 'logicapp' } });
+
+      expect(screen.getByText('Function folder name cannot be the same as the logic app name.')).toBeInTheDocument();
+    });
+
+    it('shows the namespace validation message for invalid namespaces', () => {
+      renderWithStore({ logicAppType: ProjectType.customCode });
+      const { namespaceInput } = getCustomCodeInputs();
+
+      fireEvent.change(namespaceInput, { target: { value: 'Invalid-Namespace' } });
+
+      expect(screen.getByText('Function namespace must be a valid C# namespace.')).toBeInTheDocument();
+    });
+
+    it('shows the function name validation message for invalid C# identifiers', () => {
+      renderWithStore({ logicAppType: ProjectType.customCode });
+      const { functionNameInput } = getCustomCodeInputs();
+
+      fireEvent.change(functionNameInput, { target: { value: 'my-function' } });
+
+      expect(screen.getByText('Function name must start with a letter and can only contain letters, digits, and "_".')).toBeInTheDocument();
     });
   });
 });

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/logicAppTypeStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/logicAppTypeStep.test.tsx
@@ -95,6 +95,7 @@ function createState(overrides: Partial<CreateWorkspaceState> = {}): CreateWorks
     isValidatingWorkspace: false,
     logicAppName: 'LogicApp',
     logicAppType: ProjectType.logicApp,
+    logicAppsWithoutCustomCode: undefined,
     openBehavior: '',
     packagePath: { fsPath: '', path: '' },
     packageValidationResults: {},
@@ -107,8 +108,10 @@ function createState(overrides: Partial<CreateWorkspaceState> = {}): CreateWorks
     workflowType: 'Stateful-Codeless',
     workspaceExistenceResults: {},
     workspaceFileJson: { folders: [{ name: 'DuplicateApp' }] },
+    existingFolders: ['DuplicateApp', 'CSharpProject'],
     workspaceName: 'Workspace',
     workspaceProjectPath: { fsPath: '/tmp/projects', path: '/tmp/projects' },
+    availableProjects: [],
     ...overrides,
   };
 }
@@ -169,5 +172,29 @@ describe('LogicAppTypeStep', () => {
     fireEvent.change(screen.getByPlaceholderText('Enter logic app name'), { target: { value: 'FunctionsApp' } });
 
     expect(screen.getByRole('alert')).toHaveTextContent('Logic app name must differ from the function name');
+  });
+
+  it('shows validation for invalid logic app names', () => {
+    renderLogicAppType({ logicAppName: '' });
+
+    fireEvent.change(screen.getByPlaceholderText('Enter logic app name'), { target: { value: '1logicapp' } });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Logic app name is invalid');
+  });
+
+  it('shows validation when the logic app project already exists', () => {
+    renderLogicAppType({ logicAppName: '' });
+
+    fireEvent.change(screen.getByPlaceholderText('Enter logic app name'), { target: { value: 'DuplicateApp' } });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Project already exists');
+  });
+
+  it('shows validation when the name collides with an existing folder on disk (case-insensitive)', () => {
+    renderLogicAppType({ logicAppName: '', existingFolders: ['CSharpProject', 'MyFunctions'] });
+
+    fireEvent.change(screen.getByPlaceholderText('Enter logic app name'), { target: { value: 'csharpproject' } });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Project already exists');
   });
 });

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/reviewCreateStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/reviewCreateStep.test.tsx
@@ -38,6 +38,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     isComplete: false,
     workspaceFileJson: '',
     logicAppsWithoutCustomCode: undefined,
+    existingFolders: [],
     flowType: 'createWorkspace',
     pathValidationResults: {},
     packageValidationResults: {},
@@ -47,6 +48,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     separator: '/',
     platform: null,
     isDevContainerProject: false,
+    availableProjects: [],
     ...overrides,
   };
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workflowTypeStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workflowTypeStep.test.tsx
@@ -21,11 +21,13 @@ vi.mock('../../../../intl', () => ({
   useIntlMessages: () => ({
     AGENT_TITLE: 'Conversational agents (Preview)',
     AUTONOMOUS_TITLE: 'Autonomous agents (Preview)',
+    EMPTY_WORKFLOW_NAME: 'Workflow name cannot be empty.',
     ENTER_WORKFLOW_NAME: 'Enter workflow name',
     SELECT_WORKFLOW_TYPE: 'Select workflow type',
     STATEFUL_TITLE: 'Stateful',
     STATELESS_TITLE: 'Stateless',
     WORKFLOW_CONFIGURATION: 'Workflow configuration',
+    WORKFLOW_NAME_VALIDATION_MESSAGE: 'Workflow name must start with a letter and can only contain letters, digits, "_" and "-".',
     WORKFLOW_NAME: 'Workflow name',
     WORKFLOW_TYPE: 'Workflow type',
   }),
@@ -89,6 +91,9 @@ function createState(overrides: Partial<CreateWorkspaceState> = {}): CreateWorks
     workspaceFileJson: '',
     workspaceName: 'Workspace',
     workspaceProjectPath: { fsPath: '/tmp/projects', path: '/tmp/projects' },
+    existingFolders: [],
+    logicAppsWithoutCustomCode: undefined,
+    availableProjects: [],
     ...overrides,
   };
 }
@@ -124,5 +129,38 @@ describe('WorkflowTypeStep', () => {
     fireEvent.click(screen.getByText('Choose autonomous'));
 
     expect(store.getState().createWorkspace.workflowType).toBe(WorkflowType.agenticCodeful);
+  });
+
+  it('clears validation for a valid workflow name', () => {
+    const store = renderWorkflowTypeStep({
+      workflowName: '',
+    });
+
+    fireEvent.change(screen.getByLabelText('Enter workflow name'), { target: { value: 'la-trigger-github' } });
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(store.getState().createWorkspace.workflowName).toBe('la-trigger-github');
+  });
+
+  it('shows the empty workflow name message', () => {
+    renderWorkflowTypeStep({
+      workflowName: 'workflow',
+    });
+
+    fireEvent.change(screen.getByLabelText('Enter workflow name'), { target: { value: '' } });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Workflow name cannot be empty.');
+  });
+
+  it('shows the workflow name validation message for invalid names', () => {
+    renderWorkflowTypeStep({
+      workflowName: '',
+    });
+
+    fireEvent.change(screen.getByLabelText('Enter workflow name'), { target: { value: '1workflow' } });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Workflow name must start with a letter and can only contain letters, digits, "_" and "-".'
+    );
   });
 });

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workspaceNameStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workspaceNameStep.test.tsx
@@ -48,6 +48,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     isComplete: false,
     workspaceFileJson: '',
     logicAppsWithoutCustomCode: undefined,
+    existingFolders: [],
     flowType: 'createWorkspace',
     pathValidationResults: {},
     packageValidationResults: {},
@@ -57,6 +58,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     separator: '/',
     platform: null,
     isDevContainerProject: false,
+    availableProjects: [],
     ...overrides,
   };
 
@@ -176,6 +178,56 @@ describe('WorkspaceNameStep', () => {
   });
 
   describe('workspace name validation display', () => {
+    it('should show empty path validation message when path is cleared', () => {
+      renderWithStore({
+        workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
+      });
+      const pathInput = screen.getAllByRole('textbox')[0];
+
+      fireEvent.change(pathInput, { target: { value: '' } });
+
+      expect(screen.getByText('Workspace parent folder path cannot be empty.')).toBeInTheDocument();
+    });
+
+    it('should show invalid path validation message when path validation fails', () => {
+      renderWithStore({
+        workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
+        pathValidationResults: { '/invalid/path': false },
+      });
+      const pathInput = screen.getAllByRole('textbox')[0];
+
+      fireEvent.change(pathInput, { target: { value: '/invalid/path' } });
+
+      expect(screen.getByText('The specified path does not exist or is not accessible.')).toBeInTheDocument();
+    });
+
+    it('should show workspace name validation message for invalid names', () => {
+      renderWithStore();
+      const nameInput = screen.getAllByRole('textbox')[1];
+
+      fireEvent.change(nameInput, { target: { value: '1workspace' } });
+
+      expect(
+        screen.getByText('Workspace name must start with a letter and can only contain letters, digits, "_" and "-".')
+      ).toBeInTheDocument();
+    });
+
+    it('should show existing workspace file message', async () => {
+      renderWithStore({
+        workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },
+        workspaceName: 'existing-ws',
+        pathValidationResults: { '/valid/path': true },
+        workspaceExistenceResults: {
+          '/valid/path/existing-ws': false,
+          '/valid/path/existing-ws/existing-ws.code-workspace': true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(screen.getByText('A workspace file "existing-ws.code-workspace" already exists.')).toBeInTheDocument();
+    });
+
     it('should show availability indicator when workspace name and path are valid', () => {
       renderWithStore({
         workspaceProjectPath: { fsPath: '/valid/path', path: '/valid/path' },

--- a/apps/vs-code-react/src/app/createWorkspace/steps/dotNetFrameworkStep.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/dotNetFrameworkStep.tsx
@@ -25,8 +25,17 @@ export const DotNetFrameworkStep: React.FC = () => {
   const intlText = useIntlMessages(workspaceMessages);
   const styles = useCreateWorkspaceStyles();
   const createWorkspaceState = useSelector((state: RootState) => state.createWorkspace) as CreateWorkspaceState;
-  const { targetFramework, functionNamespace, functionName, platform, functionFolderName, logicAppType, logicAppName, workspaceFileJson } =
-    createWorkspaceState;
+  const {
+    targetFramework,
+    functionNamespace,
+    functionName,
+    platform,
+    functionFolderName,
+    logicAppType,
+    logicAppName,
+    workspaceFileJson,
+    existingFolders,
+  } = createWorkspaceState;
 
   const functionNamespaceId = useId();
   const functionNameId = useId();
@@ -83,6 +92,10 @@ export const DotNetFrameworkStep: React.FC = () => {
       if (workspaceFileJson?.folders && workspaceFileJson.folders.some((folder: { name: string }) => folder.name === name)) {
         return intlText.FUNCTION_FOLDER_EXISTS;
       }
+      // Check if the name collides with any existing folder on disk (case-insensitive)
+      if (existingFolders?.some((folder: string) => folder.toLowerCase() === name.trim().toLowerCase())) {
+        return intlText.FUNCTION_FOLDER_EXISTS;
+      }
       return undefined;
     },
     [
@@ -92,6 +105,7 @@ export const DotNetFrameworkStep: React.FC = () => {
       intlText.FUNCTION_FOLDER_NAME_VALIDATION,
       logicAppName,
       workspaceFileJson,
+      existingFolders,
     ]
   );
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/logicAppTypeStep.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/logicAppTypeStep.tsx
@@ -26,6 +26,7 @@ export const LogicAppTypeStep: React.FC = () => {
     workspaceProjectPath,
     workspaceFileJson,
     logicAppsWithoutCustomCode,
+    existingFolders,
     flowType,
     separator,
   } = createWorkspaceState;
@@ -63,10 +64,16 @@ export const LogicAppTypeStep: React.FC = () => {
         return undefined; // Valid - existing logic app for custom code/rules engine
       }
 
-      // Check if the logic app name already exists in workspace folders (for new names)
+      // Check if the logic app name already exists in workspace folders
       if (workspaceFileJson?.folders && workspaceFileJson.folders.some((folder: { name: string }) => folder.name === name)) {
         return intlText.PROJECT_NAME_EXISTS;
       }
+
+      // Check if the name collides with any existing folder on disk (case-insensitive)
+      if (existingFolders.some((folder: string) => folder.toLowerCase() === name.trim().toLowerCase())) {
+        return intlText.PROJECT_NAME_EXISTS;
+      }
+
       return undefined;
     },
     [
@@ -78,6 +85,7 @@ export const LogicAppTypeStep: React.FC = () => {
       logicAppType,
       logicAppsWithoutCustomCode,
       workspaceFileJson,
+      existingFolders,
     ]
   );
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/workflowTypeStep.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/workflowTypeStep.tsx
@@ -22,8 +22,14 @@ export const WorkflowTypeStep: React.FC = () => {
   const dispatch = useDispatch();
   const styles = useCreateWorkspaceStyles();
   const createWorkspaceState = useSelector((state: RootState) => state.createWorkspace);
-  const { workflowType, workflowName, logicAppType } = createWorkspaceState;
+  const { workflowType, workflowName, logicAppType, logicAppName, availableProjects } = createWorkspaceState;
   const intlText = useIntlMessages(workspaceMessages);
+
+  // Get existing workflows for the currently selected project
+  const existingWorkflows = useMemo(() => {
+    const selectedProject = (availableProjects || []).find((p) => p.name === logicAppName);
+    return selectedProject?.existingWorkflows ?? [];
+  }, [availableProjects, logicAppName]);
 
   // Validation state
   const [workflowNameError, setWorkflowNameError] = useState<string | undefined>(undefined);
@@ -52,7 +58,7 @@ export const WorkflowTypeStep: React.FC = () => {
 
   const handleWorkflowNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(setWorkflowName(event.target.value));
-    setWorkflowNameError(validateWorkflowName(event.target.value, intlText));
+    setWorkflowNameError(validateWorkflowName(event.target.value, intlText, existingWorkflows));
   };
 
   const selectWorkflowTypes = useMemo(() => {

--- a/apps/vs-code-react/src/app/createWorkspace/steps/workspaceNameStep.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/workspaceNameStep.tsx
@@ -111,7 +111,7 @@ export const WorkspaceNameStep: React.FC = () => {
         const workspaceFile = `${workspaceFolder}${separator}${name}.code-workspace`;
 
         // Check if we already have results for these paths
-        if (workspaceFolder in workspaceExistenceResults || workspaceFile in workspaceExistenceResults) {
+        if (workspaceFolder in workspaceExistenceResults && workspaceFile in workspaceExistenceResults) {
           setIsValidatingWorkspaceName(false);
           const validationError = validateWorkspaceName(name);
           setWorkspaceNameError(validationError);

--- a/apps/vs-code-react/src/app/createWorkspace/utils/__test__/validation.test.ts
+++ b/apps/vs-code-react/src/app/createWorkspace/utils/__test__/validation.test.ts
@@ -1,25 +1,139 @@
 import { describe, expect, it } from 'vitest';
-import { validateFunctionName, validateFunctionNamespace } from '../validation';
+import {
+  functionNameValidation,
+  nameValidation,
+  namespaceValidation,
+  reservedWorkflowNames,
+  validateFunctionName,
+  validateFunctionNamespace,
+  validateWorkflowName,
+} from '../validation';
 
 describe('create workspace validation utilities', () => {
   const intlText = {
+    EMPTY_WORKFLOW_NAME: 'Workflow name cannot be empty.',
+    WORKFLOW_NAME_VALIDATION_MESSAGE: 'Workflow name must start with a letter and can only contain letters, digits, "_" and "-".',
     FUNCTION_NAMESPACE_EMPTY: 'Function namespace cannot be empty.',
     FUNCTION_NAMESPACE_VALIDATION: 'Function namespace must be a valid C# namespace.',
     FUNCTION_NAME_EMPTY: 'Function name cannot be empty.',
     FUNCTION_NAME_VALIDATION: 'Function name must start with a letter and can only contain letters, digits, and "_".',
   };
 
-  it('rejects function names that are not valid C# identifiers', () => {
-    expect(validateFunctionName('my-function', intlText)).toBe(intlText.FUNCTION_NAME_VALIDATION);
-    expect(validateFunctionName('1function', intlText)).toBe(intlText.FUNCTION_NAME_VALIDATION);
+  describe('nameValidation', () => {
+    it.each(['a', 'myapp', 'MyApp', 'my_app', 'my-app', 'app123', 'my_app-v2', 'la-trigger-github'])('accepts "%s"', (name) => {
+      expect(nameValidation.test(name)).toBe(true);
+    });
+
+    it.each(['', '123abc', '_abc', '-abc', 'my app', 'my.app', 'my--app', 'my__app', 'my-', 'my_', 'my@app'])('rejects "%s"', (name) => {
+      expect(nameValidation.test(name)).toBe(false);
+    });
   });
 
-  it('allows function names with letters, digits, and underscores', () => {
-    expect(validateFunctionName('MyFunction_1', intlText)).toBeUndefined();
+  describe('validateWorkflowName', () => {
+    it.each(['workflow', 'my_app', 'la-trigger-github'])('returns undefined for valid workflow name "%s"', (name) => {
+      expect(validateWorkflowName(name, intlText)).toBeUndefined();
+    });
+
+    it('returns the empty workflow name message', () => {
+      expect(validateWorkflowName('', intlText)).toBe(intlText.EMPTY_WORKFLOW_NAME);
+    });
+
+    it('returns the workflow validation message for invalid names', () => {
+      expect(validateWorkflowName('1workflow', intlText)).toBe(intlText.WORKFLOW_NAME_VALIDATION_MESSAGE);
+      expect(validateWorkflowName('workflow.name', intlText)).toBe(intlText.WORKFLOW_NAME_VALIDATION_MESSAGE);
+    });
+
+    it('returns collision message when workflow name exists in project (case-insensitive)', () => {
+      const existingWorkflows = ['MyWorkflow', 'another-workflow'];
+      const collisionMessage = 'A workflow with this name already exists in the selected project.';
+      const intlWithCollision = { ...intlText, WORKFLOW_NAME_EXISTS: collisionMessage };
+
+      expect(validateWorkflowName('MyWorkflow', intlWithCollision, existingWorkflows)).toBe(collisionMessage);
+      expect(validateWorkflowName('myworkflow', intlWithCollision, existingWorkflows)).toBe(collisionMessage);
+      expect(validateWorkflowName('MYWORKFLOW', intlWithCollision, existingWorkflows)).toBe(collisionMessage);
+      expect(validateWorkflowName('another-workflow', intlWithCollision, existingWorkflows)).toBe(collisionMessage);
+    });
+
+    it('returns undefined when workflow name does not collide', () => {
+      const existingWorkflows = ['MyWorkflow', 'another-workflow'];
+      expect(validateWorkflowName('new-workflow', intlText, existingWorkflows)).toBeUndefined();
+      expect(validateWorkflowName('unique-name', intlText, existingWorkflows)).toBeUndefined();
+    });
+
+    it('returns undefined when existingWorkflows is empty or not provided', () => {
+      expect(validateWorkflowName('workflow', intlText, [])).toBeUndefined();
+      expect(validateWorkflowName('workflow', intlText, undefined)).toBeUndefined();
+    });
+
+    it('rejects reserved project folder names (case-insensitive)', () => {
+      const reservedMessage = 'This name is reserved and cannot be used as a workflow name.';
+      const intlWithReserved = { ...intlText, WORKFLOW_NAME_RESERVED: reservedMessage };
+
+      expect(validateWorkflowName('Artifacts', intlWithReserved)).toBe(reservedMessage);
+      expect(validateWorkflowName('artifacts', intlWithReserved)).toBe(reservedMessage);
+      expect(validateWorkflowName('lib', intlWithReserved)).toBe(reservedMessage);
+      expect(validateWorkflowName('Tests', intlWithReserved)).toBe(reservedMessage);
+      expect(validateWorkflowName('custom', intlWithReserved)).toBe(reservedMessage);
+      expect(validateWorkflowName('diagnostics', intlWithReserved)).toBe(reservedMessage);
+      expect(validateWorkflowName('wwwroot', intlWithReserved)).toBe(reservedMessage);
+    });
+
+    it('exports the reservedWorkflowNames list', () => {
+      expect(reservedWorkflowNames).toContain('Artifacts');
+      expect(reservedWorkflowNames).toContain('lib');
+      expect(reservedWorkflowNames).toContain('workflow-designtime');
+      expect(reservedWorkflowNames).toContain('.vscode');
+      expect(reservedWorkflowNames).toContain('.debug');
+      expect(reservedWorkflowNames).toContain('Tests');
+    });
   });
 
-  it('returns function namespace validation messages from workspace message keys', () => {
-    expect(validateFunctionNamespace('', intlText)).toBe(intlText.FUNCTION_NAMESPACE_EMPTY);
-    expect(validateFunctionNamespace('Invalid-Namespace', intlText)).toBe(intlText.FUNCTION_NAMESPACE_VALIDATION);
+  describe('functionNameValidation', () => {
+    it.each(['MyFunction', 'myFunction', 'MyFunction_1', 'func123', 'a_'])('accepts "%s"', (name) => {
+      expect(functionNameValidation.test(name)).toBe(true);
+    });
+
+    it.each(['', 'my-function', '1function', '_function', 'function.name', 'function name'])('rejects "%s"', (name) => {
+      expect(functionNameValidation.test(name)).toBe(false);
+    });
+  });
+
+  describe('validateFunctionName', () => {
+    it('rejects function names that are not valid C# identifiers', () => {
+      expect(validateFunctionName('my-function', intlText)).toBe(intlText.FUNCTION_NAME_VALIDATION);
+      expect(validateFunctionName('1function', intlText)).toBe(intlText.FUNCTION_NAME_VALIDATION);
+    });
+
+    it('allows function names with letters, digits, and underscores', () => {
+      expect(validateFunctionName('MyFunction_1', intlText)).toBeUndefined();
+    });
+
+    it('returns the empty function name message', () => {
+      expect(validateFunctionName('', intlText)).toBe(intlText.FUNCTION_NAME_EMPTY);
+    });
+  });
+
+  describe('namespaceValidation', () => {
+    it.each(['MyNamespace', 'My.Company.Functions', '_Root.Sub', 'A.B.C', 'A1.B2'])('accepts "%s"', (namespace) => {
+      expect(namespaceValidation.test(namespace)).toBe(true);
+    });
+
+    it.each(['', 'Invalid-Namespace', '123.Root', '.Root', 'Root.', 'Root..Sub', 'Root.123', 'Root.Sub-Name'])(
+      'rejects "%s"',
+      (namespace) => {
+        expect(namespaceValidation.test(namespace)).toBe(false);
+      }
+    );
+  });
+
+  describe('validateFunctionNamespace', () => {
+    it('returns function namespace validation messages from workspace message keys', () => {
+      expect(validateFunctionNamespace('', intlText)).toBe(intlText.FUNCTION_NAMESPACE_EMPTY);
+      expect(validateFunctionNamespace('Invalid-Namespace', intlText)).toBe(intlText.FUNCTION_NAMESPACE_VALIDATION);
+    });
+
+    it('allows valid C# namespaces', () => {
+      expect(validateFunctionNamespace('MyCompany.Functions', intlText)).toBeUndefined();
+    });
   });
 });

--- a/apps/vs-code-react/src/app/createWorkspace/utils/validation.ts
+++ b/apps/vs-code-react/src/app/createWorkspace/utils/validation.ts
@@ -4,12 +4,39 @@ export const nameValidation = /^[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*$/i;
 export const namespaceValidation = /^([A-Za-z_][A-Za-z0-9_]*)(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
 export const functionNameValidation = /^[a-z][a-z\d_]*$/i;
 
-export const validateWorkflowName = (name: string, intlText: any) => {
+// Reserved folder names that exist in Logic App projects by default.
+// Workflows must not use these names to avoid conflicts.
+export const reservedWorkflowNames = [
+  '.vscode',
+  '.debug',
+  '.devcontainer',
+  '.testResults',
+  'Artifacts',
+  'lib',
+  'workflow-designtime',
+  'Tests',
+  'diagnostics',
+  'locks',
+  'wwwroot',
+  'custom',
+  'DeploymentScriptTemplates',
+  'WorkspaceTemplates',
+];
+
+const reservedNamesLower = new Set(reservedWorkflowNames.map((n) => n.toLowerCase()));
+
+export const validateWorkflowName = (name: string, intlText: any, existingWorkflows?: string[]) => {
   if (!name) {
     return intlText.EMPTY_WORKFLOW_NAME;
   }
-  if (!functionNameValidation.test(name)) {
+  if (!nameValidation.test(name)) {
     return intlText.WORKFLOW_NAME_VALIDATION_MESSAGE;
+  }
+  if (reservedNamesLower.has(name.trim().toLowerCase())) {
+    return intlText.WORKFLOW_NAME_RESERVED ?? 'This name is reserved and cannot be used as a workflow name.';
+  }
+  if (existingWorkflows?.some((w) => w.toLowerCase() === name.trim().toLowerCase())) {
+    return intlText.WORKFLOW_NAME_EXISTS ?? 'A workflow with this name already exists in the selected project.';
   }
   return undefined;
 };
@@ -57,7 +84,7 @@ export const getValidationRequirements = (flowType: string, logicAppType: string
   // Override for specific flow types that need more fields
   if (flowType === 'createWorkflow') {
     requirements.needsLogicAppType = false;
-    requirements.needsLogicAppName = false;
+    requirements.needsLogicAppName = true;
     requirements.needsWorkspaceName = false;
     requirements.needsWorkspacePath = false;
     requirements.needsWorkflowFields = true;

--- a/apps/vs-code-react/src/intl/messages.ts
+++ b/apps/vs-code-react/src/intl/messages.ts
@@ -171,6 +171,16 @@ export const workspaceMessages = defineMessages({
     id: 'V3DWT4',
     description: 'Workflow name validation message text',
   },
+  WORKFLOW_NAME_EXISTS: {
+    defaultMessage: 'A workflow with this name already exists in the selected project.',
+    id: 'aIk72V',
+    description: 'Warning message when workflow name collides with an existing workflow in the project',
+  },
+  WORKFLOW_NAME_RESERVED: {
+    defaultMessage: 'This name is reserved and cannot be used as a workflow name.',
+    id: '1Ch1Od',
+    description: 'Error message when workflow name matches a reserved project folder name',
+  },
   // Package step messages
   PACKAGE_SETUP: {
     defaultMessage: 'Package setup',

--- a/apps/vs-code-react/src/state/createWorkspaceSlice.ts
+++ b/apps/vs-code-react/src/state/createWorkspaceSlice.ts
@@ -8,6 +8,13 @@ import type { PayloadAction, SliceCaseReducers } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import type { ITargetDirectory } from '../run-service';
 
+export interface AvailableProject {
+  name: string;
+  path: string;
+  isCodeful: boolean;
+  existingWorkflows: string[];
+}
+
 export interface CreateWorkspaceState {
   currentStep: number;
   packagePath: ITargetDirectory;
@@ -28,6 +35,7 @@ export interface CreateWorkspaceState {
   isComplete: boolean;
   workspaceFileJson: any;
   logicAppsWithoutCustomCode: any | undefined;
+  existingFolders: string[];
   flowType: 'createWorkspace' | 'createWorkspaceFromPackage' | 'createLogicApp' | 'convertToWorkspace' | 'createWorkflow';
   pathValidationResults: Record<string, boolean>;
   packageValidationResults: Record<string, boolean>;
@@ -37,6 +45,7 @@ export interface CreateWorkspaceState {
   separator: string;
   platform: Platform | null;
   isDevContainerProject: boolean;
+  availableProjects: AvailableProject[];
 }
 
 const initialState: CreateWorkspaceState = {
@@ -64,6 +73,7 @@ const initialState: CreateWorkspaceState = {
   isComplete: false,
   workspaceFileJson: '',
   logicAppsWithoutCustomCode: undefined,
+  existingFolders: [],
   flowType: 'createWorkspace',
   pathValidationResults: {},
   packageValidationResults: {},
@@ -73,6 +83,7 @@ const initialState: CreateWorkspaceState = {
   separator: '/',
   platform: null,
   isDevContainerProject: false,
+  availableProjects: [],
 };
 
 export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseReducers<CreateWorkspaceState>, 'createWorkspace'>({
@@ -80,16 +91,18 @@ export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseR
   initialState,
   reducers: {
     initializeProject: (state, action: PayloadAction<any>) => {
-      const { workspaceFileJson, logicAppsWithoutCustomCode } = action.payload;
+      const { workspaceFileJson, logicAppsWithoutCustomCode, existingFolders } = action.payload;
       state.workspaceFileJson = workspaceFileJson;
       state.logicAppsWithoutCustomCode = logicAppsWithoutCustomCode;
+      state.existingFolders = existingFolders || [];
     },
     initializeWorkspace: (state, action: PayloadAction<any>) => {
-      const { separator, platform, logicAppType, logicAppName } = action.payload;
+      const { separator, platform, logicAppType, logicAppName, availableProjects } = action.payload;
       state.separator = separator;
       state.platform = platform;
       state.logicAppType = logicAppType || '';
       state.logicAppName = logicAppName || '';
+      state.availableProjects = availableProjects || [];
     },
     setCurrentStep: (state, action: PayloadAction<number>) => {
       state.currentStep = action.payload;
@@ -198,6 +211,7 @@ export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseR
       const preservedLogicAppName = preserveLogicAppData ? state.logicAppName : '';
       const preservedSeparator = preserveLogicAppData ? state.separator : '/';
       const preservedPlatform = preserveLogicAppData ? state.platform : null;
+      const preservedAvailableProjects = preserveLogicAppData ? state.availableProjects : [];
 
       Object.assign(state, initialState);
 
@@ -206,6 +220,7 @@ export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseR
         state.logicAppName = preservedLogicAppName;
         state.separator = preservedSeparator;
         state.platform = preservedPlatform;
+        state.availableProjects = preservedAvailableProjects;
       }
     },
     nextStep: (state) => {

--- a/docs/ai-setup/packages/vs-code-designer.md
+++ b/docs/ai-setup/packages/vs-code-designer.md
@@ -97,10 +97,10 @@ Run Phase 4.2 only (requires workspaces from a prior Phase 4.1 run):
 cd apps/vs-code-designer
 npx tsup --config tsup.e2e.test.config.ts
 $env:E2E_MODE = "designeronly"
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 ```
 
-Key files: `designerActions.test.ts`, `run-e2e.js`, `SKILL.md` (detailed learning document)
+Key files: `designerActions.test.ts`, `run-e2e.ts`, `SKILL.md` (detailed learning document)
 
 ## Configuration
 
@@ -177,7 +177,7 @@ Each test runs in its own fresh VS Code session to avoid workspace-switch conten
 
 11. **Only use built-in operations (Request, Response) for reliable tests**: Connector operations (Compose) may not appear if the design-time API hasn't loaded the catalog.
 
-12. **Always run tests automatically after creating or modifying them**: After writing or editing any test file, immediately: lint (`npx biome check --write`), build (`npx tsup`), and run (`node src/test/ui/run-e2e.js`) — don't wait for the user to ask. Report pass/fail results with any failure details.
+12. **Always run tests automatically after creating or modifying them**: After writing or editing any test file, immediately: lint (`npx biome check --write`), build (`npx tsup`), and run (`node out/test/run-e2e.js`) — don't wait for the user to ask. Report pass/fail results with any failure details.
 
 ### Running Tests
 
@@ -200,7 +200,7 @@ $env:E2E_MODE = "independentonly"         # 4.0 + 4.8b + 4.11 — no Phase 4.1 d
 $env:E2E_MODE = "createplusdesigner"      # 4.1 → 4.2, 4.7
 $env:E2E_MODE = "createplusnewtests"      # 4.1 → 4.3, 4.4, 4.5, 4.6
 $env:E2E_MODE = "createplusconversion"    # 4.1 → 4.8a, 4.8c, 4.8d, 4.8e
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 ```
 
 The four `createplus*` / `independentonly` modes are how `.github/workflows/vscode-e2e.yml` shards the suite across parallel runners. `full` remains the single-runner debug fallback.
@@ -238,3 +238,4 @@ Do NOT stop after pushing and tell the user "I'll wait" — proactively check an
 ## Graphify
 
 Read `apps/vs-code-designer/src/graphify-out/GRAPH_REPORT.md` for structural context (god nodes, communities, surprising connections).
+

--- a/docs/ai-setup/shared.md
+++ b/docs/ai-setup/shared.md
@@ -63,7 +63,7 @@ pnpm run vscode:designer:e2e:headless # Headless mode
 ```bash
 cd apps/vs-code-designer
 npx tsup --config tsup.e2e.test.config.ts
-node src/test/ui/run-e2e.js
+node out/test/run-e2e.js
 
 # Run specific phases via E2E_MODE env var
 E2E_MODE="createonly"    # Phase 4.1: workspace creation
@@ -81,7 +81,7 @@ Key knowledge files for E2E tests:
 - `apps/vs-code-designer/src/test/ui/SKILL.md` — Complete learning document (700+ lines)
 - `apps/vs-code-designer/src/test/ui/designerHelpers.ts` — Shared designer test helpers
 - `apps/vs-code-designer/src/test/ui/runHelpers.ts` — Shared debug/run test helpers
-- `apps/vs-code-designer/src/test/ui/run-e2e.js` — Test launcher (7 phases)
+- `apps/vs-code-designer/src/test/ui/run-e2e.ts` — Test launcher (7 phases)
 
 ### Code Quality
 ```bash
@@ -367,3 +367,4 @@ Each package has detailed guidance in `docs/ai-setup/packages/<name>.md`. Read t
 ## Squad Agents
 
 This repo uses Squad for AI agent specialization. See `.squad/README.md` for the team roster and `.squad/routing.md` for work dispatch.
+


### PR DESCRIPTION
Byte-for-byte cherry-pick of #9289 (`967b27d7`) — workflow/webview validation + E2E launcher migration. Final pick in the sequential hotfix series (9294 → 9330 → 9341 → **9289**).

- `git cherry-pick` onto the hotfix tip: **40 files, 0 graphify artifacts**.
- Conflicts in the E2E infra files (`vscode-e2e.yml`, `designerHelpers.ts`, `runHelpers.ts`) resolved to 9289's canonical version — these files are fully owned by the E2E line (9164 → 9289) with no hotfix-unique edits, so canonical = byte-for-byte fidelity.
- `package.json` intentionally keeps the hotfix's `uuid` pin (out-of-scope base-divergence, not part of #9289).

## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
**Part 2 of 2** (depends on #9330). Adds webview validation features and E2E test infrastructure for the VS Code extension.

Key features:
- **Workflow name collision detection**: Block workflow names that already exist in the selected logic app project
- **Reserved folder name validation**: Prevent workflow names like `Artifacts`, `lib`, `.vscode`, `workflow-designtime` etc. (case-insensitive)
- **Create Project folder gate**: Block project creation when folder name collides with existing workspace folders
- **resetState race condition fix**: Remove `resetState()` from `CreateLogicApp` component that was wiping `existingFolders` data
- **E2E behavior tests**: 5 new reserved workflow name tests in `createWorkspace.behavior.test.ts`
- **E2E infrastructure**: Runtime dependency hardening in `run-e2e.js`, func+gozip permission repair

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Better validation prevents accidental overwrite of reserved/existing workflow folders during creation
- **Developers**: New E2E behavior test pattern for webview validation
- **System**: No new dependencies; validation logic is client-side only

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in: VS Code on Windows, all 18 vscode-e2e CI jobs passed including `p41b-createworkspace-behavior` (14m25s)

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft
@Copilot

## Screenshots/Videos
<!-- Visual changes only -->
N/A

