### PR TITLE
Fix connection changes racing autosave

### DIFF
--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
@@ -45,7 +45,7 @@ let spy: any;
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
 
 beforeAll(() => {
-  InitLoggerService([{ log: () => {} }]);
+  InitLoggerService([]);
 });
 
 describe('connection workflow mappings', () => {

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
@@ -1,4 +1,5 @@
 import { MockHttpClient } from '../../../../__test__/mock-http-client';
+import { getMockedInitialRootState } from '../../../../__test__/mock-root-state';
 import Constants from '../../../../common/constants';
 import { getReactQueryClient } from '../../../ReactQueryProvider';
 import {
@@ -9,15 +10,27 @@ import {
   isConnectionRequiredForOperation,
   getConnectionMetadata,
   needsConnection,
+  updateNodeConnectionAndProperties,
 } from '../../../actions/bjsworkflow/connections';
+import connectionsReducer, { changeConnectionMapping } from '../../../state/connection/connectionSlice';
+import workflowReducer, { setIsWorkflowDirty } from '../../../state/workflow/workflowSlice';
+import type { RootState } from '../../../store';
 import {
   InitOperationManifestService,
   StandardOperationManifestService,
   OperationManifestService,
   createItem,
   ConnectionReferenceKeyFormat,
+  InitLoggerService,
 } from '@microsoft/logic-apps-shared';
 import type { LogicAppsV2, OperationManifest, Connector } from '@microsoft/logic-apps-shared';
+
+const updateDynamicDataInNodeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../utils/parameters/helper', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../utils/parameters/helper')>()),
+  updateDynamicDataInNode: updateDynamicDataInNodeMock,
+}));
 
 const nodeId = '1';
 const connectionName = 'name123';
@@ -30,6 +43,11 @@ const serviceOptions: any = {
 
 let spy: any;
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
+
+beforeAll(() => {
+  InitLoggerService([{ log: () => {} }]);
+});
+
 describe('connection workflow mappings', () => {
   afterEach(() => {
     if (spy) {
@@ -109,6 +127,68 @@ describe('connection workflow mappings', () => {
     };
     const key = getLegacyConnectionReferenceKey(mockLegacyConnection);
     expect(key).toEqual('123');
+  });
+});
+
+describe('connection update dirty state', () => {
+  const connectorId = '/subscriptions/subscription/providers/Microsoft.Web/locations/westus/managedApis/test';
+  const connectionId = '/subscriptions/subscription/resourceGroups/group/providers/Microsoft.Web/connections/connection-b';
+  const updatePayload = {
+    nodeId,
+    connectorId,
+    connectionId,
+  };
+
+  beforeEach(() => {
+    updateDynamicDataInNodeMock.mockReset();
+  });
+
+  it('marks the mapping dirty before dynamic data loads and again after it settles', async () => {
+    const deferredDynamicData = createDeferred<void>();
+    updateDynamicDataInNodeMock.mockReturnValue(deferredDynamicData.promise);
+    const harness = createConnectionUpdateHarness();
+
+    const updatePromise = updateNodeConnectionAndProperties(updatePayload, harness.dispatch, harness.getState);
+
+    const pendingState = harness.getState();
+    const referenceKey = pendingState.connections.connectionsMapping[nodeId];
+    expect(referenceKey).toBeTruthy();
+    expect(pendingState.connections.connectionReferences[referenceKey as string].connection.id).toBe(connectionId);
+    expect(pendingState.workflow.isDirty).toBe(true);
+    expect(pendingState.workflow.changeCount).toBe(1);
+    expect(getDirtyActions(harness.actions)).toHaveLength(1);
+
+    harness.dispatch(setIsWorkflowDirty(false));
+    deferredDynamicData.resolve();
+    await updatePromise;
+
+    expect(harness.getState().workflow.isDirty).toBe(true);
+    expect(harness.getState().workflow.changeCount).toBe(2);
+    expect(getDirtyActions(harness.actions)).toHaveLength(2);
+  });
+
+  it('marks the connection change dirty again when dynamic data loading rejects', async () => {
+    const deferredDynamicData = createDeferred<void>();
+    updateDynamicDataInNodeMock.mockReturnValue(deferredDynamicData.promise);
+    const harness = createConnectionUpdateHarness();
+
+    const updatePromise = updateNodeConnectionAndProperties(updatePayload, harness.dispatch, harness.getState);
+    harness.dispatch(setIsWorkflowDirty(false));
+    deferredDynamicData.reject(new Error('Dynamic data failed.'));
+
+    await expect(updatePromise).rejects.toThrow('Dynamic data failed.');
+    expect(harness.getState().workflow.isDirty).toBe(true);
+    expect(harness.getState().workflow.changeCount).toBe(2);
+    expect(getDirtyActions(harness.actions)).toHaveLength(2);
+  });
+
+  it('does not mark initialization mapping actions dirty', () => {
+    const mappingAction = changeConnectionMapping(updatePayload);
+
+    const workflowState = workflowReducer(harnessInitialState().workflow, mappingAction);
+
+    expect(workflowState.isDirty).toBe(false);
+    expect(workflowState.changeCount).toBe(0);
   });
 });
 
@@ -216,4 +296,62 @@ function makeMockStdOperationManifestService(referenceKeyFormat: ConnectionRefer
       return Promise.resolve(mockManifest);
     });
   InitOperationManifestService(new StandardOperationManifestService(serviceOptions));
+}
+
+function harnessInitialState(): RootState {
+  const state = getMockedInitialRootState();
+  return {
+    ...state,
+    connections: { ...state.connections, connectionsMapping: {}, connectionReferences: {} },
+    operations: {
+      ...state.operations,
+      operationInfo: {
+        ...state.operations.operationInfo,
+        [nodeId]: {
+          connectorId: 'connector-id',
+          operationId: 'operation-id',
+          type: Constants.NODE.TYPE.OPEN_API_CONNECTION,
+        } as any,
+      },
+      dependencies: {
+        ...state.operations.dependencies,
+        [nodeId]: { inputs: {}, outputs: {} },
+      },
+    },
+    workflow: { ...state.workflow, isDirty: false, changeCount: 0 },
+  };
+}
+
+function createConnectionUpdateHarness() {
+  let state = harnessInitialState();
+  const actions: any[] = [];
+  const dispatch = (action: any) => {
+    actions.push(action);
+    state = {
+      ...state,
+      connections: connectionsReducer(state.connections, action),
+      workflow: workflowReducer(state.workflow, action),
+    };
+    return action;
+  };
+
+  return {
+    actions,
+    dispatch,
+    getState: () => state,
+  };
+}
+
+function getDirtyActions(actions: any[]) {
+  return actions.filter((action) => action.type === setIsWorkflowDirty.type && action.payload === true);
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: any) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
 }

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/connections.ts
@@ -55,6 +55,7 @@ import type { Dispatch } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { openPanel, setIsCreatingConnection, setIsPanelLoading } from '../../state/panel/panelSlice';
 import type { PanelMode } from '../../state/panel/panelTypes';
+import { setIsWorkflowDirty } from '../../state/workflow/workflowSlice';
 import { createLiteralValueSegment } from '../../utils/parameters/segment';
 export interface ConnectionPayload {
   nodeId: string;
@@ -290,13 +291,14 @@ export const reloadParametersTab = createAsyncThunk<void, void>('reloadParameter
   dispatch(setIsPanelLoading(false));
 });
 
-const updateNodeConnectionAndProperties = async (
+export const updateNodeConnectionAndProperties = async (
   payload: UpdateConnectionPayload,
   dispatch: Dispatch,
   getState: () => RootState
 ): Promise<void> => {
   const { nodeId } = payload;
   dispatch(changeConnectionMapping(payload));
+  dispatch(setIsWorkflowDirty(true));
 
   const newState = getState() as RootState;
   const operationInfo = getRecordEntry(newState.operations.operationInfo, nodeId);
@@ -309,19 +311,23 @@ const updateNodeConnectionAndProperties = async (
     return;
   }
 
-  return updateDynamicDataInNode(
-    nodeId,
-    isTriggerNode(nodeId, newState.workflow.nodesMetadata),
-    operationInfo,
-    getConnectionReference(newState.connections, nodeId),
-    dependencies,
-    dispatch,
-    getState,
-    newState.tokens?.variables ?? {},
-    newState.workflowParameters?.definitions ?? {},
-    !!newState.tokens /* updateTokenMetadata */,
-    newlyAddedOperations ? undefined : operation
-  );
+  try {
+    await updateDynamicDataInNode(
+      nodeId,
+      isTriggerNode(nodeId, newState.workflow.nodesMetadata),
+      operationInfo,
+      getConnectionReference(newState.connections, nodeId),
+      dependencies,
+      dispatch,
+      getState,
+      newState.tokens?.variables ?? {},
+      newState.workflowParameters?.definitions ?? {},
+      !!newState.tokens /* updateTokenMetadata */,
+      newlyAddedOperations ? undefined : operation
+    );
+  } finally {
+    dispatch(setIsWorkflowDirty(true));
+  }
 };
 
 const getConnectionPropertiesIfRequired = (connection: Connection, connector: Connector): Record<string, any> | undefined => {

--- a/libs/designer-v2/src/lib/core/state/__test__/workflowSlice.spec.ts
+++ b/libs/designer-v2/src/lib/core/state/__test__/workflowSlice.spec.ts
@@ -18,7 +18,7 @@ import { OperationDefinition } from '../../../../../../logic-apps-shared/src/uti
 import type { UpdateAgenticGraphPayload } from '../../parsers/updateAgenticGraph';
 
 beforeAll(() => {
-  InitLoggerService([{ log: () => {} }]);
+  InitLoggerService([]);
 });
 
 describe('workflow slice reducers', () => {

--- a/libs/designer-v2/src/lib/core/state/__test__/workflowSlice.spec.ts
+++ b/libs/designer-v2/src/lib/core/state/__test__/workflowSlice.spec.ts
@@ -1,5 +1,5 @@
-import { SUBGRAPH_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
-import { describe, expect, it } from 'vitest';
+import { InitLoggerService, SUBGRAPH_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { getMockedUndoRedoPartialRootState } from '../../../__test__/mock-root-state';
 import { initialState } from '../../parsers/__test__/mocks/workflowMock';
 import type { AddNodePayload } from '../../parsers/addNodeToWorkflow';
@@ -17,7 +17,18 @@ import { initializeInputsOutputsBinding, fetchBuiltInToolRunData } from '../../a
 import { OperationDefinition } from '../../../../../../logic-apps-shared/src/utils/src/lib/models/logicApps';
 import type { UpdateAgenticGraphPayload } from '../../parsers/updateAgenticGraph';
 
+beforeAll(() => {
+  InitLoggerService([{ log: () => {} }]);
+});
+
 describe('workflow slice reducers', () => {
+  it('should not mark the workflow dirty when a connection update thunk fulfills', () => {
+    const state = reducer(initialWorkflowState, { type: 'updateNodeConnection/fulfilled' });
+
+    expect(state.isDirty).toBe(false);
+    expect(state.changeCount).toBe(0);
+  });
+
   it('should add initial node to the workflow', () => {
     const mockAddNode: AddNodePayload = {
       nodeId: '123',

--- a/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/workflow/workflowSlice.ts
@@ -1,5 +1,4 @@
 import constants from '../../../common/constants';
-import { updateNodeConnection } from '../../actions/bjsworkflow/connections';
 import { initializeGraphState } from '../../parsers/ParseReduxAction';
 import type { AddNodePayload } from '../../parsers/addNodeToWorkflow';
 import {
@@ -1063,7 +1062,6 @@ export const workflowSlice = createSlice({
         removeRunAfter,
         addRunAfter,
         replaceId,
-        updateNodeConnection.fulfilled,
         updateStaticResults,
         updateParameterConditionalVisibility
       ),

--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
@@ -1,4 +1,5 @@
 import { MockHttpClient } from '../../../../__test__/mock-http-client';
+import { getMockedInitialRootState } from '../../../../__test__/mock-root-state';
 import Constants from '../../../../common/constants';
 import { getReactQueryClient } from '../../../ReactQueryProvider';
 import {
@@ -10,15 +11,27 @@ import {
   isConnectionAutoSelectionDisabled,
   getConnectionMetadata,
   needsConnection,
+  updateNodeConnectionAndProperties,
 } from '../../../actions/bjsworkflow/connections';
+import connectionsReducer, { changeConnectionMapping } from '../../../state/connection/connectionSlice';
+import workflowReducer, { setIsWorkflowDirty } from '../../../state/workflow/workflowSlice';
+import type { RootState } from '../../../store';
 import {
   InitOperationManifestService,
   StandardOperationManifestService,
   OperationManifestService,
   createItem,
   ConnectionReferenceKeyFormat,
+  InitLoggerService,
 } from '@microsoft/logic-apps-shared';
 import type { LogicAppsV2, OperationManifest, Connector } from '@microsoft/logic-apps-shared';
+
+const updateDynamicDataInNodeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../utils/parameters/helper', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../utils/parameters/helper')>()),
+  updateDynamicDataInNode: updateDynamicDataInNodeMock,
+}));
 
 const nodeId = '1';
 const connectionName = 'name123';
@@ -31,6 +44,11 @@ const serviceOptions: any = {
 
 let spy: any;
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
+
+beforeAll(() => {
+  InitLoggerService([{ log: () => {} }]);
+});
+
 describe('connection workflow mappings', () => {
   afterEach(() => {
     if (spy) {
@@ -110,6 +128,64 @@ describe('connection workflow mappings', () => {
     };
     const key = getLegacyConnectionReferenceKey(mockLegacyConnection);
     expect(key).toEqual('123');
+  });
+});
+
+describe('connection update dirty state', () => {
+  const connectorId = '/subscriptions/subscription/providers/Microsoft.Web/locations/westus/managedApis/test';
+  const connectionId = '/subscriptions/subscription/resourceGroups/group/providers/Microsoft.Web/connections/connection-b';
+  const updatePayload = {
+    nodeId,
+    connectorId,
+    connectionId,
+  };
+
+  beforeEach(() => {
+    updateDynamicDataInNodeMock.mockReset();
+  });
+
+  it('marks the mapping dirty before dynamic data loads and again after it settles', async () => {
+    const deferredDynamicData = createDeferred<void>();
+    updateDynamicDataInNodeMock.mockReturnValue(deferredDynamicData.promise);
+    const harness = createConnectionUpdateHarness();
+
+    const updatePromise = updateNodeConnectionAndProperties(updatePayload, harness.dispatch, harness.getState);
+
+    const pendingState = harness.getState();
+    const referenceKey = pendingState.connections.connectionsMapping[nodeId];
+    expect(referenceKey).toBeTruthy();
+    expect(pendingState.connections.connectionReferences[referenceKey as string].connection.id).toBe(connectionId);
+    expect(pendingState.workflow.isDirty).toBe(true);
+    expect(getDirtyActions(harness.actions)).toHaveLength(1);
+
+    harness.dispatch(setIsWorkflowDirty(false));
+    deferredDynamicData.resolve();
+    await updatePromise;
+
+    expect(harness.getState().workflow.isDirty).toBe(true);
+    expect(getDirtyActions(harness.actions)).toHaveLength(2);
+  });
+
+  it('marks the connection change dirty again when dynamic data loading rejects', async () => {
+    const deferredDynamicData = createDeferred<void>();
+    updateDynamicDataInNodeMock.mockReturnValue(deferredDynamicData.promise);
+    const harness = createConnectionUpdateHarness();
+
+    const updatePromise = updateNodeConnectionAndProperties(updatePayload, harness.dispatch, harness.getState);
+    harness.dispatch(setIsWorkflowDirty(false));
+    deferredDynamicData.reject(new Error('Dynamic data failed.'));
+
+    await expect(updatePromise).rejects.toThrow('Dynamic data failed.');
+    expect(harness.getState().workflow.isDirty).toBe(true);
+    expect(getDirtyActions(harness.actions)).toHaveLength(2);
+  });
+
+  it('does not mark initialization mapping actions dirty', () => {
+    const mappingAction = changeConnectionMapping(updatePayload);
+
+    const workflowState = workflowReducer(harnessInitialState().workflow, mappingAction);
+
+    expect(workflowState.isDirty).toBe(false);
   });
 });
 
@@ -234,4 +310,62 @@ function makeMockStdOperationManifestService(referenceKeyFormat: ConnectionRefer
       return Promise.resolve(mockManifest);
     });
   InitOperationManifestService(new StandardOperationManifestService(serviceOptions));
+}
+
+function harnessInitialState(): RootState {
+  const state = getMockedInitialRootState();
+  return {
+    ...state,
+    connections: { ...state.connections, connectionsMapping: {}, connectionReferences: {} },
+    operations: {
+      ...state.operations,
+      operationInfo: {
+        ...state.operations.operationInfo,
+        [nodeId]: {
+          connectorId: 'connector-id',
+          operationId: 'operation-id',
+          type: Constants.NODE.TYPE.OPEN_API_CONNECTION,
+        } as any,
+      },
+      dependencies: {
+        ...state.operations.dependencies,
+        [nodeId]: { inputs: {}, outputs: {} },
+      },
+    },
+    workflow: { ...state.workflow, isDirty: false },
+  };
+}
+
+function createConnectionUpdateHarness() {
+  let state = harnessInitialState();
+  const actions: any[] = [];
+  const dispatch = (action: any) => {
+    actions.push(action);
+    state = {
+      ...state,
+      connections: connectionsReducer(state.connections, action),
+      workflow: workflowReducer(state.workflow, action),
+    };
+    return action;
+  };
+
+  return {
+    actions,
+    dispatch,
+    getState: () => state,
+  };
+}
+
+function getDirtyActions(actions: any[]) {
+  return actions.filter((action) => action.type === setIsWorkflowDirty.type && action.payload === true);
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: any) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
 }

--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
@@ -46,7 +46,7 @@ let spy: any;
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
 
 beforeAll(() => {
-  InitLoggerService([{ log: () => {} }]);
+  InitLoggerService([]);
 });
 
 describe('connection workflow mappings', () => {

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -55,6 +55,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { openPanel, setIsCreatingConnection, setIsPanelLoading } from '../../state/panel/panelSlice';
 import type { PanelMode } from '../../state/panel/panelTypes';
 import { isBuiltInMcpOperation, isManagedMcpOperation } from '../../state/workflow/helper';
+import { setIsWorkflowDirty } from '../../state/workflow/workflowSlice';
 import { createLiteralValueSegment } from '../../utils/parameters/segment';
 export interface ConnectionPayload {
   nodeId: string;
@@ -290,13 +291,14 @@ export const reloadParametersTab = createAsyncThunk<void, void>('reloadParameter
   dispatch(setIsPanelLoading(false));
 });
 
-const updateNodeConnectionAndProperties = async (
+export const updateNodeConnectionAndProperties = async (
   payload: UpdateConnectionPayload,
   dispatch: Dispatch,
   getState: () => RootState
 ): Promise<void> => {
   const { nodeId } = payload;
   dispatch(changeConnectionMapping(payload));
+  dispatch(setIsWorkflowDirty(true));
 
   const newState = getState() as RootState;
   const operationInfo = getRecordEntry(newState.operations.operationInfo, nodeId);
@@ -309,19 +311,23 @@ const updateNodeConnectionAndProperties = async (
     return;
   }
 
-  return updateDynamicDataInNode(
-    nodeId,
-    isTriggerNode(nodeId, newState.workflow.nodesMetadata),
-    operationInfo,
-    getConnectionReference(newState.connections, nodeId),
-    dependencies,
-    dispatch,
-    getState,
-    newState.tokens?.variables ?? {},
-    newState.workflowParameters?.definitions ?? {},
-    !!newState.tokens /* updateTokenMetadata */,
-    newlyAddedOperations ? undefined : operation
-  );
+  try {
+    await updateDynamicDataInNode(
+      nodeId,
+      isTriggerNode(nodeId, newState.workflow.nodesMetadata),
+      operationInfo,
+      getConnectionReference(newState.connections, nodeId),
+      dependencies,
+      dispatch,
+      getState,
+      newState.tokens?.variables ?? {},
+      newState.workflowParameters?.definitions ?? {},
+      !!newState.tokens /* updateTokenMetadata */,
+      newlyAddedOperations ? undefined : operation
+    );
+  } finally {
+    dispatch(setIsWorkflowDirty(true));
+  }
 };
 
 const getConnectionPropertiesIfRequired = (connection: Connection, connector: Connector): Record<string, any> | undefined => {

--- a/libs/designer/src/lib/core/state/__test__/workflowSlice.spec.ts
+++ b/libs/designer/src/lib/core/state/__test__/workflowSlice.spec.ts
@@ -1,15 +1,32 @@
-import { SUBGRAPH_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
-import { describe, expect, it } from 'vitest';
+import { InitLoggerService, SUBGRAPH_TYPES, WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { getMockedUndoRedoPartialRootState } from '../../../__test__/mock-root-state';
 import { initialState } from '../../parsers/__test__/mocks/workflowMock';
 import type { AddNodePayload } from '../../parsers/addNodeToWorkflow';
 import { setStateAfterUndoRedo } from '../global';
 import { WorkflowState, NodeMetadata } from '../workflow/workflowInterfaces';
-import reducer, { addNode, addMcpServer, deleteMcpServer, setToolRunIndex, updateAgenticMetadata } from '../workflow/workflowSlice';
+import reducer, {
+  addNode,
+  addMcpServer,
+  deleteMcpServer,
+  setToolRunIndex,
+  updateAgenticMetadata,
+  initialWorkflowState,
+} from '../workflow/workflowSlice';
 import { OperationDefinition } from '../../../../../../logic-apps-shared/src/utils/src/lib/models/logicApps';
 import type { UpdateAgenticGraphPayload } from '../../parsers/updateAgenticGraph';
 
+beforeAll(() => {
+  InitLoggerService([{ log: () => {} }]);
+});
+
 describe('workflow slice reducers', () => {
+  it('should not mark the workflow dirty when a connection update thunk fulfills', () => {
+    const state = reducer(initialWorkflowState, { type: 'updateNodeConnection/fulfilled' });
+
+    expect(state.isDirty).toBe(false);
+  });
+
   it('should add initial node to the workflow', () => {
     const mockAddNode: AddNodePayload = {
       nodeId: '123',

--- a/libs/designer/src/lib/core/state/__test__/workflowSlice.spec.ts
+++ b/libs/designer/src/lib/core/state/__test__/workflowSlice.spec.ts
@@ -17,7 +17,7 @@ import { OperationDefinition } from '../../../../../../logic-apps-shared/src/uti
 import type { UpdateAgenticGraphPayload } from '../../parsers/updateAgenticGraph';
 
 beforeAll(() => {
-  InitLoggerService([{ log: () => {} }]);
+  InitLoggerService([]);
 });
 
 describe('workflow slice reducers', () => {

--- a/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
+++ b/libs/designer/src/lib/core/state/workflow/workflowSlice.ts
@@ -1,5 +1,4 @@
 import constants from '../../../common/constants';
-import { updateNodeConnection } from '../../actions/bjsworkflow/connections';
 import { initializeGraphState } from '../../parsers/ParseReduxAction';
 import type { AddNodePayload } from '../../parsers/addNodeToWorkflow';
 import {
@@ -888,7 +887,6 @@ export const workflowSlice = createSlice({
         removeRunAfter,
         addRunAfter,
         replaceId,
-        updateNodeConnection.fulfilled,
         updateStaticResults,
         updateParameterConditionalVisibility
       ),


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Changing an action's connection updated the connection mapping immediately, but the workflow revision was not marked dirty until asynchronous dynamic-data loading completed. An autosave already in flight could therefore persist an older snapshot and clear dirty state before the new connection was serialized.

This change marks the workflow dirty immediately after committing the connection mapping, then reasserts dirty state after connection-dependent dynamic data settles. It removes the old thunk-fulfillment dirty matcher to prevent a duplicate revision and keeps Designer V1 and V2 behavior aligned.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Newly selected action connections are retained across overlapping autosaves and dynamic-data refreshes.
- **Developers**: Connection updates now expose explicit pre-load and post-load dirty-state boundaries in both Designer implementations.
- **System**: Autosave may schedule a follow-up save after dynamic data settles, ensuring the persisted snapshot includes all connection-dependent updates.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: Focused V1/V2 Vitest suites (138 passed) and direct TypeScript checks for both affected packages.

## Contributors
@rllyy97

## Screenshots/Videos
Not applicable; no visual changes.
