### PR TITLE
fix(designer): invokefunction manifest corrections

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/__test__/invokeFunctionManifest.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/__test__/invokeFunctionManifest.spec.ts
@@ -35,29 +35,43 @@ describe('InvokeFunction Manifest', () => {
   });
 
   describe('manifest inputs', () => {
-    it('should have required functionName input', () => {
+    it('should have required functionName and parameters inputs', () => {
       const { inputs } = invokeFunctionManifest.properties;
       expect(inputs).toBeDefined();
       expect(inputs?.type).toBe('object');
       expect(inputs?.required).toContain('functionName');
+      expect(inputs?.required).toContain('parameters');
     });
 
-    it('should have functionName and parameters properties', () => {
+    it('should have functionName with x-ms-dynamic-list', () => {
       const properties = invokeFunctionManifest.properties.inputs?.properties as Record<string, any>;
       expect(properties?.functionName).toBeDefined();
       expect(properties?.functionName?.type).toBe('string');
+      expect(properties?.functionName?.['x-ms-dynamic-list']).toBeDefined();
+      expect(properties?.functionName?.['x-ms-dynamic-list']?.dynamicState?.operationId).toBe('getFunctions');
+    });
+
+    it('should have parameters with x-ms-dynamic-properties', () => {
+      const properties = invokeFunctionManifest.properties.inputs?.properties as Record<string, any>;
       expect(properties?.parameters).toBeDefined();
       expect(properties?.parameters?.type).toBe('object');
+      expect(properties?.parameters?.['x-ms-dynamic-properties']).toBeDefined();
+      expect(properties?.parameters?.['x-ms-dynamic-properties']?.dynamicState?.extension?.operationId).toBe('getParameters');
+      expect(properties?.parameters?.['x-ms-dynamic-properties']?.dynamicState?.isInput).toBe(true);
+      expect(properties?.parameters?.['x-ms-dynamic-properties']?.parameters?.functionName?.parameterReference).toBe('functionName');
     });
   });
 
   describe('manifest outputs', () => {
-    it('should have body output', () => {
+    it('should have body output with x-ms-dynamic-properties', () => {
       const { outputs } = invokeFunctionManifest.properties;
       expect(outputs).toBeDefined();
       expect(outputs?.type).toBe('object');
       const outputProperties = outputs?.properties as Record<string, any>;
       expect(outputProperties?.body).toBeDefined();
+      expect(outputProperties?.body?.['x-ms-dynamic-properties']).toBeDefined();
+      expect(outputProperties?.body?.['x-ms-dynamic-properties']?.dynamicState?.extension?.operationId).toBe('getOutputSchema');
+      expect(outputProperties?.body?.['x-ms-dynamic-properties']?.parameters?.functionName?.parameterReference).toBe('functionName');
     });
   });
 
@@ -69,12 +83,6 @@ describe('InvokeFunction Manifest', () => {
       expect(settings?.retryPolicy?.scopes).toContain(SettingScope.Action);
     });
 
-    it('should have timeout setting with Action scope', () => {
-      const { settings } = invokeFunctionManifest.properties;
-      expect(settings?.timeout).toBeDefined();
-      expect(settings?.timeout?.scopes).toContain(SettingScope.Action);
-    });
-
     it('should have trackedProperties setting with Action scope', () => {
       const { settings } = invokeFunctionManifest.properties;
       expect(settings?.trackedProperties).toBeDefined();
@@ -84,6 +92,14 @@ describe('InvokeFunction Manifest', () => {
     it('should have secureData setting', () => {
       const { settings } = invokeFunctionManifest.properties;
       expect(settings?.secureData).toBeDefined();
+    });
+  });
+
+  describe('dynamic content', () => {
+    it('should have WorkflowAppLocation in payloadConfiguration', () => {
+      const { dynamicContent } = invokeFunctionManifest.properties as any;
+      expect(dynamicContent).toBeDefined();
+      expect(dynamicContent?.payloadConfiguration).toContain('WorkflowAppLocation');
     });
   });
 });

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/invokefunction.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/invokefunction.ts
@@ -28,19 +28,38 @@ const invokeFunctionManifest = {
 
     inputs: {
       type: 'object',
-      required: ['functionName'],
+      required: ['functionName', 'parameters'],
       properties: {
         functionName: {
-          title: 'Function Name',
           type: 'string',
-          description: 'The name of the local function to invoke',
-          'x-ms-visibility': 'important',
+          title: 'Function name',
+          description: 'The name for the function.',
+          'x-ms-dynamic-list': {
+            dynamicState: {
+              operationId: 'getFunctions',
+              parameters: {},
+            },
+            parameters: {},
+          },
         },
         parameters: {
-          title: 'Parameters',
           type: 'object',
-          description: 'Parameters to pass to the local function',
-          'x-ms-visibility': 'important',
+          title: 'Function parameters',
+          description: 'The function parameters.',
+          'x-ms-dynamic-properties': {
+            dynamicState: {
+              extension: {
+                operationId: 'getParameters',
+              },
+              isInput: true,
+            },
+            parameters: {
+              functionName: {
+                parameterReference: 'functionName',
+                required: true,
+              },
+            },
+          },
         },
       },
     },
@@ -51,25 +70,40 @@ const invokeFunctionManifest = {
       type: 'object',
       properties: {
         body: {
-          title: 'Body',
-          description: 'The return value from the local function',
+          type: 'object',
+          title: 'Function output',
+          description: "The function's output.",
+          'x-ms-dynamic-properties': {
+            dynamicState: {
+              extension: {
+                operationId: 'getOutputSchema',
+              },
+            },
+            parameters: {
+              functionName: {
+                parameterReference: 'functionName',
+                required: true,
+              },
+            },
+          },
         },
       },
     },
     isOutputsOptional: false,
-    includeRootOutputs: true,
+    includeRootOutputs: false,
 
     connector,
 
+    dynamicContent: {
+      payloadConfiguration: ['WorkflowAppLocation'],
+    },
+
     settings: {
-      retryPolicy: {
-        scopes: [SettingScope.Action],
-      },
       secureData: {},
       trackedProperties: {
         scopes: [SettingScope.Action],
       },
-      timeout: {
+      retryPolicy: {
         scopes: [SettingScope.Action],
       },
     },


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Operation manifest for invokefunction had fallen out of sync with backend manifest, and didn't include dynamic list for function names or dynamic parameters content. Corrected manifest to fix designer issue displaying dynamic content. Closes #7773

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Dynamic list for function names and dynamic parameters work correctly
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge

https://github.com/user-attachments/assets/1477078f-b296-4e05-b262-e0a42f5dc6a9
