### PR TITLE
fix(designer): Route Standard built-in MCP through manifest path + v2 save-flow reliability (#9346) [hotfix/v5.970]

### DIFF
--- a/__mocks__/workflows/AgentWithMcp.json
+++ b/__mocks__/workflows/AgentWithMcp.json
@@ -31,9 +31,8 @@
             "type": "McpClientTool",
             "kind": "BuiltIn",
             "inputs": {
-              "Connection": {
-                "Authentication": "None",
-                "McpServerUrl": "https://mcp.time.mcpcentral.io/"
+              "connectionReference": {
+                "connectionName": "mcpclient"
               }
             }
           },
@@ -65,6 +64,12 @@
       }
     }
   },
-  "connectionReferences": {},
+  "connections": {
+    "mcpclient": {
+      "connection": { "id": "/connectionProviders/mcpclient/connections/mcpclient" },
+      "connectionName": "mcpclient",
+      "api": { "id": "connectionProviders/mcpclient" }
+    }
+  },
   "parameters": {}
 }

--- a/__mocks__/workflows/AgentWithMcpConsumption.json
+++ b/__mocks__/workflows/AgentWithMcpConsumption.json
@@ -1,0 +1,66 @@
+{
+  "definition": {
+    "metadata": {
+      "agentType": "autonomous"
+    },
+    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+    "contentVersion": "1.0.0.0",
+    "triggers": {
+      "When_a_HTTP_request_is_received": {
+        "type": "Request",
+        "kind": "Http"
+      }
+    },
+    "actions": {
+      "WorkflowAgent": {
+        "type": "Agent",
+        "inputs": {
+          "parameters": {
+            "messages": [
+              {
+                "role": "system",
+                "content": "You are a helpful assistant that can use an MCP server."
+              }
+            ],
+            "agentModelType": "AzureOpenAI",
+            "agentModelSettings": {
+              "agentHistoryReductionSettings": {
+                "agentHistoryReductionType": "maximumTokenCountReduction",
+                "maximumTokenCount": 128000
+              }
+            }
+          }
+        },
+        "tools": {
+          "BuiltIn_MCP_Server": {
+            "type": "McpClientTool",
+            "kind": "BuiltIn",
+            "inputs": {
+              "Connection": {
+                "McpServerUrl": "https://mcp.time.mcpcentral.io/",
+                "Authentication": "None"
+              }
+            }
+          }
+        },
+        "runAfter": {},
+        "limit": {
+          "count": 100
+        }
+      }
+    },
+    "outputs": {},
+    "parameters": {
+      "$connections": {
+        "type": "Object",
+        "defaultValue": {}
+      }
+    }
+  },
+  "parameters": {
+    "$connections": {
+      "type": "Object",
+      "value": {}
+    }
+  }
+}

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesigner.tsx
@@ -292,7 +292,6 @@ const DesignerEditor = () => {
     };
     const newServiceProviderConnections: Record<string, any> = {};
     const newAgentConnections: Record<string, any> = {};
-    const newAgentMcpConnections: Record<string, any> = {};
 
     const referenceKeys = Object.keys(connectionReferences ?? {});
     if (referenceKeys.length) {
@@ -326,11 +325,6 @@ const DesignerEditor = () => {
             // We need to move the data out to a new object, delete the old data, then apply the new data at the end
             newAgentConnections[referenceKey] = connectionsData?.agentConnections?.[connectionKey];
             delete connectionsData?.agentConnections?.[connectionKey];
-          } else if (reference?.connection?.id.startsWith('/connectionProviders/mcpclient/')) {
-            // MCP Connection
-            const connectionKey = reference.connection.id.split('/').splice(-1)[0];
-            newAgentMcpConnections[referenceKey] = connectionsData?.agentMcpConnections?.[connectionKey];
-            delete connectionsData?.agentMcpConnections?.[connectionKey];
           } else if (reference?.connection?.id.startsWith('/serviceProviders/')) {
             // Service Provider Connection
             const connectionKey = reference.connection.id.split('/').splice(-1)[0];
@@ -345,10 +339,6 @@ const DesignerEditor = () => {
       (connectionsData as ConnectionsData).serviceProviderConnections = {
         ...connectionsData?.serviceProviderConnections,
         ...newServiceProviderConnections,
-      };
-      (connectionsData as ConnectionsData).agentMcpConnections = {
-        ...connectionsData?.agentMcpConnections,
-        ...newAgentMcpConnections,
       };
       (connectionsData as ConnectionsData).agentConnections = {
         ...connectionsData?.agentConnections,

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/laDesignerV2.tsx
@@ -98,6 +98,24 @@ import { FloatingRunButton } from '../../../../../../libs/designer-v2/src/lib/ui
 const apiVersion = '2020-06-01';
 const httpClient = new HttpClient();
 
+// Merge server data with local mutations; local wins per category so in-flight new connections
+// survive re-sync when the workflow-artifacts fetch resolves.
+const mergeConnectionsData = (fromServer: ConnectionsData, local: ConnectionsData | undefined): ConnectionsData => {
+  if (!local) {
+    return fromServer;
+  }
+  return {
+    ...fromServer,
+    ...local,
+    managedApiConnections: { ...(fromServer?.managedApiConnections ?? {}), ...(local?.managedApiConnections ?? {}) },
+    serviceProviderConnections: { ...(fromServer?.serviceProviderConnections ?? {}), ...(local?.serviceProviderConnections ?? {}) },
+    functionConnections: { ...(fromServer?.functionConnections ?? {}), ...(local?.functionConnections ?? {}) },
+    apiManagementConnections: { ...(fromServer?.apiManagementConnections ?? {}), ...(local?.apiManagementConnections ?? {}) },
+    agentConnections: { ...(fromServer?.agentConnections ?? {}), ...(local?.agentConnections ?? {}) },
+    agentMcpConnections: { ...(fromServer?.agentMcpConnections ?? {}), ...(local?.agentMcpConnections ?? {}) },
+  };
+};
+
 const DesignerEditor = () => {
   const { id: workflowId } = useSelector((state: RootState) => ({
     id: state.workflowLoader.resourcePath!,
@@ -185,11 +203,21 @@ const DesignerEditor = () => {
     setCurrentParameters(parameters ?? {});
   }, [parameters]);
   const queryClient = getReactQueryClient();
-  const connectionsData = useMemo(
-    () =>
-      resolveConnectionsReferences(JSON.stringify(clone(originalConnectionsData ?? {})), currentParameters, settingsData?.properties ?? {}),
-    [originalConnectionsData, currentParameters, settingsData?.properties]
+  // State + merge (not useMemo) so in-place mutations from addConnectionDataInternal survive the
+  // initial workflow-artifacts fetch. Pure useMemo would clone fresh server data on fetch complete.
+  const [connectionsData, setConnectionsData] = useState<ConnectionsData>(() =>
+    resolveConnectionsReferences(JSON.stringify(clone(originalConnectionsData ?? {})), currentParameters, settingsData?.properties ?? {})
   );
+  useEffect(() => {
+    setConnectionsData((prev) => {
+      const fromServer = resolveConnectionsReferences(
+        JSON.stringify(clone(originalConnectionsData ?? {})),
+        currentParameters,
+        settingsData?.properties ?? {}
+      );
+      return mergeConnectionsData(fromServer, prev);
+    });
+  }, [originalConnectionsData, currentParameters, settingsData?.properties]);
   const connectionReferences = WorkflowUtility.convertConnectionsDataToReferences(connectionsData);
   const { data: runInstanceData } = useRun(runId);
 
@@ -389,7 +417,6 @@ const DesignerEditor = () => {
       };
       const newServiceProviderConnections: Record<string, any> = {};
       const newAgentConnections: Record<string, any> = {};
-      const newAgentMcpConnections: Record<string, any> = {};
 
       const referenceKeys = Object.keys(connectionReferences ?? {});
       if (referenceKeys.length) {
@@ -423,11 +450,6 @@ const DesignerEditor = () => {
               // We need to move the data out to a new object, delete the old data, then apply the new data at the end
               newAgentConnections[referenceKey] = connectionsData?.agentConnections?.[connectionKey];
               delete connectionsData?.agentConnections?.[connectionKey];
-            } else if (reference?.connection?.id.startsWith('/connectionProviders/mcpclient/')) {
-              // MCP Connection
-              const connectionKey = reference.connection.id.split('/').splice(-1)[0];
-              newAgentMcpConnections[referenceKey] = connectionsData?.agentMcpConnections?.[connectionKey];
-              delete connectionsData?.agentMcpConnections?.[connectionKey];
             } else if (reference?.connection?.id.startsWith('/serviceProviders/')) {
               // Service Provider Connection
               const connectionKey = reference.connection.id.split('/').splice(-1)[0];
@@ -442,10 +464,6 @@ const DesignerEditor = () => {
         (connectionsData as ConnectionsData).serviceProviderConnections = {
           ...connectionsData?.serviceProviderConnections,
           ...newServiceProviderConnections,
-        };
-        (connectionsData as ConnectionsData).agentMcpConnections = {
-          ...connectionsData?.agentMcpConnections,
-          ...newAgentMcpConnections,
         };
         (connectionsData as ConnectionsData).agentConnections = {
           ...connectionsData?.agentConnections,
@@ -504,10 +522,6 @@ const DesignerEditor = () => {
         isDraftSave
       );
 
-      // Invalidate cached workflow artifacts so the next load fetches fresh data
-      // (including any new connection references added during this session)
-      getReactQueryClient().invalidateQueries(['workflowArtifactsStandard', workflowId]);
-
       return workflowToSave;
     },
     [
@@ -521,7 +535,6 @@ const DesignerEditor = () => {
       settingsData?.properties,
       siteResourceId,
       workflow,
-      workflowId,
       workflowName,
     ]
   );

--- a/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
@@ -24,6 +24,8 @@ const fileOptions = [
   { key: 'Agent.json', text: 'Simple Agent' },
   { key: 'AgentWithChannels.json', text: 'Agent with Channels' },
   { key: 'AgentWithMcp.json', text: 'Agent with MCP Tools' },
+  { key: 'AgentWithMcpUami.json', text: 'Agent with MCP UAMI' },
+  { key: 'AgentWithMcpConsumption.json', text: 'Agent with MCP Tools (Consumption)' },
 
   // A2A
   { key: 'divider_A2A', text: '-', itemType: DropdownMenuItemType.Divider },

--- a/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
+++ b/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
@@ -244,7 +244,7 @@ export const workflowLoadingSlice = createSlice({
       state.connections = action.payload?.connectionReferences ?? {};
       state.parameters = action.payload?.parameters ?? {};
       state.runFiles = action.payload?.runFiles ?? [];
-      state.workflowKind = action.payload?.workflowKind ?? 'stateful';
+      state.workflowKind = action.payload?.workflowKind ?? (state.hostingPlan === 'consumption' ? undefined : 'stateful');
     });
     builder.addCase(loadWorkflow.rejected, (state) => {
       state.workflowDefinition = null;

--- a/e2e/designer/mcpSerialization.spec.ts
+++ b/e2e/designer/mcpSerialization.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { GoToMockWorkflow } from './utils/GoToWorkflow';
-import { getSerializedWorkflowFromState } from './utils/designerFunctions';
+import {
+  getConnectionReferencesFromState,
+  getSerializedWorkflowFromState,
+  getSerializedWorkflowFromStateV2,
+} from './utils/designerFunctions';
 
 test.describe(
   'MCP Serialization Tests',
@@ -33,21 +37,25 @@ test.describe(
       expect(agent.tools.Regular_Tool.actions).toBeDefined();
       expect(agent.tools.Regular_Tool.actions.Compose).toBeDefined();
 
-      // Built-in MCP tool should be serialized with Connection block
+      // Standard emits connectionReference; inline Connection is Consumption-only.
       expect(agent.tools.BuiltIn_MCP_Server).toBeDefined();
       expect(agent.tools.BuiltIn_MCP_Server.type).toBe('McpClientTool');
       expect(agent.tools.BuiltIn_MCP_Server.kind).toBe('BuiltIn');
       expect(agent.tools.BuiltIn_MCP_Server.inputs).toBeDefined();
-      expect(agent.tools.BuiltIn_MCP_Server.inputs.Connection).toBeDefined();
-      expect(agent.tools.BuiltIn_MCP_Server.inputs.Connection.McpServerUrl).toBe('https://mcp.time.mcpcentral.io/');
-      expect(agent.tools.BuiltIn_MCP_Server.inputs.Connection.Authentication).toBe('None');
+      expect(agent.tools.BuiltIn_MCP_Server.inputs.connectionReference).toBeDefined();
+      expect(agent.tools.BuiltIn_MCP_Server.inputs.connectionReference.connectionName).toBe('mcpclient');
+      expect(agent.tools.BuiltIn_MCP_Server.inputs.Connection).toBeUndefined();
 
-      // Managed MCP tool should be serialized with connectionReference
+      // Managed MCP tool should be serialized with connectionReference AND preserve its parameters
+      // (mcpServerPath) — serializeManagedMcpOperation injects the swagger path into inputs.parameters.
       expect(agent.tools.Managed_MCP_Server).toBeDefined();
       expect(agent.tools.Managed_MCP_Server.type).toBe('McpClientTool');
       expect(agent.tools.Managed_MCP_Server.kind).toBe('Managed');
       expect(agent.tools.Managed_MCP_Server.inputs).toBeDefined();
       expect(agent.tools.Managed_MCP_Server.inputs.connectionReference).toBeDefined();
+      expect(agent.tools.Managed_MCP_Server.inputs.connectionReference.connectionName).toBe('office365');
+      expect(agent.tools.Managed_MCP_Server.inputs.parameters).toBeDefined();
+      expect(agent.tools.Managed_MCP_Server.inputs.parameters.mcpServerPath).toBe('/mcp/contacts');
     });
 
     test('Should not include built-in MCP connections in connectionReferences', async ({ page }) => {
@@ -78,6 +86,88 @@ test.describe(
       expect(toolKeys).toContain('BuiltIn_MCP_Server');
       expect(toolKeys).toContain('Managed_MCP_Server');
       expect(toolKeys.length).toBe(3);
+    });
+
+    test('Should preserve inline Connection shape for built-in MCP tool on Consumption', async ({ page }) => {
+      await page.goto('/');
+
+      // Toggle Plan to Consumption to route through serializeConsumptionBuiltInMcpOperation.
+      await page.getByRole('radio', { name: 'Consumption' }).click({ force: true });
+
+      await GoToMockWorkflow(page, 'Agent with MCP Tools (Consumption)');
+
+      const serialized: any = await getSerializedWorkflowFromState(page);
+      const tool = serialized.definition.actions.WorkflowAgent.tools.BuiltIn_MCP_Server;
+
+      expect(tool).toBeDefined();
+      expect(tool.type).toBe('McpClientTool');
+      expect(tool.kind).toBe('BuiltIn');
+      expect(tool.inputs).toBeDefined();
+      // Consumption preserves inline Connection; Standard's connectionReference shape must not appear.
+      expect(tool.inputs.Connection).toBeDefined();
+      expect(tool.inputs.Connection.McpServerUrl).toBe('https://mcp.time.mcpcentral.io/');
+      expect(tool.inputs.Connection.Authentication).toBe('None');
+      expect(tool.inputs.connectionReference).toBeUndefined();
+    });
+
+    test('Should serialize Standard built-in MCP as connectionReference on designer-v2', async ({ page }) => {
+      // Mirrors the v1 shape assertion on the v2 designer to catch divergence between the two
+      // packages' serializers — both must emit `inputs.connectionReference.connectionName` on Standard.
+      await page.goto('/v2');
+
+      await GoToMockWorkflow(page, 'Agent with MCP Tools');
+
+      const serialized: any = await getSerializedWorkflowFromStateV2(page);
+      const tool = serialized.definition.actions.WorkflowAgent.tools.BuiltIn_MCP_Server;
+
+      expect(tool).toBeDefined();
+      expect(tool.type).toBe('McpClientTool');
+      expect(tool.kind).toBe('BuiltIn');
+      expect(tool.inputs?.connectionReference?.connectionName).toBe('mcpclient');
+      expect(tool.inputs?.Connection).toBeUndefined();
+    });
+
+    test('Should preserve inline Connection shape for built-in MCP tool on Consumption (designer-v2)', async ({ page }) => {
+      // Mirrors the v1 Consumption test on the v2 designer so a regression on
+      // serializeConsumptionBuiltInMcpOperation in the v2 package is caught.
+      await page.goto('/v2');
+
+      await page.getByRole('radio', { name: 'Consumption' }).click({ force: true });
+
+      await GoToMockWorkflow(page, 'Agent with MCP Tools (Consumption)');
+
+      const serialized: any = await getSerializedWorkflowFromStateV2(page);
+      const tool = serialized.definition.actions.WorkflowAgent.tools.BuiltIn_MCP_Server;
+
+      expect(tool).toBeDefined();
+      expect(tool.type).toBe('McpClientTool');
+      expect(tool.kind).toBe('BuiltIn');
+      expect(tool.inputs?.Connection?.McpServerUrl).toBe('https://mcp.time.mcpcentral.io/');
+      expect(tool.inputs?.Connection?.Authentication).toBe('None');
+      expect(tool.inputs?.connectionReference).toBeUndefined();
+    });
+
+    test('Should surface UAMI identity on a managed MCP connection loaded from $connections.value', async ({ page }) => {
+      // The connectionReferences rebuild from $connections.value lives in the designer-v2 deserializer.
+      await page.goto('/v2');
+
+      await GoToMockWorkflow(page, 'Agent with MCP UAMI');
+
+      // Consumption workflows store connections in parameters.$connections.value. The deserializer
+      // rebuilds connectionReferences from that, preserving connectionProperties so the UAMI surfaces on load.
+      await page.waitForFunction(() => {
+        const state = (window as any).DesignerStoreV2?.getState?.();
+        return !!state?.connections?.connectionReferences?.mcp;
+      });
+
+      const references: any = await getConnectionReferencesFromState(page);
+
+      const mcpRef = references?.mcp;
+      expect(mcpRef).toBeDefined();
+      expect(mcpRef.connectionProperties?.authentication?.type).toBe('ManagedServiceIdentity');
+      expect(mcpRef.connectionProperties?.authentication?.identity).toBe(
+        '/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-uami'
+      );
     });
   }
 );

--- a/e2e/designer/utils/designerFunctions.ts
+++ b/e2e/designer/utils/designerFunctions.ts
@@ -6,3 +6,17 @@ export const getSerializedWorkflowFromState = (page: Page) => {
     return await (window as any).DesignerModule.serializeBJSWorkflow(state);
   });
 };
+
+export const getSerializedWorkflowFromStateV2 = (page: Page) => {
+  return page.evaluate(async () => {
+    const state = (window as any).DesignerStoreV2.getState();
+    return await (window as any).DesignerModuleV2.serializeBJSWorkflow(state);
+  });
+};
+
+export const getConnectionReferencesFromState = (page: Page) => {
+  return page.evaluate(() => {
+    const state = (window as any).DesignerStoreV2.getState();
+    return state.connections.connectionReferences;
+  });
+};

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/resolveMcpConnectionName.spec.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/resolveMcpConnectionName.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMcpConnectionName } from '../serializer';
+
+// Locks in the defense against Redux's `changeConnectionMapping` minting a fresh referenceKey that
+// doesn't match `connections.agentMcpConnections`. `serializeHost`'s McpConnection case must emit
+// the connection.id's last segment when a reference is present, and fall back to the referenceKey
+// otherwise. See PR description: "Defense in `serializeHost`'s `McpConnection` case".
+describe('resolveMcpConnectionName', () => {
+  it('uses the connection.id last segment when it is present', () => {
+    // Redux minted `mcpclient-9`, but the actual connection.id points at `mcpclient-8` — emit the latter.
+    expect(resolveMcpConnectionName('mcpclient-9', '/connectionProviders/mcpclient/connections/mcpclient-8')).toBe('mcpclient-8');
+  });
+
+  it('returns the referenceKey when they agree (happy path, no divergence)', () => {
+    expect(resolveMcpConnectionName('mcpclient', '/connectionProviders/mcpclient/connections/mcpclient')).toBe('mcpclient');
+  });
+
+  it('falls back to the referenceKey when connectionId is undefined', () => {
+    expect(resolveMcpConnectionName('mcpclient-9', undefined)).toBe('mcpclient-9');
+  });
+
+  it('falls back to the referenceKey when connectionId is empty', () => {
+    expect(resolveMcpConnectionName('mcpclient-9', '')).toBe('mcpclient-9');
+  });
+
+  it('handles a trailing-slash connection.id by falling back to referenceKey', () => {
+    // `.split('/').pop()` on `.../mcpclient-8/` returns '' which is falsy, so we fall back.
+    expect(resolveMcpConnectionName('mcpclient-9', '/connectionProviders/mcpclient/connections/mcpclient-8/')).toBe('mcpclient-9');
+  });
+
+  it('supports connection.id without a leading slash', () => {
+    expect(resolveMcpConnectionName('mcpclient-9', 'connectionProviders/mcpclient/connections/mcpclient-8')).toBe('mcpclient-8');
+  });
+});

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -308,12 +308,14 @@ export const serializeOperation = async (
 
   let serializedOperation: LogicAppsV2.OperationDefinition;
   const isManagedMcpClient = isManagedMcpOperation(operation);
-  const isBuiltInMcpClient = isBuiltInMcpOperation(operation);
+  // Consumption-only: inline `inputs.Connection` (PR #8953). Standard has workflowKind set and
+  // falls through to the manifest branch, which emits `inputs.connectionReference.connectionName`.
+  const isConsumptionBuiltInMcpClient = isBuiltInMcpOperation(operation) && !rootState.workflow.workflowKind;
 
   if (isManagedMcpClient) {
     serializedOperation = await serializeManagedMcpOperation(rootState, operationId);
-  } else if (isBuiltInMcpClient) {
-    serializedOperation = await serializeBuiltInMcpOperation(rootState, operationId);
+  } else if (isConsumptionBuiltInMcpClient) {
+    serializedOperation = await serializeConsumptionBuiltInMcpOperation(rootState, operationId);
   } else if (OperationManifestService().isSupported(operation.type, operation.kind)) {
     serializedOperation = await serializeManifestBasedOperation(rootState, operationId);
   } else {
@@ -554,7 +556,9 @@ const serializeManagedMcpOperation = async (rootState: RootState, nodeId: string
   };
 };
 
-const serializeBuiltInMcpOperation = async (rootState: RootState, nodeId: string): Promise<LogicAppsV2.OperationDefinition> => {
+// Consumption has no `agentMcpConnections` category, so the tool must inline
+// `inputs.Connection.{McpServerUrl,Authentication}`. Standard is routed via the manifest path.
+const serializeConsumptionBuiltInMcpOperation = async (rootState: RootState, nodeId: string): Promise<LogicAppsV2.OperationDefinition> => {
   const operationInfo = getRecordEntry(rootState.operations.operationInfo, nodeId) as NodeOperation;
   if (!operationInfo) {
     throw new AssertionException(AssertionErrorCode.OPERATION_NOT_FOUND, `Operation with id ${nodeId} not found`);
@@ -1022,6 +1026,13 @@ interface McpConnectionInfo {
   };
 }
 
+// Resolve the authoritative `agentMcpConnections` key from a Redux reference. Prefers connection.id's
+// last segment (which by construction matches the connections.json key) and falls back to the raw
+// referenceKey when the id is missing or produces an empty segment (e.g. trailing slash). Exported
+// for unit tests.
+export const resolveMcpConnectionName = (referenceKey: string, connectionId: string | undefined): string =>
+  connectionId?.split('/').pop() || referenceKey;
+
 const serializeHost = (
   nodeId: string,
   manifest: OperationManifest,
@@ -1101,12 +1112,14 @@ const serializeHost = (
           },
         },
       };
-    case ConnectionReferenceKeyFormat.McpConnection:
+    case ConnectionReferenceKeyFormat.McpConnection: {
+      const reference = getRecordEntry(rootState.connections.connectionReferences, referenceKey);
       return {
         connectionReference: {
-          connectionName: referenceKey,
+          connectionName: resolveMcpConnectionName(referenceKey, reference?.connection?.id),
         },
       };
+    }
     default:
       throw new AssertionException(
         AssertionErrorCode.UNSUPPORTED_MANIFEST_CONNECTION_REFERENCE_FORMAT,

--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/resolveMcpConnectionName.spec.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/resolveMcpConnectionName.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMcpConnectionName } from '../serializer';
+
+// Locks in the defense against Redux's `changeConnectionMapping` minting a fresh referenceKey that
+// doesn't match `connections.agentMcpConnections`. `serializeHost`'s McpConnection case must emit
+// the connection.id's last segment when a reference is present, and fall back to the referenceKey
+// otherwise. See PR description: "Defense in `serializeHost`'s `McpConnection` case".
+describe('resolveMcpConnectionName', () => {
+  it('uses the connection.id last segment when it is present', () => {
+    // Redux minted `mcpclient-9`, but the actual connection.id points at `mcpclient-8` — emit the latter.
+    expect(resolveMcpConnectionName('mcpclient-9', '/connectionProviders/mcpclient/connections/mcpclient-8')).toBe('mcpclient-8');
+  });
+
+  it('returns the referenceKey when they agree (happy path, no divergence)', () => {
+    expect(resolveMcpConnectionName('mcpclient', '/connectionProviders/mcpclient/connections/mcpclient')).toBe('mcpclient');
+  });
+
+  it('falls back to the referenceKey when connectionId is undefined', () => {
+    expect(resolveMcpConnectionName('mcpclient-9', undefined)).toBe('mcpclient-9');
+  });
+
+  it('falls back to the referenceKey when connectionId is empty', () => {
+    expect(resolveMcpConnectionName('mcpclient-9', '')).toBe('mcpclient-9');
+  });
+
+  it('handles a trailing-slash connection.id by falling back to referenceKey', () => {
+    // `.split('/').pop()` on `.../mcpclient-8/` returns '' which is falsy, so we fall back.
+    expect(resolveMcpConnectionName('mcpclient-9', '/connectionProviders/mcpclient/connections/mcpclient-8/')).toBe('mcpclient-9');
+  });
+
+  it('supports connection.id without a leading slash', () => {
+    expect(resolveMcpConnectionName('mcpclient-9', 'connectionProviders/mcpclient/connections/mcpclient-8')).toBe('mcpclient-8');
+  });
+});

--- a/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/serializer.ts
@@ -304,12 +304,14 @@ export const serializeOperation = async (
 
   let serializedOperation: LogicAppsV2.OperationDefinition;
   const isManagedMcpClient = isManagedMcpOperation(operation);
-  const isBuiltInMcpClient = isBuiltInMcpOperation(operation);
+  // Consumption-only: inline `inputs.Connection` (PR #8953). Standard has workflowKind set and
+  // falls through to the manifest branch, which emits `inputs.connectionReference.connectionName`.
+  const isConsumptionBuiltInMcpClient = isBuiltInMcpOperation(operation) && !rootState.workflow.workflowKind;
 
   if (isManagedMcpClient) {
     serializedOperation = await serializeManagedMcpOperation(rootState, operationId);
-  } else if (isBuiltInMcpClient) {
-    serializedOperation = await serializeBuiltInMcpOperation(rootState, operationId);
+  } else if (isConsumptionBuiltInMcpClient) {
+    serializedOperation = await serializeConsumptionBuiltInMcpOperation(rootState, operationId);
   } else if (OperationManifestService().isSupported(operation.type, operation.kind)) {
     serializedOperation = await serializeManifestBasedOperation(rootState, operationId);
   } else {
@@ -532,7 +534,9 @@ const serializeManagedMcpOperation = async (rootState: RootState, nodeId: string
   };
 };
 
-const serializeBuiltInMcpOperation = async (rootState: RootState, nodeId: string): Promise<LogicAppsV2.OperationDefinition> => {
+// Consumption has no `agentMcpConnections` category, so the tool must inline
+// `inputs.Connection.{McpServerUrl,Authentication}`. Standard is routed via the manifest path.
+const serializeConsumptionBuiltInMcpOperation = async (rootState: RootState, nodeId: string): Promise<LogicAppsV2.OperationDefinition> => {
   const operationInfo = getRecordEntry(rootState.operations.operationInfo, nodeId) as NodeOperation;
   if (!operationInfo) {
     throw new AssertionException(AssertionErrorCode.OPERATION_NOT_FOUND, `Operation with id ${nodeId} not found`);
@@ -986,6 +990,13 @@ interface McpConnectionInfo {
   };
 }
 
+// Resolve the authoritative `agentMcpConnections` key from a Redux reference. Prefers connection.id's
+// last segment (which by construction matches the connections.json key) and falls back to the raw
+// referenceKey when the id is missing or produces an empty segment (e.g. trailing slash). Exported
+// for unit tests.
+export const resolveMcpConnectionName = (referenceKey: string, connectionId: string | undefined): string =>
+  connectionId?.split('/').pop() || referenceKey;
+
 const serializeHost = (
   nodeId: string,
   manifest: OperationManifest,
@@ -1065,12 +1076,14 @@ const serializeHost = (
           },
         },
       };
-    case ConnectionReferenceKeyFormat.McpConnection:
+    case ConnectionReferenceKeyFormat.McpConnection: {
+      const reference = getRecordEntry(rootState.connections.connectionReferences, referenceKey);
       return {
         connectionReference: {
-          connectionName: referenceKey,
+          connectionName: resolveMcpConnectionName(referenceKey, reference?.connection?.id),
         },
       };
+    }
     default:
       throw new AssertionException(
         AssertionErrorCode.UNSUPPORTED_MANIFEST_CONNECTION_REFERENCE_FORMAT,


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] test - Test-related changes

## Risk Level
- [x] Medium - Moderate changes, some user impact

## Summary
- Cherry-pick of #9346 (commit de7ecd56) from `main` into `hotfix/v5.970`
- Routes Standard built-in MCP tools through the manifest serializer path (emitting `inputs.connectionReference.connectionName`) instead of the Consumption-only inline `Connection` shape
- Adds `resolveMcpConnectionName` defense in `serializeHost` for divergent referenceKey vs connection.id
- Fixes v2 Standalone save-flow races (`connectionsData` promoted to state with merge semantics, post-save `invalidateQueries` removed)
- Adds unit tests for `resolveMcpConnectionName` and E2E tests for Standard/Consumption MCP serialization on both v1 and v2

## Test plan
- [ ] Unit tests pass (`pnpm run test:lib`)
- [ ] E2E mock tests pass (`pnpm run test:e2e --grep @mock`)
- [ ] Verify Standard MCP tool save/validate works in hotfix build
