### PR TITLE
fix(vscode): V2 designer fixes

### DIFF
--- a/apps/vs-code-designer/src/app/commands/workflows/connectionView/panels/connectionPanel.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/connectionView/panels/connectionPanel.ts
@@ -103,7 +103,7 @@ export default class ConnectionPanel extends DesignerPanel {
       throw new Error(localize('designTimePortNotFound', 'Design time port not found.'));
     }
     this.baseUrl = `http://localhost:${designTimePort}${managementApiPrefix}`;
-    this.workflowRuntimeBaseUrl = `http://localhost:${ext.workflowRuntimePort}${managementApiPrefix}`;
+    this.workflowRuntimeBaseUrl = ext.getWorkflowRuntimeBaseUrl();
 
     this.panelMetadata = panelMetadata;
 
@@ -324,13 +324,7 @@ export default class ConnectionPanel extends DesignerPanel {
       throw new Error(localize('FunctionRootFolderError', 'Unable to determine function project root folder.'));
     }
 
-    const [
-      connectionsData,
-      parametersData,
-      artifacts,
-      bundleVersionNumber,
-      azureDetails
-    ] = await Promise.all([
+    const [connectionsData, parametersData, artifacts, bundleVersionNumber, azureDetails] = await Promise.all([
       getConnectionsFromFile(this.context, this.workflowFilePath),
       getParametersFromFile(this.context, this.workflowFilePath),
       getArtifactsInLocalProject(projectPath),

--- a/apps/vs-code-designer/src/app/commands/workflows/designer-v2/__test__/openDesignerV2.test.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/designer-v2/__test__/openDesignerV2.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { workspace } from 'vscode';
+import { ext } from '../../../../../extensionVariables';
+
+vi.mock('../../../../../localize', () => ({
+  localize: (_key: string, defaultMsg: string) => defaultMsg,
+}));
+
+vi.mock('../../../../utils/workspace', () => ({
+  getWorkflowNode: vi.fn((node: any) => node),
+}));
+
+vi.mock('../../../../utils/customCodeUtils', () => ({
+  customCodeArtifactsExist: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../../buildCustomCodeFunctionsProject', () => ({
+  tryBuildCustomCodeFunctionsProject: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../../utils/vsCodeConfig/settings', () => ({
+  shouldAlwaysBuildCustomCode: vi.fn().mockReturnValue(false),
+}));
+
+const mockCreate = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../panels/localDesignerV2Panel', () => ({
+  default: class MockLocalDesignerV2Panel {
+    create = mockCreate;
+  },
+}));
+
+vi.mock('../panels/remoteDesignerV2Panel', () => ({
+  RemoteDesignerV2Panel: vi.fn().mockImplementation(() => ({ create: vi.fn().mockResolvedValue(undefined) })),
+}));
+
+import { openDesignerV2 } from '../openDesignerV2';
+import { tryBuildCustomCodeFunctionsProject } from '../../../buildCustomCodeFunctionsProject';
+import { customCodeArtifactsExist } from '../../../../utils/customCodeUtils';
+import { shouldAlwaysBuildCustomCode } from '../../../../utils/vsCodeConfig/settings';
+
+describe('openDesignerV2', () => {
+  const mockContext = { telemetry: { properties: {} } } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (ext as any).outputChannel = { appendLog: vi.fn() };
+    vi.mocked(workspace.getConfiguration).mockReturnValue({ get: vi.fn(() => 2) } as any);
+  });
+
+  it('skips custom code build when opened with runId (monitoring mode)', async () => {
+    const mockUri = { fsPath: '/test/project/myWorkflow/workflow.json' } as any;
+
+    await openDesignerV2(mockContext, mockUri, 'workflows/myWorkflow/runs/run-1');
+
+    expect(tryBuildCustomCodeFunctionsProject).not.toHaveBeenCalled();
+    expect(customCodeArtifactsExist).not.toHaveBeenCalled();
+  });
+
+  it('checks custom code artifacts when opened without runId (editing mode)', async () => {
+    vi.mocked(customCodeArtifactsExist).mockResolvedValue(true);
+    const mockUri = { fsPath: '/test/project/myWorkflow/workflow.json' } as any;
+
+    await openDesignerV2(mockContext, mockUri);
+
+    expect(customCodeArtifactsExist).toHaveBeenCalled();
+    expect(tryBuildCustomCodeFunctionsProject).not.toHaveBeenCalled();
+  });
+
+  it('builds custom code when artifacts do not exist', async () => {
+    vi.mocked(customCodeArtifactsExist).mockResolvedValue(false);
+    const mockUri = { fsPath: '/test/project/myWorkflow/workflow.json' } as any;
+
+    await openDesignerV2(mockContext, mockUri);
+
+    expect(tryBuildCustomCodeFunctionsProject).toHaveBeenCalled();
+  });
+
+  it('builds custom code when alwaysBuildCustomCode setting is enabled', async () => {
+    vi.mocked(shouldAlwaysBuildCustomCode).mockReturnValue(true);
+    vi.mocked(customCodeArtifactsExist).mockResolvedValue(true);
+    const mockUri = { fsPath: '/test/project/myWorkflow/workflow.json' } as any;
+
+    await openDesignerV2(mockContext, mockUri);
+
+    expect(tryBuildCustomCodeFunctionsProject).toHaveBeenCalled();
+  });
+
+  it('does not build custom code in monitoring mode even with alwaysBuild enabled', async () => {
+    vi.mocked(shouldAlwaysBuildCustomCode).mockReturnValue(true);
+    const mockUri = { fsPath: '/test/project/myWorkflow/workflow.json' } as any;
+
+    await openDesignerV2(mockContext, mockUri, 'workflows/myWorkflow/runs/run-1');
+
+    expect(tryBuildCustomCodeFunctionsProject).not.toHaveBeenCalled();
+  });
+
+  it('logs and returns early when node is undefined', async () => {
+    const { getWorkflowNode } = await import('../../../../utils/workspace');
+    vi.mocked(getWorkflowNode).mockReturnValue(undefined);
+
+    await openDesignerV2(mockContext, undefined);
+
+    expect(ext.outputChannel.appendLog).toHaveBeenCalled();
+    expect(tryBuildCustomCodeFunctionsProject).not.toHaveBeenCalled();
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/workflows/designer-v2/openDesignerV2.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/designer-v2/openDesignerV2.ts
@@ -45,7 +45,8 @@ async function getDesignerV2Panel(
   }
 
   const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
-  if (shouldAlwaysBuildCustomCode() || !(await customCodeArtifactsExist(logicAppNode.fsPath))) {
+  const isMonitoringView = !!runId;
+  if (!isMonitoringView && (shouldAlwaysBuildCustomCode() || !(await customCodeArtifactsExist(logicAppNode.fsPath)))) {
     await tryBuildCustomCodeFunctionsProject(context, logicAppNode);
   }
 

--- a/apps/vs-code-designer/src/app/commands/workflows/designer-v2/openDesignerV2.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/designer-v2/openDesignerV2.ts
@@ -10,6 +10,7 @@ import { tryBuildCustomCodeFunctionsProject } from '../../buildCustomCodeFunctio
 import { customCodeArtifactsExist } from '../../../utils/customCodeUtils';
 import { ext } from '../../../../extensionVariables';
 import { localize } from '../../../../localize';
+import { shouldAlwaysBuildCustomCode } from '../../../utils/vsCodeConfig/settings';
 import type { DesignerV2Panel } from './panels/designerV2Panel';
 import LocalDesignerV2Panel from './panels/localDesignerV2Panel';
 import { RemoteDesignerV2Panel } from './panels/remoteDesignerV2Panel';
@@ -44,7 +45,7 @@ async function getDesignerV2Panel(
   }
 
   const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
-  if (!(await customCodeArtifactsExist(logicAppNode.fsPath))) {
+  if (shouldAlwaysBuildCustomCode() || !(await customCodeArtifactsExist(logicAppNode.fsPath))) {
     await tryBuildCustomCodeFunctionsProject(context, logicAppNode);
   }
 

--- a/apps/vs-code-designer/src/app/commands/workflows/designer-v2/panels/localDesignerV2Panel.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/designer-v2/panels/localDesignerV2Panel.ts
@@ -118,7 +118,7 @@ export default class LocalDesignerV2Panel extends DesignerV2Panel {
     }
 
     this.baseUrl = `http://localhost:${designTimePort}${managementApiPrefix}`;
-    this.workflowRuntimeBaseUrl = this.getWorkflowRuntimeBaseUrl();
+    this.workflowRuntimeBaseUrl = ext.getWorkflowRuntimeBaseUrl();
 
     this.panel = window.createWebviewPanel(this.panelGroupKey, this.panelName, ViewColumn.Active, this.getPanelOptions());
     this.panel.iconPath = {
@@ -179,7 +179,7 @@ export default class LocalDesignerV2Panel extends DesignerV2Panel {
       case ExtensionCommand.initialize: {
         clearInterval(this.workflowRuntimeBaseUrlInterval);
         this.workflowRuntimeBaseUrlInterval = setInterval(async () => {
-          const updatedRuntimeBaseUrl = this.getWorkflowRuntimeBaseUrl();
+          const updatedRuntimeBaseUrl = ext.getWorkflowRuntimeBaseUrl();
 
           if (updatedRuntimeBaseUrl !== this.workflowRuntimeBaseUrl) {
             this.workflowRuntimeBaseUrl = updatedRuntimeBaseUrl;
@@ -351,10 +351,6 @@ export default class LocalDesignerV2Panel extends DesignerV2Panel {
   // endregion
 
   // region Workflow utilities
-
-  private getWorkflowRuntimeBaseUrl(): string | undefined {
-    return ext.workflowRuntimePort ? `http://localhost:${ext.workflowRuntimePort}${managementApiPrefix}` : undefined;
-  }
 
   private async saveWorkflow(
     context: IActionContext,

--- a/apps/vs-code-designer/src/app/commands/workflows/designer/__test__/openDesigner.test.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/designer/__test__/openDesigner.test.ts
@@ -18,8 +18,16 @@ vi.mock('../../../buildCustomCodeFunctionsProject', () => ({
   tryBuildCustomCodeFunctionsProject: vi.fn(),
 }));
 
+vi.mock('../../../../utils/vsCodeConfig/settings', () => ({
+  shouldAlwaysBuildCustomCode: vi.fn().mockReturnValue(false),
+}));
+
+const mockCreate = vi.fn().mockResolvedValue(undefined);
+
 vi.mock('../panels/localDesignerPanel', () => ({
-  default: vi.fn().mockImplementation(() => ({ create: vi.fn().mockResolvedValue(undefined) })),
+  default: class MockLocalDesignerPanel {
+    create = mockCreate;
+  },
 }));
 
 vi.mock('../panels/remoteDesignerPanel', () => ({
@@ -32,6 +40,9 @@ vi.mock('../../designer-v2/openDesignerV2', () => ({
 
 import { openDesigner } from '../openDesigner';
 import { openDesignerV2 } from '../../designer-v2/openDesignerV2';
+import { tryBuildCustomCodeFunctionsProject } from '../../../buildCustomCodeFunctionsProject';
+import { customCodeArtifactsExist } from '../../../../utils/customCodeUtils';
+import { shouldAlwaysBuildCustomCode } from '../../../../utils/vsCodeConfig/settings';
 
 describe('openDesigner', () => {
   const mockContext = { telemetry: { properties: {} } } as any;
@@ -39,14 +50,45 @@ describe('openDesigner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (ext as any).outputChannel = { appendLog: vi.fn() };
+    vi.mocked(workspace.getConfiguration).mockReturnValue({ get: vi.fn(() => 1) } as any);
   });
 
   it('routes to openDesignerV2 when designer version is 2', async () => {
     vi.mocked(workspace.getConfiguration).mockReturnValue({ get: vi.fn(() => 2) } as any);
-    const mockUri = { fsPath: '/test/project/myWorkflow/workflow.json' } as any;
+    const mockUri = { fsPath: 'D:\\test\\project\\myWorkflow\\workflow.json' } as any;
 
     await openDesigner(mockContext, mockUri);
 
     expect(openDesignerV2).toHaveBeenCalledWith(mockContext, mockUri);
+  });
+
+  it('builds custom code when alwaysBuildCustomCode setting is enabled', async () => {
+    vi.mocked(shouldAlwaysBuildCustomCode).mockReturnValue(true);
+    vi.mocked(customCodeArtifactsExist).mockResolvedValue(true);
+    const mockUri = { fsPath: 'D:\\test\\project\\myWorkflow\\workflow.json' } as any;
+
+    await openDesigner(mockContext, mockUri);
+
+    expect(tryBuildCustomCodeFunctionsProject).toHaveBeenCalled();
+  });
+
+  it('builds custom code when artifacts do not exist', async () => {
+    vi.mocked(customCodeArtifactsExist).mockResolvedValue(false);
+    const mockUri = { fsPath: 'D:\\test\\project\\myWorkflow\\workflow.json' } as any;
+
+    await openDesigner(mockContext, mockUri);
+
+    expect(tryBuildCustomCodeFunctionsProject).toHaveBeenCalled();
+  });
+
+  it('does not build custom code when artifacts exist and alwaysBuildCustomCode is false', async () => {
+    vi.mocked(shouldAlwaysBuildCustomCode).mockReturnValue(false);
+    vi.mocked(customCodeArtifactsExist).mockResolvedValue(true);
+    const mockUri = { fsPath: 'D:\\test\\project\\myWorkflow\\workflow.json' } as any;
+
+    await openDesigner(mockContext, mockUri);
+
+    expect(customCodeArtifactsExist).toHaveBeenCalled();
+    expect(tryBuildCustomCodeFunctionsProject).not.toHaveBeenCalled();
   });
 });

--- a/apps/vs-code-designer/src/app/commands/workflows/designer/openDesigner.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/designer/openDesigner.ts
@@ -16,6 +16,7 @@ import { localize } from '../../../../localize';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { openDesignerV2 } from '../designer-v2/openDesignerV2';
 import { defaultDesignerVersion, designerVersionSetting } from '../../../../constants';
+import { shouldAlwaysBuildCustomCode } from '../../../utils/vsCodeConfig/settings';
 
 export async function openDesigner(context: IActionContext, node: Uri | RemoteWorkflowTreeItem | undefined): Promise<void> {
   const designerVersion = workspace.getConfiguration(ext.prefix).get<number>(designerVersionSetting) ?? defaultDesignerVersion;
@@ -39,7 +40,7 @@ async function getDesignerPanel(context: IActionContext, workflowNode: Uri | Rem
   }
 
   const logicAppNode = Uri.file(path.join(workflowNode.fsPath, '../../'));
-  if (!(await customCodeArtifactsExist(logicAppNode.fsPath))) {
+  if (shouldAlwaysBuildCustomCode() || !(await customCodeArtifactsExist(logicAppNode.fsPath))) {
     await tryBuildCustomCodeFunctionsProject(context, logicAppNode);
   }
 

--- a/apps/vs-code-designer/src/app/commands/workflows/designer/panels/localDesignerPanel.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/designer/panels/localDesignerPanel.ts
@@ -111,7 +111,7 @@ export default class LocalDesignerPanel extends DesignerPanel {
     }
 
     this.baseUrl = `http://localhost:${designTimePort}${managementApiPrefix}`;
-    this.workflowRuntimeBaseUrl = this.getWorkflowRuntimeBaseUrl();
+    this.workflowRuntimeBaseUrl = ext.getWorkflowRuntimeBaseUrl();
 
     this.panel = window.createWebviewPanel(
       this.panelGroupKey, // Key used to reference the panel
@@ -174,7 +174,7 @@ export default class LocalDesignerPanel extends DesignerPanel {
     switch (msg.command) {
       case ExtensionCommand.initialize: {
         this.workflowRuntimeBaseUrlInterval = setInterval(async () => {
-          const updatedRuntimeBaseUrl = this.getWorkflowRuntimeBaseUrl();
+          const updatedRuntimeBaseUrl = ext.getWorkflowRuntimeBaseUrl();
 
           if (updatedRuntimeBaseUrl !== this.workflowRuntimeBaseUrl) {
             this.workflowRuntimeBaseUrl = updatedRuntimeBaseUrl;
@@ -257,7 +257,7 @@ export default class LocalDesignerPanel extends DesignerPanel {
         await createUnitTestFromRun(Uri.file(this.workflowFilePath), msg.runId, msg.definition);
         break;
       }
-      
+
       case ExtensionCommand.addConnection: {
         await callWithTelemetryAndErrorHandling('AddConnectionFromDesigner', async (activateContext: IActionContext) => {
           await addConnectionData(activateContext, this.workflowFilePath, msg.connectionAndSetting);
@@ -316,10 +316,6 @@ export default class LocalDesignerPanel extends DesignerPanel {
       default:
         break;
     }
-  }
-
-  private getWorkflowRuntimeBaseUrl(): string | undefined {
-    return ext.workflowRuntimePort ? `http://localhost:${ext.workflowRuntimePort}${managementApiPrefix}` : undefined;
   }
 
   /**

--- a/apps/vs-code-designer/src/app/commands/workflows/monitoringView/panels/localMonitoringPanel.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/monitoringView/panels/localMonitoringPanel.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { assetsFolderName, localSettingsFileName, managementApiPrefix } from '../../../../../constants';
+import { assetsFolderName, localSettingsFileName } from '../../../../../constants';
 import { ext } from '../../../../../extensionVariables';
 import { localize } from '../../../../../localize';
 import { getLocalSettingsJson } from '../../../../utils/appSettings/localSettings';
@@ -71,7 +71,10 @@ export default class LocalMonitoringPanel extends MonitoringPanel {
       throw new Error(localize('FunctionRootFolderError', 'Unable to determine function project root folder.'));
     }
 
-    this.baseUrl = `http://localhost:${ext.workflowRuntimePort}${managementApiPrefix}`;
+    this.baseUrl = ext.getWorkflowRuntimeBaseUrl();
+    if (!this.baseUrl) {
+      throw new Error(localize('FunctionRuntimeNotStarted', 'Unable to determine function runtime base url. Please ensure the local runtime is started.'));
+    }
 
     // Fetch panel metadata which does all operations in parallel internally
     this.panelMetadata = await this.getDesignerPanelMetadata();
@@ -192,23 +195,16 @@ export default class LocalMonitoringPanel extends MonitoringPanel {
       throw new Error(localize('FunctionRootFolderError', 'Unable to determine function project root folder.'));
     }
 
-    const [
-      connectionsData,
-      parametersData,
-      customCodeData,
-      bundleVersionNumber,
-      azureDetails,
-      artifacts,
-      workflowContent,
-    ] = await Promise.all([
-      getConnectionsFromFile(this.context, this.workflowFilePath),
-      getParametersFromFile(this.context, this.workflowFilePath),
-      getCustomCodeFromFiles(this.workflowFilePath),
-      getBundleVersionNumber(projectPath),
-      getAzureConnectorDetailsForLocalProject(this.context, projectPath),
-      getArtifactsInLocalProject(projectPath),
-      this.getWorkflowContent(),
-    ]);
+    const [connectionsData, parametersData, customCodeData, bundleVersionNumber, azureDetails, artifacts, workflowContent] =
+      await Promise.all([
+        getConnectionsFromFile(this.context, this.workflowFilePath),
+        getParametersFromFile(this.context, this.workflowFilePath),
+        getCustomCodeFromFiles(this.workflowFilePath),
+        getBundleVersionNumber(projectPath),
+        getAzureConnectorDetailsForLocalProject(this.context, projectPath),
+        getArtifactsInLocalProject(projectPath),
+        this.getWorkflowContent(),
+      ]);
 
     const localSettings = (await getLocalSettingsJson(this.context, path.join(projectPath, localSettingsFileName))).Values!;
 

--- a/apps/vs-code-designer/src/app/commands/workflows/monitoringView/panels/localMonitoringPanel.ts
+++ b/apps/vs-code-designer/src/app/commands/workflows/monitoringView/panels/localMonitoringPanel.ts
@@ -54,17 +54,6 @@ export default class LocalMonitoringPanel extends MonitoringPanel {
       return;
     }
 
-    this.panel = vscode.window.createWebviewPanel(
-      this.panelGroupKey, // Key used to reference the panel
-      this.panelName, // Title display in the tab
-      ViewColumn.Active, // Editor column to show the new webview panel in.
-      this.getPanelOptions()
-    );
-    this.panel.iconPath = {
-      light: Uri.file(path.join(ext.context.extensionPath, assetsFolderName, 'light', 'workflow.svg')),
-      dark: Uri.file(path.join(ext.context.extensionPath, assetsFolderName, 'dark', 'workflow.svg')),
-    };
-
     this.projectPath = await getLogicAppProjectRoot(this.context, this.workflowFilePath);
 
     if (!this.projectPath) {
@@ -75,6 +64,18 @@ export default class LocalMonitoringPanel extends MonitoringPanel {
     if (!this.baseUrl) {
       throw new Error(localize('FunctionRuntimeNotStarted', 'Unable to determine function runtime base url. Please ensure the local runtime is started.'));
     }
+
+    this.panel = vscode.window.createWebviewPanel(
+      this.panelGroupKey, // Key used to reference the panel
+      this.panelName, // Title display in the tab
+      ViewColumn.Active, // Editor column to show the new webview panel in.
+      this.getPanelOptions()
+    );
+    
+    this.panel.iconPath = {
+      light: Uri.file(path.join(ext.context.extensionPath, assetsFolderName, 'light', 'workflow.svg')),
+      dark: Uri.file(path.join(ext.context.extensionPath, assetsFolderName, 'dark', 'workflow.svg')),
+    };
 
     // Fetch panel metadata which does all operations in parallel internally
     this.panelMetadata = await this.getDesignerPanelMetadata();

--- a/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
+++ b/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
@@ -24,29 +24,22 @@ export async function customCodeArtifactsExist(projectPath: string): Promise<boo
   }
 
   const customCodeArtifactsPath = path.join(projectPath, libDirectory, customDirectory);
-  const customFolderExists = await fse.pathExists(customCodeArtifactsPath);
-  if (!customFolderExists) {
+  if (!(await fse.pathExists(customCodeArtifactsPath))) {
     return false;
   }
 
-  const customCodeProjectPaths = await tryGetLogicAppCustomCodeFunctionsProjects(projectPath);
-  if (!customCodeProjectPaths || customCodeProjectPaths.length === 0) {
-    return false;
-  }
-  const customCodeProjects = customCodeProjectPaths.map((p) => path.basename(p));
-
-  const customCodeArtifactFiles = await fse.readdir(customCodeArtifactsPath);
-  for (const projectName of customCodeProjects) {
-    if (!customCodeArtifactFiles.includes(projectName)) {
-      return false;
-    }
-
-    if (!fse.pathExistsSync(path.join(customCodeArtifactsPath, projectName, 'function.json'))) {
-      return false;
+  const entries = await fse.readdir(customCodeArtifactsPath);
+  for (const entry of entries) {
+    const entryPath = path.join(customCodeArtifactsPath, entry);
+    if ((await fse.stat(entryPath)).isDirectory()) {
+      const files = await fse.readdir(entryPath);
+      if (files.some((f) => f.endsWith('.dll'))) {
+        return true;
+      }
     }
   }
 
-  return true;
+  return false;
 }
 
 export async function getAllCustomCodeFunctionsProjects(context: IActionContext): Promise<string[]> {

--- a/apps/vs-code-designer/src/app/utils/funcCoreTools/__test__/funcHostTask.test.ts
+++ b/apps/vs-code-designer/src/app/utils/funcCoreTools/__test__/funcHostTask.test.ts
@@ -1,0 +1,124 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { ext } from '../../../../extensionVariables';
+
+const { registerEventMock } = vi.hoisted(() => ({
+  registerEventMock: vi.fn(),
+}));
+
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+  registerEvent: registerEventMock,
+}));
+
+import { isFuncHostTask, registerFuncHostTaskEvents, runningFuncTaskMap } from '../funcHostTask';
+
+function createShellTask(command: string, scope?: vscode.WorkspaceFolder | vscode.TaskScope): vscode.Task {
+  return {
+    definition: { type: 'shell' },
+    execution: {
+      command,
+      commandLine: command,
+    },
+    scope,
+  } as vscode.Task;
+}
+
+function createProcessTask(commandLine: string, scope?: vscode.WorkspaceFolder | vscode.TaskScope): vscode.Task {
+  return {
+    definition: { type: 'process' },
+    execution: {
+      commandLine,
+    },
+    scope,
+  } as vscode.Task;
+}
+
+describe('funcHostTask', () => {
+  const workspaceFolder = {
+    name: 'logicapp',
+    index: 0,
+    uri: vscode.Uri.file('D:\\test\\logicapp'),
+  } as vscode.WorkspaceFolder;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runningFuncTaskMap.clear();
+    (ext as any).workflowRuntimePort = '7071';
+    (vscode as any).tasks = {
+      onDidStartTaskProcess: vi.fn(),
+      onDidEndTaskProcess: vi.fn(),
+    };
+    (vscode as any).debug = {
+      onDidTerminateDebugSession: vi.fn(),
+    };
+  });
+
+  describe('isFuncHostTask', () => {
+    it('returns true for shell tasks using funcCoreToolsBinaryPath config', () => {
+      const task = createShellTask('${config:azureLogicAppsStandard.funcCoreToolsBinaryPath}');
+
+      expect(isFuncHostTask(task)).toBe(true);
+    });
+
+    it('returns true for func host start command lines', () => {
+      const task = createProcessTask('func host start');
+
+      expect(isFuncHostTask(task)).toBe(true);
+    });
+
+    it('returns true for func start command lines with custom ports', () => {
+      const task = createProcessTask('func start --port 7072');
+
+      expect(isFuncHostTask(task)).toBe(true);
+    });
+
+    it('returns false for unrelated command lines', () => {
+      const task = createProcessTask('npm run start');
+
+      expect(isFuncHostTask(task)).toBe(false);
+    });
+  });
+
+  describe('registerFuncHostTaskEvents', () => {
+    it('tracks running func host tasks when they start', async () => {
+      registerFuncHostTaskEvents();
+      const startHandler = registerEventMock.mock.calls.find((call) => call[0] === 'azureLogicAppsStandard.onDidStartTask')?.[2];
+      const task = createProcessTask('func host start', workspaceFolder);
+
+      await startHandler(
+        { errorHandling: {}, telemetry: {} },
+        {
+          execution: { task },
+          processId: 1234,
+        }
+      );
+
+      expect(runningFuncTaskMap.get(workspaceFolder)).toEqual({
+        startTime: expect.any(Number),
+        processId: 1234,
+      });
+    });
+
+    it('clears the cached workflow runtime port when a func host task ends', async () => {
+      registerFuncHostTaskEvents();
+      const endHandler = registerEventMock.mock.calls.find((call) => call[0] === 'azureLogicAppsStandard.onDidEndTask')?.[2];
+      const task = createProcessTask('func start --port 7072', workspaceFolder);
+      runningFuncTaskMap.set(workspaceFolder, { processId: 5678, startTime: Date.now() });
+
+      await endHandler(
+        { errorHandling: {}, telemetry: {} },
+        {
+          execution: { task },
+          exitCode: 0,
+        }
+      );
+
+      expect(runningFuncTaskMap.has(workspaceFolder)).toBe(false);
+      expect((ext as any).workflowRuntimePort).toBeUndefined();
+    });
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/funcCoreTools/funcHostTask.ts
+++ b/apps/vs-code-designer/src/app/utils/funcCoreTools/funcHostTask.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { defaultFuncPort, localSettingsFileName, stopFuncTaskPostDebugSetting } from '../../../constants';
+import { ext } from '../../../extensionVariables';
 import { getLocalSettingsJson } from '../appSettings/localSettings';
 import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
@@ -32,8 +33,11 @@ export function isFuncHostTask(task: vscode.Task): boolean {
   const commandLine: string | undefined = task.execution && (task.execution as vscode.ShellExecution).commandLine;
   if (task.definition.type === 'shell') {
     const command = (task.execution as vscode.ShellExecution).command?.toString();
+    if (!command) {
+      return false;
+    }
+
     const funcRegex = /\$\{config:azureLogicAppsStandard\.funcCoreToolsBinaryPath\}/;
-    // check for args?
     return funcRegex.test(command);
   }
   return /func (host )?start/i.test(commandLine || '');
@@ -60,6 +64,7 @@ export function registerFuncHostTaskEvents(): void {
       context.telemetry.suppressIfSuccessful = true;
       if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
         runningFuncTaskMap.delete(e.execution.task.scope);
+        ext.workflowRuntimePort = undefined;
       }
     }
   );

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/__test__/settings.test.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/__test__/settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as vscode from 'vscode';
-import { createSettingsDetails, removeSharedSetting } from '../settings';
+import { createSettingsDetails, removeSharedSetting, shouldAlwaysBuildCustomCode } from '../settings';
 import { ext } from '../../../../extensionVariables';
 
 describe('utils/vsCodeConfig/settings', () => {
@@ -165,6 +165,35 @@ describe('utils/vsCodeConfig/settings', () => {
 
       await expect(removeSharedSetting('integrated.env.windows', 'terminal')).resolves.toBeUndefined();
       expect(ext.outputChannel?.appendLog).toHaveBeenCalled();
+    });
+  });
+
+  describe('shouldAlwaysBuildCustomCode', () => {
+    const mockGetConfiguration = vi.mocked(vscode.workspace.getConfiguration);
+    let inspect: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      inspect = vi.fn();
+      mockGetConfiguration.mockReturnValue({ inspect } as any);
+    });
+
+    it('returns false by default when the setting is not configured', () => {
+      inspect.mockReturnValue(undefined);
+
+      expect(shouldAlwaysBuildCustomCode()).toBe(false);
+    });
+
+    it('returns true when the setting is explicitly enabled', () => {
+      inspect.mockReturnValue({ globalValue: true });
+
+      expect(shouldAlwaysBuildCustomCode()).toBe(true);
+    });
+
+    it('returns false when the setting is explicitly disabled', () => {
+      inspect.mockReturnValue({ globalValue: false });
+
+      expect(shouldAlwaysBuildCustomCode()).toBe(false);
     });
   });
 });

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
@@ -188,8 +188,8 @@ export function isManagedIdentityAuthEnabled(): boolean {
  * regardless of whether build artifacts already exist. Controlled by the
  * `azureLogicAppsStandard.alwaysBuildCustomCode` setting. Defaults to `false`.
  */
-export function shouldAlwaysBuildCustomCode(fsPath?: string | WorkspaceFolder): boolean {
-  return getWorkspaceSetting<boolean>(alwaysBuildCustomCodeSetting, fsPath) === true;
+export function shouldAlwaysBuildCustomCode(): boolean {
+  return getGlobalSetting<boolean>(alwaysBuildCustomCodeSetting) === true;
 }
 
 function getScope(fsPath: WorkspaceFolder | string | undefined): Uri | WorkspaceFolder | undefined {

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
-import { enableManagedIdentityAuthSetting, useNodeDesignTimeWorkerSetting } from '../../../constants';
+import { alwaysBuildCustomCodeSetting, enableManagedIdentityAuthSetting, useNodeDesignTimeWorkerSetting } from '../../../constants';
 import { isString } from '@microsoft/logic-apps-shared';
 import type { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions } from '@microsoft/vscode-azext-utils';
 import { openUrl } from '@microsoft/vscode-azext-utils';
@@ -181,6 +181,15 @@ export function isManagedIdentityAuthEnabled(): boolean {
   } catch {
     return true;
   }
+}
+
+/**
+ * Indicates whether custom code projects should always be rebuilt when opening the designer,
+ * regardless of whether build artifacts already exist. Controlled by the
+ * `azureLogicAppsStandard.alwaysBuildCustomCode` setting. Defaults to `false`.
+ */
+export function shouldAlwaysBuildCustomCode(fsPath?: string | WorkspaceFolder): boolean {
+  return getWorkspaceSetting<boolean>(alwaysBuildCustomCodeSetting, fsPath) === true;
 }
 
 function getScope(fsPath: WorkspaceFolder | string | undefined): Uri | WorkspaceFolder | undefined {

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -262,6 +262,7 @@ export const projectSubpathSetting = 'projectSubpath';
 export const projectTemplateKeySetting = 'projectTemplateKey';
 export const projectOpenBehaviorSetting = 'projectOpenBehavior';
 export const stopFuncTaskPostDebugSetting = 'stopFuncTaskPostDebug';
+export const alwaysBuildCustomCodeSetting = 'alwaysBuildCustomCode';
 export const validateFuncCoreToolsSetting = 'validateFuncCoreTools';
 export const validateDotNetSDKSetting = 'validateDotNetSDK';
 export const validateNodeJsSetting = 'validateNodeJs';

--- a/apps/vs-code-designer/src/extensionVariables.ts
+++ b/apps/vs-code-designer/src/extensionVariables.ts
@@ -41,7 +41,10 @@ export namespace ext {
   export let workflowNodeProcess: cp.ChildProcess | undefined;
   export let defaultLogicAppPath: string;
   export let outputChannel: IAzExtOutputChannel;
-  export let workflowRuntimePort: number;
+  // TODO(aeldridge): Multiple runtime processes are supported with runningFuncTaskMap, but only a single runtime port is tracked.
+  // This will cause issues if multiple runtime processes are started on different ports. Currently we use the default port (7071)
+  // unless user modifies the 'func: host start' task to use a different port so this issue isn't surfaced by default.
+  export let workflowRuntimePort: number | undefined;
   export let extensionVersion: string;
   export let bundleFolderRoot: string | undefined;
   export const prefix = 'azureLogicAppsStandard';

--- a/apps/vs-code-designer/src/extensionVariables.ts
+++ b/apps/vs-code-designer/src/extensionVariables.ts
@@ -5,7 +5,7 @@
 import type { VSCodeAzureSubscriptionProvider } from '@microsoft/vscode-azext-azureauth';
 import type DataMapperPanel from './app/commands/dataMapper/DataMapperPanel';
 import type { AzureAccountTreeItemWithProjects } from './app/tree/AzureAccountTreeItemWithProjects';
-import { dotnet, func, node, npm } from './constants';
+import { dotnet, func, managementApiPrefix, node, npm } from './constants';
 import type { ContainerApp, Site } from '@azure/arm-appservice';
 import type { IAzExtOutputChannel } from '@microsoft/vscode-azext-utils';
 import type { AzureHostExtensionApi } from '@microsoft/vscode-azext-utils/hostapi';
@@ -121,6 +121,10 @@ export namespace ext {
     }
     window.showErrorMessage(errMsg, options);
   };
+
+  export function getWorkflowRuntimeBaseUrl(): string | undefined {
+    return ext.workflowRuntimePort ? `http://localhost:${ext.workflowRuntimePort}${managementApiPrefix}` : undefined;
+  }
 
   // Telemetry
   export let telemetryReporter: TelemetryReporter;

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -909,6 +909,11 @@
             "description": "Automatically stop the task running the Azure Functions host when a debug sessions ends.",
             "default": true
           },
+          "azureLogicAppsStandard.alwaysBuildCustomCode": {
+            "type": "boolean",
+            "description": "Always build custom code projects when opening the designer, even if build artifacts already exist.",
+            "default": false
+          },
           "azureLogicAppsStandard.validateFuncCoreTools": {
             "type": "boolean",
             "description": "Make sure that Azure Functions Core Tools is installed before you start debugging.",

--- a/apps/vs-code-designer/test-setup.ts
+++ b/apps/vs-code-designer/test-setup.ts
@@ -198,9 +198,12 @@ vi.mock('./src/extensionVariables', () => ({
     extensionVersion: '1.0.0',
     latestBundleVersion: '1.2.3',
     prefix: 'azureLogicAppsStandard',
+    getWorkflowRuntimeBaseUrl: vi.fn(() => 'http://localhost:7071/runtime/webhooks/workflow/api/management'),
     webViewKey: {
       designerLocal: 'designerLocal',
+      designerLocalV2: 'designerLocalV2',
       designerAzure: 'designerAzure',
+      designerAzureV2: 'designerAzureV2',
       monitoring: 'monitoring',
       export: 'export',
       overview: 'overview',

--- a/apps/vs-code-react/src/app/designer/CodeViewEditor/index.tsx
+++ b/apps/vs-code-react/src/app/designer/CodeViewEditor/index.tsx
@@ -61,6 +61,7 @@ const CodeViewEditor = forwardRef(({ workflowKind, workflowFile, readOnly }: Cod
   useImperativeHandle(ref, () => ({
     getValue: () => code,
     hasChanges: () => changesMade,
+    resetChanges: () => setChangesMade(false),
   }));
 
   return isNullOrUndefined(code) ? null : (

--- a/apps/vs-code-react/src/app/designer/appV2.tsx
+++ b/apps/vs-code-react/src/app/designer/appV2.tsx
@@ -69,7 +69,7 @@ export const DesignerApp = () => {
   const [designerID, setDesignerID] = useState(guid());
   const [workflowDefinitionId, setWorkflowDefinitionId] = useState<string>(guid());
 
-  const codeEditorRef = useRef<{ getValue: () => string | undefined; hasChanges: () => boolean }>(null);
+  const codeEditorRef = useRef<{ getValue: () => string | undefined; hasChanges: () => boolean; resetChanges: () => void }>(null);
   const [theme, setTheme] = useState<Theme>(getTheme(document.body));
   const queryClient = useQueryClient();
 
@@ -224,6 +224,7 @@ export const DesignerApp = () => {
         setInitialWorkflow(newWorkflow);
 
         clearDirtyState?.();
+        codeEditorRef.current?.resetChanges();
         return newWorkflow;
       } catch (error: any) {
         if (error.status !== 404) {

--- a/apps/vs-code-react/src/app/designer/appV2.tsx
+++ b/apps/vs-code-react/src/app/designer/appV2.tsx
@@ -14,6 +14,7 @@ import {
   useThemeObserver,
   FloatingRunButton,
   useRun,
+  resetServiceInitialization,
 } from '@microsoft/logic-apps-designer-v2';
 import { BundleVersionRequirements, guid, isEmptyString, isVersionSupported, Theme } from '@microsoft/logic-apps-shared';
 import type { FileSystemConnectionInfo, MessageToVsix, StandardApp } from '@microsoft/vscode-extension-logic-apps';
@@ -78,6 +79,16 @@ export const DesignerApp = () => {
 
   const commonText = useIntlMessages(commonMessages);
   const isRuntimeAvailable = !isEmptyString(workflowRuntimeBaseUrl);
+
+  // When the runtime base URL changes (e.g., debugger starts/stops), reset service initialization
+  // so that BJSWorkflowProvider re-registers services with the updated URL.
+  const prevRuntimeBaseUrl = useRef(workflowRuntimeBaseUrl);
+  useEffect(() => {
+    if (prevRuntimeBaseUrl.current !== workflowRuntimeBaseUrl) {
+      prevRuntimeBaseUrl.current = workflowRuntimeBaseUrl;
+      dispatch(resetServiceInitialization());
+    }
+  }, [workflowRuntimeBaseUrl, dispatch]);
 
   useThemeObserver(document.body, theme, setTheme, {
     attributes: true,
@@ -351,11 +362,10 @@ export const DesignerApp = () => {
               <div style={{ display: 'flex', flexDirection: 'row', flexGrow: 1, height: '80%', position: 'relative' }}>
                 <Designer />
                 <FloatingRunButton
-                  id={workflowDefinitionId}
                   saveDraftWorkflow={saveWorkflowFromDesigner}
-                  onRun={(newRunId: string | undefined) => {
+                  onRun={(newRunId: string) => {
                     switchToMonitoringView();
-                    setRunId(newRunId ?? '');
+                    setRunId(newRunId);
                   }}
                   isDarkMode={theme === Theme.Dark}
                   isDisabled={!isRuntimeAvailable}

--- a/apps/vs-code-react/src/app/designer/appV2.tsx
+++ b/apps/vs-code-react/src/app/designer/appV2.tsx
@@ -70,6 +70,8 @@ export const DesignerApp = () => {
   const [workflowDefinitionId, setWorkflowDefinitionId] = useState<string>(guid());
 
   const codeEditorRef = useRef<{ getValue: () => string | undefined; hasChanges: () => boolean }>(null);
+  const runtimeBaseUrlRef = useRef(workflowRuntimeBaseUrl);
+  runtimeBaseUrlRef.current = workflowRuntimeBaseUrl;
 
   const [theme, setTheme] = useState<Theme>(getTheme(document.body));
   const queryClient = useQueryClient();
@@ -121,7 +123,8 @@ export const DesignerApp = () => {
       hostVersion,
       queryClient,
       sendMsgToVsix,
-      setRunId
+      setRunId,
+      () => runtimeBaseUrlRef.current
     );
   }, [
     baseUrl,
@@ -205,6 +208,9 @@ export const DesignerApp = () => {
   const validateAndSaveCodeView = useCallback(
     async (clearDirtyState?: () => void) => {
       try {
+        if (!codeEditorRef.current?.hasChanges()) {
+          return workflow;
+        }
         const codeToConvert = JSON.parse(codeEditorRef.current?.getValue() ?? '');
         const { definition, parameters, connectionReferences } = codeToConvert;
         // code view editor cannot add/remove connections, parameters, settings, or customcode
@@ -352,7 +358,6 @@ export const DesignerApp = () => {
                     setRunId(newRunId ?? '');
                   }}
                   isDarkMode={theme === Theme.Dark}
-                  isDraftMode={true}
                   isDisabled={!isRuntimeAvailable}
                   tooltipOverride={isRuntimeAvailable ? undefined : commonText.RUNTIME_NOT_AVAILABLE}
                 />

--- a/apps/vs-code-react/src/app/designer/appV2.tsx
+++ b/apps/vs-code-react/src/app/designer/appV2.tsx
@@ -14,7 +14,6 @@ import {
   useThemeObserver,
   FloatingRunButton,
   useRun,
-  resetServiceInitialization,
 } from '@microsoft/logic-apps-designer-v2';
 import { BundleVersionRequirements, guid, isEmptyString, isVersionSupported, Theme } from '@microsoft/logic-apps-shared';
 import type { FileSystemConnectionInfo, MessageToVsix, StandardApp } from '@microsoft/vscode-extension-logic-apps';
@@ -71,24 +70,11 @@ export const DesignerApp = () => {
   const [workflowDefinitionId, setWorkflowDefinitionId] = useState<string>(guid());
 
   const codeEditorRef = useRef<{ getValue: () => string | undefined; hasChanges: () => boolean }>(null);
-  const runtimeBaseUrlRef = useRef(workflowRuntimeBaseUrl);
-  runtimeBaseUrlRef.current = workflowRuntimeBaseUrl;
-
   const [theme, setTheme] = useState<Theme>(getTheme(document.body));
   const queryClient = useQueryClient();
 
   const commonText = useIntlMessages(commonMessages);
   const isRuntimeAvailable = !isEmptyString(workflowRuntimeBaseUrl);
-
-  // When the runtime base URL changes (e.g., debugger starts/stops), reset service initialization
-  // so that BJSWorkflowProvider re-registers services with the updated URL.
-  const prevRuntimeBaseUrl = useRef(workflowRuntimeBaseUrl);
-  useEffect(() => {
-    if (prevRuntimeBaseUrl.current !== workflowRuntimeBaseUrl) {
-      prevRuntimeBaseUrl.current = workflowRuntimeBaseUrl;
-      dispatch(resetServiceInitialization());
-    }
-  }, [workflowRuntimeBaseUrl, dispatch]);
 
   useThemeObserver(document.body, theme, setTheme, {
     attributes: true,
@@ -134,8 +120,7 @@ export const DesignerApp = () => {
       hostVersion,
       queryClient,
       sendMsgToVsix,
-      setRunId,
-      () => runtimeBaseUrlRef.current
+      setRunId
     );
   }, [
     baseUrl,

--- a/apps/vs-code-react/src/app/designer/appV2.tsx
+++ b/apps/vs-code-react/src/app/designer/appV2.tsx
@@ -352,6 +352,7 @@ export const DesignerApp = () => {
                     setRunId(newRunId ?? '');
                   }}
                   isDarkMode={theme === Theme.Dark}
+                  isDraftMode={true}
                   isDisabled={!isRuntimeAvailable}
                   tooltipOverride={isRuntimeAvailable ? undefined : commonText.RUNTIME_NOT_AVAILABLE}
                 />

--- a/apps/vs-code-react/src/app/designer/appV2.tsx
+++ b/apps/vs-code-react/src/app/designer/appV2.tsx
@@ -338,7 +338,7 @@ export const DesignerApp = () => {
               switchToDesignerView={switchToDesignerView}
               switchToCodeView={switchToCodeView}
               switchToMonitoringView={switchToMonitoringView}
-              showRunHistory={!isCodefulWorkflow}
+              showRunHistory={!isCodefulWorkflow && isRuntimeAvailable}
             />
 
             {!isCodeView && (

--- a/apps/vs-code-react/src/app/designer/servicesHelper.ts
+++ b/apps/vs-code-react/src/app/designer/servicesHelper.ts
@@ -77,8 +77,7 @@ export const getDesignerServices = (
   hostVersion: string,
   queryClient: QueryClient,
   sendMsgToVsix: (msg: MessageToVsix) => void,
-  setRunId?: (runId: string) => void,
-  getCurrentRuntimeBaseUrl?: () => string
+  setRunId?: (runId: string) => void
 ): IDesignerServices => {
   let authToken = '';
   let panelId = '';
@@ -324,8 +323,7 @@ export const getDesignerServices = (
     getCallbackUrl: async (triggerId: string) => {
       if (isLocal) {
         try {
-          const currentRuntimeBaseUrl = getCurrentRuntimeBaseUrl?.() || workflowRuntimeBaseUrl;
-          const url = `${currentRuntimeBaseUrl}/workflows/${workflowName}/triggers/${triggerId}/listCallbackUrl?api-version=${apiVersion}`;
+          const url = `${workflowRuntimeBaseUrl}/workflows/${workflowName}/triggers/${triggerId}/listCallbackUrl?api-version=${apiVersion}`;
           return (await httpClient.post({ uri: url })) as any;
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {

--- a/apps/vs-code-react/src/app/designer/servicesHelper.ts
+++ b/apps/vs-code-react/src/app/designer/servicesHelper.ts
@@ -77,7 +77,8 @@ export const getDesignerServices = (
   hostVersion: string,
   queryClient: QueryClient,
   sendMsgToVsix: (msg: MessageToVsix) => void,
-  setRunId?: (runId: string) => void
+  setRunId?: (runId: string) => void,
+  getCurrentRuntimeBaseUrl?: () => string
 ): IDesignerServices => {
   let authToken = '';
   let panelId = '';
@@ -325,7 +326,9 @@ export const getDesignerServices = (
     getCallbackUrl: async (triggerId: string) => {
       if (isLocal) {
         try {
-          const url = `${workflowRuntimeBaseUrl}/workflows/${workflowName}/triggers/${triggerId}/listCallbackUrl?api-version=${apiVersion}`;
+          const currentRuntimeBaseUrl = getCurrentRuntimeBaseUrl?.() || workflowRuntimeBaseUrl;
+          const localApiVersion = '2019-10-01-edge-preview';
+          const url = `${currentRuntimeBaseUrl}/workflows/${workflowName}/triggers/${triggerId}/listCallbackUrl?api-version=${localApiVersion}`;
           return (await httpClient.post({ uri: url })) as any;
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {

--- a/apps/vs-code-react/src/app/designer/servicesHelper.ts
+++ b/apps/vs-code-react/src/app/designer/servicesHelper.ts
@@ -92,9 +92,7 @@ export const getDesignerServices = (
   const { subscriptionId = 'subscriptionId', resourceGroup, location } = apiHubDetails;
 
   const armUrl = 'https://management.azure.com';
-
   const emptyArmId = '00000000-0000-0000-0000-000000000000';
-
   if (panelMetadata) {
     authToken = panelMetadata.accessToken ?? '';
     panelId = panelMetadata.panelId;
@@ -327,8 +325,7 @@ export const getDesignerServices = (
       if (isLocal) {
         try {
           const currentRuntimeBaseUrl = getCurrentRuntimeBaseUrl?.() || workflowRuntimeBaseUrl;
-          const localApiVersion = '2019-10-01-edge-preview';
-          const url = `${currentRuntimeBaseUrl}/workflows/${workflowName}/triggers/${triggerId}/listCallbackUrl?api-version=${localApiVersion}`;
+          const url = `${currentRuntimeBaseUrl}/workflows/${workflowName}/triggers/${triggerId}/listCallbackUrl?api-version=${apiVersion}`;
           return (await httpClient.post({ uri: url })) as any;
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {

--- a/apps/vs-code-react/src/webviewCommunication.tsx
+++ b/apps/vs-code-react/src/webviewCommunication.tsx
@@ -120,6 +120,7 @@ type DataMapperMessageType =
   | GetTestFeatureEnablementStatus;
 type WorkflowMessageType =
   | UpdateCallbackInfoMessage
+  | UpdateWorkflowPropertiesMessage
   | UpdateRuntimeBaseUrlMessage
   | UpdateAccessTokenMessage
   | UpdateExportPathMessage

--- a/libs/designer-v2/src/lib/core/BJSWorkflowProvider.tsx
+++ b/libs/designer-v2/src/lib/core/BJSWorkflowProvider.tsx
@@ -80,10 +80,8 @@ export const BJSWorkflowProvider: React.FC<BJSWorkflowProviderProps> = (props) =
   }
 
   useEffect(() => {
-    if (!servicesInitialized) {
-      dispatch(initializeServices(wrapped));
-    }
-  }, [dispatch, servicesInitialized, wrapped]);
+    dispatch(initializeServices(wrapped));
+  }, [dispatch, wrapped]);
 
   useEffect(() => {
     initializeDiscoveryPanelFavoriteOperations(dispatch);

--- a/libs/designer-v2/src/lib/core/index.ts
+++ b/libs/designer-v2/src/lib/core/index.ts
@@ -68,7 +68,7 @@ export {
   useOperationAlternateSelectedNodeId,
   useOperationPanelSelectedNodeId,
 } from './state/panel/panelSelectors';
-export { initializeServices } from './state/designerOptions/designerOptionsSlice';
+export { initializeServices, resetServiceInitialization } from './state/designerOptions/designerOptionsSlice';
 export { resetWorkflowState, resetNodesLoadStatus } from './state/global';
 export { TemplatesDataProvider } from './templates/TemplatesDataProvider';
 export { TemplatesDesignerProvider } from './templates/TemplatesDesignerProvider';

--- a/libs/designer-v2/src/lib/core/index.ts
+++ b/libs/designer-v2/src/lib/core/index.ts
@@ -68,7 +68,7 @@ export {
   useOperationAlternateSelectedNodeId,
   useOperationPanelSelectedNodeId,
 } from './state/panel/panelSelectors';
-export { initializeServices, resetServiceInitialization } from './state/designerOptions/designerOptionsSlice';
+export { initializeServices } from './state/designerOptions/designerOptionsSlice';
 export { resetWorkflowState, resetNodesLoadStatus } from './state/global';
 export { TemplatesDataProvider } from './templates/TemplatesDataProvider';
 export { TemplatesDesignerProvider } from './templates/TemplatesDesignerProvider';

--- a/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -181,6 +181,9 @@ export const designerOptionsSlice = createSlice({
       state.designerOptionsInitialized = true;
       state.isVSCode = action.payload.isVSCode ?? false;
     },
+    resetServiceInitialization: (state) => {
+      state.servicesInitialized = false;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(initializeServices.fulfilled, (state, action) => {
@@ -190,6 +193,6 @@ export const designerOptionsSlice = createSlice({
 });
 
 // Action creators are generated for each case reducer function
-export const { initDesignerOptions } = designerOptionsSlice.actions;
+export const { initDesignerOptions, resetServiceInitialization } = designerOptionsSlice.actions;
 
 export default designerOptionsSlice.reducer;

--- a/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsSlice.ts
@@ -181,9 +181,6 @@ export const designerOptionsSlice = createSlice({
       state.designerOptionsInitialized = true;
       state.isVSCode = action.payload.isVSCode ?? false;
     },
-    resetServiceInitialization: (state) => {
-      state.servicesInitialized = false;
-    },
   },
   extraReducers: (builder) => {
     builder.addCase(initializeServices.fulfilled, (state, action) => {
@@ -193,6 +190,6 @@ export const designerOptionsSlice = createSlice({
 });
 
 // Action creators are generated for each case reducer function
-export const { initDesignerOptions, resetServiceInitialization } = designerOptionsSlice.actions;
+export const { initDesignerOptions } = designerOptionsSlice.actions;
 
 export default designerOptionsSlice.reducer;

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/__tests__/floatingRunButton.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/__tests__/floatingRunButton.spec.tsx
@@ -368,6 +368,22 @@ describe('FloatingRunButton', () => {
       expect(screen.getByText('Run draft')).toBeInTheDocument();
     });
   });
+
+  describe('Local Workflow (no siteResourceId)', () => {
+    it('should render the run button when siteResourceId is not provided', () => {
+      const { siteResourceId, workflowName, ...localProps } = defaultProps;
+      renderWithProviders(localProps);
+      expect(screen.getByText('Run')).toBeInTheDocument();
+    });
+
+    it('should render as non-draft mode when siteResourceId is not provided', () => {
+      const { siteResourceId, workflowName, ...localProps } = defaultProps;
+      renderWithProviders(localProps);
+      // Should show "Run" not "Run draft" since isDraftMode is not set
+      expect(screen.getByText('Run')).toBeInTheDocument();
+      expect(screen.queryByText('Run draft')).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('getPublishedRunUrl', () => {

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -272,7 +272,8 @@ export const FloatingRunButton = ({
         await new Promise((resolve) => setTimeout(resolve, 500));
         const runResponse = await RunService().runTrigger(callbackInfo, payload);
         const runId = runResponse?.responseHeaders?.['x-ms-workflow-run-id'] ?? runResponse?.headers?.['x-ms-workflow-run-id'];
-        onRun?.(runId);
+        onRun?.(runId ?? '');
+        setRunStatusMessage(null);
         return;
       }
 

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -11,6 +11,7 @@ import {
   isNullOrEmpty,
   parseErrorMessage,
   RunService,
+  WorkflowService,
 } from '@microsoft/logic-apps-shared';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -260,6 +261,20 @@ export const FloatingRunButton = ({
       }
 
       setRunHasPayload(!!payload);
+
+      // Local workflow — use callback URL from runtime API
+      if (!siteResourceId) {
+        setRunStatusMessage(runStatusMessages.running);
+        const callbackInfo = await WorkflowService().getCallbackUrl?.(triggerId);
+        if (!callbackInfo) {
+          throw new Error('Unable to get trigger callback URL. Please ensure the workflow runtime is running.');
+        }
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        const runResponse = await RunService().runTrigger(callbackInfo, payload);
+        const runId = runResponse?.responseHeaders?.['x-ms-workflow-run-id'] ?? runResponse?.headers?.['x-ms-workflow-run-id'];
+        onRun?.(runId);
+        return;
+      }
 
       if (isDraftMode) {
         await runDraftWorkflow(triggerId, payload);


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Multiple fixes to V2 designer for vscode. Includes regressions from recent designer panel refactor for vscode extension, as well as previously existing issues. Main fixes/changes:
- Disable floating run button and 'Run history' tab when runtime not available
- Clear ext.workflowRuntimePort when runtime stopped
- Fix customCodeArtifactsExist logic
- Add extension setting to optionally always build custom code projects when opening designer
- Skip custom code build when opening v2 designer from overview (monitoring view)

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Addresses the listed bugs and quality of life issues
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge

