### PR TITLE
fix(vscode): Disable MI auth by default, prompt user to enable on startup

### DIFF
--- a/apps/vs-code-designer/src/app/utils/__test__/managedIdentity.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/managedIdentity.test.ts
@@ -1,0 +1,214 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { ext } from '../../../extensionVariables';
+import { suppressManagedIdentityAuthNotification } from '../../../constants';
+
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage: vi.fn(),
+  },
+  workspace: {
+    workspaceFolders: undefined,
+    getConfiguration: vi.fn(() => ({
+      inspect: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
+    })),
+  },
+  ConfigurationTarget: { Global: 1 },
+  Uri: { file: (p: string) => ({ fsPath: p }) },
+}));
+
+vi.mock('../vsCodeConfig/settings', () => ({
+  isManagedIdentityAuthEnabled: vi.fn(),
+  updateGlobalSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../verifyIsProject', () => ({
+  tryGetLogicAppProjectRoot: vi.fn(),
+}));
+
+vi.mock('../appSettings/localSettings', () => ({
+  addOrUpdateLocalAppSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../localize', () => ({
+  localize: (_key: string, defaultValue: string) => defaultValue,
+}));
+
+import * as vscode from 'vscode';
+import { isManagedIdentityAuthEnabled, updateGlobalSetting } from '../vsCodeConfig/settings';
+import { tryGetLogicAppProjectRoot } from '../verifyIsProject';
+import { addOrUpdateLocalAppSettings } from '../appSettings/localSettings';
+import { promptManagedIdentityAuth } from '../managedIdentity';
+
+describe('managedIdentity', () => {
+  let globalStateGet: Mock;
+  let globalStateUpdate: Mock;
+  let appendLog: Mock;
+  let mockContext: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    globalStateGet = vi.fn();
+    globalStateUpdate = vi.fn().mockResolvedValue(undefined);
+    appendLog = vi.fn();
+
+    (ext as any).context = {
+      globalState: {
+        get: globalStateGet,
+        update: globalStateUpdate,
+      },
+    };
+    (ext as any).outputChannel = { appendLog };
+    (ext as any).prefix = 'azureLogicAppsStandard';
+
+    mockContext = { telemetry: { properties: {} }, errorHandling: {} } as any;
+
+    (vscode.workspace as any).workspaceFolders = undefined;
+  });
+
+  describe('promptManagedIdentityAuth', () => {
+    it('returns early when notification is suppressed via globalState', async () => {
+      globalStateGet.mockReturnValue(true);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns early when managed identity auth is already enabled', async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(true);
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    });
+
+    it('shows information message when not suppressed and not enabled', async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+      (vscode.window.showInformationMessage as Mock).mockResolvedValue(undefined);
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'Managed identity authentication for local workflows is now supported.',
+        'Enable',
+        'Close',
+        "Don't show again"
+      );
+    });
+
+    it('enables setting and updates local settings when user clicks Enable', async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+      (vscode.window.showInformationMessage as Mock).mockResolvedValue('Enable');
+      (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/project1' } }];
+      (tryGetLogicAppProjectRoot as Mock).mockResolvedValue('/project1');
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(updateGlobalSetting).toHaveBeenCalledWith('enableManagedIdentityAuth', true);
+      expect(addOrUpdateLocalAppSettings).toHaveBeenCalledWith(mockContext, '/project1', {
+        WORKFLOWS_AUTHENTICATION_METHOD: 'managedServiceIdentity',
+      });
+      expect(appendLog).toHaveBeenCalledWith('Managed identity authentication has been enabled for local workflows.');
+    });
+
+    it("suppresses notification when user clicks Don't show again", async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+      (vscode.window.showInformationMessage as Mock).mockResolvedValue("Don't show again");
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(globalStateUpdate).toHaveBeenCalledWith(suppressManagedIdentityAuthNotification, true);
+    });
+
+    it('does nothing when user clicks Close', async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+      (vscode.window.showInformationMessage as Mock).mockResolvedValue('Close');
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(updateGlobalSetting).not.toHaveBeenCalled();
+      expect(globalStateUpdate).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when user dismisses the notification', async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+      (vscode.window.showInformationMessage as Mock).mockResolvedValue(undefined);
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(updateGlobalSetting).not.toHaveBeenCalled();
+      expect(globalStateUpdate).not.toHaveBeenCalled();
+    });
+
+    it('updates local settings for multiple workspace folders', async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+      (vscode.window.showInformationMessage as Mock).mockResolvedValue('Enable');
+      (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/project1' } }, { uri: { fsPath: '/project2' } }];
+      (tryGetLogicAppProjectRoot as Mock).mockResolvedValueOnce('/project1').mockResolvedValueOnce('/project2');
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(addOrUpdateLocalAppSettings).toHaveBeenCalledTimes(2);
+      expect(addOrUpdateLocalAppSettings).toHaveBeenCalledWith(mockContext, '/project1', {
+        WORKFLOWS_AUTHENTICATION_METHOD: 'managedServiceIdentity',
+      });
+      expect(addOrUpdateLocalAppSettings).toHaveBeenCalledWith(mockContext, '/project2', {
+        WORKFLOWS_AUTHENTICATION_METHOD: 'managedServiceIdentity',
+      });
+    });
+
+    it('skips folders that are not Logic App projects', async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+      (vscode.window.showInformationMessage as Mock).mockResolvedValue('Enable');
+      (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/project1' } }, { uri: { fsPath: '/not-logic-app' } }];
+      (tryGetLogicAppProjectRoot as Mock).mockResolvedValueOnce('/project1').mockResolvedValueOnce(undefined);
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(addOrUpdateLocalAppSettings).toHaveBeenCalledTimes(1);
+      expect(addOrUpdateLocalAppSettings).toHaveBeenCalledWith(mockContext, '/project1', {
+        WORKFLOWS_AUTHENTICATION_METHOD: 'managedServiceIdentity',
+      });
+    });
+
+    it('does not throw when no workspace folders exist', async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+      (vscode.window.showInformationMessage as Mock).mockResolvedValue('Enable');
+      (vscode.workspace as any).workspaceFolders = undefined;
+
+      await expect(promptManagedIdentityAuth(mockContext)).resolves.toBeUndefined();
+    });
+
+    it('logs error and continues when updating a project fails', async () => {
+      globalStateGet.mockReturnValue(false);
+      (isManagedIdentityAuthEnabled as Mock).mockReturnValue(false);
+      (vscode.window.showInformationMessage as Mock).mockResolvedValue('Enable');
+      (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/project1' } }, { uri: { fsPath: '/project2' } }];
+      (tryGetLogicAppProjectRoot as Mock).mockRejectedValueOnce(new Error('Permission denied')).mockResolvedValueOnce('/project2');
+
+      await promptManagedIdentityAuth(mockContext);
+
+      expect(appendLog).toHaveBeenCalledWith(expect.stringContaining('Failed to update local.settings.json in /project1'));
+      expect(appendLog).toHaveBeenCalledWith(expect.stringContaining('Permission denied'));
+      expect(addOrUpdateLocalAppSettings).toHaveBeenCalledWith(mockContext, '/project2', {
+        WORKFLOWS_AUTHENTICATION_METHOD: 'managedServiceIdentity',
+      });
+    });
+  });
+});

--- a/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
+++ b/apps/vs-code-designer/src/app/utils/appSettings/__test__/localSettings.test.ts
@@ -13,7 +13,6 @@ import {
   localEmulatorConnectionString,
   logicAppKind,
   multiLanguageWorkerSetting,
-  workflowAuthenticationMethodKey,
   workerRuntimeKey,
   workflowCodefulEnabledKey,
 } from '../../../../constants';
@@ -75,7 +74,6 @@ describe('utils/appSettings', () => {
         [workerRuntimeKey]: WorkerRuntime.Dotnet,
         [appKindSetting]: logicAppKind,
         [ProjectDirectoryPathKey]: projectPath,
-        [workflowAuthenticationMethodKey]: 'managedServiceIdentity',
       };
 
       it('logicApp: 5 base keys, no feature or codeful flags', () => {
@@ -126,7 +124,6 @@ describe('utils/appSettings', () => {
             [functionsInprocNet8Enabled]: functionsInprocNet8EnabledTrue,
             [workerRuntimeKey]: WorkerRuntime.Dotnet,
             [appKindSetting]: logicAppKind,
-            [workflowAuthenticationMethodKey]: 'managedServiceIdentity',
           },
         });
       });
@@ -186,7 +183,6 @@ describe('utils/appSettings', () => {
           workerRuntimeKey,
           appKindSetting,
           ProjectDirectoryPathKey,
-          workflowAuthenticationMethodKey,
         ]);
       });
 
@@ -198,7 +194,6 @@ describe('utils/appSettings', () => {
           workerRuntimeKey,
           appKindSetting,
           ProjectDirectoryPathKey,
-          workflowAuthenticationMethodKey,
           azureWebJobsFeatureFlagsKey,
           workflowCodefulEnabledKey,
         ]);

--- a/apps/vs-code-designer/src/app/utils/managedIdentity.ts
+++ b/apps/vs-code-designer/src/app/utils/managedIdentity.ts
@@ -22,6 +22,7 @@ import * as vscode from 'vscode';
  * authentication for local workflows. The notification is suppressed if:
  * - The user has already enabled the setting.
  * - The user previously selected "Don't show again".
+ * 
  * @param {IActionContext} context - The action context for telemetry and error handling.
  */
 export async function promptManagedIdentityAuth(context: IActionContext): Promise<void> {

--- a/apps/vs-code-designer/src/app/utils/managedIdentityNotification.ts
+++ b/apps/vs-code-designer/src/app/utils/managedIdentityNotification.ts
@@ -11,7 +11,7 @@ import {
 } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
-import { updateGlobalSetting } from './vsCodeConfig/settings';
+import { isManagedIdentityAuthEnabled, updateGlobalSetting } from './vsCodeConfig/settings';
 import { tryGetLogicAppProjectRoot } from './verifyIsProject';
 import { addOrUpdateLocalAppSettings } from './appSettings/localSettings';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -26,12 +26,7 @@ import * as vscode from 'vscode';
  */
 export async function promptManagedIdentityAuth(context: IActionContext): Promise<void> {
   const isSuppressed = ext.context.globalState.get<boolean>(suppressManagedIdentityAuthNotification) === true;
-  if (isSuppressed) {
-    return;
-  }
-
-  const currentValue = vscode.workspace.getConfiguration(ext.prefix).get<boolean>(enableManagedIdentityAuthSetting);
-  if (currentValue === true) {
+  if (isSuppressed || isManagedIdentityAuthEnabled()) {
     return;
   }
 

--- a/apps/vs-code-designer/src/app/utils/managedIdentityNotification.ts
+++ b/apps/vs-code-designer/src/app/utils/managedIdentityNotification.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import {
+  enableManagedIdentityAuthSetting,
+  localSettingsFileName,
+  suppressManagedIdentityAuthNotification,
+  workflowAuthenticationMethodKey,
+  workflowAuthenticationMethodMIValue,
+} from '../../constants';
+import { ext } from '../../extensionVariables';
+import { localize } from '../../localize';
+import { updateGlobalSetting } from './vsCodeConfig/settings';
+import { tryGetLogicAppProjectRoot } from './verifyIsProject';
+import { addOrUpdateLocalAppSettings } from './appSettings/localSettings';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+
+/**
+ * Shows a non-blocking information message on startup prompting the user to enable managed identity
+ * authentication for local workflows. The notification is suppressed if:
+ * - The user has already enabled the setting.
+ * - The user previously selected "Don't show again".
+ * @param {IActionContext} context - The action context for telemetry and error handling.
+ */
+export async function promptManagedIdentityAuth(context: IActionContext): Promise<void> {
+  const isSuppressed = ext.context.globalState.get<boolean>(suppressManagedIdentityAuthNotification) === true;
+  if (isSuppressed) {
+    return;
+  }
+
+  const currentValue = vscode.workspace.getConfiguration(ext.prefix).get<boolean>(enableManagedIdentityAuthSetting);
+  if (currentValue === true) {
+    return;
+  }
+
+  const enableButton = localize('enable', 'Enable');
+  const closeButton = localize('close', 'Close');
+  const dontShowAgain = localize('dontShowAgain', "Don't show again");
+  const message = localize('managedIdentityAuthAvailable', 'Managed identity authentication for local workflows is now supported.');
+
+  const selection = await vscode.window.showInformationMessage(message, enableButton, closeButton, dontShowAgain);
+
+  if (selection === enableButton) {
+    await updateGlobalSetting(enableManagedIdentityAuthSetting, true);
+    await updateLocalSettingsForAllProjects(context);
+    ext.outputChannel.appendLog(localize('managedIdentityAuthEnabled', 'Managed identity authentication has been enabled for local workflows.'));
+  } else if (selection === dontShowAgain) {
+    await ext.context.globalState.update(suppressManagedIdentityAuthNotification, true);
+  }
+}
+
+/**
+ * Iterates over all workspace folders and adds/updates `WORKFLOWS_AUTHENTICATION_METHOD` to
+ * `managedServiceIdentity` in each Logic Apps project's `local.settings.json`.
+ */
+async function updateLocalSettingsForAllProjects(context: IActionContext): Promise<void> {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    return;
+  }
+
+  for (const folder of folders) {
+    try {
+      const projectPath = await tryGetLogicAppProjectRoot(context, folder);
+      if (projectPath) {
+        await addOrUpdateLocalAppSettings(context, projectPath, {
+          [workflowAuthenticationMethodKey]: workflowAuthenticationMethodMIValue,
+        });
+      }
+    } catch (error) {
+      ext.outputChannel.appendLog(
+        `Failed to update ${localSettingsFileName} in ${folder.uri.fsPath}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}

--- a/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
+++ b/apps/vs-code-designer/src/app/utils/vsCodeConfig/settings.ts
@@ -173,13 +173,13 @@ export function useNodeDesignTimeWorker(fsPath?: string | WorkspaceFolder): bool
 /**
  * Indicates whether the extension should enforce `WORKFLOWS_AUTHENTICATION_METHOD = managedServiceIdentity`
  * in local.settings.json. Controlled by the `azureLogicAppsStandard.enableManagedIdentityAuth` setting.
- * Defaults to `true` when the setting is absent or unset, or when the VS Code API is unavailable (e.g. in tests).
+ * Defaults to `false` when the setting is absent or unset, or when the VS Code API is unavailable (e.g. in tests).
  */
 export function isManagedIdentityAuthEnabled(): boolean {
   try {
-    return getGlobalSetting<boolean>(enableManagedIdentityAuthSetting) !== false;
+    return getGlobalSetting<boolean>(enableManagedIdentityAuthSetting) === true;
   } catch {
-    return true;
+    return false;
   }
 }
 

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -291,6 +291,7 @@ export const useExperimentalExtensionBundleSettingKey = 'useExperimentalExtensio
 export const experimentalExtensionBundleSourceUriSettingKey = 'experimentalExtensionBundleSourceUri';
 export const experimentalExtensionBundleVersionSettingKey = 'experimentalExtensionBundleVersion';
 export const enableManagedIdentityAuthSetting = 'enableManagedIdentityAuth';
+export const suppressManagedIdentityAuthNotification = 'suppressManagedIdentityAuthNotification';
 export const dependencyMetadataRequestTimeoutMs = 30 * 1000;
 export const dependencyIntegrityManifestFileName = '.logicapps-integrity.json';
 export const verifyConnectionKeysSetting = 'verifyConnectionKeys';

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -35,6 +35,7 @@ import { runPostExtractStepsFromCache } from './app/utils/cloudToLocalUtils';
 import { codefulProjectsExist } from './app/utils/codeful';
 import { logicAppDebugConfigProvider } from './app/utils/debug';
 import { promptManagedIdentityAuth } from './app/utils/managedIdentityNotification';
+import { localize } from './localize';
 
 const perfStats = {
   loadStartTime: Date.now(),
@@ -93,7 +94,7 @@ export async function activate(context: vscode.ExtensionContext) {
       // leave the design-time host pointing at a half-extracted bundle.
       downloadExtensionBundle(activateContext).catch((error) => {
         ext.outputChannel?.appendLog(
-          `Background extension-bundle download failed: ${error instanceof Error ? error.message : String(error)}`
+          localize('bundleDownloadFailed', `Background extension-bundle download failed: ${error instanceof Error ? error.message : String(error)}`)
         );
       });
     }
@@ -105,7 +106,11 @@ export async function activate(context: vscode.ExtensionContext) {
       startLanguageServer();
     }
 
-    promptManagedIdentityAuth(activateContext);
+    promptManagedIdentityAuth(activateContext).catch((error) => {
+      ext.outputChannel?.appendLog(
+        localize('managedIdentityAuthPromptFailed', `Managed identity auth startup prompt failed: ${error instanceof Error ? error.message : String(error)}`)
+      );
+    });
 
     ext.rgApi = await getResourceGroupsApi();
     // @ts-expect-error _rootTreeItem does not exist on type AzExtTreeDataProvider

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -34,7 +34,7 @@ import { startLanguageServer } from './app/languageServer/languageServer';
 import { runPostExtractStepsFromCache } from './app/utils/cloudToLocalUtils';
 import { codefulProjectsExist } from './app/utils/codeful';
 import { logicAppDebugConfigProvider } from './app/utils/debug';
-import { promptManagedIdentityAuth } from './app/utils/managedIdentityNotification';
+import { promptManagedIdentityAuth } from './app/utils/managedIdentity';
 import { localize } from './localize';
 
 const perfStats = {

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -34,6 +34,7 @@ import { startLanguageServer } from './app/languageServer/languageServer';
 import { runPostExtractStepsFromCache } from './app/utils/cloudToLocalUtils';
 import { codefulProjectsExist } from './app/utils/codeful';
 import { logicAppDebugConfigProvider } from './app/utils/debug';
+import { promptManagedIdentityAuth } from './app/utils/managedIdentityNotification';
 
 const perfStats = {
   loadStartTime: Date.now(),
@@ -103,6 +104,8 @@ export async function activate(context: vscode.ExtensionContext) {
     if (hasCodefulProjects) {
       startLanguageServer();
     }
+
+    promptManagedIdentityAuth(activateContext);
 
     ext.rgApi = await getResourceGroupsApi();
     // @ts-expect-error _rootTreeItem does not exist on type AzExtTreeDataProvider

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -1071,7 +1071,7 @@
           },
           "azureLogicAppsStandard.enableManagedIdentityAuth": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "When enabled, automatically sets WORKFLOWS_AUTHENTICATION_METHOD to managedServiceIdentity in local.settings.json for all projects. Disable to manage this setting manually."
           }
         }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
MI auth for local workflows setting ('WORKFLOWS_AUTHENTICATION_METHOD': 'managedServiceIdentity') should not be set by default without user approval. Update 'enableManagedIdentityAuth' extension setting to be disabled by default, prompt user to enable on startup.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Disabled MI auth by default, adds prompt on startup to enable
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge @wsilveiranz 

