### PR TITLE
feat(vscode): Add "Don't show again" for designer version notifications

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/__test__/openDesignerBase.test.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/__test__/openDesignerBase.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as vscode from 'vscode';
-import { designerVersionSetting, defaultDesignerVersion } from '../../../../../constants';
+import { designerVersionSetting, defaultDesignerVersion, suppressDesignerVersionNotification } from '../../../../../constants';
 import { ext } from '../../../../../extensionVariables';
 
 // Mock dependencies before importing the class
@@ -74,11 +74,17 @@ describe('OpenDesignerBase', () => {
     get: vi.fn(),
     update: vi.fn().mockResolvedValue(undefined),
   };
+  const mockGlobalState = {
+    get: vi.fn().mockReturnValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+  };
   let designer: TestDesigner;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetConfiguration.mockReturnValue(mockConfig as any);
+    mockGlobalState.get.mockReturnValue(undefined);
+    ext.context = { globalState: mockGlobalState } as any;
     designer = new TestDesigner();
   });
 
@@ -120,7 +126,11 @@ describe('OpenDesignerBase', () => {
 
       await designer.testShowDesignerVersionNotification();
 
-      expect(mockShowInformationMessage).toHaveBeenCalledWith('A new Logic Apps experience is available for preview!', 'Enable preview');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith(
+        'A new Logic Apps experience is available for preview!',
+        'Enable preview',
+        "Don't show again"
+      );
     });
 
     it('should show previewing message when version is 2', async () => {
@@ -132,7 +142,8 @@ describe('OpenDesignerBase', () => {
 
       expect(mockShowInformationMessage).toHaveBeenCalledWith(
         'You are previewing the new Logic Apps experience.',
-        'Go back to previous version'
+        'Go back to previous version',
+        "Don't show again"
       );
     });
 
@@ -175,6 +186,36 @@ describe('OpenDesignerBase', () => {
       await designer.testShowDesignerVersionNotification();
 
       expect(mockDispose).toHaveBeenCalled();
+    });
+
+    it("should suppress notification and update setting when Don't show again is clicked on v1", async () => {
+      mockConfig.get.mockReturnValue(1);
+      mockShowInformationMessage.mockResolvedValueOnce("Don't show again" as any);
+      designer.setTestPanel({ dispose: vi.fn() });
+
+      await designer.testShowDesignerVersionNotification();
+
+      expect(mockGlobalState.update).toHaveBeenCalledWith(suppressDesignerVersionNotification, true);
+    });
+
+    it("should suppress notification and update setting when Don't show again is clicked on v2", async () => {
+      mockConfig.get.mockReturnValue(2);
+      mockShowInformationMessage.mockResolvedValueOnce("Don't show again" as any);
+      designer.setTestPanel({ dispose: vi.fn() });
+
+      await designer.testShowDesignerVersionNotification();
+
+      expect(mockGlobalState.update).toHaveBeenCalledWith(suppressDesignerVersionNotification, true);
+    });
+
+    it('should not show notification when suppressed', async () => {
+      mockConfig.get.mockReturnValue(2);
+      mockGlobalState.get.mockReturnValue(true);
+      designer.setTestPanel({ dispose: vi.fn() });
+
+      await designer.testShowDesignerVersionNotification();
+
+      expect(mockShowInformationMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/__test__/openDesignerForAzureResource.test.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/__test__/openDesignerForAzureResource.test.ts
@@ -104,7 +104,11 @@ describe('OpenDesignerForAzureResource', () => {
         iconPath: undefined,
       };
       vi.mocked(vscode.window as any).createWebviewPanel = vi.fn().mockReturnValue(mockPanel);
-      ext.context = { extensionPath: '/test', subscriptions: [] } as any;
+      ext.context = {
+        extensionPath: '/test',
+        subscriptions: [],
+        globalState: { get: vi.fn().mockReturnValue(undefined), update: vi.fn().mockResolvedValue(undefined) },
+      } as any;
 
       const mockShowInfo = vi.mocked(vscode.window.showInformationMessage);
       const mockGetConfig = vi.mocked(vscode.workspace.getConfiguration);
@@ -117,7 +121,11 @@ describe('OpenDesignerForAzureResource', () => {
 
       expect(cacheWebviewPanel).toHaveBeenCalled();
       // showDesignerVersionNotification was called (shows v1 message)
-      expect(mockShowInfo).toHaveBeenCalledWith('A new Logic Apps experience is available for preview!', 'Enable preview');
+      expect(mockShowInfo).toHaveBeenCalledWith(
+        'A new Logic Apps experience is available for preview!',
+        'Enable preview',
+        "Don't show again"
+      );
     });
   });
 });

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/__test__/openDesignerForLocalProject.test.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/__test__/openDesignerForLocalProject.test.ts
@@ -143,7 +143,11 @@ describe('OpenDesignerForLocalProject', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     ext.designTimeInstances.clear();
-    (ext as any).context = { extensionPath: '/extension', subscriptions: [] };
+    (ext as any).context = {
+      extensionPath: '/extension',
+      subscriptions: [],
+      globalState: { get: vi.fn().mockReturnValue(undefined), update: vi.fn().mockResolvedValue(undefined) },
+    };
     (ext as any).telemetryReporter = { sendTelemetryEvent: vi.fn() };
     (ext as any).extensionVersion = '1.0.0';
     (ext as any).workflowRuntimePort = 8080;

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
@@ -8,7 +8,7 @@ import type { IAzureConnectorsContext } from '../azureConnectorWizard';
 import { getRecordEntry, isEmptyString, resolveConnectionsReferences } from '@microsoft/logic-apps-shared';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { Artifacts, AzureConnectorDetails, ConnectionsData, FileDetails, Parameter } from '@microsoft/vscode-extension-logic-apps';
-import { azurePublicBaseUrl, workflowManagementBaseURIKey, designerVersionSetting, defaultDesignerVersion } from '../../../../constants';
+import { azurePublicBaseUrl, workflowManagementBaseURIKey, designerVersionSetting, defaultDesignerVersion, suppressDesignerVersionNotification } from '../../../../constants';
 import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
 import type { WebviewPanel, WebviewOptions, WebviewPanelOptions } from 'vscode';
@@ -191,13 +191,21 @@ export abstract class OpenDesignerBase {
   protected async showDesignerVersionNotification(): Promise<void> {
     const currentVersion = this.getDesignerVersion();
     const config = workspace.getConfiguration(ext.prefix);
+    const isSuppressed = ext.context.globalState.get<boolean>(suppressDesignerVersionNotification) === true;
+
+    if (isSuppressed) {
+      return;
+    }
 
     if (currentVersion === 1) {
       const enablePreview = localize('enablePreview', 'Enable preview');
+      const dontShowAgain = localize('dontShowAgain', "Don't show again");
       const message = localize('previewAvailable', 'A new Logic Apps experience is available for preview!');
 
-      const selection = await window.showInformationMessage(message, enablePreview);
-      if (selection === enablePreview) {
+      const selection = await window.showInformationMessage(message, enablePreview, dontShowAgain);
+      if (selection === dontShowAgain) {
+        await ext.context.globalState.update(suppressDesignerVersionNotification, true);
+      } else if (selection === enablePreview) {
         await config.update(designerVersionSetting, 2, ConfigurationTarget.Global);
         const closeButton = localize('close', 'Close');
         const reopenMessage = localize(
@@ -211,9 +219,10 @@ export abstract class OpenDesignerBase {
       }
     } else {
       const goBack = localize('goBack', 'Go back to previous version');
+      const dontShowAgain = localize('dontShowAgain', "Don't show again");
       const message = localize('previewingNew', 'You are previewing the new Logic Apps experience.');
 
-      const selection = await window.showInformationMessage(message, goBack);
+      const selection = await window.showInformationMessage(message, goBack, dontShowAgain);
       if (selection === goBack) {
         await config.update(designerVersionSetting, 1, ConfigurationTarget.Global);
         const closeButton = localize('close', 'Close');
@@ -222,6 +231,8 @@ export abstract class OpenDesignerBase {
         if (reopenSelection === closeButton) {
           this.panel?.dispose();
         }
+      } else if (selection === dontShowAgain) {
+        await ext.context.globalState.update(suppressDesignerVersionNotification, true);
       }
     }
   }

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerBase.ts
@@ -189,51 +189,59 @@ export abstract class OpenDesignerBase {
   }
 
   protected async showDesignerVersionNotification(): Promise<void> {
-    const currentVersion = this.getDesignerVersion();
-    const config = workspace.getConfiguration(ext.prefix);
     const isSuppressed = ext.context.globalState.get<boolean>(suppressDesignerVersionNotification) === true;
-
     if (isSuppressed) {
       return;
     }
 
+    const currentVersion = this.getDesignerVersion();
     if (currentVersion === 1) {
-      const enablePreview = localize('enablePreview', 'Enable preview');
-      const dontShowAgain = localize('dontShowAgain', "Don't show again");
-      const message = localize('previewAvailable', 'A new Logic Apps experience is available for preview!');
-
-      const selection = await window.showInformationMessage(message, enablePreview, dontShowAgain);
-      if (selection === dontShowAgain) {
-        await ext.context.globalState.update(suppressDesignerVersionNotification, true);
-      } else if (selection === enablePreview) {
-        await config.update(designerVersionSetting, 2, ConfigurationTarget.Global);
-        const closeButton = localize('close', 'Close');
-        const reopenMessage = localize(
-          'closeToApply',
-          'Setting updated. Please close and reopen the workflow to apply the new experience.'
-        );
-        const reopenSelection = await window.showInformationMessage(reopenMessage, closeButton);
-        if (reopenSelection === closeButton) {
-          this.panel?.dispose();
-        }
-      }
+      await this.showUpgradeDesignerNotification();
     } else {
-      const goBack = localize('goBack', 'Go back to previous version');
-      const dontShowAgain = localize('dontShowAgain', "Don't show again");
-      const message = localize('previewingNew', 'You are previewing the new Logic Apps experience.');
+      await this.showDowngradeDesignerNotification();
+    }
+  }
 
-      const selection = await window.showInformationMessage(message, goBack, dontShowAgain);
-      if (selection === goBack) {
-        await config.update(designerVersionSetting, 1, ConfigurationTarget.Global);
-        const closeButton = localize('close', 'Close');
-        const reopenMessage = localize('closeToApply', 'Setting updated. Please close and reopen the workflow to apply the change.');
-        const reopenSelection = await window.showInformationMessage(reopenMessage, closeButton);
-        if (reopenSelection === closeButton) {
-          this.panel?.dispose();
-        }
-      } else if (selection === dontShowAgain) {
-        await ext.context.globalState.update(suppressDesignerVersionNotification, true);
+  private async showUpgradeDesignerNotification(): Promise<void> {
+    const config = workspace.getConfiguration(ext.prefix);
+    const enablePreview = localize('enablePreview', 'Enable preview');
+    const dontShowAgain = localize('dontShowAgain', "Don't show again");
+    const message = localize('previewAvailable', 'A new Logic Apps experience is available for preview!');
+
+    const selection = await window.showInformationMessage(message, enablePreview, dontShowAgain);
+    if (selection === dontShowAgain) {
+      await ext.context.globalState.update(suppressDesignerVersionNotification, true);
+    } else if (selection === enablePreview) {
+      await config.update(designerVersionSetting, 2, ConfigurationTarget.Global);
+      const closeButton = localize('close', 'Close');
+      const reopenMessage = localize(
+        'closeToApply',
+        'Setting updated. Please close and reopen the workflow to apply the new experience.'
+      );
+      const reopenSelection = await window.showInformationMessage(reopenMessage, closeButton);
+      if (reopenSelection === closeButton) {
+        this.panel?.dispose();
       }
+    }
+  }
+
+  private async showDowngradeDesignerNotification(): Promise<void> {
+    const config = workspace.getConfiguration(ext.prefix);
+    const goBack = localize('goBack', 'Go back to previous version');
+    const dontShowAgain = localize('dontShowAgain', "Don't show again");
+    const message = localize('previewingNew', 'You are previewing the new Logic Apps experience.');
+
+    const selection = await window.showInformationMessage(message, goBack, dontShowAgain);
+    if (selection === goBack) {
+      await config.update(designerVersionSetting, 1, ConfigurationTarget.Global);
+      const closeButton = localize('close', 'Close');
+      const reopenMessage = localize('closeToApply', 'Setting updated. Please close and reopen the workflow to apply the change.');
+      const reopenSelection = await window.showInformationMessage(reopenMessage, closeButton);
+      if (reopenSelection === closeButton) {
+        this.panel?.dispose();
+      }
+    } else if (selection === dontShowAgain) {
+      await ext.context.globalState.update(suppressDesignerVersionNotification, true);
     }
   }
 }

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForAzureResource.ts
@@ -75,7 +75,6 @@ export class OpenDesignerForAzureResource extends OpenDesignerBase {
     cacheWebviewPanel(this.panelGroupKey, this.panelName, this.panel);
     ext.context.subscriptions.push(this.panel);
 
-    // Show notification about designer version
     this.showDesignerVersionNotification();
   }
 

--- a/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/openDesigner/openDesignerForLocalProject.ts
@@ -194,7 +194,6 @@ export default class OpenDesignerForLocalProject extends OpenDesignerBase {
     cacheWebviewPanel(this.panelGroupKey, this.panelName, this.panel);
     ext.context.subscriptions.push(this.panel);
 
-    // Show notification about designer version
     this.showDesignerVersionNotification();
   }
 

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -228,6 +228,9 @@ export type customExtensionContext = (typeof customExtensionContext)[keyof typeo
 // Context
 export const contextValuePrefix = 'azLogicApps';
 
+// Global state
+export const suppressDesignerVersionNotification = 'suppressDesignerVersionNotification';
+
 // API
 export const defaultRoutePrefix = 'api';
 export const timeoutKey = 'requestTimeout';


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Quality of life improvement, "Don't show again" option will prevent designer version notification (switch from v1->v2 or v2->v1) from showing each time designer is opened.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Adds option to suppress designer version notifications whenever designer is opened
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge

