### PR TITLE
fix(vscode): Fix azure connectors prompt silent fail on startup

### DIFF
--- a/apps/vs-code-designer/src/app/commands/__test__/pickFuncProcess.test.ts
+++ b/apps/vs-code-designer/src/app/commands/__test__/pickFuncProcess.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../debug/validatePreDebug', () => ({
 }));
 
 vi.mock('../../utils/appSettings/connectionKeys', () => ({
-  verifyLocalConnectionKeys: vi.fn(),
+  refreshConnectionKeys: vi.fn(),
 }));
 
 vi.mock('../../utils/azurite/activateAzurite', () => ({
@@ -83,6 +83,7 @@ import { getWorkspaceSetting } from '../../utils/vsCodeConfig/settings';
 import { tryBuildCustomCodeFunctionsProject } from '../buildCustomCodeFunctionsProject';
 import * as pickFuncProcessModule from '../pickFuncProcess';
 import { publishCodefulProject } from '../publishCodefulProject';
+import { refreshConnectionKeys } from '../../utils/appSettings/connectionKeys';
 
 let originalPlatform: NodeJS.Platform;
 let originalKill: typeof process.kill;

--- a/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
+++ b/apps/vs-code-designer/src/app/commands/parameterizeConnections.ts
@@ -18,37 +18,40 @@ import { window, workspace } from 'vscode';
 import type { ConnectionsData } from '@microsoft/vscode-extension-logic-apps';
 
 /**
- * Prompts the user to parameterize connections at project load.
+ * Parameterizes the connections in each workspace project if needed.
  * @param {IActionContext} context - The action context.
  * @param {boolean} [showMessage] - A flag indicating whether to show information message to the user.
  * @returns A promise that resolves when the operation is complete.
  */
-export async function promptParameterizeConnections(context: IActionContext, showMessage?: boolean): Promise<void> {
+export async function parameterizeConnectionsIfNeeded(context: IActionContext, showMessage?: boolean): Promise<void> {
   const parameterizeConnectionsStartTime = Date.now();
-  if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-    const message = localize('allowParameterizeConnections', 'Allow parameterization for connections when your project loads?');
-    const parameterizeConnectionsSetting = getGlobalSetting(parameterizeConnectionsInProjectLoadSetting);
-    let shouldParameterizeConnections = false;
-    if (parameterizeConnectionsSetting === null || parameterizeConnectionsSetting === undefined) {
-      const result = await window.showInformationMessage(message, DialogResponses.yes, DialogResponses.no, DialogResponses.dontWarnAgain);
-      if (result === DialogResponses.yes) {
-        await updateGlobalSetting(parameterizeConnectionsInProjectLoadSetting, true);
-        shouldParameterizeConnections = true;
-        context.telemetry.properties.parameterizeConnectionsInProjectLoadSetting = 'true';
-      } else if (result === DialogResponses.dontWarnAgain) {
-        await updateGlobalSetting(parameterizeConnectionsInProjectLoadSetting, false);
-        context.telemetry.properties.parameterizeConnectionsInProjectLoadSetting = 'false';
-      }
-    } else if (parameterizeConnectionsSetting) {
-      shouldParameterizeConnections = true;
-    }
-
-    if (shouldParameterizeConnections) {
-      const projectPaths = await getWorkspaceLogicAppFolders();
-      await Promise.all(projectPaths.map((projectPath) => parameterizeConnections(context, projectPath, showMessage)));
-    }
+  if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0 && (await shouldParameterizeConnections(context))) {
+    const projectPaths = await getWorkspaceLogicAppFolders();
+    await Promise.all(projectPaths.map((projectPath) => parameterizeConnections(context, projectPath, showMessage)));
   }
   context.telemetry.measurements.parameterizeConnectionsDuration = (Date.now() - parameterizeConnectionsStartTime) / 1000;
+}
+
+async function shouldParameterizeConnections(context: IActionContext): Promise<boolean> {
+  const message = localize('allowParameterizeConnections', 'Allow parameterization for connections when your project loads?');
+  const parameterizeConnectionsSetting = getGlobalSetting(parameterizeConnectionsInProjectLoadSetting);
+  if (parameterizeConnectionsSetting) {
+    return true;
+  }
+  
+  const result = await window.showInformationMessage(message, DialogResponses.yes, DialogResponses.no, DialogResponses.dontWarnAgain);
+  if (result === DialogResponses.yes) {
+    await updateGlobalSetting(parameterizeConnectionsInProjectLoadSetting, true);
+    context.telemetry.properties.parameterizeConnectionsInProjectLoadSetting = 'true';
+    return true;
+  }
+
+  if (result === DialogResponses.dontWarnAgain) {
+    await updateGlobalSetting(parameterizeConnectionsInProjectLoadSetting, false);
+    context.telemetry.properties.parameterizeConnectionsInProjectLoadSetting = 'false';
+  }
+
+  return false;
 }
 
 /**

--- a/apps/vs-code-designer/src/app/commands/pickFuncProcess.ts
+++ b/apps/vs-code-designer/src/app/commands/pickFuncProcess.ts
@@ -12,7 +12,7 @@ import {
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { getMatchingWorkspaceFolder, preDebugValidate } from '../debug/validatePreDebug';
-import { verifyLocalConnectionKeys } from '../utils/appSettings/connectionKeys';
+import { refreshConnectionKeys } from '../utils/appSettings/connectionKeys';
 import { activateAzurite } from '../utils/azurite/activateAzurite';
 import { getFuncPortFromTaskOrProject, isFuncHostTask, runningFuncTaskMap } from '../utils/funcCoreTools/funcHostTask';
 import type { IRunningFuncTask } from '../utils/funcCoreTools/funcHostTask';
@@ -80,7 +80,7 @@ export async function pickFuncProcessInternal(
 
   await callWithTelemetryAndErrorHandling(verifyConnectionKeysSetting, async (actionContext: IActionContext) => {
     await runWithDurationTelemetry(actionContext, verifyConnectionKeysSetting, async () => {
-      await verifyLocalConnectionKeys(context, projectPath);
+      await refreshConnectionKeys(context, projectPath);
     });
   });
 

--- a/apps/vs-code-designer/src/app/utils/appSettings/__test__/connectionKeys.test.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/__test__/connectionKeys.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
-import { verifyLocalConnectionKeys } from '../connectionKeys';
+import { refreshConnectionKeys } from '../connectionKeys';
 import * as vscode from 'vscode';
 import * as workspace from '../../workspace';
 import * as verifyIsProject from '../../verifyIsProject';
@@ -33,7 +33,7 @@ vi.mock('@microsoft/logic-apps-shared', () => ({
   isEmptyString: (value: string) => value === '',
 }));
 
-describe('verifyLocalConnectionKeys', () => {
+describe('refreshConnectionKeys', () => {
   let testContext: any;
   const testLogicAppName1 = 'LogicApp1';
   const testLogicAppName2 = 'LogicApp2';
@@ -67,14 +67,14 @@ describe('verifyLocalConnectionKeys', () => {
   it('should do nothing when no workspace folders exist', async () => {
     const getConnectionsJsonSpy = vi.spyOn(connection, 'getConnectionsJson');
     (vscode.workspace as any).workspaceFolders = undefined;
-    await verifyLocalConnectionKeys(testContext, testLogicAppProjectPath1);
+    await refreshConnectionKeys(testContext, testLogicAppProjectPath1);
     expect(getConnectionsJsonSpy).not.toHaveBeenCalled();
   });
 
   it('should log message when connectionsJson is empty', async () => {
     vi.spyOn(connection, 'getConnectionsJson').mockResolvedValue('');
-    await verifyLocalConnectionKeys(testContext, testLogicAppProjectPath1);
-    expect(ext.outputChannel.appendLog).toHaveBeenCalledWith(localize('noConnectionKeysFound', 'No connection keys found to verify'));
+    await refreshConnectionKeys(testContext, testLogicAppProjectPath1);
+    expect(ext.outputChannel.appendLog).toHaveBeenCalledWith(localize('noConnectionKeysFound', 'No connection keys found.'));
   });
 
   it('should save connection references when connections exist', async () => {
@@ -95,7 +95,7 @@ describe('verifyLocalConnectionKeys', () => {
     vi.spyOn(connection, 'getConnectionsAndSettingsToUpdate').mockResolvedValue(connectionsAndSettingsToUpdate);
     vi.spyOn(connection, 'saveConnectionReferences').mockResolvedValue(undefined);
 
-    await verifyLocalConnectionKeys(testContext, testLogicAppProjectPath1);
+    await refreshConnectionKeys(testContext, testLogicAppProjectPath1);
 
     expect(connection.getConnectionsAndSettingsToUpdate).toHaveBeenCalledWith(
       testContext,
@@ -114,58 +114,18 @@ describe('verifyLocalConnectionKeys', () => {
       .spyOn(connection, 'getConnectionsJson')
       .mockResolvedValue(JSON.stringify({ managedApiConnections: { conn1: {} } }));
 
-    await verifyLocalConnectionKeys(testContext, testLogicAppProjectPath1);
+    await refreshConnectionKeys(testContext, testLogicAppProjectPath1);
 
     expect(getConnectionsJsonSpy).not.toHaveBeenCalled();
-    expect(ext.outputChannel.appendLog).toHaveBeenCalledWith('Azure connectors are disabled. Skipping connection key verification.');
-  });
-
-  it('should save connection references for the user-selected project', async () => {
-    vi.spyOn(workspace, 'getWorkspaceFolder').mockResolvedValue(testWorkspaceFolders[0].uri.fsPath);
-    vi.spyOn(verifyIsProject, 'tryGetLogicAppProjectRoot').mockResolvedValue(testWorkspaceFolders[0].uri.fsPath);
-
-    const sampleConnections = { managedApiConnections: { conn1: {} } };
-    vi.spyOn(connection, 'getConnectionsJson').mockResolvedValue(JSON.stringify(sampleConnections));
-
-    const azureDetails = {
-      enabled: true,
-      tenantId: '4bb01b15-004c-4b95-9568-5165b5f89c41',
-      workflowManagementBaseUrl: 'https://management.azure.com/',
-    };
-    vi.spyOn(common, 'getAzureConnectorDetailsForLocalProject').mockResolvedValue(azureDetails);
-
-    const parametersData = { param: { type: 'string', value: 'test' } };
-    vi.spyOn(parameter, 'getParametersJson').mockResolvedValue(parametersData);
-
-    const connectionsAndSettingsToUpdate = { connections: {}, settings: {} };
-    vi.spyOn(connection, 'getConnectionsAndSettingsToUpdate').mockResolvedValue(connectionsAndSettingsToUpdate);
-    vi.spyOn(connection, 'saveConnectionReferences').mockResolvedValue(undefined);
-
-    await verifyLocalConnectionKeys(testContext);
-
-    expect(connection.getConnectionsJson).toHaveBeenCalledTimes(1);
-    expect(connection.getConnectionsAndSettingsToUpdate).toHaveBeenCalledTimes(1);
-    expect(connection.saveConnectionReferences).toHaveBeenCalledTimes(1);
-  });
-
-  it('should return without saving connection references when project path is undefined after user selection', async () => {
-    vi.spyOn(workspace, 'getWorkspaceFolder').mockResolvedValue(undefined);
-    vi.spyOn(verifyIsProject, 'tryGetLogicAppProjectRoot').mockResolvedValue(undefined);
-    const getAzureConnectorDetailsSpy = vi
-      .spyOn(common, 'getAzureConnectorDetailsForLocalProject')
-      .mockResolvedValue({} as AzureConnectorDetails);
-
-    await verifyLocalConnectionKeys(testContext);
-
-    expect(common.getAzureConnectorDetailsForLocalProject).not.toHaveBeenCalled();
+    expect(ext.outputChannel.appendLog).toHaveBeenCalledWith('Azure connectors are disabled. Skipping connection key refresh.');
   });
 
   it('should throw error when an error occurs during verification', async () => {
     const error = new Error('Test error');
     vi.spyOn(connection, 'getConnectionsJson').mockRejectedValue(error);
 
-    await expect(verifyLocalConnectionKeys(testContext, testLogicAppProjectPath1)).rejects.toThrow(
-      'Error while verifying existing managed api connections: Test error'
+    await expect(refreshConnectionKeys(testContext, testLogicAppProjectPath1)).rejects.toThrow(
+      'Error while refreshing existing managed api connections: Test error'
     );
 
     expect(ext.outputChannel.appendLog).toHaveBeenCalled();

--- a/apps/vs-code-designer/src/app/utils/appSettings/connectionKeys.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/connectionKeys.ts
@@ -9,9 +9,9 @@ import type { ConnectionsData } from '@microsoft/vscode-extension-logic-apps';
 import { getConnectionsAndSettingsToUpdate, getConnectionsJson, saveConnectionReferences } from '../codeless/connection';
 
 /**
- * Refreshes the connection keys for the specified Logic App project, or all workspace projects by default.
+ * Refreshes the connection keys for the specified Logic App project.
  * @param {IActionContext} context - The action context.
- * @param {string} projectPath - The path to the Logic App project. If not provided, all Logic App projects in the workspace will be verified.
+ * @param {string} projectPath - The path to the Logic App project.
  * @returns {Promise<void>} A promise that resolves when the refresh is complete.
  */
 export async function refreshConnectionKeys(context: IActionContext, projectPath: string): Promise<void> {

--- a/apps/vs-code-designer/src/app/utils/appSettings/connectionKeys.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/connectionKeys.ts
@@ -1,6 +1,5 @@
 import { isEmptyString } from '@microsoft/logic-apps-shared';
 import { localize } from '../../../localize';
-import { getWorkspaceFolder } from '../workspace';
 import { getAzureConnectorDetailsForLocalProject } from '../codeless/common';
 import { getParametersJson } from '../codeless/parameter';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -8,29 +7,20 @@ import { workspace } from 'vscode';
 import { ext } from '../../../extensionVariables';
 import type { ConnectionsData } from '@microsoft/vscode-extension-logic-apps';
 import { getConnectionsAndSettingsToUpdate, getConnectionsJson, saveConnectionReferences } from '../codeless/connection';
-import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
 
 /**
- * Verifies the local connection keys for the specified Logic App project, or all Logic App projects in the workspace by default.
- * @param {IActionContext} context - The command context.
+ * Refreshes the connection keys for the specified Logic App project, or all workspace projects by default.
+ * @param {IActionContext} context - The action context.
  * @param {string} projectPath - The path to the Logic App project. If not provided, all Logic App projects in the workspace will be verified.
- * @returns {Promise<void>} A promise that resolves when the verification is complete.
+ * @returns {Promise<void>} A promise that resolves when the refresh is complete.
  */
-export async function verifyLocalConnectionKeys(context: IActionContext, projectPath?: string): Promise<void> {
-  const verifyConnectionKeysStartTime = Date.now();
+export async function refreshConnectionKeys(context: IActionContext, projectPath: string): Promise<void> {
+  const refreshConnectionKeysStartTime = Date.now();
   if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-    if (!projectPath) {
-      const workspaceFolder = await getWorkspaceFolder(context, undefined, true);
-      projectPath = await tryGetLogicAppProjectRoot(context, workspaceFolder, true);
-      if (!projectPath) {
-        return;
-      }
-    }
-
-    const azureDetails = await getAzureConnectorDetailsForLocalProject(context, projectPath);
-    if (!azureDetails.enabled) {
+    const azureConnectorDetails = await getAzureConnectorDetailsForLocalProject(context, projectPath);
+    if (!azureConnectorDetails.enabled) {
       ext.outputChannel.appendLog(
-        localize('azureConnectorsDisabled', 'Azure connectors are disabled. Skipping connection key verification.')
+        localize('azureConnectorsDisabled', 'Azure connectors are disabled. Skipping connection key refresh.')
       );
       return;
     }
@@ -38,20 +28,19 @@ export async function verifyLocalConnectionKeys(context: IActionContext, project
     try {
       const connectionsJson = await getConnectionsJson(projectPath);
       if (isEmptyString(connectionsJson)) {
-        ext.outputChannel.appendLog(localize('noConnectionKeysFound', 'No connection keys found to verify'));
+        ext.outputChannel.appendLog(localize('noConnectionKeysFound', 'No connection keys found.'));
         return;
       }
-      const connectionsData: ConnectionsData = JSON.parse(connectionsJson);
+      const connections: ConnectionsData = JSON.parse(connectionsJson);
       const parametersData = await getParametersJson(projectPath);
-      const managedApiConnectionReferences = connectionsData.managedApiConnections;
 
-      if (connectionsData.managedApiConnections && !(Object.keys(managedApiConnectionReferences).length === 0)) {
+      if (connections.managedApiConnections && (Object.keys(connections.managedApiConnections!).length !== 0)) {
         const connectionsAndSettingsToUpdate = await getConnectionsAndSettingsToUpdate(
           context,
           projectPath,
-          managedApiConnectionReferences,
-          azureDetails.tenantId,
-          azureDetails.workflowManagementBaseUrl,
+          connections.managedApiConnections,
+          azureConnectorDetails.tenantId!,
+          azureConnectorDetails.workflowManagementBaseUrl!,
           parametersData
         );
 
@@ -59,14 +48,14 @@ export async function verifyLocalConnectionKeys(context: IActionContext, project
       }
     } catch (error) {
       const errorMessage = localize(
-        'errorVerifyingConnectionKeys',
-        'Error while verifying existing managed api connections: {0}',
-        error.message ?? error
+        'errorRefreshingConnectionKeys',
+        'Error while refreshing existing managed api connections: {0}',
+        (error as Error).message ?? error
       );
       ext.outputChannel.appendLog(errorMessage);
       context.telemetry.properties.error = errorMessage;
       throw new Error(errorMessage);
     }
   }
-  context.telemetry.measurements.verifyConnectionKeysDuration = (Date.now() - verifyConnectionKeysStartTime) / 1000;
+  context.telemetry.measurements.refreshConnectionKeysDuration = (Date.now() - refreshConnectionKeysStartTime) / 1000;
 }

--- a/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
@@ -99,12 +99,13 @@ export async function getLocalSettingsJson(
     if (/[^\s]/.test(data)) {
       try {
         const localSettings = parseJson(data) as ILocalSettingsJson;
+        localSettings.Values = localSettings.Values || {};
         const decryptedlocalSettings = await getDecryptedLocalSettings(context, localSettings, localSettingsUri, localSettingsPath);
         decryptedlocalSettings.Values ??= {};
 
         if (isDesignTime) {
-          decryptedlocalSettings.Values[azureWebJobsSecretStorageTypeKey] = azureStorageTypeSetting;
-          delete decryptedlocalSettings.Values[azureWebJobsStorageKey];
+          decryptedlocalSettings.Values![azureWebJobsSecretStorageTypeKey] = azureStorageTypeSetting;
+          delete decryptedlocalSettings.Values![azureWebJobsStorageKey];
         }
         return decryptedlocalSettings;
       } catch (error) {
@@ -200,7 +201,6 @@ export const getLocalSettingsSchema = (isDesignTime: boolean, projectPath?: stri
     baseSettings.Values![functionsInprocNet8Enabled] = functionsInprocNet8EnabledTrue;
   }
 
-  // Add codeful-specific settings
   if (isCodeful) {
     baseSettings.Values![workflowCodefulEnabledKey] = 'true';
   }

--- a/apps/vs-code-designer/src/app/utils/codeless/common.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/common.ts
@@ -233,14 +233,14 @@ export async function getAzureConnectorDetailsForLocalProject(
   const localSettingsFilePath = path.join(projectPath, localSettingsFileName);
   const connectorsContext = context as IAzureConnectorsContext;
   const localSettings = await getLocalSettingsJson(context, localSettingsFilePath);
-  let tenantId = localSettings.Values[workflowTenantIdKey];
-  let subscriptionId = localSettings.Values[workflowSubscriptionIdKey];
-  let resourceGroupName = localSettings.Values[workflowResourceGroupNameKey];
-  let location = localSettings.Values[workflowLocationKey];
+  let tenantId = localSettings.Values![workflowTenantIdKey];
+  let subscriptionId = localSettings.Values![workflowSubscriptionIdKey];
+  let resourceGroupName = localSettings.Values![workflowResourceGroupNameKey];
+  let location = localSettings.Values![workflowLocationKey];
   let accessToken = undefined;
   let clientId = undefined;
   // Set default for customers who created Logic Apps before sovereign cloud support was added.
-  let workflowManagementBaseUrl = localSettings.Values[workflowManagementBaseURIKey] ?? `${azurePublicBaseUrl}/`;
+  let workflowManagementBaseUrl = localSettings.Values![workflowManagementBaseURIKey] ?? `${azurePublicBaseUrl}/`;
 
   if (subscriptionId === undefined) {
     const wizard = createAzureWizard(connectorsContext, projectPath);

--- a/apps/vs-code-designer/src/app/utils/debug.ts
+++ b/apps/vs-code-designer/src/app/utils/debug.ts
@@ -72,7 +72,7 @@ export const logicAppDebugConfigProvider: DebugConfigurationProvider = {
     }
     return undefined;
   },
-}
+};
 
 export async function getDebugSymbolDll(): Promise<string> {
   const bundleFolderRoot = await getExtensionBundleFolder();

--- a/apps/vs-code-designer/src/app/utils/debug.ts
+++ b/apps/vs-code-designer/src/app/utils/debug.ts
@@ -3,11 +3,76 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { FuncVersion, ProjectType, TargetFramework } from '@microsoft/vscode-extension-logic-apps';
-import type { DebugConfiguration } from 'vscode';
+import type { DebugConfiguration, DebugConfigurationProvider } from 'vscode';
 import { debugSymbolDll, extensionBundleId, extensionCommand } from '../../constants';
-
+import * as vscode from 'vscode';
 import * as path from 'path';
 import { getBundleVersionNumber, getExtensionBundleFolder } from './bundleFeed';
+import { ext } from '../../extensionVariables';
+import { localize } from '../../localize';
+
+export const logicAppDebugConfigProvider: DebugConfigurationProvider = {
+  resolveDebugConfiguration: async (folder, debugConfig) => {
+    const logDebugAttach = (message: string) => {
+      ext.outputChannel?.appendLog(message);
+    };
+
+    if (!debugConfig.funcRuntime) {
+      debugConfig.funcRuntime = 'coreclr';
+    }
+
+    const maxRetries = 3;
+    const delayMs = 5000;
+    const debugConfigName = debugConfig.name ?? folder?.name ?? 'logic app';
+    logDebugAttach(
+      localize(
+        'resolveDebugConfigurationStart',
+        'Resolving logic app debug configuration "{0}" for workspace "{1}". funcRuntime={2}, customCodeRuntime={3}.',
+        debugConfigName,
+        folder?.uri.fsPath ?? 'unknown workspace',
+        debugConfig.funcRuntime,
+        debugConfig.customCodeRuntime ?? 'none'
+      )
+    );
+
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        await vscode.commands.executeCommand(extensionCommand.debugLogicApp, debugConfig, folder);
+        logDebugAttach(
+          localize(
+            'resolveDebugConfigurationSucceeded',
+            'Logic app debug configuration "{0}" resolved on attempt {1}/{2}.',
+            debugConfigName,
+            i + 1,
+            maxRetries
+          )
+        );
+        break;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logDebugAttach(
+          localize(
+            'resolveDebugConfigurationFailed',
+            'Logic app debug configuration "{0}" failed on attempt {1}/{2}. Error: {3}',
+            debugConfigName,
+            i + 1,
+            maxRetries,
+            errorMessage
+          )
+        );
+        if (i === maxRetries - 1) {
+          throw error;
+        }
+
+        logDebugAttach(
+          localize('resolveDebugConfigurationRetry', 'Retrying logic app debug configuration "{0}" in {1} ms.', debugConfigName, delayMs)
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    return undefined;
+  },
+}
 
 export async function getDebugSymbolDll(): Promise<string> {
   const bundleFolderRoot = await getExtensionBundleFolder();

--- a/apps/vs-code-designer/src/app/utils/startRuntimeApi.ts
+++ b/apps/vs-code-designer/src/app/utils/startRuntimeApi.ts
@@ -5,7 +5,7 @@
 import { callWithTelemetryAndErrorHandling, type IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { runWithDurationTelemetry } from './telemetry';
 import { activateAzurite } from './azurite/activateAzurite';
-import { verifyLocalConnectionKeys } from './appSettings/connectionKeys';
+import { refreshConnectionKeys } from './appSettings/connectionKeys';
 import { autoStartAzuriteSetting, designerApiLoadTimeout, designerStartApi, verifyConnectionKeysSetting } from '../../constants';
 import { getContainingWorkspace } from './workspace';
 import { preDebugValidate } from '../debug/validatePreDebug';
@@ -34,7 +34,7 @@ export async function startRuntimeApi(projectPath: string): Promise<void> {
 
     await callWithTelemetryAndErrorHandling(verifyConnectionKeysSetting, async (actionContext: IActionContext) => {
       await runWithDurationTelemetry(actionContext, verifyConnectionKeysSetting, async () => {
-        await verifyLocalConnectionKeys(context, projectPath);
+        await refreshConnectionKeys(context, projectPath);
       });
     });
 

--- a/apps/vs-code-designer/src/extensionVariables.ts
+++ b/apps/vs-code-designer/src/extensionVariables.ts
@@ -46,7 +46,6 @@ type FuncInstance = {
 // biome-ignore lint/style/noNamespace:
 export namespace ext {
   export let context: ExtensionContext;
-  export let codefulEnabled: boolean;
   export const designTimeInstances: Map<string, FuncInstance> = new Map();
   export const runtimeInstances: Map<string, FuncInstance> = new Map();
   export let workflowDotNetProcess: cp.ChildProcess | undefined;

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -1,6 +1,6 @@
 import './nodeUtilCompatibility';
 import { LogicAppResolver } from './LogicAppResolver';
-import { promptParameterizeConnections } from './app/commands/parameterizeConnections';
+import { parameterizeConnectionsIfNeeded } from './app/commands/parameterizeConnections';
 import { registerCommands } from './app/commands/registerCommands';
 import { getResourceGroupsApi } from './app/resourcesExtension/getExtensionApi';
 import type { AzureAccountTreeItemWithProjects } from './app/tree/AzureAccountTreeItemWithProjects';
@@ -13,10 +13,8 @@ import { shouldRequireStrictDependencyValidation } from './app/utils/strictDepen
 import { verifyVSCodeConfigOnActivate } from './app/utils/vsCodeConfig/verifyVSCodeConfigOnActivate';
 import { extensionCommand, logicAppFilter } from './constants';
 import { ext } from './extensionVariables';
-import { localize } from './localize';
 import { startOnboarding } from './onboarding';
 import { registerAppServiceExtensionVariables } from '@microsoft/vscode-azext-azureappservice';
-import { verifyLocalConnectionKeys } from './app/utils/appSettings/connectionKeys';
 import {
   callWithTelemetryAndErrorHandling,
   createAzExtOutputChannel,
@@ -35,6 +33,7 @@ import { getAzExtResourceType, getAzureResourcesExtensionApi } from '@microsoft/
 import { startLanguageServer } from './app/languageServer/languageServer';
 import { runPostExtractStepsFromCache } from './app/utils/cloudToLocalUtils';
 import { codefulProjectsExist } from './app/utils/codeful';
+import { logicAppDebugConfigProvider } from './app/utils/debug';
 
 const perfStats = {
   loadStartTime: Date.now(),
@@ -52,73 +51,9 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(workspaceWatcher);
 
-  vscode.debug.registerDebugConfigurationProvider('logicapp', {
-    resolveDebugConfiguration: async (folder, debugConfig) => {
-      const logDebugAttach = (message: string) => {
-        if (ext.outputChannel) {
-          ext.outputChannel.appendLog(message);
-        }
-      };
-
-      if (!debugConfig.funcRuntime) {
-        debugConfig.funcRuntime = 'coreclr';
-      }
-
-      const maxRetries = 3;
-      const delayMs = 5000;
-      const debugConfigName = debugConfig.name ?? folder?.name ?? 'logic app';
-      logDebugAttach(
-        localize(
-          'resolveDebugConfigurationStart',
-          'Resolving logic app debug configuration "{0}" for workspace "{1}". funcRuntime={2}, customCodeRuntime={3}.',
-          debugConfigName,
-          folder?.uri.fsPath ?? 'unknown workspace',
-          debugConfig.funcRuntime,
-          debugConfig.customCodeRuntime ?? 'none'
-        )
-      );
-
-      for (let i = 0; i < maxRetries; i++) {
-        try {
-          await vscode.commands.executeCommand(extensionCommand.debugLogicApp, debugConfig, folder);
-          logDebugAttach(
-            localize(
-              'resolveDebugConfigurationSucceeded',
-              'Logic app debug configuration "{0}" resolved on attempt {1}/{2}.',
-              debugConfigName,
-              i + 1,
-              maxRetries
-            )
-          );
-          break;
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          logDebugAttach(
-            localize(
-              'resolveDebugConfigurationFailed',
-              'Logic app debug configuration "{0}" failed on attempt {1}/{2}. Error: {3}',
-              debugConfigName,
-              i + 1,
-              maxRetries,
-              errorMessage
-            )
-          );
-          if (i === maxRetries - 1) {
-            throw error;
-          }
-
-          logDebugAttach(
-            localize('resolveDebugConfigurationRetry', 'Retrying logic app debug configuration "{0}" in {1} ms.', debugConfigName, delayMs)
-          );
-        }
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-      }
-      return undefined;
-    },
-  });
+  vscode.debug.registerDebugConfigurationProvider('logicapp', logicAppDebugConfigProvider);
 
   ext.context = context;
-  ext.codefulEnabled = false; // flag that prevents codeful use until public preview
   ext.extensionVersion = getExtensionVersion();
   ext.telemetryReporter = new TelemetryReporter(telemetryString);
   context.subscriptions.push(ext.telemetryReporter);
@@ -161,8 +96,7 @@ export async function activate(context: vscode.ExtensionContext) {
         );
       });
     }
-    promptParameterizeConnections(activateContext, false);
-    verifyLocalConnectionKeys(activateContext);
+    parameterizeConnectionsIfNeeded(activateContext, false);
     await startOnboarding(activateContext);
 
     const hasCodefulProjects = await codefulProjectsExist();

--- a/apps/vs-code-react/src/app/designer/appV2.tsx
+++ b/apps/vs-code-react/src/app/designer/appV2.tsx
@@ -27,7 +27,6 @@ import { commonMessages, useIntlMessages } from '../../intl';
 import { useAppStyles } from './appStyles';
 import { DesignerViewType } from './constants';
 import CodeViewEditor from './CodeViewEditor';
-import { workflowCodefulEnabledKey } from '../../../../vs-code-designer/src/constants';
 
 export const DesignerApp = () => {
   const vscode = useContext(VSCodeContext);
@@ -62,7 +61,7 @@ export const DesignerApp = () => {
   const [initialWorkflow, setInitialWorkflow] = useState<StandardApp | undefined>(panelMetaData?.standardApp);
   const [workflow, setWorkflow] = useState<StandardApp | undefined>(panelMetaData?.standardApp);
   const [customCode, setCustomCode] = useState<Record<string, string> | undefined>(panelMetaData?.customCodeData);
-  const isCodefulWorkflow = panelMetaData?.localSettings?.[workflowCodefulEnabledKey] === 'true';
+  const isCodefulWorkflow = panelMetaData?.localSettings?.WORKFLOW_CODEFUL_ENABLED === 'true';
 
   const [designerID, setDesignerID] = useState(guid());
   const [workflowDefinitionId, setWorkflowDefinitionId] = useState<string>(guid());


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
When refreshing connection keys on startup, if azure connectors configuration doesn't exist in local settings then user is prompted with the azureConnectorWizard. This ultimately results in azureConnectorWizard silently failing after 'Use connectors from Azure' is selected since connection keys refresh is unawaited on startup. This is confusing to the user who then has to restart connectors setup when opening designer or running workflow.

As a solution, removed connections key refresh from startup entirely- it is now only done prior to starting runtime, so there is no longer an azureConnectorWizard prompt on startup.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes connectors wizard silently failing on startup after selecting 'Use connectors from Azure'. User will now be prompted only when opening designer or running workflow instead
- **Developers**: Refactored connectionKeys and other startup code, removed old tests
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge
