### PR TITLE
chore(designer): drop (Preview) from Foundry project agent model source label

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/__test__/agentloop.spec.ts
@@ -30,9 +30,9 @@ describe('agentloop – Foundry V2 regression', () => {
       expect(dropdownValues).toContain('AzureOpenAI');
     });
 
-    it('should label the V2 option as "Foundry project (Preview)"', () => {
+    it('should label the V2 option as "Foundry project"', () => {
       const v2Option = agentModelTypeOptions.find((o) => o.value === 'FoundryAgentServiceV2');
-      expect(v2Option?.displayName).toBe('Foundry project (Preview)');
+      expect(v2Option?.displayName).toBe('Foundry project');
     });
   });
 

--- a/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/standard/manifest/agentloop.ts
@@ -59,7 +59,7 @@ export default {
               },
               {
                 value: 'FoundryAgentServiceV2',
-                displayName: 'Foundry project (Preview)',
+                displayName: 'Foundry project',
                 unSupportedWorkflowKind: ['agent'],
               },
               {


### PR DESCRIPTION
## Commit Type
- [x] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
The "Foundry project" option in the agent model source dropdown (Create connection panel) is shipping to GA, so it no longer needs a "(Preview)" suffix. This tag is defined entirely in UX code, not the backend, so removing it is a frontend-only change.

Removes "(Preview)" from the `FoundryAgentServiceV2` option's `displayName` in the agent loop client manifest and updates the mirrored label assertion in the manifest test.

This also aligns the dropdown label with the internal `AgentUtils.ManifestToDisplayName.FoundryAgentServiceV2` mapping, which already resolved to `Foundry project` (no "Preview").

## Impact of Change
- **Users**: The agent model source dropdown now shows "Foundry project" instead of "Foundry project (Preview)". No behavioral change; the option value (`FoundryAgentServiceV2`), visibility dependencies, and required fields are unchanged.
- **Developers**: N/A
- **System**: N/A

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed

The manifest test (`agentloop.spec.ts`) was updated to assert the new label; full file passes (17/17). The existing E2E test selects the option via a `Foundry project` substring match, so it remains valid without changes. Only the Foundry project option was updated; the other Preview-tagged options in the same dropdown were intentionally left untouched.

## Contributors
N/A

## Screenshots/Videos
N/A
