### PR TITLE
fix(designer): keep dynamic operation errors within panel

### DIFF
--- a/__mocks__/workflows/DynamicOutputsOverflow.json
+++ b/__mocks__/workflows/DynamicOutputsOverflow.json
@@ -1,0 +1,22 @@
+{
+  "definition": {
+    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+    "actions": {},
+    "contentVersion": "1.0.0.0",
+    "outputs": {},
+    "triggers": {
+      "manual": {
+        "type": "Request",
+        "kind": "Http",
+        "inputs": {
+          "schema": {
+            "type": "object"
+          }
+        },
+        "splitOn": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/overflow-test/providers/Microsoft.Insights/components/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-DYNAMIC-OUTPUTS-SENTINEL?api-version=2020-02-02"
+      }
+    }
+  },
+  "connectionReferences": {},
+  "parameters": {}
+}

--- a/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
@@ -11,6 +11,7 @@ const fileOptions = [
   { key: 'GeneralHeader', text: 'General Workflows', itemType: DropdownMenuItemType.Header },
   { key: 'Empty.json', text: 'Empty/New' },
   { key: 'Panel.json', text: 'Panel' },
+  { key: 'DynamicOutputsOverflow.json', text: 'Dynamic Outputs Overflow' },
   { key: 'Recurrence.json', text: 'Recurrence' },
   { key: 'MultiVariable.json', text: 'Multi Variable' },
   // { key: 'straightLine.json', text: 'Straight Line' },

--- a/e2e/designer/operationPanel.spec.ts
+++ b/e2e/designer/operationPanel.spec.ts
@@ -156,5 +156,37 @@ test.describe(
       await expect(page.getByRole('tab', { name: 'Parameters' })).toBeVisible();
       await expect(page.getByRole('tab', { name: 'Testing' })).toBeVisible();
     });
+
+    for (const { designer, route } of [
+      { designer: 'designer v1', route: '/' },
+      { designer: 'designer v2', route: '/v2' },
+    ]) {
+      test(`Should keep dynamic output failure details inside the panel in ${designer}`, async ({ page }) => {
+        await page.goto(route);
+        await GoToMockWorkflow(page, 'Dynamic Outputs Overflow');
+
+        await page.getByTestId('card-manual').click();
+
+        const errorMessage = page.getByTestId('msla-operation-error-message');
+        await expect(errorMessage).toContainText('DYNAMIC-OUTPUTS-SENTINEL');
+
+        const dimensions = await errorMessage.evaluate((element) => {
+          const panelContent = element.closest('.msla-panel-content-container');
+          if (!panelContent) {
+            throw new Error('Operation error message is not inside the panel content container.');
+          }
+
+          return {
+            clientWidth: element.clientWidth,
+            scrollWidth: element.scrollWidth,
+            errorRight: element.getBoundingClientRect().right,
+            panelRight: panelContent.getBoundingClientRect().right,
+          };
+        });
+
+        expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 1);
+        expect(dimensions.errorRight).toBeLessThanOrEqual(dimensions.panelRight + 1);
+      });
+    }
   }
 );

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -60,6 +60,7 @@ import {
   Field,
   Input,
   Link,
+  makeStyles,
   MessageBar,
   MessageBarBody,
   Option,
@@ -155,8 +156,16 @@ export interface ParametersTabProps extends PanelTabProps {
   isTabReadOnly?: boolean;
 }
 
+const useParametersTabStyles = makeStyles({
+  errorMessageBody: {
+    minWidth: 0,
+    overflowWrap: 'anywhere',
+  },
+});
+
 export const ParametersTab: React.FC<ParametersTabProps> = (props) => {
   const { nodeId: selectedNodeId, isTabReadOnly } = props;
+  const styles = useParametersTabStyles();
   const nodeMetadata = useNodeMetadata(selectedNodeId);
   const inputs = useSelector((state: RootState) => state.operations.inputParameters[selectedNodeId]);
   const { tokenState, workflowParametersState, workflowState } = useSelector((state: RootState) => ({
@@ -244,7 +253,7 @@ export const ParametersTab: React.FC<ParametersTabProps> = (props) => {
           }
           layout="multiline"
         >
-          <MessageBarBody>
+          <MessageBarBody className={styles.errorMessageBody} data-automation-id="msla-operation-error-message">
             <Text>{errorInfo.message}</Text>
           </MessageBarBody>
         </MessageBar>

--- a/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -60,6 +60,7 @@ import {
   Field,
   Input,
   Link,
+  makeStyles,
   MessageBar,
   MessageBarBody,
   Option,
@@ -155,8 +156,16 @@ export interface ParametersTabProps extends PanelTabProps {
   isTabReadOnly?: boolean;
 }
 
+const useParametersTabStyles = makeStyles({
+  errorMessageBody: {
+    minWidth: 0,
+    overflowWrap: 'anywhere',
+  },
+});
+
 export const ParametersTab: React.FC<ParametersTabProps> = (props) => {
   const { nodeId: selectedNodeId, isTabReadOnly } = props;
+  const styles = useParametersTabStyles();
   const nodeMetadata = useNodeMetadata(selectedNodeId);
   const inputs = useSelector((state: RootState) => state.operations.inputParameters[selectedNodeId]);
   const { tokenState, workflowParametersState, workflowState } = useSelector((state: RootState) => ({
@@ -243,7 +252,7 @@ export const ParametersTab: React.FC<ParametersTabProps> = (props) => {
           }
           layout="multiline"
         >
-          <MessageBarBody>
+          <MessageBarBody className={styles.errorMessageBody} data-automation-id="msla-operation-error-message">
             <Text>{errorInfo.message}</Text>
           </MessageBarBody>
         </MessageBar>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->

Fixes #9386.

Keep dynamic operation failure details within the Parameters panel in designer v1 and v2. Both `libs/designer` and `libs/designer-v2` ParametersTab error `MessageBarBody` components now use local Fluent `makeStyles` with `minWidth: 0` and `overflowWrap: anywhere`, plus a stable automation ID.

This also adds a deterministic `DynamicOutputsOverflow` mock workflow, registers it in Standalone, and adds Playwright geometry regression coverage for `/` and `/v2`.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Long dynamic operation error messages wrap within the Parameters panel instead of rendering offscreen.
- **Developers**: Adds a deterministic Standalone mock workflow and Playwright regression coverage for both designer versions.
- **System**: Local presentation-only error wrapping; no shared panel styles, state, APIs, or dependencies are changed.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: <!-- environments/scenarios -->

- Pre-fix: both new geometry tests failed with `errorRight` `2454.234375` versus `panelRight + 1` `1281`.
- Post-fix: targeted Playwright tests passed 2/2; full `operationPanel` suite passed 9/9.
- Designer v1 and v2 `build:lib` passed.
- Standalone build passed with `--configLoader native`; default Vite config bundling encountered the local `ERR_PACKAGE_IMPORT_NOT_DEFINED` environment issue.
- Tested locally in Standalone on both `/` and `/v2`.
- Unit tests were not added because the regression depends on rendered browser geometry and is covered by Playwright.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

N/A

## Screenshots/Videos
<!-- Visual changes only -->

- **Before**: Original issue screenshot: https://github.com/user-attachments/assets/6a749c9c-1bf2-4b1a-98c3-d9950e10388c
- **After**: No after screenshot is available. The result is enforced by the `/` and `/v2` Playwright geometry regression, which verifies the error boundary remains within the panel.