### PR TITLE
test(e2e): stabilize designer startup and panel assertions

### DIFF
--- a/e2e/designer/globalSetup.ts
+++ b/e2e/designer/globalSetup.ts
@@ -1,0 +1,99 @@
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { chromium, type FullConfig, type Page } from '@playwright/test';
+
+const WARMUP_TIMEOUT_MS = 120_000;
+const MAX_DIAGNOSTIC_ENTRIES = 20;
+
+const addDiagnostic = (diagnostics: string[], message: string) => {
+  diagnostics.push(message);
+  if (diagnostics.length > MAX_DIAGNOSTIC_ENTRIES) {
+    diagnostics.shift();
+  }
+};
+
+const remainingTime = (deadline: number) => Math.max(1, deadline - Date.now());
+
+const captureFailureState = async (page: Page, outputDir: string) => {
+  const screenshotPath = join(outputDir, 'designer-warmup-failure.png');
+  await mkdir(outputDir, { recursive: true });
+
+  const bodyText = await page
+    .locator('body')
+    .innerText({ timeout: 2_000 })
+    .then((text) => text.replace(/\s+/g, ' ').slice(0, 1_000))
+    .catch(() => '<body text unavailable>');
+
+  const screenshotResult = await page
+    .screenshot({ path: screenshotPath, timeout: 5_000 })
+    .then(() => screenshotPath)
+    .catch((error) => `<screenshot failed: ${error instanceof Error ? error.message : String(error)}>`);
+
+  return {
+    url: page.url(),
+    bodyText,
+    screenshot: screenshotResult,
+  };
+};
+
+const globalSetup = async (config: FullConfig) => {
+  const project = config.projects[0];
+  const baseURL = project?.use.baseURL;
+  if (typeof baseURL !== 'string') {
+    throw new Error('[designer warmup] A string baseURL is required in the first Playwright project.');
+  }
+
+  const startedAt = Date.now();
+  const deadline = startedAt + WARMUP_TIMEOUT_MS;
+  const diagnostics: string[] = [];
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  page.on('console', (message) => {
+    if (message.type() === 'warning' || message.type() === 'error') {
+      addDiagnostic(diagnostics, `console.${message.type()}: ${message.text()}`);
+    }
+  });
+  page.on('pageerror', (error) => addDiagnostic(diagnostics, `pageerror: ${error.message}`));
+  page.on('requestfailed', (request) => {
+    addDiagnostic(diagnostics, `requestfailed: ${request.method()} ${request.url()} (${request.failure()?.errorText ?? 'unknown error'})`);
+  });
+  page.on('response', (response) => {
+    if (response.status() >= 400) {
+      addDiagnostic(diagnostics, `response: ${response.status()} ${response.url()}`);
+    }
+  });
+
+  console.log(`[designer warmup] Waiting up to ${WARMUP_TIMEOUT_MS / 1_000}s for the Local designer shell at ${baseURL}.`);
+
+  try {
+    const response = await page.goto(baseURL, {
+      waitUntil: 'domcontentloaded',
+      timeout: remainingTime(deadline),
+    });
+    addDiagnostic(diagnostics, `navigation: ${response?.status() ?? 'no response'} ${page.url()}`);
+
+    await page.getByText('Local', { exact: true }).waitFor({
+      state: 'visible',
+      timeout: remainingTime(deadline),
+    });
+
+    console.log(`[designer warmup] Local designer shell ready after ${((Date.now() - startedAt) / 1_000).toFixed(1)}s.`);
+  } catch (error) {
+    const failureState = await captureFailureState(page, project.outputDir);
+    const reason = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+    throw new Error(
+      [
+        `[designer warmup] Local designer shell was not ready within ${WARMUP_TIMEOUT_MS / 1_000}s.`,
+        `Reason: ${reason}`,
+        `Page state: ${JSON.stringify(failureState)}`,
+        `Recent browser diagnostics:\n${diagnostics.length > 0 ? diagnostics.join('\n') : '<none>'}`,
+      ].join('\n')
+    );
+  } finally {
+    await browser.close();
+  }
+};
+
+export default globalSetup;

--- a/e2e/designer/operationPanel.spec.ts
+++ b/e2e/designer/operationPanel.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { GoToMockWorkflow } from './utils/GoToWorkflow';
 
 test.describe(
@@ -7,6 +7,28 @@ test.describe(
     tag: '@mock',
   },
   () => {
+    const openSelectedAndPinnedPanels = async (page: Page) => {
+      await page.goto('/');
+      await GoToMockWorkflow(page, 'Panel');
+
+      // Left-click on 'Parse JSON' node.
+      await page.getByTestId('card-parse_json').click();
+
+      // Right-click on 'Initialize ArrayVariable' node, and select 'Pin' from the menu.
+      await page.getByTestId('card-initialize_arrayvariable').click({ button: 'right' });
+      await page.getByTestId('msla-pin-menu-option').click();
+
+      const selectedPanel = page.locator('.msla-panel-border-selected');
+      const pinnedPanel = page.locator('.msla-panel-layout-pinned');
+
+      await expect(selectedPanel.locator('.msla-panel-card-header input#Parse_JSON-title')).toBeVisible();
+      await expect(selectedPanel.locator('.msla-panel-card-header button[aria-label="Unpin action"]')).not.toBeVisible();
+      await expect(pinnedPanel.locator('.msla-panel-card-header input#Initialize_ArrayVariable-title')).toBeVisible();
+      await expect(pinnedPanel.locator('.msla-panel-card-header button[aria-label="Unpin action"]')).toBeVisible();
+      await expect(page.locator('.msla-panel-container-nested')).toHaveClass(/msla-panel-container-nested-dual/);
+      await expect(page.locator('.msla-panel-container')).toHaveCSS('width', '680px');
+    };
+
     test('Can select a node, and close the panel', async ({ page }) => {
       const validatePanel = async (state: 'open' | 'closed') => {
         if (state === 'open') {
@@ -34,17 +56,6 @@ test.describe(
     });
 
     test('Can pin a node, and close the panel', async ({ page }) => {
-      const validatePanel = async (state: 'open' | 'closed') => {
-        if (state === 'open') {
-          await expect(page.locator('.msla-panel-container-nested .msla-panel-border-selected')).toBeVisible();
-          await expect(page.locator('.msla-panel-card-header input#Initialize_ArrayVariable-title')).toBeVisible();
-          await expect(page.locator('.msla-panel-card-header button[aria-label="Unpin action"]')).toBeVisible();
-          return;
-        }
-
-        await expect(page.locator('.msla-panel-container-nested')).not.toBeVisible();
-      };
-
       await page.goto('/');
       await GoToMockWorkflow(page, 'Panel');
 
@@ -53,62 +64,58 @@ test.describe(
       await page.getByTestId('msla-pin-menu-option').click();
 
       // Panel should be open, with 'Initialize Variable' action.
-      await validatePanel('open');
+      const selectedPanel = page.locator('.msla-panel-border-selected');
+      await expect(selectedPanel).toBeVisible();
+      await expect(selectedPanel.locator('.msla-panel-card-header input#Initialize_ArrayVariable-title')).toBeVisible();
+      await expect(selectedPanel.locator('.msla-panel-card-header button[aria-label="Unpin action"]')).not.toBeVisible();
 
-      // Collapse the panel and verify.
-      await page.getByTestId('msla-panel-header-close-nav').first().click();
-      await validatePanel('closed');
+      // Closing the single selected+pinned panel should collapse the drawer and unpin the action.
+      await selectedPanel.getByTestId('msla-panel-header-close-nav').click();
+      await expect(page.locator('.msla-panel-container')).not.toBeVisible();
+
+      await page.getByTestId('card-initialize_arrayvariable').click({ button: 'right' });
+      await expect(page.getByTestId('msla-pin-menu-option')).toHaveText('Pin action');
     });
 
     test('Can have both selected and pinned operations open, and close the panel', async ({ page }) => {
-      const validatePanel = async (state: 'open' | 'closed') => {
-        if (state === 'open') {
-          // Node panel tab should be open with 'Parse JSON' node.
-          await expect(page.locator('.msla-panel-border-selected .msla-panel-card-header input#Parse_JSON-title')).toBeVisible();
-          await expect(
-            page.locator('.msla-panel-border-selected .msla-panel-card-header button[aria-label="Unpin action"]')
-          ).not.toBeVisible();
+      await openSelectedAndPinnedPanels(page);
 
-          // Node panel tab should also be open with 'Initialize Variable' action pinned.
-          await expect(
-            page.locator('.msla-panel-layout-pinned .msla-panel-card-header input#Initialize_ArrayVariable-title')
-          ).toBeVisible();
-          await expect(page.locator('.msla-panel-layout-pinned .msla-panel-card-header button[aria-label="Unpin action"]')).toBeVisible();
+      const drawer = page.locator('.msla-panel-container');
+      const nestedPanel = page.locator('.msla-panel-container-nested');
+      const selectedPanel = page.locator('.msla-panel-border-selected');
+      const pinnedPanel = page.locator('.msla-panel-layout-pinned');
 
-          return;
-        }
+      // Closing the selected pane should leave the pinned action open in a single-width drawer.
+      await selectedPanel.getByTestId('msla-panel-header-close-nav').click();
+      await expect(selectedPanel.locator('.msla-panel-card-header input#Parse_JSON-title')).not.toBeVisible();
+      await expect(pinnedPanel.locator('.msla-panel-card-header input#Initialize_ArrayVariable-title')).toBeVisible();
+      await expect(drawer).toBeVisible();
+      await expect(nestedPanel).not.toHaveClass(/msla-panel-container-nested-dual/);
+      await expect(drawer).toHaveCSS('width', '480px');
 
-        await expect(page.locator('.msla-panel-container-nested')).not.toBeVisible();
-      };
+      // Closing the remaining pinned pane should collapse the drawer.
+      await pinnedPanel.getByTestId('msla-panel-header-close-nav').click();
+      await expect(drawer).not.toBeVisible();
+    });
 
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
+    test('Closing the pinned operation keeps the selected operation open', async ({ page }) => {
+      await openSelectedAndPinnedPanels(page);
 
-      // Left-click on 'Parse JSON' node.
-      await page.getByTestId('card-parse_json').click();
+      const drawer = page.locator('.msla-panel-container');
+      const nestedPanel = page.locator('.msla-panel-container-nested');
+      const selectedPanel = page.locator('.msla-panel-border-selected');
+      const pinnedPanel = page.locator('.msla-panel-layout-pinned');
 
-      // Right-click on 'Initialize ArrayVariable' node, and select 'Pin' from the menu.
-      await page.getByTestId('card-initialize_arrayvariable').click({ button: 'right' });
-      await page.getByTestId('msla-pin-menu-option').click();
-
-      // Panel should be open, with 'Initialize Variable' and 'Parse JSON' actions.
-      await validatePanel('open');
-
-      // Collapse the panel and verify.
-      await page.getByTestId('msla-panel-header-close-nav').first().click();
-      await validatePanel('closed');
+      await pinnedPanel.getByTestId('msla-panel-header-close-nav').click();
+      await expect(pinnedPanel.locator('.msla-panel-card-header input#Initialize_ArrayVariable-title')).not.toBeVisible();
+      await expect(selectedPanel.locator('.msla-panel-card-header input#Parse_JSON-title')).toBeVisible();
+      await expect(drawer).toBeVisible();
+      await expect(nestedPanel).not.toHaveClass(/msla-panel-container-nested-dual/);
+      await expect(drawer).toHaveCSS('width', '480px');
     });
 
     test('Can switch between different tabs independently in selected/pinned panels', async ({ page }) => {
-      await page.goto('/');
-      await GoToMockWorkflow(page, 'Panel');
-
-      // Left-click on 'Parse JSON' node.
-      await page.getByTestId('card-parse_json').click();
-
-      // Right-click on 'Initialize ArrayVariable' node, and select 'Pin' from the menu.
-      await page.getByTestId('card-initialize_arrayvariable').click({ button: 'right' });
-      await page.getByTestId('msla-pin-menu-option').click();
+      await openSelectedAndPinnedPanels(page);
 
       // Click on 'Settings' tab for 'Parse JSON' and on 'Code view' tab for 'Initialize ArrayVariable'.
       await page.locator('.msla-panel-border-selected #msla-node-details-panel-Parse_JSON button[value=SETTINGS]').click();

--- a/playwright.designer.config.ts
+++ b/playwright.designer.config.ts
@@ -6,6 +6,7 @@ import 'dotenv/config';
 export default defineConfig({
   testDir: './e2e',
   testMatch: ['designer/**/*.spec.ts', 'templates/**/*.spec.ts'],
+  globalSetup: './e2e/designer/globalSetup.ts',
   reporter: process.env.TEST_SHARDED ? 'blob' : 'html',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [x] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Stabilize the designer Playwright suite by warming the local designer shell before workers begin and by making operation-panel assertions target the selected and pinned panes explicitly.

The global warmup separates Vite's cold compilation from individual test timeouts and records bounded browser diagnostics when the shell cannot become ready. The panel tests now validate the intended selected/pinned behavior without relying on ambiguous first-match locators.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No product behavior changes.
- **Developers**: More deterministic designer Playwright startup and clearer panel regression coverage.
- **System**: Adds one pre-suite Chromium warmup that closes before test workers start; normal worker parallelism, retries, traces, and videos are unchanged.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: Local Windows, Chromium, 2 workers, zero retries

Validation included two repetitions of the representative operation-panel, scope-action, and workflow-parameter suites (24 tests total), with all tests passing after the designer warmup completed.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A
