### PR TITLE
fix(vscode): write machine-local path settings to User settings instead of shared .code-workspace

### DIFF
--- a/apps/vs-code-designer/src/app/utils/azurite/__test__/activateAzurite.test.ts
+++ b/apps/vs-code-designer/src/app/utils/azurite/__test__/activateAzurite.test.ts
@@ -1,0 +1,228 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  azuriteBinariesLocationSetting,
+  azuriteExtensionPrefix,
+  azuriteLocationSetting,
+  defaultAzuritePathValue,
+  extensionCommand,
+  showAutoStartAzuriteWarning,
+} from '../../../../constants';
+
+// Distinct sentinels so the function's `result === DialogResponses.*` comparisons are meaningful.
+// Declared via vi.hoisted so they are available inside the hoisted vi.mock factory below.
+const { dialogNo, dialogDontWarnAgain } = vi.hoisted(() => ({
+  dialogNo: { title: 'No' },
+  dialogDontWarnAgain: { title: "Don't warn again" },
+}));
+
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+  DialogResponses: { no: dialogNo, dontWarnAgain: dialogDontWarnAgain },
+}));
+
+vi.mock('../../../../localize', () => ({
+  localize: (_key: string, msg: string) => msg,
+}));
+
+vi.mock('../../vsCodeConfig/settings', () => ({
+  getWorkspaceSetting: vi.fn(),
+  updateGlobalSetting: vi.fn(),
+  removeSharedSetting: vi.fn(),
+}));
+
+vi.mock('../../workspace', () => ({
+  getWorkspaceFolder: vi.fn(),
+}));
+
+vi.mock('../../verifyIsProject', () => ({
+  tryGetLogicAppProjectRoot: vi.fn(),
+}));
+
+vi.mock('../../../debug/validatePreDebug', () => ({
+  validateEmulatorIsRunning: vi.fn(),
+}));
+
+vi.mock('../../../azuriteExtension/executeOnAzuriteExt', () => ({
+  executeOnAzurite: vi.fn(),
+}));
+
+import * as vscode from 'vscode';
+import { activateAzurite } from '../activateAzurite';
+import { getWorkspaceSetting, updateGlobalSetting, removeSharedSetting } from '../../vsCodeConfig/settings';
+import { getWorkspaceFolder } from '../../workspace';
+import { tryGetLogicAppProjectRoot } from '../../verifyIsProject';
+import { validateEmulatorIsRunning } from '../../../debug/validatePreDebug';
+import { executeOnAzurite } from '../../../azuriteExtension/executeOnAzuriteExt';
+
+const PROJECT_PATH = '/workspace/logicapp';
+
+/** Build the settings the function reads, keyed by the first arg to getWorkspaceSetting. */
+function mockSettings(values: {
+  globalAzuriteLocation?: string;
+  binariesLocation?: string;
+  showWarning?: boolean;
+  autoStart?: boolean;
+}) {
+  (getWorkspaceSetting as any).mockImplementation((section: string) => {
+    switch (section) {
+      case azuriteLocationSetting:
+        return values.globalAzuriteLocation;
+      case azuriteBinariesLocationSetting:
+        return values.binariesLocation;
+      case showAutoStartAzuriteWarning:
+        return values.showWarning;
+      default:
+        return values.autoStart;
+    }
+  });
+}
+
+function createContext(overrides?: { showWarningMessage?: any; showInputBox?: any }) {
+  return {
+    telemetry: { properties: {}, measurements: {} },
+    ui: {
+      showWarningMessage: overrides?.showWarningMessage ?? vi.fn(),
+      showInputBox: overrides?.showInputBox ?? vi.fn(),
+    },
+  } as any;
+}
+
+describe('activateAzurite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: PROJECT_PATH } }];
+    (validateEmulatorIsRunning as any).mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    (vscode.workspace as any).workspaceFolders = [];
+  });
+
+  it('returns early and touches no settings when there are no workspace folders', async () => {
+    (vscode.workspace as any).workspaceFolders = [];
+    await activateAzurite(createContext(), PROJECT_PATH);
+    expect(getWorkspaceSetting).not.toHaveBeenCalled();
+    expect(updateGlobalSetting).not.toHaveBeenCalled();
+    expect(executeOnAzurite).not.toHaveBeenCalled();
+  });
+
+  it('resolves the project root when no projectPath is provided and returns early when none is found', async () => {
+    (getWorkspaceFolder as any).mockResolvedValue({ uri: { fsPath: PROJECT_PATH } });
+    (tryGetLogicAppProjectRoot as any).mockResolvedValue(undefined);
+    const ctx = createContext();
+
+    await activateAzurite(ctx);
+
+    // With no resolvable project root the function returns before reading/writing any settings.
+    expect(tryGetLogicAppProjectRoot).toHaveBeenCalled();
+    expect(getWorkspaceSetting).not.toHaveBeenCalled();
+    expect(updateGlobalSetting).not.toHaveBeenCalled();
+    expect(executeOnAzurite).not.toHaveBeenCalled();
+  });
+
+  it('only disables the warning when the user selects "Don\'t warn again"', async () => {
+    mockSettings({ showWarning: true, autoStart: false });
+    const showWarningMessage = vi.fn().mockResolvedValue(dialogDontWarnAgain);
+    (validateEmulatorIsRunning as any).mockResolvedValue(false);
+
+    await activateAzurite(createContext({ showWarningMessage }), PROJECT_PATH);
+
+    expect(updateGlobalSetting).toHaveBeenCalledWith(showAutoStartAzuriteWarning, false);
+    expect(executeOnAzurite).not.toHaveBeenCalled();
+  });
+
+  it('enables autostart and stores the user-provided azurite directory', async () => {
+    mockSettings({ showWarning: true, autoStart: false, binariesLocation: undefined });
+    // showWarningMessage returns the first passed item (enableMessage) so result === enableMessage.
+    const showWarningMessage = vi.fn().mockImplementation((_title, enableMessage) => Promise.resolve(enableMessage));
+    const showInputBox = vi.fn().mockResolvedValue('/custom/azurite/dir');
+    (validateEmulatorIsRunning as any).mockResolvedValue(true);
+
+    await activateAzurite(createContext({ showWarningMessage, showInputBox }), PROJECT_PATH);
+
+    expect(updateGlobalSetting).toHaveBeenCalledWith(azuriteBinariesLocationSetting, '/custom/azurite/dir');
+  });
+
+  it('enables autostart and falls back to the default path when input is cancelled', async () => {
+    mockSettings({ showWarning: true, autoStart: false, binariesLocation: undefined });
+    const showWarningMessage = vi.fn().mockImplementation((_title, enableMessage) => Promise.resolve(enableMessage));
+    const showInputBox = vi.fn().mockResolvedValue(undefined);
+    (validateEmulatorIsRunning as any).mockResolvedValue(true);
+
+    await activateAzurite(createContext({ showWarningMessage, showInputBox }), PROJECT_PATH);
+
+    expect(updateGlobalSetting).toHaveBeenCalledWith(azuriteBinariesLocationSetting, defaultAzuritePathValue);
+  });
+
+  it('sets the default binaries location when the warning is off and autostart is on', async () => {
+    mockSettings({ showWarning: false, autoStart: true, binariesLocation: undefined });
+    (validateEmulatorIsRunning as any).mockResolvedValue(true);
+
+    await activateAzurite(createContext(), PROJECT_PATH);
+
+    expect(updateGlobalSetting).toHaveBeenCalledWith(azuriteBinariesLocationSetting, defaultAzuritePathValue);
+    expect(executeOnAzurite).not.toHaveBeenCalled();
+  });
+
+  it('writes azurite.location to global settings, strips shared copies, and starts azurite (key path)', async () => {
+    mockSettings({ showWarning: false, autoStart: true, binariesLocation: '/ext/azurite/loc' });
+    (validateEmulatorIsRunning as any).mockResolvedValue(false);
+    const context = createContext();
+
+    await activateAzurite(context, PROJECT_PATH);
+
+    expect(updateGlobalSetting).toHaveBeenCalledWith(azuriteLocationSetting, '/ext/azurite/loc', azuriteExtensionPrefix);
+    expect(removeSharedSetting).toHaveBeenCalledWith(azuriteLocationSetting, azuriteExtensionPrefix);
+    expect(executeOnAzurite).toHaveBeenCalledWith(context, extensionCommand.azureAzuriteStart);
+    expect(context.telemetry.properties.azuriteStart).toBe('true');
+    expect(context.telemetry.properties.azuriteLocation).toBe('/ext/azurite/loc');
+  });
+
+  it('defaults the started azurite location when no ext location is configured', async () => {
+    mockSettings({ showWarning: false, autoStart: true, binariesLocation: undefined });
+    (validateEmulatorIsRunning as any).mockResolvedValue(false);
+
+    await activateAzurite(createContext(), PROJECT_PATH);
+
+    expect(updateGlobalSetting).toHaveBeenCalledWith(azuriteLocationSetting, defaultAzuritePathValue, azuriteExtensionPrefix);
+    expect(removeSharedSetting).toHaveBeenCalledWith(azuriteLocationSetting, azuriteExtensionPrefix);
+    expect(executeOnAzurite).toHaveBeenCalled();
+  });
+
+  it('enables autostart without prompting for a directory when an ext location already exists', async () => {
+    mockSettings({ showWarning: true, autoStart: false, binariesLocation: '/ext/azurite/loc' });
+    const showWarningMessage = vi.fn().mockImplementation((_title, enableMessage) => Promise.resolve(enableMessage));
+    const showInputBox = vi.fn();
+    (validateEmulatorIsRunning as any).mockResolvedValue(true);
+
+    await activateAzurite(createContext({ showWarningMessage, showInputBox }), PROJECT_PATH);
+
+    // The input box is skipped because a binaries location is already configured.
+    expect(showInputBox).not.toHaveBeenCalled();
+    expect(updateGlobalSetting).toHaveBeenCalledWith(showAutoStartAzuriteWarning, false);
+  });
+
+  it('does nothing to warning/autostart settings when the user dismisses the prompt', async () => {
+    mockSettings({ showWarning: true, autoStart: false });
+    const showWarningMessage = vi.fn().mockResolvedValue(dialogNo);
+    (validateEmulatorIsRunning as any).mockResolvedValue(true);
+
+    await activateAzurite(createContext({ showWarningMessage }), PROJECT_PATH);
+
+    expect(updateGlobalSetting).not.toHaveBeenCalled();
+    expect(executeOnAzurite).not.toHaveBeenCalled();
+  });
+
+  it('does not start azurite when it is already running', async () => {
+    mockSettings({ showWarning: false, autoStart: true, binariesLocation: '/ext/azurite/loc' });
+    (validateEmulatorIsRunning as any).mockResolvedValue(true);
+
+    await activateAzurite(createContext(), PROJECT_PATH);
+
+    expect(removeSharedSetting).not.toHaveBeenCalled();
+    expect(executeOnAzurite).not.toHaveBeenCalled();
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/azurite/activateAzurite.ts
+++ b/apps/vs-code-designer/src/app/utils/azurite/activateAzurite.ts
@@ -16,7 +16,7 @@ import { localize } from '../../../localize';
 import { executeOnAzurite } from '../../azuriteExtension/executeOnAzuriteExt';
 import { validateEmulatorIsRunning } from '../../debug/validatePreDebug';
 import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
-import { getWorkspaceSetting, updateGlobalSetting, updateWorkspaceSetting } from '../vsCodeConfig/settings';
+import { getWorkspaceSetting, updateGlobalSetting, removeSharedSetting } from '../vsCodeConfig/settings';
 import { getWorkspaceFolder } from '../workspace';
 import { DialogResponses, type IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
@@ -87,7 +87,10 @@ export async function activateAzurite(context: IActionContext, projectPath?: str
       if (autoStartAzurite && !isAzuriteRunning) {
         // Use the configured location, or default to the global default path
         const azuriteLocation = azuriteLocationExtSetting || defaultAzuritePathValue;
-        await updateWorkspaceSetting(azuriteLocationSetting, azuriteLocation, projectPath, azuriteExtensionPrefix);
+        // azurite.location is a machine-local absolute path, so write it to the user's global
+        // settings instead of the shared .code-workspace file (which is committed to the repo).
+        await updateGlobalSetting(azuriteLocationSetting, azuriteLocation, azuriteExtensionPrefix);
+        await removeSharedSetting(azuriteLocationSetting, azuriteExtensionPrefix);
         await executeOnAzurite(context, extensionCommand.azureAzuriteStart);
         context.telemetry.properties.azuriteStart = 'true';
         context.telemetry.properties.azuriteLocation = azuriteLocation;

--- a/apps/vs-code-designer/src/app/utils/dotnet/__test__/dotnet.setCommand.test.ts
+++ b/apps/vs-code-designer/src/app/utils/dotnet/__test__/dotnet.setCommand.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../vsCodeConfig/settings', () => ({
   getGlobalSetting: vi.fn(),
   updateGlobalSetting: vi.fn(),
   updateWorkspaceSetting: vi.fn(),
+  removeSharedSetting: vi.fn(),
 }));
 
 vi.mock('../../workspace', () => ({
@@ -61,7 +62,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
 import { setDotNetCommand, getDotNetCommand, getLocalDotNetVersionFromBinaries } from '../dotnet';
-import { getGlobalSetting, updateGlobalSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
+import { getGlobalSetting, updateGlobalSetting, removeSharedSetting } from '../../vsCodeConfig/settings';
 import { getWorkspaceLogicAppFolders } from '../../workspace';
 
 const BIN_ROOT = '/usr/local/azurelogicapps/dependencies';
@@ -117,13 +118,14 @@ describe('dotnet command resolution', () => {
 
       expect(updateGlobalSetting).toHaveBeenCalledWith('dotNetBinaryPath', path.join(DOTNET_DIR, 'dotnet.exe'));
       expect(fs.chmodSync).toHaveBeenCalledWith(DOTNET_DIR, 0o777);
-      expect(updateWorkspaceSetting).toHaveBeenCalledWith(
+      expect(updateGlobalSetting).toHaveBeenCalledWith(
         'integrated.env.windows',
         expect.objectContaining({ PATH: expect.stringContaining(DOTNET_DIR) }),
-        'C:/projects/logic-app',
         'terminal'
       );
-      expect(updateWorkspaceSetting).toHaveBeenCalledWith('dotNetCliPaths', [DOTNET_DIR], 'C:/projects/logic-app', 'omnisharp');
+      expect(updateGlobalSetting).toHaveBeenCalledWith('dotNetCliPaths', [DOTNET_DIR], 'omnisharp');
+      expect(removeSharedSetting).toHaveBeenCalledWith('integrated.env.windows', 'terminal');
+      expect(removeSharedSetting).toHaveBeenCalledWith('dotNetCliPaths', 'omnisharp');
     });
 
     it('writes <dotNetBinariesPath>/dotnet on Linux and updates terminal.integrated.env.linux', async () => {
@@ -135,13 +137,14 @@ describe('dotnet command resolution', () => {
       await setDotNetCommand();
 
       expect(updateGlobalSetting).toHaveBeenCalledWith('dotNetBinaryPath', path.join(DOTNET_DIR, 'dotnet'));
-      expect(updateWorkspaceSetting).toHaveBeenCalledWith(
+      expect(updateGlobalSetting).toHaveBeenCalledWith(
         'integrated.env.linux',
         expect.objectContaining({ PATH: expect.stringContaining(DOTNET_DIR) }),
-        '/home/me/logic-app',
         'terminal'
       );
-      expect(updateWorkspaceSetting).toHaveBeenCalledWith('dotNetCliPaths', [DOTNET_DIR], '/home/me/logic-app', 'omnisharp');
+      expect(updateGlobalSetting).toHaveBeenCalledWith('dotNetCliPaths', [DOTNET_DIR], 'omnisharp');
+      expect(removeSharedSetting).toHaveBeenCalledWith('integrated.env.linux', 'terminal');
+      expect(removeSharedSetting).toHaveBeenCalledWith('dotNetCliPaths', 'omnisharp');
     });
 
     it('writes <dotNetBinariesPath>/dotnet on macOS and updates terminal.integrated.env.osx', async () => {
@@ -153,13 +156,14 @@ describe('dotnet command resolution', () => {
       await setDotNetCommand();
 
       expect(updateGlobalSetting).toHaveBeenCalledWith('dotNetBinaryPath', path.join(DOTNET_DIR, 'dotnet'));
-      expect(updateWorkspaceSetting).toHaveBeenCalledWith(
+      expect(updateGlobalSetting).toHaveBeenCalledWith(
         'integrated.env.osx',
         expect.objectContaining({ PATH: expect.stringContaining(DOTNET_DIR) }),
-        '/Users/me/logic-app',
         'terminal'
       );
-      expect(updateWorkspaceSetting).toHaveBeenCalledWith('dotNetCliPaths', [DOTNET_DIR], '/Users/me/logic-app', 'omnisharp');
+      expect(updateGlobalSetting).toHaveBeenCalledWith('dotNetCliPaths', [DOTNET_DIR], 'omnisharp');
+      expect(removeSharedSetting).toHaveBeenCalledWith('integrated.env.osx', 'terminal');
+      expect(removeSharedSetting).toHaveBeenCalledWith('dotNetCliPaths', 'omnisharp');
     });
 
     it('still writes the global setting when getWorkspaceLogicAppFolders throws', async () => {

--- a/apps/vs-code-designer/src/app/utils/dotnet/dotnet.ts
+++ b/apps/vs-code-designer/src/app/utils/dotnet/dotnet.ts
@@ -14,7 +14,7 @@ import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { executeCommand } from '../funcCoreTools/cpUtils';
 import { runWithDurationTelemetry } from '../telemetry';
-import { getGlobalSetting, updateGlobalSetting, updateWorkspaceSetting } from '../vsCodeConfig/settings';
+import { getGlobalSetting, updateGlobalSetting, removeSharedSetting } from '../vsCodeConfig/settings';
 import { findFiles, getWorkspaceLogicAppFolders } from '../workspace';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
@@ -242,30 +242,36 @@ export async function setDotNetCommand(): Promise<void> {
 
     try {
       const workspaceLogicAppFolders = await getWorkspaceLogicAppFolders();
-      for (const projectPath of workspaceLogicAppFolders) {
+      if (workspaceLogicAppFolders.length > 0) {
         const pathEnv = {
           PATH: newPath,
         };
 
+        // These point at machine-local binary paths, so they belong in the user's global
+        // settings rather than the shared .code-workspace file (which is committed to the repo).
         // Required for dotnet cli in VSCode Terminal
         switch (process.platform) {
           case Platform.windows: {
-            await updateWorkspaceSetting('integrated.env.windows', pathEnv, projectPath, 'terminal');
+            await updateGlobalSetting('integrated.env.windows', pathEnv, 'terminal');
+            await removeSharedSetting('integrated.env.windows', 'terminal');
             break;
           }
 
           case Platform.linux: {
-            await updateWorkspaceSetting('integrated.env.linux', pathEnv, projectPath, 'terminal');
+            await updateGlobalSetting('integrated.env.linux', pathEnv, 'terminal');
+            await removeSharedSetting('integrated.env.linux', 'terminal');
             break;
           }
 
           case Platform.mac: {
-            await updateWorkspaceSetting('integrated.env.osx', pathEnv, projectPath, 'terminal');
+            await updateGlobalSetting('integrated.env.osx', pathEnv, 'terminal');
+            await removeSharedSetting('integrated.env.osx', 'terminal');
             break;
           }
         }
         // Required for CoreClr
-        await updateWorkspaceSetting('dotNetCliPaths', [dotNetBinariesPath], projectPath, 'omnisharp');
+        await updateGlobalSetting('dotNetCliPaths', [dotNetBinariesPath], 'omnisharp');
+        await removeSharedSetting('dotNetCliPaths', 'omnisharp');
       }
     } catch (error) {
       console.log(error);

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/__test__/settings.test.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/__test__/settings.test.ts
@@ -138,11 +138,11 @@ describe('utils/vsCodeConfig/settings', () => {
       const folderB = { uri: vscode.Uri.file('/ws/functions') };
       (vscode.workspace as any).workspaceFolders = [folderA, folderB];
 
-      await removeSharedSetting('azurite.location', 'azurite');
+      await removeSharedSetting('location', 'azurite');
 
       expect(mockGetConfiguration).toHaveBeenCalledWith('azurite', folderA.uri);
       expect(mockGetConfiguration).toHaveBeenCalledWith('azurite', folderB.uri);
-      expect(update).toHaveBeenCalledWith('azurite.location', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      expect(update).toHaveBeenCalledWith('location', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
       // workspace scope (1) + two folder scopes (2) = 3 update calls
       expect(update).toHaveBeenCalledTimes(3);
     });

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/__test__/settings.test.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/__test__/settings.test.ts
@@ -110,7 +110,12 @@ describe('utils/vsCodeConfig/settings', () => {
       update = vi.fn().mockResolvedValue(undefined);
       mockConfig = {
         update,
-        inspect: vi.fn().mockReturnValue({ globalValue: ['/global/path'] }),
+        // Default: a value exists in every scope, so every scope is a removal candidate.
+        inspect: vi.fn().mockReturnValue({
+          globalValue: ['/global/path'],
+          workspaceValue: ['/workspace/path'],
+          workspaceFolderValue: ['/folder/path'],
+        }),
       };
       mockGetConfiguration.mockReturnValue(mockConfig as any);
       (vscode.workspace as any).workspaceFolders = [];
@@ -121,6 +126,11 @@ describe('utils/vsCodeConfig/settings', () => {
 
       expect(mockGetConfiguration).toHaveBeenCalledWith('omnisharp');
       expect(update).toHaveBeenCalledWith('dotNetCliPaths', undefined, vscode.ConfigurationTarget.Workspace);
+      // A shared value existed and was removed, so the summary line is logged.
+      const summaryLogs = vi
+        .mocked(ext.outputChannel?.appendLog as any)
+        .mock.calls.filter((call: any[]) => String(call[0]).includes('-> global='));
+      expect(summaryLogs).toHaveLength(1);
     });
 
     it('removes the value from each workspace folder scope', async () => {
@@ -135,6 +145,19 @@ describe('utils/vsCodeConfig/settings', () => {
       expect(update).toHaveBeenCalledWith('azurite.location', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
       // workspace scope (1) + two folder scopes (2) = 3 update calls
       expect(update).toHaveBeenCalledTimes(3);
+    });
+
+    it('skips scopes that have no value (application/window-scoped settings) without logging', async () => {
+      // Value only exists globally — no workspace or folder value to remove.
+      mockConfig.inspect.mockReturnValue({ globalValue: { PATH: '/global/path' } });
+      (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file('/ws/logicapp') }];
+
+      await removeSharedSetting('integrated.env.windows', 'terminal');
+
+      // No removal attempted because there is nothing to remove in those scopes.
+      expect(update).not.toHaveBeenCalled();
+      // And nothing is logged at all — no "Skipped" errors and no summary line for a no-op.
+      expect(ext.outputChannel?.appendLog).not.toHaveBeenCalled();
     });
 
     it('does not throw when an update fails and logs the skip', async () => {

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/__test__/settings.test.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/__test__/settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as vscode from 'vscode';
-import { createSettingsDetails } from '../settings';
+import { createSettingsDetails, removeSharedSetting } from '../settings';
 import { ext } from '../../../../extensionVariables';
 
 describe('utils/vsCodeConfig/settings', () => {
@@ -97,6 +97,51 @@ describe('utils/vsCodeConfig/settings', () => {
         zeroSetting: 0,
         emptySetting: '',
       });
+    });
+  });
+
+  describe('removeSharedSetting', () => {
+    const mockGetConfiguration = vi.mocked(vscode.workspace.getConfiguration);
+    let update: ReturnType<typeof vi.fn>;
+    let mockConfig: { update: ReturnType<typeof vi.fn>; inspect: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      update = vi.fn().mockResolvedValue(undefined);
+      mockConfig = {
+        update,
+        inspect: vi.fn().mockReturnValue({ globalValue: ['/global/path'] }),
+      };
+      mockGetConfiguration.mockReturnValue(mockConfig as any);
+      (vscode.workspace as any).workspaceFolders = [];
+    });
+
+    it('removes the value from the workspace (.code-workspace) scope', async () => {
+      await removeSharedSetting('dotNetCliPaths', 'omnisharp');
+
+      expect(mockGetConfiguration).toHaveBeenCalledWith('omnisharp');
+      expect(update).toHaveBeenCalledWith('dotNetCliPaths', undefined, vscode.ConfigurationTarget.Workspace);
+    });
+
+    it('removes the value from each workspace folder scope', async () => {
+      const folderA = { uri: vscode.Uri.file('/ws/logicapp') };
+      const folderB = { uri: vscode.Uri.file('/ws/functions') };
+      (vscode.workspace as any).workspaceFolders = [folderA, folderB];
+
+      await removeSharedSetting('azurite.location', 'azurite');
+
+      expect(mockGetConfiguration).toHaveBeenCalledWith('azurite', folderA.uri);
+      expect(mockGetConfiguration).toHaveBeenCalledWith('azurite', folderB.uri);
+      expect(update).toHaveBeenCalledWith('azurite.location', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      // workspace scope (1) + two folder scopes (2) = 3 update calls
+      expect(update).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not throw when an update fails and logs the skip', async () => {
+      update.mockRejectedValueOnce(new Error('window scoped setting'));
+
+      await expect(removeSharedSetting('integrated.env.windows', 'terminal')).resolves.toBeUndefined();
+      expect(ext.outputChannel?.appendLog).toHaveBeenCalled();
     });
   });
 });

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
@@ -37,6 +37,46 @@ export async function updateGlobalSetting<T = string>(section: string, value: T,
 }
 
 /**
+ * Removes a setting from the shared workspace scopes so it only lives in the user's global
+ * settings. This strips the key from the multi-root `.code-workspace` file
+ * (`ConfigurationTarget.Workspace`) and from every folder's `.vscode/settings.json`
+ * (`ConfigurationTarget.WorkspaceFolder`).
+ *
+ * Used to migrate machine-local settings (absolute binary paths, terminal env, etc.) out of
+ * files that get committed/shared in a repository. Each removal is best-effort: removing a
+ * value that is absent, or one whose registered scope forbids that target, can throw and must
+ * not break extension setup.
+ * @param {string} section - The setting key (without prefix).
+ * @param {string} prefix - The configuration prefix/section (default: ext.prefix).
+ */
+export async function removeSharedSetting(section: string, prefix: string = ext.prefix): Promise<void> {
+  // Remove the workspace-level value (the .code-workspace file in a multi-root workspace).
+  try {
+    await workspace.getConfiguration(prefix).update(section, undefined, ConfigurationTarget.Workspace);
+  } catch (error) {
+    ext.outputChannel?.appendLog(`[removeSharedSetting] Skipped workspace removal for ${prefix}.${section}: ${error}`);
+  }
+
+  // Remove any folder-level values (each folder's .vscode/settings.json).
+  for (const folder of workspace.workspaceFolders ?? []) {
+    try {
+      await workspace.getConfiguration(prefix, folder.uri).update(section, undefined, ConfigurationTarget.WorkspaceFolder);
+    } catch (error) {
+      ext.outputChannel?.appendLog(
+        `[removeSharedSetting] Skipped folder removal for ${prefix}.${section} in ${folder.uri.fsPath}: ${error}`
+      );
+    }
+  }
+
+  // Log where the value now resolves so the landing scope can be verified at runtime.
+  const inspection = workspace.getConfiguration(prefix).inspect(section);
+  ext.outputChannel?.appendLog(
+    `[removeSharedSetting] ${prefix}.${section} -> global=${JSON.stringify(inspection?.globalValue)}, ` +
+      `workspace=${JSON.stringify(inspection?.workspaceValue)}, folder=${JSON.stringify(inspection?.workspaceFolderValue)}`
+  );
+}
+
+/**
  * Searches through all open folders and gets the current workspace setting (as long as there are no conflicts)
  * Uses ext.prefix 'azureLogicAppsStandard' unless otherwise specified
  */

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
@@ -89,10 +89,13 @@ export async function removeSharedSetting(section: string, prefix: string = ext.
   }
 
   // Log where the value now resolves so the landing scope can be verified at runtime.
+  // Only global and workspace values are meaningful from a non-resource-scoped inspection;
+  // workspaceFolderValue is per-folder and would be ambiguous here, so it is intentionally
+  // omitted (per-folder removals are already handled/logged in the loop above).
   const inspection = config.inspect(section);
   ext.outputChannel?.appendLog(
     `[removeSharedSetting] ${prefix}.${section} -> global=${JSON.stringify(inspection?.globalValue)}, ` +
-      `workspace=${JSON.stringify(inspection?.workspaceValue)}, folder=${JSON.stringify(inspection?.workspaceFolderValue)}`
+      `workspace=${JSON.stringify(inspection?.workspaceValue)}`
   );
 }
 

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
@@ -43,24 +43,39 @@ export async function updateGlobalSetting<T = string>(section: string, value: T,
  * (`ConfigurationTarget.WorkspaceFolder`).
  *
  * Used to migrate machine-local settings (absolute binary paths, terminal env, etc.) out of
- * files that get committed/shared in a repository. Each removal is best-effort: removing a
- * value that is absent, or one whose registered scope forbids that target, can throw and must
- * not break extension setup.
+ * files that get committed/shared in a repository. Each scope is only touched when a value is
+ * actually present there (checked via `inspect`), so application/window-scoped settings that
+ * cannot be written at workspace/folder scope are skipped instead of throwing. Any remaining
+ * failure is swallowed and logged so it never breaks extension setup.
  * @param {string} section - The setting key (without prefix).
  * @param {string} prefix - The configuration prefix/section (default: ext.prefix).
  */
 export async function removeSharedSetting(section: string, prefix: string = ext.prefix): Promise<void> {
-  // Remove the workspace-level value (the .code-workspace file in a multi-root workspace).
-  try {
-    await workspace.getConfiguration(prefix).update(section, undefined, ConfigurationTarget.Workspace);
-  } catch (error) {
-    ext.outputChannel?.appendLog(`[removeSharedSetting] Skipped workspace removal for ${prefix}.${section}: ${error}`);
+  const config: WorkspaceConfiguration = workspace.getConfiguration(prefix);
+  let removedAny = false;
+
+  // Only remove the workspace-level value (the .code-workspace file) when one actually exists.
+  // Application/window-scoped settings (e.g. terminal.integrated.env.*, omnisharp.dotNetCliPaths)
+  // never have a workspace/folder value and cannot be written at those scopes, so attempting the
+  // removal would throw needlessly.
+  if (config.inspect(section)?.workspaceValue !== undefined) {
+    removedAny = true;
+    try {
+      await config.update(section, undefined, ConfigurationTarget.Workspace);
+    } catch (error) {
+      ext.outputChannel?.appendLog(`[removeSharedSetting] Skipped workspace removal for ${prefix}.${section}: ${error}`);
+    }
   }
 
-  // Remove any folder-level values (each folder's .vscode/settings.json).
+  // Remove any folder-level values (each folder's .vscode/settings.json), again only where present.
   for (const folder of workspace.workspaceFolders ?? []) {
+    const folderConfig: WorkspaceConfiguration = workspace.getConfiguration(prefix, folder.uri);
+    if (folderConfig.inspect(section)?.workspaceFolderValue === undefined) {
+      continue;
+    }
+    removedAny = true;
     try {
-      await workspace.getConfiguration(prefix, folder.uri).update(section, undefined, ConfigurationTarget.WorkspaceFolder);
+      await folderConfig.update(section, undefined, ConfigurationTarget.WorkspaceFolder);
     } catch (error) {
       ext.outputChannel?.appendLog(
         `[removeSharedSetting] Skipped folder removal for ${prefix}.${section} in ${folder.uri.fsPath}: ${error}`
@@ -68,8 +83,13 @@ export async function removeSharedSetting(section: string, prefix: string = ext.
     }
   }
 
+  // Nothing lived in a shared scope, so there's nothing to report — stay quiet.
+  if (!removedAny) {
+    return;
+  }
+
   // Log where the value now resolves so the landing scope can be verified at runtime.
-  const inspection = workspace.getConfiguration(prefix).inspect(section);
+  const inspection = config.inspect(section);
   ext.outputChannel?.appendLog(
     `[removeSharedSetting] ${prefix}.${section} -> global=${JSON.stringify(inspection?.globalValue)}, ` +
       `workspace=${JSON.stringify(inspection?.workspaceValue)}, folder=${JSON.stringify(inspection?.workspaceFolderValue)}`


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Machine-specific settings that hold **absolute local paths** were being written into the shared multi-root `.code-workspace` file. When that workspace file is committed and shared in a repo, those absolute paths break for every other developer.

**Root cause:** `updateWorkspaceSetting()` called `WorkspaceConfiguration.update(section, value)` with **no explicit `ConfigurationTarget`**. Callers pass the workspace root (the directory *containing* the `.code-workspace`, which is not a registered workspace folder), so VS Code falls back to `ConfigurationTarget.Workspace` and writes into the shared file.

**Fix:**
- Write the 5 machine-local path settings to **User (global) settings** via `updateGlobalSetting` (`ConfigurationTarget.Global`), which always lands in the user's `settings.json`:
  - `terminal.integrated.env.{windows,linux,osx}` and `omnisharp.dotNetCliPaths` (dotnet setup)
  - `azurite.location`
- Add `removeSharedSetting(section, prefix)` to strip any **stale** copies of these keys out of the shared `.code-workspace` (Workspace scope) and each folder's `.vscode/settings.json` (WorkspaceFolder scope). This is required because VS Code setting precedence is **Folder > Workspace > User** — a stale shared value would otherwise shadow the new user-level value.
- Removal is guarded by `inspect()` so it only touches a scope where a value actually exists (application/window-scoped settings can't be written at folder scope and would otherwise throw). It only logs a summary line when something was actually removed, keeping the output channel quiet on no-ops.
- Hoisted the dotnet global writes out of the per-folder loop since they are folder-independent.

Project-structure settings (`projectSubpath`, `deploySubpath`, `funcVersion`, `projectLanguage`, etc.) are intentionally left as workspace settings — they are the same for every developer and meant to be shared.

## Impact of Change
- **Users**: Machine-local paths (dotnet SDK/CLI paths, terminal `PATH` env, azurite location) now persist in each developer's own User settings instead of the shared `.code-workspace`. Sharing/committing a workspace no longer leaks another machine's absolute paths.
- **Developers**: New helper `removeSharedSetting` in `vsCodeConfig/settings.ts` for migrating machine-local keys out of shared scopes. Callers switched from `updateWorkspaceSetting` to `updateGlobalSetting` for these keys.
- **System**: No architectural or dependency changes. Behavior change is limited to which settings scope these specific keys are written to/removed from.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: VS Code Extension Development Host (Windows) — verified via the "Azure Logic Apps" output channel that the keys resolve as `global=<value>, workspace=undefined, folder=undefined`, appear in User `settings.json`, and are absent from the `.code-workspace`.

Unit tests: `settings.test.ts` (new `removeSharedSetting` cases: workspace removal, per-folder removal, no-op skip with no logging, error swallowing) and `dotnet.setCommand.test.ts` (asserts global writes + cleanup per platform). 23/23 passing; Biome clean.

## Contributors
@lambrianmsft

## Screenshots/Videos
N/A — no visual changes.
