### PR TITLE
fix(vscode): Disable MSI option in connector setup

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/__test__/authenticationMethodStep.test.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/__test__/authenticationMethodStep.test.ts
@@ -52,10 +52,19 @@ describe('AuthenticationMethodSelectionStep', () => {
     expect(context.authenticationMethod).toBe('rawKeys');
   });
 
-  it('does not prompt when Azure connectors are disabled', () => {
-    context.enabled = false;
+  it('defaults to rawKeys without prompting when MSI is disabled', () => {
+    context.enabled = true;
 
     expect(new AuthenticationMethodSelectionStep().shouldPrompt(context)).toBe(false);
+    expect(context.authenticationMethod).toBe('rawKeys');
+  });
+
+  it('does not override an already-set authentication method', () => {
+    context.enabled = true;
+    context.authenticationMethod = 'managedServiceIdentity';
+
+    expect(new AuthenticationMethodSelectionStep().shouldPrompt(context)).toBe(false);
+    expect(context.authenticationMethod).toBe('managedServiceIdentity');
   });
 
   it('rethrows non-cancellation errors', async () => {

--- a/apps/vs-code-designer/src/app/commands/workflows/authenticationMethodStep.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/authenticationMethodStep.ts
@@ -70,8 +70,13 @@ export class AuthenticationMethodSelectionStep<
 
   /**
    * Determines if this step should prompt again (only if no method is selected yet).
+   *
+   * TODO: MSI option is temporarily disabled until functions extension fix deployed — always default to rawKeys.
    */
   public shouldPrompt(context: T): boolean {
-    return context.enabled === true && context.authenticationMethod === undefined;
+    if (context.enabled === true && context.authenticationMethod === undefined) {
+      context.authenticationMethod = 'rawKeys';
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Disabling MSI option in azureConnectorWizard setup until #8684 is resolved to support MSI connections in local authoring

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Removes auth type step from azureConnectorWizard flow, now defaults to connection key auth
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge

