### PR TITLE
fix(vscode): Data Mapper Test Panel 400 From NetFxWorker not launching

### DIFF
--- a/apps/vs-code-designer/src/app/commands/dataMapper/FxWorkflowRuntime.ts
+++ b/apps/vs-code-designer/src/app/commands/dataMapper/FxWorkflowRuntime.ts
@@ -8,6 +8,8 @@ import {
   appKindSetting,
   designTimeDirectoryName,
   designerStartApi,
+  functionsInprocNet8Enabled,
+  functionsInprocNet8EnabledTrue,
   hostFileContent,
   hostFileName,
   localSettingsFileName,
@@ -17,6 +19,7 @@ import {
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { addOrUpdateLocalAppSettings, getLocalSettingsSchema } from '../../utils/appSettings/localSettings';
+import { useNodeDesignTimeWorker } from '../../utils/vsCodeConfig/settings';
 import {
   createJsonFile,
   getOrCreateDesignTimeDirectory,
@@ -57,22 +60,22 @@ export async function startBackendRuntime(context: IActionContext, projectPath: 
       return;
     }
 
-    const settingsFileContent = getLocalSettingsSchema(true, projectPath);
+    const useNodeWorker = useNodeDesignTimeWorker(projectPath);
+    const settingsFileContent = getLocalSettingsSchema(true, projectPath, undefined, useNodeWorker);
 
     try {
       if (designTimeDirectory) {
         await createJsonFile(designTimeDirectory, hostFileName, hostFileContent);
         await createJsonFile(designTimeDirectory, localSettingsFileName, settingsFileContent);
-        await addOrUpdateLocalAppSettings(
-          context,
-          designTimeDirectory.fsPath,
-          {
-            [appKindSetting]: logicAppKind,
-            [ProjectDirectoryPathKey]: projectPath,
-            [workerRuntimeKey]: WorkerRuntime.Dotnet,
-          },
-          true
-        );
+        const runtimeSettings: Record<string, string> = {
+          [appKindSetting]: logicAppKind,
+          [ProjectDirectoryPathKey]: projectPath,
+          [workerRuntimeKey]: useNodeWorker ? WorkerRuntime.Node : WorkerRuntime.Dotnet,
+        };
+        if (!useNodeWorker) {
+          runtimeSettings[functionsInprocNet8Enabled] = functionsInprocNet8EnabledTrue;
+        }
+        await addOrUpdateLocalAppSettings(context, designTimeDirectory.fsPath, runtimeSettings, true);
         const cwd: string = designTimeDirectory.fsPath;
         const portArgs = `--port ${designTimeInst.port}`;
         startDesignTimeProcess(ext.outputChannel, cwd, getFunctionsCommand(), 'host', 'start', portArgs);

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -80,6 +80,7 @@ import { localize } from '../../localize';
 import { guid } from '@microsoft/logic-apps-shared';
 import { openLanguageServerConnectionView } from './workflows/languageServer/connectionView';
 import { enableDevContainer } from './enableDevContainer/enableDevContainer';
+import { toggleDesignTimeNodeWorker } from './toggleDesignTimeNodeWorker';
 
 export function registerCommands(): void {
   registerCommandWithTreeNodeUnwrapping(extensionCommand.openDesigner, openDesigner);
@@ -111,6 +112,7 @@ export function registerCommands(): void {
   registerCommandWithTreeNodeUnwrapping(extensionCommand.exportLogicApp, exportLogicApp);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.reviewValidation, reviewValidation);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.switchToDotnetProject, switchToDotnetProjectCommand);
+  registerCommand(extensionCommand.toggleDesignTimeNodeWorker, toggleDesignTimeNodeWorker);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.openInPortal, openInPortal);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.browseWebsite, browseWebsite);
   registerCommandWithTreeNodeUnwrapping(extensionCommand.viewProperties, viewProperties);

--- a/apps/vs-code-designer/src/app/commands/toggleDesignTimeNodeWorker.ts
+++ b/apps/vs-code-designer/src/app/commands/toggleDesignTimeNodeWorker.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { useNodeDesignTimeWorkerSetting } from '../../constants';
+import { localize } from '../../localize';
+import { startAllDesignTimeApis, stopAllDesignTimeApis } from '../utils/codeless/startDesignTimeApi';
+import { updateWorkspaceSetting, useNodeDesignTimeWorker } from '../utils/vsCodeConfig/settings';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+
+/**
+ * Toggles the `azureLogicAppsStandard.useNodeDesignTimeWorker` workspace setting and restarts the
+ * design-time host so the change takes effect immediately. This is the user-facing escape hatch for the
+ * design-time worker runtime: by default the host runs in-process .NET 8 (required by the Data Mapper Test
+ * map's NetFxWorker); enabling the fallback runs it on the Node worker instead.
+ * @param {IActionContext} context - The action context.
+ */
+export async function toggleDesignTimeNodeWorker(context: IActionContext): Promise<void> {
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  if (folders.length === 0) {
+    vscode.window.showWarningMessage(
+      localize('noWorkspaceForDesignTimeWorker', 'Open a Logic Apps workspace before changing the design-time worker runtime.')
+    );
+    return;
+  }
+
+  const enableNodeWorker = !useNodeDesignTimeWorker(folders[0].uri.fsPath);
+  for (const folder of folders) {
+    await updateWorkspaceSetting(useNodeDesignTimeWorkerSetting, enableNodeWorker, folder.uri.fsPath);
+  }
+  context.telemetry.properties.useNodeDesignTimeWorker = String(enableNodeWorker);
+
+  const message = enableNodeWorker
+    ? localize(
+        'designTimeNodeWorkerEnabled',
+        'Design-time host set to the Node.js worker (fallback). The Data Mapper Test map is unavailable in this mode. Restarting the design-time host…'
+      )
+    : localize('designTimeNodeWorkerDisabled', 'Design-time host set to in-process .NET 8 (default). Restarting the design-time host…');
+  vscode.window.showInformationMessage(message);
+
+  // Restart the design-time host so the regenerated local.settings.json (with the new worker runtime) is picked up.
+  await stopAllDesignTimeApis();
+  await startAllDesignTimeApis();
+}

--- a/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
@@ -47,6 +47,12 @@ describe('utils/appSettings', () => {
       expect(settings['Values']).toHaveProperty(ProjectDirectoryPathKey, projectPath);
     });
 
+    it('Should run the design time host in-process .NET 8 (dotnet worker runtime + inproc flag)', () => {
+      const settings = getLocalSettingsSchema(true, projectPath);
+      expect(settings['Values']).toHaveProperty(workerRuntimeKey, WorkerRuntime.Dotnet);
+      expect(settings['Values']).toHaveProperty(functionsInprocNet8Enabled, functionsInprocNet8EnabledTrue);
+    });
+
     it('Should have the AzureWebJobsStorage when is not design time localsettings and have ProjectDirectoryPath property when sent', () => {
       const settings = getLocalSettingsSchema(false, projectPath);
       expect(settings['Values']).toHaveProperty(azureWebJobsStorageKey, localEmulatorConnectionString);
@@ -124,13 +130,14 @@ describe('utils/appSettings', () => {
     });
 
     describe('expected design-time content by logic app type', () => {
-      it('design-time local.settings.json (codeless / Standard Node)', () => {
+      it('design-time local.settings.json (codeless / Standard in-process .NET 8)', () => {
         expect(getLocalSettingsSchema(true, projectPath, ProjectType.logicApp)).toEqual({
           IsEncrypted: false,
           Values: {
             [appKindSetting]: logicAppKind,
             [ProjectDirectoryPathKey]: projectPath,
-            [workerRuntimeKey]: WorkerRuntime.Node,
+            [workerRuntimeKey]: WorkerRuntime.Dotnet,
+            [functionsInprocNet8Enabled]: functionsInprocNet8EnabledTrue,
             [azureWebJobsSecretStorageTypeKey]: azureStorageTypeSetting,
           },
         });
@@ -142,9 +149,22 @@ describe('utils/appSettings', () => {
           Values: {
             [appKindSetting]: logicAppKind,
             [ProjectDirectoryPathKey]: projectPath,
-            [workerRuntimeKey]: WorkerRuntime.Node,
+            [workerRuntimeKey]: WorkerRuntime.Dotnet,
+            [functionsInprocNet8Enabled]: functionsInprocNet8EnabledTrue,
             [azureWebJobsSecretStorageTypeKey]: azureStorageTypeSetting,
             [workflowCodefulEnabledKey]: 'true',
+          },
+        });
+      });
+
+      it('design-time local.settings.json (Node-worker fallback) uses the Node runtime without the in-process .NET 8 flag', () => {
+        expect(getLocalSettingsSchema(true, projectPath, ProjectType.logicApp, true)).toEqual({
+          IsEncrypted: false,
+          Values: {
+            [appKindSetting]: logicAppKind,
+            [ProjectDirectoryPathKey]: projectPath,
+            [workerRuntimeKey]: WorkerRuntime.Node,
+            [azureWebJobsSecretStorageTypeKey]: azureStorageTypeSetting,
           },
         });
       });

--- a/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/localSettings.ts
@@ -190,18 +190,32 @@ export async function getAzureWebJobsStorage(context: IActionContext, projectPat
  * @param {boolean} isDesignTime - Whether to build the design-time folder file (true) or the project-root file (false).
  * @param {string} [projectPath] - Absolute path to the logic app project folder (ProjectDirectoryPath value). Omitted -> the key is not written.
  * @param {ProjectType} [logicAppType] - The logic app project type; drives the multi-language worker and codeful flags.
+ * @param {boolean} [useNodeWorker] - Design-time only: emit the Node worker runtime (fallback) instead of dotnet + in-process .NET 8.
  * @returns {ILocalSettingsJson} The local.settings.json content.
  */
-export const getLocalSettingsSchema = (isDesignTime: boolean, projectPath?: string, logicAppType?: ProjectType): ILocalSettingsJson => {
+export const getLocalSettingsSchema = (
+  isDesignTime: boolean,
+  projectPath?: string,
+  logicAppType?: ProjectType,
+  useNodeWorker = false
+): ILocalSettingsJson => {
   const values: Record<string, string> = {};
 
   if (isDesignTime) {
-    // Design-time order: APP_KIND, ProjectDirectoryPath, FUNCTIONS_WORKER_RUNTIME, AzureWebJobsSecretStorageType.
+    // Design-time order: APP_KIND, ProjectDirectoryPath, FUNCTIONS_WORKER_RUNTIME, FUNCTIONS_INPROC_NET8_ENABLED, AzureWebJobsSecretStorageType.
+    // Run the design-time host in-process .NET 8 so the Functions runtime spawns the NetFxWorker that the
+    // Data Mapper Test map relies on for its XSLT transform. When the user opts into the Node-worker
+    // fallback, emit the Node runtime instead (no in-process .NET 8 flag) at the cost of the Test map.
     values[appKindSetting] = logicAppKind;
     if (projectPath) {
       values[ProjectDirectoryPathKey] = projectPath;
     }
-    values[workerRuntimeKey] = WorkerRuntime.Node;
+    if (useNodeWorker) {
+      values[workerRuntimeKey] = WorkerRuntime.Node;
+    } else {
+      values[workerRuntimeKey] = WorkerRuntime.Dotnet;
+      values[functionsInprocNet8Enabled] = functionsInprocNet8EnabledTrue;
+    }
     values[azureWebJobsSecretStorageTypeKey] = azureStorageTypeSetting;
   } else {
     // Root order mirrors the creation path (CreateLogicAppWorkspace.createLocalConfigurationFiles) so a

--- a/apps/vs-code-designer/src/app/utils/codeless/__test__/validateProjectArtifacts.test.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/__test__/validateProjectArtifacts.test.ts
@@ -29,6 +29,7 @@ import * as localSettings from '../../appSettings/localSettings';
 import { writeFormattedJson } from '../../fs';
 import { hasCodefulSdkReference } from '../../codeful';
 import { isCustomCodeFunctionsProjectInRoot } from '../../customCodeUtils';
+import { useNodeDesignTimeWorker } from '../../vsCodeConfig/settings';
 import {
   detectLogicAppProjectType,
   extractAppSettingReferences,
@@ -66,6 +67,14 @@ vi.mock('../../codeful', () => ({
 vi.mock('../../customCodeUtils', () => ({
   isCustomCodeFunctionsProjectInRoot: vi.fn(() => Promise.resolve(false)),
 }));
+
+vi.mock('../../vsCodeConfig/settings', async (importActual) => {
+  const actual = await importActual<typeof import('../../vsCodeConfig/settings')>();
+  return {
+    ...actual,
+    useNodeDesignTimeWorker: vi.fn(() => false),
+  };
+});
 
 const projectPath = '/workspace/LogicApp';
 
@@ -108,6 +117,7 @@ describe('validateProjectArtifacts', () => {
     mockedIsCodeful.mockResolvedValue(false);
     mockedIsCustomCodeInRoot.mockResolvedValue(false);
     mockedFse.readdir.mockResolvedValue([]);
+    vi.mocked(useNodeDesignTimeWorker).mockReturnValue(false);
     (workspace as any).fs = { createDirectory: vi.fn(() => Promise.resolve()) };
   });
 
@@ -367,7 +377,12 @@ describe('validateProjectArtifacts', () => {
       extensions: { workflow: { settings: { [workflowOperationDiscoveryHostModeKey]: 'true' } } },
     });
     const validSettings = JSON.stringify({
-      Values: { APP_KIND: 'workflowapp', FUNCTIONS_WORKER_RUNTIME: 'node', ProjectDirectoryPath: projectPath },
+      Values: {
+        APP_KIND: 'workflowapp',
+        FUNCTIONS_WORKER_RUNTIME: 'dotnet',
+        FUNCTIONS_INPROC_NET8_ENABLED: '1',
+        ProjectDirectoryPath: projectPath,
+      },
     });
 
     it('reports invalid when the directory does not exist', async () => {
@@ -455,6 +470,98 @@ describe('validateProjectArtifacts', () => {
       expect(result.settingsFileValid).toBe(false);
       expect(result.isValid).toBe(false);
     });
+
+    it('reports invalid settings for a stale Node design-time file lacking the in-process .NET 8 flag', async () => {
+      // An older extension generated a design-time file on the Node worker without
+      // FUNCTIONS_INPROC_NET8_ENABLED. It must be treated as invalid so it is regenerated to the
+      // in-process .NET 8 host that spawns the NetFxWorker required by the Data Mapper Test map.
+      mockFiles({
+        [designTimeDir]: '',
+        [hostPath]: validHost,
+        [settingsPath]: JSON.stringify({
+          Values: { APP_KIND: 'workflowapp', FUNCTIONS_WORKER_RUNTIME: 'node', ProjectDirectoryPath: projectPath },
+        }),
+      });
+
+      const result = await validateDesignTimeDirectory(projectPath);
+      expect(result.hostFileValid).toBe(true);
+      expect(result.settingsFileValid).toBe(false);
+      expect(result.isValid).toBe(false);
+    });
+
+    it('reports invalid settings when all required keys are present but the worker runtime is still Node', async () => {
+      // Presence of every required key is not enough: a file that carries the in-process .NET 8 flag but
+      // still points FUNCTIONS_WORKER_RUNTIME at "node" would launch the host on the wrong worker. It must
+      // be treated as invalid so it is regenerated to dotnet + in-process .NET 8.
+      mockFiles({
+        [designTimeDir]: '',
+        [hostPath]: validHost,
+        [settingsPath]: JSON.stringify({
+          Values: {
+            APP_KIND: 'workflowapp',
+            FUNCTIONS_WORKER_RUNTIME: 'node',
+            FUNCTIONS_INPROC_NET8_ENABLED: '1',
+            ProjectDirectoryPath: projectPath,
+          },
+        }),
+      });
+
+      const result = await validateDesignTimeDirectory(projectPath);
+      expect(result.hostFileValid).toBe(true);
+      expect(result.settingsFileValid).toBe(false);
+      expect(result.isValid).toBe(false);
+    });
+
+    it('reports invalid settings when the worker runtime is dotnet but the in-process .NET 8 flag is disabled', async () => {
+      mockFiles({
+        [designTimeDir]: '',
+        [hostPath]: validHost,
+        [settingsPath]: JSON.stringify({
+          Values: {
+            APP_KIND: 'workflowapp',
+            FUNCTIONS_WORKER_RUNTIME: 'dotnet',
+            FUNCTIONS_INPROC_NET8_ENABLED: '0',
+            ProjectDirectoryPath: projectPath,
+          },
+        }),
+      });
+
+      const result = await validateDesignTimeDirectory(projectPath);
+      expect(result.hostFileValid).toBe(true);
+      expect(result.settingsFileValid).toBe(false);
+      expect(result.isValid).toBe(false);
+    });
+
+    it('reports valid settings for a Node design-time file when the Node-worker fallback is enabled', async () => {
+      vi.mocked(useNodeDesignTimeWorker).mockReturnValue(true);
+      mockFiles({
+        [designTimeDir]: '',
+        [hostPath]: validHost,
+        [settingsPath]: JSON.stringify({
+          Values: { APP_KIND: 'workflowapp', FUNCTIONS_WORKER_RUNTIME: 'node', ProjectDirectoryPath: projectPath },
+        }),
+      });
+
+      const result = await validateDesignTimeDirectory(projectPath);
+      expect(result.hostFileValid).toBe(true);
+      expect(result.settingsFileValid).toBe(true);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('reports invalid settings for a dotnet + in-process .NET 8 file when the Node-worker fallback is enabled', async () => {
+      // Toggling into the fallback must invalidate the dotnet file so it is regenerated to Node.
+      vi.mocked(useNodeDesignTimeWorker).mockReturnValue(true);
+      mockFiles({
+        [designTimeDir]: '',
+        [hostPath]: validHost,
+        [settingsPath]: validSettings,
+      });
+
+      const result = await validateDesignTimeDirectory(projectPath);
+      expect(result.hostFileValid).toBe(true);
+      expect(result.settingsFileValid).toBe(false);
+      expect(result.isValid).toBe(false);
+    });
   });
 
   describe('regenerateDesignTimeDirectory', () => {
@@ -473,6 +580,18 @@ describe('validateProjectArtifacts', () => {
       expect(mockedAddOrUpdate).toHaveBeenCalled();
     });
 
+    it('regenerates the design-time settings on the Node worker when the fallback is enabled', async () => {
+      vi.mocked(useNodeDesignTimeWorker).mockReturnValue(true);
+      mockFiles({});
+      mockedFse.readdir.mockResolvedValue([]);
+
+      await regenerateDesignTimeDirectory(context, projectPath);
+
+      const runtimeSettings = mockedAddOrUpdate.mock.calls[0]?.[2] as Record<string, string>;
+      expect(runtimeSettings[workerRuntimeKey]).toBe(WorkerRuntime.Node);
+      expect(runtimeSettings[functionsInprocNet8Enabled]).toBeUndefined();
+    });
+
     it('preserves valid existing files and does not rewrite them', async () => {
       const hostPath = `${designTimeDir}/host.json`;
       const settingsPath = `${designTimeDir}/local.settings.json`;
@@ -482,7 +601,12 @@ describe('validateProjectArtifacts', () => {
         extensions: { workflow: { settings: { [workflowOperationDiscoveryHostModeKey]: 'true' } } },
       });
       const validSettings = JSON.stringify({
-        Values: { APP_KIND: 'workflowapp', FUNCTIONS_WORKER_RUNTIME: 'node', ProjectDirectoryPath: projectPath },
+        Values: {
+          APP_KIND: 'workflowapp',
+          FUNCTIONS_WORKER_RUNTIME: 'dotnet',
+          FUNCTIONS_INPROC_NET8_ENABLED: '1',
+          ProjectDirectoryPath: projectPath,
+        },
       });
 
       mockFiles({ [designTimeDir]: '', [hostPath]: validHost, [settingsPath]: validSettings });
@@ -552,7 +676,7 @@ describe('validateProjectArtifacts', () => {
         expect(writtenContentFor('host.json')).toEqual(expectedHostJson);
       });
 
-      it('writes design-time local.settings.json with the exact baseline and upserts Node runtime (codeless)', async () => {
+      it('writes design-time local.settings.json with the exact baseline and upserts dotnet in-process .NET 8 runtime (codeless)', async () => {
         mockFiles({});
         mockedFse.readdir.mockResolvedValue([]);
         mockedIsCodeful.mockResolvedValue(false);
@@ -564,14 +688,20 @@ describe('validateProjectArtifacts', () => {
           Values: {
             [appKindSetting]: logicAppKind,
             [ProjectDirectoryPathKey]: projectPath,
-            [workerRuntimeKey]: WorkerRuntime.Node,
+            [workerRuntimeKey]: WorkerRuntime.Dotnet,
+            [functionsInprocNet8Enabled]: functionsInprocNet8EnabledTrue,
             [azureWebJobsSecretStorageTypeKey]: azureStorageTypeSetting,
           },
         });
         expect(mockedAddOrUpdate).toHaveBeenCalledWith(
           context,
           expect.stringContaining('workflow-designtime'),
-          { [appKindSetting]: logicAppKind, [ProjectDirectoryPathKey]: projectPath, [workerRuntimeKey]: WorkerRuntime.Node },
+          {
+            [appKindSetting]: logicAppKind,
+            [ProjectDirectoryPathKey]: projectPath,
+            [workerRuntimeKey]: WorkerRuntime.Dotnet,
+            [functionsInprocNet8Enabled]: functionsInprocNet8EnabledTrue,
+          },
           true
         );
       });
@@ -588,7 +718,8 @@ describe('validateProjectArtifacts', () => {
           Values: {
             [appKindSetting]: logicAppKind,
             [ProjectDirectoryPathKey]: projectPath,
-            [workerRuntimeKey]: WorkerRuntime.Node,
+            [workerRuntimeKey]: WorkerRuntime.Dotnet,
+            [functionsInprocNet8Enabled]: functionsInprocNet8EnabledTrue,
             [azureWebJobsSecretStorageTypeKey]: azureStorageTypeSetting,
             [workflowCodefulEnabledKey]: 'true',
           },
@@ -620,7 +751,8 @@ describe('validateProjectArtifacts', () => {
           Values: {
             [appKindSetting]: logicAppKind,
             [ProjectDirectoryPathKey]: projectPath,
-            [workerRuntimeKey]: WorkerRuntime.Node,
+            [workerRuntimeKey]: WorkerRuntime.Dotnet,
+            [functionsInprocNet8Enabled]: functionsInprocNet8EnabledTrue,
             [azureWebJobsSecretStorageTypeKey]: azureStorageTypeSetting,
             [workflowCodefulEnabledKey]: 'true',
           },
@@ -699,7 +831,12 @@ describe('validateProjectArtifacts', () => {
       extensions: { workflow: { settings: { [workflowOperationDiscoveryHostModeKey]: 'true' } } },
     });
     const validDesignSettings = JSON.stringify({
-      Values: { APP_KIND: 'workflowapp', FUNCTIONS_WORKER_RUNTIME: 'node', ProjectDirectoryPath: projectPath },
+      Values: {
+        APP_KIND: 'workflowapp',
+        FUNCTIONS_WORKER_RUNTIME: 'dotnet',
+        FUNCTIONS_INPROC_NET8_ENABLED: '1',
+        ProjectDirectoryPath: projectPath,
+      },
     });
 
     it('regenerates the root host.json, root local.settings.json and design-time directory when all are missing', async () => {

--- a/apps/vs-code-designer/src/app/utils/codeless/validateProjectArtifacts.ts
+++ b/apps/vs-code-designer/src/app/utils/codeless/validateProjectArtifacts.ts
@@ -14,12 +14,15 @@ import {
   localSettingsFileName,
   logicAppKind,
   parametersFileName,
+  functionsInprocNet8Enabled,
+  functionsInprocNet8EnabledTrue,
   workerRuntimeKey,
   workflowFileName,
   workflowOperationDiscoveryHostModeKey,
 } from '../../../constants';
 import { localize } from '../../../localize';
 import { ext } from '../../../extensionVariables';
+import { useNodeDesignTimeWorker } from '../vsCodeConfig/settings';
 import { addOrUpdateLocalAppSettings, getLocalSettingsJson, getLocalSettingsSchema } from '../appSettings/localSettings';
 import { writeFormattedJson } from '../fs';
 import { parseJson } from '../parseJson';
@@ -39,9 +42,12 @@ import { Uri, workspace } from 'vscode';
 const appSettingReferenceRegex = /appsetting\(\s*['"]([^'"]+)['"]\s*\)/g;
 
 /**
- * App setting keys that are required for the design-time local.settings.json to be considered valid.
+ * App setting keys that must always be present (non-empty) for the design-time local.settings.json to be
+ * considered valid, regardless of which worker runtime is selected. The worker-runtime value itself (and the
+ * in-process .NET 8 flag when applicable) is validated separately in isDesignTimeSettingsFileValid so the
+ * check can adapt to the Node-worker fallback.
  */
-const requiredDesignTimeSettingKeys = [appKindSetting, workerRuntimeKey, ProjectDirectoryPathKey];
+const baseRequiredDesignTimeSettingKeys = [appKindSetting, workerRuntimeKey, ProjectDirectoryPathKey];
 
 /**
  * Reads the text content of a file, returning an empty string when the file does not exist or cannot be read.
@@ -318,7 +324,7 @@ async function isHostFileValid(hostFilePath: string, isDesignTime: boolean): Pro
  * @param {string} settingsFilePath - Absolute path to the design-time local.settings.json file.
  * @returns {Promise<boolean>} True when the file is present and contains the required keys.
  */
-async function isDesignTimeSettingsFileValid(settingsFilePath: string): Promise<boolean> {
+async function isDesignTimeSettingsFileValid(settingsFilePath: string, useNodeWorker: boolean): Promise<boolean> {
   const content = await readFileTextSafe(settingsFilePath);
   if (!content) {
     return false;
@@ -327,7 +333,22 @@ async function isDesignTimeSettingsFileValid(settingsFilePath: string): Promise<
   try {
     const parsed = parseJson(content) as ILocalSettingsJson;
     const values = parsed?.Values ?? {};
-    return requiredDesignTimeSettingKeys.every((key) => values[key] !== undefined && values[key] !== '');
+    const allRequiredKeysPresent = baseRequiredDesignTimeSettingKeys.every((key) => values[key] !== undefined && values[key] !== '');
+    if (!allRequiredKeysPresent) {
+      return false;
+    }
+
+    // Presence alone is not enough: the file must also point at the expected worker runtime. When the
+    // Node-worker fallback is enabled, a Node file is valid. Otherwise the design-time host must run
+    // in-process .NET 8 so the Functions runtime spawns the NetFxWorker that the Data Mapper Test map
+    // relies on, so require dotnet + FUNCTIONS_INPROC_NET8_ENABLED. A file left on the wrong runtime is
+    // treated as invalid and regenerated.
+    const workerRuntime = (values[workerRuntimeKey] ?? '').toLowerCase();
+    if (useNodeWorker) {
+      return workerRuntime === WorkerRuntime.Node;
+    }
+    const inprocNet8Enabled = values[functionsInprocNet8Enabled] === functionsInprocNet8EnabledTrue;
+    return workerRuntime === WorkerRuntime.Dotnet && inprocNet8Enabled;
   } catch {
     return false;
   }
@@ -358,7 +379,10 @@ export async function validateDesignTimeDirectory(projectPath: string): Promise<
   }
 
   const hostFileValid = await isHostFileValid(path.join(designTimeDirectoryPath, hostFileName), true);
-  const settingsFileValid = await isDesignTimeSettingsFileValid(path.join(designTimeDirectoryPath, localSettingsFileName));
+  const settingsFileValid = await isDesignTimeSettingsFileValid(
+    path.join(designTimeDirectoryPath, localSettingsFileName),
+    useNodeDesignTimeWorker(projectPath)
+  );
 
   return {
     directoryExists: true,
@@ -407,18 +431,18 @@ export async function regenerateDesignTimeDirectory(context: IActionContext, pro
 
   if (!validation.settingsFileValid) {
     const logicAppType = await detectLogicAppProjectType(projectPath);
-    const settingsFileContent = getLocalSettingsSchema(true, projectPath, logicAppType);
+    const useNodeWorker = useNodeDesignTimeWorker(projectPath);
+    const settingsFileContent = getLocalSettingsSchema(true, projectPath, logicAppType, useNodeWorker);
     await writeFormattedJson(path.join(designTimeDirectory.fsPath, localSettingsFileName), settingsFileContent);
-    await addOrUpdateLocalAppSettings(
-      context,
-      designTimeDirectory.fsPath,
-      {
-        [appKindSetting]: logicAppKind,
-        [ProjectDirectoryPathKey]: projectPath,
-        [workerRuntimeKey]: WorkerRuntime.Node,
-      },
-      true
-    );
+    const runtimeSettings: Record<string, string> = {
+      [appKindSetting]: logicAppKind,
+      [ProjectDirectoryPathKey]: projectPath,
+      [workerRuntimeKey]: useNodeWorker ? WorkerRuntime.Node : WorkerRuntime.Dotnet,
+    };
+    if (!useNodeWorker) {
+      runtimeSettings[functionsInprocNet8Enabled] = functionsInprocNet8EnabledTrue;
+    }
+    await addOrUpdateLocalAppSettings(context, designTimeDirectory.fsPath, runtimeSettings, true);
     ext.outputChannel.appendLog(
       localize('regeneratedDesignTimeSettings', 'Regenerated design-time local.settings.json for project "{0}".', projectPath)
     );

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
+import { useNodeDesignTimeWorkerSetting } from '../../../constants';
 import { isString } from '@microsoft/logic-apps-shared';
 import type { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions } from '@microsoft/vscode-azext-utils';
 import { openUrl } from '@microsoft/vscode-azext-utils';
@@ -92,6 +93,18 @@ export async function updateWorkspaceSetting<T = string>(
 export function getWorkspaceSetting<T>(key: string, fsPath?: string | WorkspaceFolder, prefix: string = ext.prefix): T | undefined {
   const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, getScope(fsPath));
   return projectConfiguration.get<T>(key);
+}
+
+/**
+ * Resolves whether the shared design-time host should fall back to the Node worker instead of running
+ * in-process .NET 8. Defaults to false (dotnet + FUNCTIONS_INPROC_NET8_ENABLED), which is required for the
+ * Data Mapper Test map's NetFxWorker. Users can opt into the Node worker via the
+ * `azureLogicAppsStandard.useNodeDesignTimeWorker` setting if the .NET 8 host is problematic for them.
+ * @param {string | WorkspaceFolder} [fsPath] - Optional project path/folder to scope the setting lookup.
+ * @returns {boolean} True when the Node-worker fallback is enabled.
+ */
+export function useNodeDesignTimeWorker(fsPath?: string | WorkspaceFolder): boolean {
+  return getWorkspaceSetting<boolean>(useNodeDesignTimeWorkerSetting, fsPath) === true;
 }
 
 function getScope(fsPath: WorkspaceFolder | string | undefined): Uri | WorkspaceFolder | undefined {

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -154,6 +154,7 @@ export const extensionCommand = {
   getDebugSymbolDll: 'azureLogicAppsStandard.getDebugSymbolDll',
   deleteLogicApp: 'azureLogicAppsStandard.deleteLogicApp',
   switchToDotnetProject: 'azureLogicAppsStandard.switchToDotnetProject',
+  toggleDesignTimeNodeWorker: 'azureLogicAppsStandard.toggleDesignTimeNodeWorker',
   openInPortal: 'azureLogicAppsStandard.openInPortal',
   azureFunctionsOpenFile: 'azureFunctions.openFile',
   azureFunctionsUninstallFuncCoreTools: 'azureFunctions.uninstallFuncCoreTools',
@@ -260,6 +261,7 @@ export const showProjectWarningSetting = 'showProjectWarning';
 export const showTargetFrameworkWarningSetting = 'showTargetFrameworkWarning';
 export const showStartDesignTimeMessageSetting = 'showStartDesignTimeMessage';
 export const autoStartDesignTimeSetting = 'autoStartDesignTime';
+export const useNodeDesignTimeWorkerSetting = 'useNodeDesignTimeWorker';
 export const autoRuntimeDependenciesValidationAndInstallationSetting = 'autoRuntimeDependenciesValidationAndInstallation';
 export const azuriteBinariesLocationSetting = 'azuriteLocationSetting';
 export const driveLetterSMBSetting = 'driveLetterSMB';

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -177,6 +177,11 @@
         "category": "Azure Logic Apps"
       },
       {
+        "command": "azureLogicAppsStandard.toggleDesignTimeNodeWorker",
+        "title": "Toggle Node.js Design-Time Worker (Data Mapper Fallback)",
+        "category": "Azure Logic Apps"
+      },
+      {
         "command": "azureLogicAppsStandard.redeploy",
         "title": "Redeploy",
         "category": "Azure Logic Apps"
@@ -988,6 +993,12 @@
             "type": "boolean",
             "description": "Start background design-time process at project load time.",
             "default": true
+          },
+          "azureLogicAppsStandard.useNodeDesignTimeWorker": {
+            "type": "boolean",
+            "default": false,
+            "scope": "resource",
+            "description": "Fallback: run the design-time host on the Node.js worker instead of in-process .NET 8. Leave disabled for normal use. Enabling this disables the Data Mapper Test map, which requires the in-process .NET 8 (NetFx) worker."
           },
           "azureLogicAppsStandard.autoRuntimeDependenciesValidationAndInstallation": {
             "type": "boolean",


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
The Data Mapper **Test map** panel returns `400 - BadRequest: The .NET framework worker could not be found.` (regressed after #7785; last known-good extension was 5.230.15). Test map runs its XSLT transform on the extension bundle's `Microsoft.Azure.Workflows.Functions.NetFxWorker`, which the Functions runtime only spawns when the host runs in-process .NET 8 (`FUNCTIONS_WORKER_RUNTIME=dotnet` **and** `FUNCTIONS_INPROC_NET8_ENABLED=1`). The Data Mapper reuses the designer's shared `workflow-designtime` host, which was started as `node`, so the NetFxWorker never spawned. This configures the single shared design-time host as dotnet + inproc-net8 so the designer and Data Mapper share one correctly-configured host.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Data Mapper Test map works again (returns transformed output instead of a 400).
- **Developers**: Design-time `local.settings.json` schema now sets `FUNCTIONS_WORKER_RUNTIME=dotnet` + `FUNCTIONS_INPROC_NET8_ENABLED=1`.
- **System**: The shared `workflow-designtime` host now runs in-process .NET 8 instead of node.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in:  VS Code extension — shared host starts dotnet in-process and spawns NetFxWorker; DM Test map returns 200; designer operation discovery / dynamic data / token picker still work

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft

## Screenshots/Videos
<!-- Visual changes only -->
N/A