### PR TITLE
feat(designer-v2): add flag to hide retry policy status codes based on host options

### DIFF
--- a/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -50,6 +50,7 @@ export interface DesignerOptionsState {
     stringOverrides?: Record<string, string>; // string overrides for localization
     maxStateHistorySize?: number; // maximum number of states to save in history for undo/redo (default is 20)
     hideContentTransferSettings?: boolean; // hide content transfer settings in the designer
+    hideRetryPolicyStatusCodes?: boolean; // hide the HTTP status codes input for action retry policies
     collapseGraphsByDefault?: boolean; // collapse scope by default
     enableMultiVariable?: boolean; // prevent creating multiple variables in one action
     enableNestedAgentLoops?: boolean; // allow agent loops to be added inside regular loops (requires bundle version >= 1.115.0)

--- a/libs/designer-v2/src/lib/ui/settings/index.tsx
+++ b/libs/designer-v2/src/lib/ui/settings/index.tsx
@@ -429,7 +429,7 @@ function NetworkingSettings({
     downloadChunkSize,
   } = nodeSettings;
 
-  const { hideContentTransferSettings } = useHostOptions();
+  const { hideContentTransferSettings, hideRetryPolicyStatusCodes } = useHostOptions();
 
   const onAsyncPatternToggle = (checked: boolean): void => {
     updateSettings({
@@ -663,6 +663,7 @@ function NetworkingSettings({
         uploadChunk={uploadChunk}
         downloadChunkSize={downloadChunkSize}
         hideContentTransferSettings={hideContentTransferSettings}
+        hideRetryPolicyStatusCodes={hideRetryPolicyStatusCodes}
         onHeaderClick={(sectionName) => dispatch(setExpandedSections(sectionName))}
         onAsyncPatternToggle={onAsyncPatternToggle}
         onAsyncResponseToggle={onAsyncResponseToggle}

--- a/libs/designer-v2/src/lib/ui/settings/sections/networking.tsx
+++ b/libs/designer-v2/src/lib/ui/settings/sections/networking.tsx
@@ -13,6 +13,7 @@ export interface NetworkingSectionProps extends SectionProps {
   uploadChunkMetadata: UploadChunkMetadata | undefined;
   downloadChunkMetadata: DownloadChunkMetadata | undefined;
   hideContentTransferSettings: boolean | undefined;
+  hideRetryPolicyStatusCodes: boolean | undefined;
   onAsyncPatternToggle: ToggleHandler;
   onAsyncResponseToggle: ToggleHandler;
   onRequestOptionsChange: TextChangeHandler;
@@ -49,6 +50,7 @@ export const Networking = ({
   requestOptions,
   chunkedTransferMode,
   hideContentTransferSettings,
+  hideRetryPolicyStatusCodes,
   onAsyncPatternToggle,
   onAsyncResponseToggle,
   onRequestOptionsChange,
@@ -594,6 +596,7 @@ export const Networking = ({
         ariaLabel: retryPolicyHttpStatusCodesTitle,
       },
       visible:
+        !hideRetryPolicyStatusCodes &&
         retryPolicy?.isSupported &&
         retryPolicy?.value?.type !== constants.RETRY_POLICY_TYPE.NONE &&
         retryPolicy?.value?.type !== constants.RETRY_POLICY_TYPE.DEFAULT,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
This change adds an optional flag to the host options to hide the http status code picker on action retry policies. I followed the pattern used by hideContentTransferSettings. Our workflow runner supports retry policies, but not the ability to select http status codes, and I couldn't find a way to hide it without changing the library.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any --> Does not affect current users or workflows, but adds the option for library users to hide the http status code picker.
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
