### PR TITLE
fix(designer): Fix channels in stateful workflows with agent action

### DIFF
--- a/libs/designer-v2/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer-v2/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -33,12 +33,6 @@ export const useIsAgenticWorkflow = () => {
   return equals(workflowKind, 'agentic', true) || equals(workflowKind, 'stateful', true);
 };
 
-// Temporary hook for backwards compatibility with agentic wf, TODO: delete once stateful is merged in
-export const useIsAgenticWorkflowOnly = () => {
-  const workflowKind = useSelector((state: RootState) => state.workflow.workflowKind);
-  return equals(workflowKind, 'agentic', true);
-};
-
 const selectIsA2AWorkflow = createSelector(
   (state: RootState) => state.workflow,
   (workflow) => isA2AWorkflow(workflow)

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/__tests__/usePanelTabs.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/__tests__/usePanelTabs.spec.tsx
@@ -17,7 +17,7 @@ const mocks = {
   useOperationInfo: vi.fn(),
   useOperationManifest: vi.fn(),
   useIsA2AWorkflow: vi.fn(),
-  useIsAgenticWorkflowOnly: vi.fn(),
+  useIsAgenticWorkflow: vi.fn(),
   usePanelTabHideKeys: vi.fn(),
   useUnitTest: vi.fn(),
   useMonitoringView: vi.fn(),
@@ -35,7 +35,7 @@ vi.mock('../../../../core', () => ({
 }));
 vi.mock('../../../../core/state/designerView/designerViewSelectors', () => ({
   useIsA2AWorkflow: () => mocks.useIsA2AWorkflow(),
-  useIsAgenticWorkflowOnly: () => mocks.useIsAgenticWorkflowOnly(),
+  useIsAgenticWorkflow: () => mocks.useIsAgenticWorkflow(),
 }));
 vi.mock('../../../../core/state/designerOptions/designerOptionsSelectors', () => ({
   usePanelTabHideKeys: () => mocks.usePanelTabHideKeys(),
@@ -124,7 +124,7 @@ describe('usePanelTabs', () => {
     mocks.useNodeMetadata.mockReturnValue(null);
     mocks.useOperationInfo.mockReturnValue({ type: 'http', kind: 'http', connectorId: 'test', operationId: 'test' });
     mocks.useIsA2AWorkflow.mockReturnValue(false);
-    mocks.useIsAgenticWorkflowOnly.mockReturnValue(false);
+    mocks.useIsAgenticWorkflow.mockReturnValue(false);
     mocks.usePanelTabHideKeys.mockReturnValue([]);
     mocks.useUnitTest.mockReturnValue(false);
     mocks.useMonitoringView.mockReturnValue(false);
@@ -227,7 +227,7 @@ describe('usePanelTabs', () => {
 
     it('shows channels tab for agent nodes in agentic workflow', () => {
       setAgentNode();
-      mocks.useIsAgenticWorkflowOnly.mockReturnValue(true);
+      mocks.useIsAgenticWorkflow.mockReturnValue(true);
       expect(getTabIds(renderTabs().result)).toContain(constants.PANEL_TAB_NAMES.CHANNELS);
     });
 

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -2,7 +2,7 @@ import constants from '../../../common/constants';
 import type { RootState } from '../../../core';
 import { useNodeMetadata, useOperationInfo } from '../../../core';
 import { useOperationManifest } from '../../../core/state/selectors/actionMetadataSelector';
-import { useIsA2AWorkflow, useIsAgenticWorkflowOnly } from '../../../core/state/designerView/designerViewSelectors';
+import { useIsA2AWorkflow, useIsAgenticWorkflow } from '../../../core/state/designerView/designerViewSelectors';
 import { usePanelTabHideKeys, useUnitTest, useMonitoringView } from '../../../core/state/designerOptions/designerOptionsSelectors';
 import { useParameterValidationErrors } from '../../../core/state/operation/operationSelector';
 import { useIsNodePinnedToOperationPanel } from '../../../core/state/panel/panelSelectors';
@@ -43,7 +43,7 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
   const isScopeNode = operationInfo?.type.toLowerCase() === constants.NODE.TYPE.SCOPE;
   const isAgentNode = useMemo(() => equals(operationInfo?.type ?? '', constants.NODE.TYPE.AGENT, true), [operationInfo?.type]);
   const isA2AWorkflow = useIsA2AWorkflow();
-  const isAgenticWorkflowOnly = useIsAgenticWorkflowOnly();
+  const isAgenticWorkflow = useIsAgenticWorkflow();
   const operationManifestQuery = useOperationManifest(operationInfo);
   const enableAgentHarness = operationManifestQuery.data?.properties?.enableAgentHarness ?? false;
   const parameterValidationErrors = useParameterValidationErrors(nodeId);
@@ -100,10 +100,9 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
   const channelsTabItem = useMemo(
     () => ({
       ...channelsTab(intl, tabProps),
-      // Note: Channels tab is disabled until we have the teams integration ready
-      visible: isAgentNode && isAgenticWorkflowOnly,
+      visible: isAgentNode && isAgenticWorkflow,
     }),
-    [intl, tabProps, isAgentNode, isAgenticWorkflowOnly]
+    [intl, tabProps, isAgentNode, isAgenticWorkflow]
   );
 
   const handoffTabItem = useMemo(
@@ -187,6 +186,7 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
       .filter((a) => a.visible)
       .sort((a, b) => a.order - b.order);
   }, [
+    nodeId,
     mockResultsTabItem,
     isUnitTestView,
     aboutTabItem,

--- a/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
+++ b/libs/designer/src/lib/core/state/designerView/designerViewSelectors.ts
@@ -35,12 +35,6 @@ export const useIsAgenticWorkflow = (): boolean => {
   return !workflowKind || isAgenticOrStateful;
 };
 
-// Temporary hook for backwards compatibility with agentic wf, TODO: delete once stateful is merged in
-export const useIsAgenticWorkflowOnly = () => {
-  const workflowKind = useSelector((state: RootState) => state.workflow.workflowKind);
-  return equals(workflowKind, 'agentic', true);
-};
-
 export const useIsA2AWorkflow = () => {
   return useSelector((state: RootState) => isA2AWorkflow(state.workflow));
 };

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/__test__/usePanelTabs.spec.ts
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/__test__/usePanelTabs.spec.ts
@@ -23,7 +23,7 @@ const mockUseRetryHistory = vi.fn();
 const mockUseNodeMetadata = vi.fn();
 const mockUseOperationInfo = vi.fn();
 const mockUseIsA2AWorkflow = vi.fn();
-const mockUseIsAgenticWorkflowOnly = vi.fn();
+const mockUseIsAgenticWorkflow = vi.fn();
 const mockUseOperationManifest = vi.fn();
 
 vi.mock('../../../../core', () => ({
@@ -39,7 +39,7 @@ vi.mock('../../../../core/state/designerOptions/designerOptionsSelectors', () =>
 
 vi.mock('../../../../core/state/designerView/designerViewSelectors', () => ({
   useIsA2AWorkflow: () => mockUseIsA2AWorkflow(),
-  useIsAgenticWorkflowOnly: () => mockUseIsAgenticWorkflowOnly(),
+  useIsAgenticWorkflow: () => mockUseIsAgenticWorkflow(),
 }));
 
 vi.mock('../../../../core/state/selectors/actionMetadataSelector', () => ({
@@ -144,7 +144,7 @@ describe('usePanelTabs', () => {
     mockUseNodeMetadata.mockReturnValue(null);
     mockUseOperationInfo.mockReturnValue({ type: 'Action', connectorId: 'test', operationId: 'test' });
     mockUseIsA2AWorkflow.mockReturnValue(false);
-    mockUseIsAgenticWorkflowOnly.mockReturnValue(false);
+    mockUseIsAgenticWorkflow.mockReturnValue(false);
     mockUseOperationManifest.mockReturnValue({ data: undefined, isLoading: false, isFetched: true });
   });
 
@@ -239,7 +239,7 @@ describe('usePanelTabs', () => {
 
   it('should show channels tab for agent nodes in agentic workflow', () => {
     mockUseOperationInfo.mockReturnValue({ type: constants.NODE.TYPE.AGENT, connectorId: 'test', operationId: 'test' });
-    mockUseIsAgenticWorkflowOnly.mockReturnValue(true);
+    mockUseIsAgenticWorkflow.mockReturnValue(true);
 
     const { result } = renderHook(() => usePanelTabs({ nodeId: 'testNode' }), { wrapper: createWrapper() });
 

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/usePanelTabs.tsx
@@ -1,7 +1,7 @@
 import constants from '../../../common/constants';
 import type { RootState } from '../../../core';
 import { useNodeMetadata, useOperationInfo } from '../../../core';
-import { useIsA2AWorkflow, useIsAgenticWorkflowOnly } from '../../../core/state/designerView/designerViewSelectors';
+import { useIsA2AWorkflow, useIsAgenticWorkflow } from '../../../core/state/designerView/designerViewSelectors';
 import { usePanelTabHideKeys, useUnitTest, useMonitoringView } from '../../../core/state/designerOptions/designerOptionsSelectors';
 import { useOperationManifest } from '../../../core/state/selectors/actionMetadataSelector';
 import { useParameterValidationErrors } from '../../../core/state/operation/operationSelector';
@@ -43,7 +43,7 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
   const isScopeNode = operationInfo?.type.toLowerCase() === constants.NODE.TYPE.SCOPE;
   const isAgentNode = useMemo(() => equals(operationInfo?.type ?? '', constants.NODE.TYPE.AGENT, true), [operationInfo?.type]);
   const isA2AWorkflow = useIsA2AWorkflow();
-  const isAgenticWorkflowOnly = useIsAgenticWorkflowOnly();
+  const isAgenticWorkflow = useIsAgenticWorkflow();
   const operationManifestQuery = useOperationManifest(operationInfo);
   const enableAgentHarness = operationManifestQuery.data?.properties?.enableAgentHarness ?? false;
   const parameterValidationErrors = useParameterValidationErrors(nodeId);
@@ -100,10 +100,9 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
   const channelsTabItem = useMemo(
     () => ({
       ...channelsTab(intl, tabProps),
-      // Note: Channels tab is disabled until we have the teams integration ready
-      visible: isAgentNode && isAgenticWorkflowOnly,
+      visible: isAgentNode && isAgenticWorkflow,
     }),
-    [intl, tabProps, isAgentNode, isAgenticWorkflowOnly]
+    [intl, tabProps, isAgentNode, isAgenticWorkflow]
   );
 
   const handoffTabItem = useMemo(
@@ -186,6 +185,7 @@ export const usePanelTabs = ({ nodeId }: { nodeId: string }) => {
       .filter((a) => a.visible)
       .sort((a, b) => a.order - b.order);
   }, [
+    nodeId,
     mockResultsTabItem,
     isUnitTestView,
     aboutTabItem,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
'Channels' tab on agent action node doesn't display in stateful workflows because old useIsAgenticWorkflowOnly hook is used, which doesn't recognize stateful workflows as agentic. Update to use new hook and remove old hook. Closes #9382 

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: 'Channels' tab now available on agent actions in stateful workflows
- **Developers**: Removed unneeded agentic workflow react hook
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge

## Screenshots
<img width="638" height="476" alt="image" src="https://github.com/user-attachments/assets/bbc013b6-f196-4b34-abd1-8cf819a4c189" />
