### PR TITLE
perf(e2e): share designer browser contexts

### DIFF
--- a/e2e/designer/designerStorageState.ts
+++ b/e2e/designer/designerStorageState.ts
@@ -1,0 +1,14 @@
+export const designerStorageState = {
+  cookies: [],
+  origins: [
+    {
+      origin: 'http://localhost:4200',
+      localStorage: [
+        {
+          name: 'control-expand-collapse-button',
+          value: 'true',
+        },
+      ],
+    },
+  ],
+};

--- a/e2e/designer/fixtures/sharedDesignerPage.ts
+++ b/e2e/designer/fixtures/sharedDesignerPage.ts
@@ -1,0 +1,150 @@
+import { test as base, expect } from '@playwright/test';
+import type { Browser, BrowserContext, BrowserContextOptions, Page, TestInfo, WorkerInfo } from '@playwright/test';
+import { designerStorageState } from '../designerStorageState';
+import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+
+type SharedDesignerOptions = {
+  mockWorkflow: string | undefined;
+};
+
+type SharedDesignerWorkerFixtures = {
+  sharedContextManager: {
+    getContext: (testFile: string) => Promise<BrowserContext>;
+  };
+};
+
+type ProjectInfo = Pick<WorkerInfo, 'project'>;
+
+const contextOptions = ({ project }: ProjectInfo, videoDirectory?: string): BrowserContextOptions => {
+  const options = project.use;
+  return {
+    acceptDownloads: options.acceptDownloads,
+    baseURL: options.baseURL,
+    bypassCSP: options.bypassCSP,
+    colorScheme: options.colorScheme,
+    deviceScaleFactor: options.deviceScaleFactor,
+    extraHTTPHeaders: options.extraHTTPHeaders,
+    forcedColors: options.forcedColors,
+    geolocation: options.geolocation,
+    hasTouch: options.hasTouch,
+    httpCredentials: options.httpCredentials,
+    ignoreHTTPSErrors: options.ignoreHTTPSErrors,
+    isMobile: options.isMobile,
+    javaScriptEnabled: options.javaScriptEnabled,
+    locale: options.locale,
+    offline: options.offline,
+    permissions: options.permissions,
+    proxy: options.proxy,
+    recordVideo: videoDirectory ? { dir: videoDirectory, size: options.viewport ?? undefined } : undefined,
+    reducedMotion: options.reducedMotion,
+    screen: options.screen,
+    serviceWorkers: options.serviceWorkers,
+    storageState: options.storageState,
+    timezoneId: options.timezoneId,
+    userAgent: options.userAgent,
+    viewport: options.viewport,
+  };
+};
+
+const createDesignerContext = async (browser: Browser, projectInfo: ProjectInfo, videoDirectory?: string) => {
+  const context = await browser.newContext(contextOptions(projectInfo, videoDirectory));
+  const originState = designerStorageState.origins[0];
+
+  await context.addInitScript(
+    ({ localStorageEntries, origin }) => {
+      if (window.location.origin !== origin) {
+        return;
+      }
+
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+      for (const { name, value } of localStorageEntries) {
+        window.localStorage.setItem(name, value);
+      }
+    },
+    {
+      localStorageEntries: originState.localStorage,
+      origin: originState.origin,
+    }
+  );
+
+  return context;
+};
+
+const prepareDesignerPage = async (page: Page, mockWorkflow: string | undefined) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  if (mockWorkflow) {
+    await GoToMockWorkflow(page, mockWorkflow);
+  }
+};
+
+const closeIgnoringTargetClosed = async (close: () => Promise<void>) => {
+  try {
+    await close();
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes('Target page, context or browser has been closed')) {
+      throw error;
+    }
+  }
+};
+
+const attachRetryVideo = async (context: BrowserContext, page: Page, testInfo: TestInfo) => {
+  const video = page.video();
+  await closeIgnoringTargetClosed(() => page.close());
+  await closeIgnoringTargetClosed(() => context.close());
+
+  if (video) {
+    await testInfo.attach('video', {
+      path: await video.path(),
+      contentType: 'video/webm',
+    });
+  }
+};
+
+export const test = base.extend<SharedDesignerOptions, SharedDesignerWorkerFixtures>({
+  mockWorkflow: [undefined, { option: true }],
+  sharedContextManager: [
+    async ({ browser }, use, workerInfo) => {
+      // Keep resource caches within a spec file, while pages and browser storage still reset for every test.
+      const contexts = new Map<string, BrowserContext>();
+
+      await use({
+        getContext: async (testFile) => {
+          const existingContext = contexts.get(testFile);
+          if (existingContext) {
+            return existingContext;
+          }
+
+          const context = await createDesignerContext(browser, workerInfo);
+          contexts.set(testFile, context);
+          return context;
+        },
+      });
+
+      await Promise.all([...contexts.values()].map((context) => context.close()));
+    },
+    { scope: 'worker' },
+  ],
+  page: async ({ browser, mockWorkflow, sharedContextManager }, runTest, testInfo) => {
+    const recordRetryArtifacts = testInfo.retry === 1;
+    const retryContext =
+      testInfo.retry > 0
+        ? await createDesignerContext(browser, testInfo, recordRetryArtifacts ? testInfo.outputPath('video') : undefined)
+        : undefined;
+    const context = retryContext ?? (await sharedContextManager.getContext(testInfo.file));
+    const page = await context.newPage();
+
+    try {
+      await prepareDesignerPage(page, mockWorkflow);
+      await runTest(page);
+    } finally {
+      if (retryContext) {
+        await attachRetryVideo(context, page, testInfo);
+      } else {
+        await page.close();
+      }
+    }
+  },
+});
+
+export { expect };

--- a/e2e/designer/operationPanel.spec.ts
+++ b/e2e/designer/operationPanel.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect, type Page } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures/sharedDesignerPage';
 
 test.describe(
   'OperationPanel Tests',
@@ -7,10 +7,9 @@ test.describe(
     tag: '@mock',
   },
   () => {
-    const openSelectedAndPinnedPanels = async (page: Page) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+    test.use({ mockWorkflow: 'Panel' });
 
+    const openSelectedAndPinnedPanels = async (page: Page) => {
       // Left-click on 'Parse JSON' node.
       await page.getByTestId('card-parse_json').click();
 
@@ -41,9 +40,6 @@ test.describe(
         await expect(page.locator('.msla-panel-container-nested')).not.toBeVisible();
       };
 
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
-
       // Left-click on 'Initialize ArrayVariable' node.
       await page.getByTestId('card-initialize_arrayvariable').click();
 
@@ -56,9 +52,6 @@ test.describe(
     });
 
     test('Can pin a node, and close the panel', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
-
       // Left-click on 'Initialize ArrayVariable' node.
       await page.getByTestId('card-initialize_arrayvariable').click({ button: 'right' });
       await page.getByTestId('msla-pin-menu-option').click();
@@ -127,9 +120,6 @@ test.describe(
     });
 
     test('Should only show the panel info message when trigger type is request', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
-
       // Left-click on 'manual' trigger.
       await page.getByTestId('card-manual').click();
 
@@ -145,8 +135,6 @@ test.describe(
     });
 
     test('Should show proper operation panel tabs', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
       // Left-click on 'manual' trigger.
       await page.getByTestId('card-manual').click();
       await expect(page.getByRole('tab', { name: 'Parameters' })).toBeVisible();

--- a/e2e/designer/scopeActions.spec.ts
+++ b/e2e/designer/scopeActions.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { test, expect } from './fixtures/sharedDesignerPage';
 
 test.describe(
   'Scope actions tests',
@@ -7,10 +6,9 @@ test.describe(
     tag: '@mock',
   },
   () => {
-    test('Should collapse condition actions', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
+    test.use({ mockWorkflow: 'All Scope Nodes' });
 
+    test('Should collapse condition actions', async ({ page }) => {
       // Check items inside conditions exist in true side are visible
       await expect(page.getByTestId('card-terminate').getByRole('button', { name: 'Terminate' })).toBeVisible();
       await expect(page.getByTestId('card-increment_variable_4').getByRole('button', { name: 'Increment variable' })).toBeVisible();
@@ -48,9 +46,6 @@ test.describe(
     });
 
     test('Should collapse for each actions', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
-
       // Collapse empty foreach
       await page.getByTestId('ForEach_empty-collapse-toggle').click();
 
@@ -85,9 +80,6 @@ test.describe(
     });
 
     test('Should collapse do until actions', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
-
       // Check items inside do until actions are visible
       await expect(page.getByTestId('card-until_action_1').getByRole('button', { name: 'Until Action' })).toBeVisible();
       await expect(page.getByTestId('card-until_action_2').getByRole('button', { name: 'Until Action' })).toBeVisible();
@@ -114,9 +106,6 @@ test.describe(
     });
 
     test('Should collapse switch actions', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'All Scope Nodes');
-
       // Check items inside conditions exist in true side are visible
       await expect(page.getByTestId('card-terminate').getByRole('button', { name: 'Terminate' })).toBeVisible();
       await expect(page.getByTestId('card-increment_variable_4').getByRole('button', { name: 'Increment variable' })).toBeVisible();

--- a/e2e/designer/tabFocus.spec.ts
+++ b/e2e/designer/tabFocus.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/sharedDesignerPage';
 import { GoToMockWorkflow } from './utils/GoToWorkflow';
 
 test.describe(
@@ -11,7 +11,6 @@ test.describe(
       test.skip(browserName === 'firefox', 'Still working on it');
       const tab = async () => page.locator('*:focus').press('Tab');
 
-      await page.goto('/');
       await GoToMockWorkflow(page, 'All Scope Nodes');
 
       // Find element with text 'Recurrence'
@@ -52,7 +51,6 @@ test.describe(
       const tab = async () => page.locator('*:focus').press('Tab');
       const backTab = async () => page.locator('*:focus').press('Shift+Tab');
 
-      await page.goto('/');
       await GoToMockWorkflow(page, 'Panel');
 
       // Find element with text 'manual'
@@ -79,7 +77,6 @@ test.describe(
     test('Should focus toolbar controls after workflow elements', async ({ page, browserName }) => {
       test.skip(browserName === 'firefox', 'Still working on it');
 
-      await page.goto('/');
       await GoToMockWorkflow(page, 'All Scope Nodes');
 
       // Wait for workflow to load
@@ -139,7 +136,6 @@ test.describe(
     test('Should focus toolbar controls after closing panel', async ({ page, browserName }) => {
       test.skip(browserName === 'firefox', 'Still working on it');
 
-      await page.goto('/');
       await GoToMockWorkflow(page, 'All Scope Nodes');
 
       // Wait for workflow to load
@@ -169,7 +165,6 @@ test.describe(
       test.skip(browserName === 'firefox', 'Still working on it');
       const tab = async () => page.locator('*:focus').press('Tab');
 
-      await page.goto('/');
       await GoToMockWorkflow(page, 'Panel');
 
       // Focus directly on the first toolbar control
@@ -209,7 +204,6 @@ test.describe(
     test('Should activate toolbar controls with keyboard', async ({ page, browserName }) => {
       test.skip(browserName === 'firefox', 'Still working on it');
 
-      await page.goto('/');
       await GoToMockWorkflow(page, 'Panel');
 
       // Focus on zoom in button and press Enter

--- a/e2e/designer/tokens/escapeExpressionTokens.spec.ts
+++ b/e2e/designer/tokens/escapeExpressionTokens.spec.ts
@@ -1,5 +1,4 @@
-import test, { expect } from '@playwright/test';
-import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+import { test, expect } from '../fixtures/sharedDesignerPage';
 
 test.describe(
   'Escape Expression Tokens Tests',
@@ -7,9 +6,9 @@ test.describe(
     tag: '@mock',
   },
   async () => {
+    test.use({ mockWorkflow: 'Panel' });
+
     test('Expressions should be able to use escape characters and serialize', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
       await page.getByLabel('HTTP operation, HTTP connector').click();
       await page.getByTitle('Enter request content').getByRole('paragraph').click();
       await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-expression"]').click();
@@ -29,8 +28,6 @@ test.describe(
     });
 
     test('Expressions should be able to use escaped escape characters and serialize as the same', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
       await page.getByLabel('HTTP operation, HTTP connector').click();
       await page.getByTitle('Enter request content').getByRole('paragraph').click();
       await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-expression"]').click();
@@ -50,8 +47,6 @@ test.describe(
     });
 
     test('Expressions should maintain behavior of escaped characters in all instances the user views at', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
       await page.getByLabel('HTTP operation, HTTP connector').click();
       await page.getByTitle('Enter request content').getByRole('paragraph').click();
       await page.locator('[data-automation-id="msla-token-picker-entrypoint-button-expression"]').click();

--- a/e2e/designer/tokens/tokenRemoval.spec.ts
+++ b/e2e/designer/tokens/tokenRemoval.spec.ts
@@ -1,5 +1,4 @@
-import test, { expect } from '@playwright/test';
-import { GoToMockWorkflow } from '../utils/GoToWorkflow';
+import { test, expect } from '../fixtures/sharedDesignerPage';
 import { getSerializedWorkflowFromState } from '../utils/designerFunctions';
 
 test.describe(
@@ -8,9 +7,9 @@ test.describe(
     tag: '@mock',
   },
   async () => {
+    test.use({ mockWorkflow: 'Panel' });
+
     test('Tokens should be removed from parameters when operation is deleted', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect(serializedOld.definition.actions.Filter_array.inputs.from).toEqual("@{body('Parse_JSON')}test");
       await page.getByLabel('Parse JSON operation, Data').click({
@@ -24,9 +23,6 @@ test.describe(
       expect(JSON.stringify(serializedNew)).not.toContain("@{body('Parse_JSON')}");
     });
     test('Tokens should be removed from parameters when variable is deleted', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect(serializedOld.definition.actions.Parse_JSON.inputs.content).toEqual(
         "@{triggerBody()?['string']}@{variables('ArrayVariable')}@{parameters('EILCO Admin Nominations-OCSA List (cr773_EILCOAdminNominations_OCSA_L2)')}"
@@ -47,9 +43,6 @@ test.describe(
     });
 
     test('Tokens should be removed from parameters when trigger is deleted', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect
         .soft(serializedOld.definition.actions.Parse_JSON.inputs.content)
@@ -70,9 +63,6 @@ test.describe(
     });
 
     test('Tokens should be removed from parameters when workflow parameter is deleted', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect(serializedOld.definition.actions.Parse_JSON.inputs.content).toEqual(
         "@{triggerBody()?['string']}@{variables('ArrayVariable')}@{parameters('EILCO Admin Nominations-OCSA List (cr773_EILCOAdminNominations_OCSA_L2)')}"
@@ -96,9 +86,6 @@ test.describe(
       );
     });
     test('Output should be correct when multiple tokens get removed by removing source', async ({ page }) => {
-      await page.goto('/');
-
-      await GoToMockWorkflow(page, 'Panel');
       const serializedOld: any = await getSerializedWorkflowFromState(page);
       expect(serializedOld.definition.actions.Parse_JSON.inputs.content).toEqual(
         "@{triggerBody()?['string']}@{variables('ArrayVariable')}@{parameters('EILCO Admin Nominations-OCSA List (cr773_EILCOAdminNominations_OCSA_L2)')}"

--- a/e2e/designer/workflowParametersPanel.spec.ts
+++ b/e2e/designer/workflowParametersPanel.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { test, expect } from './fixtures/sharedDesignerPage';
 
 test.describe(
   'WorkflowParametersPanel Tests',
@@ -7,10 +6,9 @@ test.describe(
     tag: '@mock',
   },
   () => {
-    test('Should open workflow parameters panel and add / edit / delete parameter', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Standard Workflow Parameters');
+    test.use({ mockWorkflow: 'Standard Workflow Parameters' });
 
+    test('Should open workflow parameters panel and add / edit / delete parameter', async ({ page }) => {
       // Open workflow parameters panel
       await page.getByText('Workflow Parameters', { exact: true }).click();
 

--- a/playwright.designer.config.ts
+++ b/playwright.designer.config.ts
@@ -2,6 +2,7 @@ process.env.NODE_ENV = 'development'; // Set before importing Playwright
 
 import { defineConfig, devices } from '@playwright/test';
 import 'dotenv/config';
+import { designerStorageState } from './e2e/designer/designerStorageState';
 
 export default defineConfig({
   testDir: './e2e',
@@ -26,20 +27,7 @@ export default defineConfig({
     baseURL: 'http://localhost:4200',
     video: 'on-first-retry',
     trace: 'on-first-retry',
-    storageState: {
-      cookies: [],
-      origins: [
-        {
-          origin: 'http://localhost:4200',
-          localStorage: [
-            {
-              name: 'control-expand-collapse-button',
-              value: 'true',
-            },
-          ],
-        },
-      ],
-    },
+    storageState: designerStorageState,
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [x] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Reuse Playwright browser contexts within each worker and spec file for selected designer mock suites. Tests still receive fresh pages, reset browser storage, freshly loaded mock workflows, and isolated retry contexts, while avoiding repeated context/cache initialization overhead.

This is stacked on `rllyy97-fix-flaky-ci-tests`; the PR diff contains only the resource-sharing commit.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No product behavior changes.
- **Developers**: Adds an opt-in shared designer page fixture and migrates 26 representative mock E2E tests.
- **System**: Reduced a 24-test repeated benchmark from 213.2s to 191.7s (10.1%) while retaining retry traces and videos.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: Local Windows, Chromium, 2 workers, zero retries; 26 migrated tests passed twice in parallel

Additional validation:
- Representative 24-test `repeat-each=2` benchmark passed.
- Forced first-retry failure preserved trace and video through blob-report merge.
- Forced timeout confirmed retry teardown does not emit secondary context-close failures.
- Biome, ESLint, and the pre-commit checks passed.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A
