### PR TITLE
chore(vscode-e2e): group scenarios into named shards

### DIFF
--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -145,7 +145,9 @@ jobs:
     name: setup-fixtures (p41a)
     needs: setup-extension-build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Headroom for one fresh-session retry (LA_E2E_SCENARIO_RETRIES) if the
+    # fixtures scenario flakes, so the retry isn't killed mid-run.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -214,6 +216,10 @@ jobs:
         env:
           LA_E2E_SCENARIO: p41a-fixtures
           LA_E2E_STRICT_DEPENDENCY_VALIDATION: '1'
+          # Retry a flaky fixtures run once in a fresh session before failing the
+          # setup job (which would block every downstream shard). Non-masking: a
+          # genuine failure still goes red after the retry.
+          LA_E2E_SCENARIO_RETRIES: '1'
           NODE_OPTIONS: --max-old-space-size=4096
           # Node's os.tmpdir() honors TMPDIR/TMP/TEMP on Linux; setting TEMP
           # pins workspace + manifest creation under $RUNNER_TEMP/la-e2e-test
@@ -305,7 +311,10 @@ jobs:
   vscode-e2e:
     name: vscode-e2e (${{ matrix.shard }})
     needs: [setup-extension-build, setup-fixtures]
-    timeout-minutes: 25
+    # Grouped shards run scenarios sequentially and each failing scenario may
+    # retry once in a fresh session (LA_E2E_SCENARIO_RETRIES). 35m gives the
+    # heaviest group room for a retry without a timeout-induced failure.
+    timeout-minutes: 35
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -488,6 +497,11 @@ jobs:
           # Grouped matrix: each shard runs one or more scenarios[] entries.
           LA_E2E_SCENARIO: ${{ matrix.scenario }}
           LA_E2E_BUNDLE_PREFLIGHT: ${{ matrix.use_bundle_artifact && '1' || '0' }}
+          # Retry a failing scenario once in a fresh VS Code session to absorb
+          # transient xvfb/focus/cold-start races. Non-masking: a scenario that
+          # fails both attempts still fails the shard; a retry-to-pass is logged
+          # as a `::warning::` flake so the race can still be root-caused.
+          LA_E2E_SCENARIO_RETRIES: '1'
           NODE_OPTIONS: --max-old-space-size=4096
           # Pin os.tmpdir() so the bootstrapper finds the manifest the
           # setup-fixtures job uploaded (same RUNNER_TEMP layout).
@@ -508,7 +522,8 @@ jobs:
   vscode-e2e-compat:
     name: vscode-e2e compatibility (${{ matrix.label }})
     needs: setup-extension-build
-    timeout-minutes: 20
+    # Headroom for one activation-smoke retry (LA_E2E_SCENARIO_RETRIES).
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -595,6 +610,9 @@ jobs:
         env:
           LA_E2E_SCENARIO: p40-nonlogicapp
           E2E_VSCODE_VERSION: ${{ matrix.vscode-version }}
+          # Retry the activation smoke once in a fresh session to absorb
+          # transient launch/activation races on the compat runtime matrix.
+          LA_E2E_SCENARIO_RETRIES: '1'
           NODE_OPTIONS: --max-old-space-size=4096
           TEMP: ${{ runner.temp }}
           TMP: ${{ runner.temp }}

--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -303,7 +303,7 @@ jobs:
           retention-days: 30
 
   vscode-e2e:
-    name: vscode-e2e (${{ matrix.scenario }})
+    name: vscode-e2e (${{ matrix.shard }})
     needs: [setup-extension-build, setup-fixtures]
     timeout-minutes: 25
     runs-on: ubuntu-latest
@@ -311,68 +311,56 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Independent / no-workspace (don't need fixtures or bundle artifacts)
-          - scenario: p40-nonlogicapp
+          # Scenarios are grouped onto fewer runners to amortize the fixed CI
+          # setup cost (pnpm install, node symlink, xvfb apt-get, artifact
+          # download/extract, bundle + fixtures hydration) that each shard pays
+          # once. `scenario` is a comma-separated list consumed by
+          # LA_E2E_SCENARIO; run-e2e.js runs each entry in its OWN fresh VS Code
+          # session (prepareFreshSession kills lingering processes between
+          # scenarios), so grouping preserves per-scenario isolation — it is NOT
+          # the flaky "multiple tests in one window" pattern. A failing scenario
+          # still runs its siblings and fails the shard (aggregate = max exit).
+          # use_* flags are the union of the group's needs.
+          #
+          # Extension activation smoke (p40) + create-a-project-for-conversion
+          # (p48b). Grouped because both are fixture-independent and self-create
+          # any workspace they need.
+          - shard: activation-and-create
+            scenario: p40-nonlogicapp,p48b-conversioncreate
             use_workspace_fixtures: false
             use_bundle_artifact: false
-          - scenario: p48b-conversioncreate
+          # Full 12-shape workspace-creation wizard validation — self-creates its
+          # own workspaces, so it doesn't consume the fixtures artifact, but it
+          # still consumes the setup-fixtures bundle artifact and runs bundle
+          # preflight. Kept on its own shard because it is the heaviest scenario.
+          - shard: workspace-creation
+            scenario: p41b-createworkspace-behavior
             use_workspace_fixtures: false
-            use_bundle_artifact: false
-          # Full 12-shape behavior validation — self-creates its own workspaces,
-          # so it doesn't consume the fixtures artifact, but it still consumes
-          # the setup-fixtures bundle artifact and runs bundle preflight.
-          - scenario: p41b-createworkspace-behavior
-            use_workspace_fixtures: false
             use_bundle_artifact: true
-          # Designer lifecycle (consume fixtures from setup-fixtures)
-          - scenario: p42-standard
+          # Designer open → edit → save → debug → run lifecycle across app types.
+          - shard: designer-lifecycle
+            scenario: p42-standard,p42-customcode,p42-rulesengine
             use_workspace_fixtures: true
             use_bundle_artifact: true
-          - scenario: p42-customcode
+          # Runtime-touching action tests (execute code / rules engine).
+          - shard: runtime-actions
+            scenario: p43-inlinejavascript,p43-customcode,p43-rulesengine
             use_workspace_fixtures: true
             use_bundle_artifact: true
-          - scenario: p42-rulesengine
+          # Designer editing interactions: variables, extended view (parallel
+          # branches / run-after), keyboard navigation.
+          - shard: designer-interactions
+            scenario: p44-statelessvariables,p45-designerviewextended,p46-keyboardnav
             use_workspace_fixtures: true
             use_bundle_artifact: true
-          # Runtime-touching consumer tests (consume fixtures)
-          - scenario: p43-inlinejavascript
+          # Multi-designer + dataMapper suite (manifest-multi) + bundle repair.
+          - shard: suite-and-bundle
+            scenario: p47-suite,p412-bundlerepair
             use_workspace_fixtures: true
             use_bundle_artifact: true
-          - scenario: p43-customcode
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          - scenario: p43-rulesengine
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          - scenario: p44-statelessvariables
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          - scenario: p45-designerviewextended
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          - scenario: p46-keyboardnav
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          # Multi-designer + dataMapper suite (manifest-multi)
-          - scenario: p47-suite
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          # Conversion suite
-          - scenario: p48a-conversionno
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          - scenario: p48c-multipledesigners
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          - scenario: p48d-conversionyes
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          - scenario: p48e-conversionsubfolder
-            use_workspace_fixtures: true
-            use_bundle_artifact: true
-          # Bundle on-disk repair / integrity gate (Phase 14 code path).
-          # Consumes the standard/Stateful fixture from setup-fixtures.
-          - scenario: p412-bundlerepair
+          # Legacy project → workspace conversion variants.
+          - shard: project-conversion
+            scenario: p48a-conversionno,p48c-multipledesigners,p48d-conversionyes,p48e-conversionsubfolder
             use_workspace_fixtures: true
             use_bundle_artifact: true
 
@@ -476,18 +464,20 @@ jobs:
           restore-keys: |
             la-runtime-deps-${{ runner.os }}-
 
-      - name: Run scenario (${{ matrix.scenario }})
-        # Phase 4.1 (commits 2672168f7 + d866b3368) targeted the 5 historically-
-        # flaky shards (p42-standard, p42-customcode, p42-rulesengine,
+      - name: Run scenario group (${{ matrix.shard }})
+        # Each shard runs one or more scenarios (comma-separated in
+        # matrix.scenario) sequentially, each in its own fresh VS Code session.
+        # Phase 4.1 (commits 2672168f7 + d866b3368) targeted the historically-
+        # flaky scenarios (p42-standard, p42-customcode, p42-rulesengine,
         # p46-keyboardnav, p47-suite) at the root cause, and added a focus-reset
-        # for the pre-existing p48d-conversionyes xvfb race. Run 25970697053
-        # had all 17 shards green at the step level with masks active.
+        # for the pre-existing p48d-conversionyes xvfb race.
         #
-        # Dropping continue-on-error so any future regression in those shards
-        # is surfaced as a job-level failure (no longer masked). Flake closure
-        # gating is now structural: a red shard fails the workflow. If the
-        # fixes don't hold under runner-image churn, the failure mode and CI
-        # diff will be visible immediately instead of hidden behind allowFailure.
+        # continue-on-error stays off so any future regression is surfaced as a
+        # job-level failure (no longer masked). Flake closure gating is
+        # structural: a red shard fails the workflow. run-e2e.js aggregates
+        # exit = max across the group, so a failing scenario still runs its
+        # siblings and fails the shard, and the failure mode + CI diff are
+        # visible immediately instead of hidden behind allowFailure.
         run: |
           # Belt-and-suspenders PATH export (see grouped-shard rationale in git history).
           export PATH="$(dirname $(which node)):/usr/local/bin:/usr/bin:/bin:$PATH"
@@ -495,7 +485,7 @@ jobs:
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
             node apps/vs-code-designer/out/test/run-e2e.js
         env:
-          # Per-scenario matrix: each shard runs exactly one scenarios[] entry.
+          # Grouped matrix: each shard runs one or more scenarios[] entries.
           LA_E2E_SCENARIO: ${{ matrix.scenario }}
           LA_E2E_BUNDLE_PREFLIGHT: ${{ matrix.use_bundle_artifact && '1' || '0' }}
           NODE_OPTIONS: --max-old-space-size=4096
@@ -508,7 +498,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: vscode-e2e-screenshots-${{ matrix.scenario }}
+          name: vscode-e2e-screenshots-${{ matrix.shard }}
           path: |
             ${{ runner.temp }}/test-resources/screenshots/
             test-resources/screenshots/

--- a/.squad/knowledge/vscode-e2e-testing.md
+++ b/.squad/knowledge/vscode-e2e-testing.md
@@ -245,11 +245,36 @@ Curated durable learnings for VS Code ExTester UI E2E tests. Add entries through
 - Applies to: `vscode-test-specialist`, `test`, `ci-sentinel`, `vscode`, `chief-engineer`.
 - Status: verified.
 
-### Strict per-scenario matrix is the preferred final VS Code E2E CI shape
+### Grouped named shards are the current VS Code E2E CI shape
 
-- Learning: VS Code E2E now fans out by scenario id and gates on strict `vscode-e2e (p*)` jobs plus the single `vscode-e2e-summary` rollup. Do not reintroduce workflow-level `continue-on-error` or internal `allowFailure` masking for strict scenarios; strict shards must fail loudly. Keep `workflow_dispatch:` as a manual fallback because path-filtered PR workflows can be coalesced after rapid pushes.
-- Why it matters: PR #9181 proved the scenario fan-out can pass under strict gating, and #9164 validated the collapsed branch with every scenario shard plus `vscode-e2e-summary` green. This preserves fast, attributable failures without hiding regressions.
-- Source: Azure/LogicAppsUX#9181 run `26081963896`; Azure/LogicAppsUX#9164 collapsed-head run `26108941288`.
+- Learning: VS Code E2E runs a small set of grouped, human-readable shards
+  (`vscode-e2e (<shard>)`, e.g. `designer-lifecycle`, `runtime-actions`,
+  `project-conversion`) plus the single `vscode-e2e-summary` rollup. Each shard
+  passes a comma-separated `LA_E2E_SCENARIO` list; `run-e2e.js` runs every
+  scenario in its OWN fresh VS Code session (`prepareFreshSession` kills
+  lingering processes between scenarios), so grouping preserves per-scenario
+  isolation and is NOT the flaky "multiple tests in one window" pattern. A
+  failing scenario still runs its siblings and fails the shard (`run-e2e.js`
+  aggregates exit = max). Do not reintroduce workflow-level `continue-on-error`
+  or internal `allowFailure` masking; strict shards must fail loudly. Keep
+  `workflow_dispatch:` as a manual fallback because path-filtered PR workflows
+  can be coalesced after rapid pushes.
+- Why it matters: the earlier strict per-scenario fan-out (one shard per
+  `p*` id) minimized wall-clock but paid the fixed setup cost (pnpm install,
+  node symlink, xvfb apt-get, artifact download/extract, bundle + fixtures
+  hydration) on ~18 runners. Grouping amortizes that setup onto ~7 runners —
+  cutting redundant setup and runner/queue pressure — while keeping failures
+  attributable to a shard (open its log or `vscode-e2e-screenshots-<shard>`
+  artifact to see which scenario failed). Group members share the same
+  `use_workspace_fixtures` / `use_bundle_artifact` needs so no scenario is
+  denied an artifact.
+- Branch protection note: required status checks match on check NAME. Renaming
+  or regrouping shards changes `vscode-e2e (<shard>)` names, so branch
+  protection must require only the stable `vscode-e2e-summary` rollup — never
+  the individual shard names — or merges will hang on never-reported checks.
+- Source: supersedes the prior "Strict per-scenario matrix" learning; see
+  Azure/LogicAppsUX#9181 run `26081963896` and #9164 run `26108941288` for the
+  strict-fan-out precedent this consolidates.
 - Applies to: `vscode-test-specialist`, `test`, `ci-sentinel`, `chief-engineer`.
 - Status: verified.
 

--- a/.squad/knowledge/vscode-e2e-testing.md
+++ b/.squad/knowledge/vscode-e2e-testing.md
@@ -278,7 +278,32 @@ Curated durable learnings for VS Code ExTester UI E2E tests. Add entries through
 - Applies to: `vscode-test-specialist`, `test`, `ci-sentinel`, `chief-engineer`.
 - Status: verified.
 
-### Scenario shards must verify only their intended shape
+### Scenario-level retry absorbs transient flakes without masking regressions
+
+- Learning: `run-e2e.js` retries a failing scenario in a fresh VS Code session
+  before giving up, gated by `LA_E2E_SCENARIO_RETRIES` (default `0` = fail fast
+  locally; CI sets `1`). Each retry is a full `prepareFreshSession()` (kills
+  VS Code/chromedriver/func, cleans `User/`), so it clears the stale-window /
+  leftover-process flake class as well as transient xvfb/focus/cold-start races.
+  This is NOT masking: a scenario that fails every attempt still fails the shard
+  (`exit = max`), and a scenario that only passes after a retry is surfaced
+  loudly via `console.warn('⚠ FLAKE…')` plus a `::warning title=E2E scenario
+  flake::` GitHub annotation so the underlying race can still be root-caused.
+  Do not conflate this with `continue-on-error`/`allowFailure` — those make a
+  genuinely failing shard green and remain forbidden.
+- Why it matters: ExTester UI flakes are dominated by transient runner-image /
+  xvfb / Fluent-UI-rerender races that the team otherwise fixes one-by-one at
+  the helper level. A single fresh-session retry recovers most of them per run
+  while keeping real regressions red and every flake visible in the CI summary.
+  Job timeouts were widened (vscode-e2e 35m, setup-fixtures 30m, compat 25m) so
+  a retry is never killed mid-run.
+- Prefer keeping retries at `1`. Raising it hides increasingly non-transient
+  failures; if a scenario needs >1 retry to pass, fix the root cause (add the
+  waits/focus/re-read patterns documented elsewhere in this file) instead.
+- Source: `apps/vs-code-designer/src/test/ui/run-e2e.ts` (`runScenarioPhases`
+  retry loop); `.github/workflows/vscode-e2e.yml` (`LA_E2E_SCENARIO_RETRIES`).
+- Applies to: `vscode-test-specialist`, `test`, `ci-sentinel`, `chief-engineer`.
+- Status: verified.
 
 - Learning: Shape-specific scenarios (`p42-*`, `p43-*`) must set and honor shape selectors such as `LA_E2E_SHAPE`; a shard named for one workflow shape must not silently run unrelated shapes.
 - Why it matters: Earlier p42 shards were misleading because each named shard could still run multiple shapes. PR #9181 isolated `p42-standard`, `p42-customcode`, `p42-rulesengine`, `p43-inlinejavascript`, `p43-customcode`, and `p43-rulesengine`, making failures attributable to the named scenario.

--- a/apps/vs-code-designer/src/test/ui/run-e2e.ts
+++ b/apps/vs-code-designer/src/test/ui/run-e2e.ts
@@ -2208,6 +2208,20 @@ namespace ${namespaceName}
     //
     // Returns the aggregate exit code.
     const runScenarioPhases = async (scenarioList: Scenario[] /* , opts */): Promise<number> => {
+      // Retry a failing scenario in a fresh VS Code session before giving up.
+      // This absorbs transient xvfb/focus/timing/cold-start races (the dominant
+      // flake class for ExTester UI tests) WITHOUT masking real regressions: a
+      // scenario that fails every attempt still fails the shard, and a scenario
+      // that only passes after a retry is surfaced loudly as a `::warning::`
+      // flake annotation so the underlying race can still be root-caused.
+      // Opt-in via LA_E2E_SCENARIO_RETRIES (default 0 = fail fast locally; CI
+      // sets it). Each retry is a full prepareFreshSession(), so it also clears
+      // the stale-window / leftover-process flakes.
+      const scenarioRetries = Math.max(0, Number.parseInt(process.env.LA_E2E_SCENARIO_RETRIES ?? '', 10) || 0);
+      const maxAttempts = scenarioRetries + 1;
+      if (scenarioRetries > 0) {
+        console.log(`Scenario retry enabled: up to ${scenarioRetries} retry(ies) per failing scenario (LA_E2E_SCENARIO_RETRIES).`);
+      }
       const exits: number[] = [];
       for (const scenario of scenarioList) {
         const { id, testFile: files, workspaceSpec, settings = {}, monolithic, env: scenarioEnv } = scenario;
@@ -2228,27 +2242,65 @@ namespace ${namespaceName}
           }
         }
 
-        await prepareFreshSession(id);
-        if (id === 'p41a-fixtures' && process.env.LA_E2E_STRICT_DEPENDENCY_VALIDATION === '1') {
-          pruneInvalidRuntimeDependencyRoots(`prelaunch:${id}`);
-          pruneUnhealthyLogicAppsExtensionBundles(`prelaunch:${id}`);
-        }
-
-        const { resources, legacyDir } = selectWorkspaceForSpec(workspaceSpec, id);
-        if (legacyDir) {
-          process.env.LA_E2E_LEGACY_PROJECT_DIR = legacyDir;
-        }
         const fileList = Array.isArray(files) ? files : [files];
         if (!monolithic && fileList.length !== 1) {
           console.warn(`  [${id}] Non-monolithic scenario received ${fileList.length} files; running all of them`);
         }
-        if (process.env.LA_E2E_BUNDLE_PREFLIGHT === '1') {
-          verifyLogicAppsExtensionBundle(`preflight:${id}`);
+
+        let exit = 1;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+          if (attempt > 1) {
+            console.log(`\n  ↻ [${id}] retry ${attempt - 1}/${scenarioRetries} in a fresh session after a failed attempt...`);
+            // Give VS Code/chromedriver/func extra time to release ports and
+            // sockets before relaunching, on top of prepareFreshSession()'s kill.
+            await new Promise((r) => setTimeout(r, 8000));
+          }
+
+          try {
+            await prepareFreshSession(id);
+            if (id === 'p41a-fixtures' && process.env.LA_E2E_STRICT_DEPENDENCY_VALIDATION === '1') {
+              pruneInvalidRuntimeDependencyRoots(`prelaunch:${id}`);
+              pruneUnhealthyLogicAppsExtensionBundles(`prelaunch:${id}`);
+            }
+
+            const { resources, legacyDir } = selectWorkspaceForSpec(workspaceSpec, id);
+            if (legacyDir) {
+              process.env.LA_E2E_LEGACY_PROJECT_DIR = legacyDir;
+            }
+            if (process.env.LA_E2E_BUNDLE_PREFLIGHT === '1') {
+              verifyLogicAppsExtensionBundle(`preflight:${id}`);
+            }
+
+            const attemptLabel = maxAttempts > 1 ? `Scenario ${id} (attempt ${attempt}/${maxAttempts})` : `Scenario ${id}`;
+            exit = await runPhase(attemptLabel, fileList, { resources });
+
+            // p41a-fixtures must also pass its post-run bundle verification to
+            // count as a successful attempt; a failure here is retryable and
+            // must not emit a "passed" flake annotation below.
+            if (exit === 0 && id === 'p41a-fixtures') {
+              verifyLogicAppsExtensionBundle('p41a-fixtures');
+            }
+          } catch (e) {
+            // Any throw in session prep / preflight / run / verify is treated as
+            // a failed (retryable) attempt rather than aborting the whole run.
+            // A deterministic failure (e.g. a genuinely corrupt bundle) simply
+            // throws again on every attempt and still fails the shard.
+            exit = 1;
+            console.warn(`  [${id}] attempt ${attempt}/${maxAttempts} threw: ${getErrorMessage(e)}`);
+          }
+
+          if (exit === 0) {
+            if (attempt > 1) {
+              // Surface the flake loudly (but non-fatally). A scenario that
+              // needed a retry to pass is a signal to fix the underlying race.
+              const flakeMsg = `${id} passed on attempt ${attempt}/${maxAttempts} (failed ${attempt - 1}x)`;
+              console.warn(`  ⚠ FLAKE: ${flakeMsg}`);
+              console.log(`::warning title=E2E scenario flake::${flakeMsg}`);
+            }
+            break;
+          }
         }
-        const exit = await runPhase(`Scenario ${id}`, fileList, { resources });
-        if (exit === 0 && id === 'p41a-fixtures') {
-          verifyLogicAppsExtensionBundle('p41a-fixtures');
-        }
+
         // Restore env overrides so subsequent scenarios aren't contaminated.
         for (const { key, prev } of envOverridesApplied) {
           if (prev === undefined) {

--- a/apps/vs-code-designer/src/test/ui/run-e2e.ts
+++ b/apps/vs-code-designer/src/test/ui/run-e2e.ts
@@ -2234,6 +2234,11 @@ namespace ${namespaceName}
         // Apply per-scenario env overrides (e.g. LA_E2E_SHAPE for parameterized
         // shape-specific shards). Captured here so we can restore afterward.
         const envOverridesApplied: EnvOverride[] = [];
+        // Re-point LA_E2E_SCENARIO at the current scenario id so tests/helpers
+        // that read it as the active scenario keep their per-scenario semantics
+        // during grouped runs.
+        envOverridesApplied.push({ key: 'LA_E2E_SCENARIO', prev: process.env.LA_E2E_SCENARIO });
+        process.env.LA_E2E_SCENARIO = id;
         if (scenarioEnv && typeof scenarioEnv === 'object') {
           for (const [key, value] of Object.entries(scenarioEnv)) {
             envOverridesApplied.push({ key, prev: process.env[key] });

--- a/apps/vs-code-designer/src/test/ui/run-e2e.ts
+++ b/apps/vs-code-designer/src/test/ui/run-e2e.ts
@@ -2267,23 +2267,51 @@ namespace ${namespaceName}
       return aggregate;
     };
 
-    // Step 3 (per-scenario matrix): LA_E2E_SCENARIO selects a single
-    // scenarios[] entry by id. Takes precedence over E2E_MODE so a matrix
-    // shard that sets both env vars (e.g. for transitional debugging)
-    // still runs exactly one scenario. E2E_MODE remains supported as a
-    // fallback for legacy grouped-shard invocations.
-    const singleScenarioId = process.env.LA_E2E_SCENARIO;
-    if (singleScenarioId) {
-      const scenarioEntry = scenarios.find((s) => s.id === singleScenarioId);
-      if (!scenarioEntry) {
-        console.error(`Unknown LA_E2E_SCENARIO: ${singleScenarioId}`);
+    // Step 3 (per-scenario matrix): LA_E2E_SCENARIO selects one or more
+    // scenarios[] entries by id. Accepts a single id or a comma-separated
+    // list so a matrix shard can run several scenarios sequentially on one
+    // runner — each scenario still gets its own fresh VS Code session via
+    // prepareFreshSession(), so grouping amortizes CI setup cost without
+    // sacrificing per-scenario isolation. Takes precedence over E2E_MODE so a
+    // matrix shard that sets both env vars (e.g. for transitional debugging)
+    // still runs exactly the selected scenarios. E2E_MODE remains supported
+    // as a fallback for legacy grouped-shard invocations.
+    const scenarioSelector = process.env.LA_E2E_SCENARIO;
+    if (scenarioSelector) {
+      const requestedIds = scenarioSelector
+        .split(',')
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0);
+      const selectedScenarios: Scenario[] = [];
+      const unknownIds: string[] = [];
+      const seenIds = new Set<string>();
+      for (const requestedId of requestedIds) {
+        // Dedup so a repeated id in the list doesn't run the same scenario twice.
+        if (seenIds.has(requestedId)) {
+          continue;
+        }
+        seenIds.add(requestedId);
+        const scenarioEntry = scenarios.find((s) => s.id === requestedId);
+        if (scenarioEntry) {
+          selectedScenarios.push(scenarioEntry);
+        } else {
+          unknownIds.push(requestedId);
+        }
+      }
+      if (unknownIds.length > 0) {
+        console.error(`Unknown LA_E2E_SCENARIO id(s): ${unknownIds.join(', ')}`);
         console.error(`Known scenarios: ${scenarios.map((s) => s.id).join(', ')}`);
         process.exit(2);
       }
-      console.log(`\nRunning single scenario (LA_E2E_SCENARIO): ${singleScenarioId}`);
+      if (selectedScenarios.length === 0) {
+        console.error(`LA_E2E_SCENARIO resolved to no scenarios: ${scenarioSelector}`);
+        console.error(`Known scenarios: ${scenarios.map((s) => s.id).join(', ')}`);
+        process.exit(2);
+      }
+      console.log(`\nRunning ${selectedScenarios.length} scenario(s) (LA_E2E_SCENARIO): ${selectedScenarios.map((s) => s.id).join(', ')}`);
       await downloadExTesterAssets();
-      const singleExit = await runScenarioPhases([scenarioEntry]);
-      process.exit(singleExit);
+      const selectedExit = await runScenarioPhases(selectedScenarios);
+      process.exit(selectedExit);
     }
 
     if (e2eMode === 'scenarios') {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Consolidates the `vscode-e2e` matrix from **18 per-scenario shards → 7 human-readable group shards**, cutting redundant CI setup while preserving per-scenario isolation and fail-loud gating.

Grouping is safe because isolation lives at the **VS Code session** level, not the shard level: `runScenarioPhases()` runs each scenario through `prepareFreshSession()` (kills lingering VS Code/chromedriver/dotnet) + a fresh `ExTester` instance. Grouped scenarios run sequentially in isolated sessions, not in one shared flaky VS Code window.

### Changes

- **`.github/workflows/vscode-e2e.yml`** — matrix collapsed to 7 named shards; each passes a comma-separated `LA_E2E_SCENARIO` list. Job name and screenshot artifacts key on `matrix.shard`.
- **`apps/vs-code-designer/src/test/ui/run-e2e.ts`** — `LA_E2E_SCENARIO` now accepts a comma-separated list (validated and deduped); single-id usage is unchanged.
- **`.squad/knowledge/vscode-e2e-testing.md`** — learning updated from strict per-scenario shards to grouped shards, including the branch-protection check-name caveat.

| Shard | Scenarios |
|---|---|
| `activation-and-create` | p40-nonlogicapp, p48b-conversioncreate |
| `workspace-creation` | p41b-createworkspace-behavior |
| `designer-lifecycle` | p42 standard / customcode / rulesengine |
| `runtime-actions` | p43 inlinejavascript / customcode / rulesengine |
| `designer-interactions` | p44-statelessvariables, p45-designerviewextended, p46-keyboardnav |
| `suite-and-bundle` | p47-suite, p412-bundlerepair |
| `project-conversion` | p48a / p48c / p48d / p48e |

### Flakiness: scenario-level retry (non-masking)

ExTester UI scenarios had no scenario-level retry, so one transient xvfb/focus/cold-start race failed the whole shard. This PR adds opt-in retry in `runScenarioPhases()` via `LA_E2E_SCENARIO_RETRIES` (default `0`; CI sets `1`). Each retry performs a full `prepareFreshSession()` and deterministic failures still fail the shard after all attempts. Retry-to-pass is emitted as a warning annotation, not hidden with `continue-on-error`.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No user-facing product changes; this is CI/test automation only.
- **Developers**: VS Code E2E CI now runs 7 named grouped shards instead of 18 per-scenario shards. `LA_E2E_SCENARIO` accepts comma-separated scenario lists, and `LA_E2E_SCENARIO_RETRIES` enables opt-in per-scenario retry.
- **System**: CI setup/runner cost drops because warm-up is paid on about 7 runners instead of 18. Branch protection should require the stable `vscode-e2e-summary` rollup rather than individual renamed shard checks.

### Measured impact
Comparing this PR's current-head run against two recent `main` (18-shard) runs:

| Metric | 18 shards (main) | 7 shards (this PR) | Delta |
|---|---|---|---|
| Runner-minutes (sum of all job durations) | ~109m | ~82m | **-25% (~27m/run)** |
| Wall-clock (critical path) | ~24.8m | ~25.0m | ~0 (unchanged) |

Wall-clock is unchanged (not the ~4-5m regression originally estimated): in both layouts the critical path is `setup-extension-build -> setup-fixtures -> slowest shard`, and the slowest shard is `workspace-creation` (p41b, ~14.4m), which was always a solo scenario and is untouched by grouping. Every multi-scenario group finishes under that ceiling, so grouping adds no critical-path time while removing 11 redundant per-shard setups.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Biome passed; workflow YAML was validated for complete one-time coverage of all 18 scenarios; full `tsup`/type-compile and grouped shard execution run in CI because this worktree has no `node_modules`.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@ccastrotrejo

## Screenshots/Videos
<!-- Visual changes only -->
N/A — no visual/UI changes.

