### PR TITLE
fix(vscode): serialize latest store state when saving workflow (#9412)

### DIFF
--- a/apps/vs-code-react/src/app/designer/DesignerCommandBar/__test__/index.test.tsx
+++ b/apps/vs-code-react/src/app/designer/DesignerCommandBar/__test__/index.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const baseState = {
+  operations: { inputParameters: {} },
+  customCode: {},
+  designerOptions: { isMonitoringView: false },
+  workflow: { workflowKind: 'stateful' },
+};
+
+// `currentStoreState` simulates the live Redux store. Tests mutate it to represent an edit that
+// happens after the command bar last rendered (e.g. a run-after change while already dirty).
+let currentStoreState: any = baseState;
+
+const { mockPostMessage, mockDispatch, mockGetState, mockSerializeWorkflow } = vi.hoisted(() => {
+  return {
+    mockPostMessage: vi.fn(),
+    mockDispatch: vi.fn(() => Promise.resolve()),
+    mockGetState: vi.fn(),
+    mockSerializeWorkflow: vi.fn(async () => ({ definition: {}, parameters: {}, connectionReferences: {} })),
+  };
+});
+
+vi.mock('../../../../webviewCommunication', async () => {
+  const React = await import('react');
+  return {
+    VSCodeContext: React.createContext({ postMessage: mockPostMessage }),
+  };
+});
+
+let mockDesignerIsDirty = true;
+
+vi.mock('@microsoft/logic-apps-designer', () => ({
+  serializeWorkflow: mockSerializeWorkflow,
+  store: { dispatch: mockDispatch, getState: mockGetState },
+  getNodeOutputOperations: vi.fn(),
+  useIsDesignerDirty: () => mockDesignerIsDirty,
+  validateParameter: vi.fn(() => []),
+  updateParameterValidation: vi.fn(),
+  openPanel: vi.fn((arg: unknown) => ({ type: 'openPanel', payload: arg })),
+  useWorkflowParameterValidationErrors: () => ({}),
+  useAllSettingsValidationErrors: () => ({}),
+  useAllConnectionErrors: () => ({}),
+  getCustomCodeFilesWithData: vi.fn(() => ({})),
+}));
+
+vi.mock('@microsoft/logic-apps-shared', () => ({
+  RUN_AFTER_COLORS: { light: { FAILED: '#f00' }, dark: { FAILED: '#f00' } },
+  equals: (a: string, b: string) => a === b,
+  isNullOrEmpty: () => true,
+}));
+
+vi.mock('@microsoft/vscode-extension-logic-apps', () => ({
+  ExtensionCommand: {
+    save: 'save',
+    createUnitTest: 'createUnitTest',
+    createUnitTestFromRun: 'createUnitTestFromRun',
+    logTelemetry: 'logTelemetry',
+    fileABug: 'fileABug',
+  },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: vi.fn((fn: any) => ({ isLoading: false, mutate: fn })),
+}));
+
+vi.mock('@fluentui/react-components', async () => {
+  const React = await import('react');
+  return {
+    Spinner: () => <span>Loading...</span>,
+    Toolbar: (props: any) => (
+      <div role="toolbar" {...props}>
+        {props.children}
+      </div>
+    ),
+    ToolbarButton: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Tooltip: (props: any) => <>{props.children}</>,
+  };
+});
+
+vi.mock('@fluentui/react-icons', () => {
+  const icon = () => null;
+  return {
+    SaveRegular: icon,
+    ArrowClockwiseRegular: icon,
+    MentionBracketsRegular: icon,
+    ReplayRegular: icon,
+    DismissCircleRegular: icon,
+    DismissCircleFilled: icon,
+    BeakerRegular: icon,
+    bundleIcon: () => icon,
+    BugFilled: icon,
+    BugRegular: icon,
+    SaveFilled: icon,
+    BeakerFilled: icon,
+    MentionBracketsFilled: icon,
+    LinkFilled: icon,
+    LinkRegular: icon,
+    ArrowClockwiseFilled: icon,
+    ReplayFilled: icon,
+  };
+});
+
+vi.mock('@microsoft/designer-ui', () => ({
+  TrafficLightDot: () => null,
+}));
+
+vi.mock('../chat', () => ({
+  ChatButton: () => null,
+}));
+
+vi.mock('../../../intl', () => ({
+  useIntlMessages: () => ({
+    SAVE: 'Save',
+    PARAMETERS: 'Parameters',
+    CONNECTIONS: 'Connections',
+    ERRORS: 'Errors',
+    FILE_BUG: 'File a bug',
+    COMMAND_BAR_ARIA: 'Command bar',
+  }),
+  designerMessages: {},
+}));
+
+import { DesignerCommandBar } from '../index';
+
+const defaultProps = {
+  isRefreshing: false,
+  isDisabled: false,
+  isWorkflowRuntimeRunning: false,
+  onRefresh: vi.fn(),
+  isDarkMode: false,
+  isLocal: true,
+  runId: '',
+};
+
+describe('DesignerCommandBar (V1) save path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDesignerIsDirty = true;
+    currentStoreState = baseState;
+    mockGetState.mockImplementation(() => currentStoreState);
+  });
+
+  it('serializes the latest store state at save time, not the render-time snapshot (issue #9412)', async () => {
+    render(<DesignerCommandBar {...defaultProps} />);
+
+    // Simulate an edit (e.g. a run-after status change) made after the command bar last rendered.
+    // The workflow was already dirty, so this component does not re-render.
+    const freshState = {
+      ...baseState,
+      marker: 'fresh',
+    };
+    currentStoreState = freshState;
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => expect(mockSerializeWorkflow).toHaveBeenCalled());
+    expect(mockSerializeWorkflow.mock.calls[0][0]).toBe(freshState);
+    expect(mockSerializeWorkflow.mock.calls[0][0]).toHaveProperty('marker', 'fresh');
+  });
+});

--- a/apps/vs-code-react/src/app/designer/DesignerCommandBar/index.tsx
+++ b/apps/vs-code-react/src/app/designer/DesignerCommandBar/index.tsx
@@ -88,6 +88,10 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({
   }, [designerState.workflow.workflowKind, isMonitoringView]);
 
   const { isLoading: isSaving, mutate: saveWorkflowMutate } = useMutation(async () => {
+    // Read the latest store state at save time. This component only re-renders when a small set of
+    // subscribed values change (e.g. the dirty flag), so a render-time snapshot can be stale and drop
+    // edits made after the workflow was already dirty (e.g. run-after status changes). See issue #9412.
+    const designerState = DesignerStore.getState();
     const { definition, parameters, connectionReferences } = await serializeBJSWorkflow(designerState, {
       skipValidation: false,
       ignoreNonCriticalErrors: true,
@@ -174,10 +178,7 @@ export const DesignerCommandBar: React.FC<DesignerCommandBarProps> = ({
   const allConnectionErrors = useAllConnectionErrors();
   const haveConnectionErrors = Object.keys(allConnectionErrors ?? {}).length > 0;
 
-  const isCreateUnitTestDisabled = useMemo(
-    () => isCreatingUnitTest || designerIsDirty,
-    [isCreatingUnitTest, designerIsDirty]
-  );
+  const isCreateUnitTestDisabled = useMemo(() => isCreatingUnitTest || designerIsDirty, [isCreatingUnitTest, designerIsDirty]);
   const haveErrors = useMemo(
     () => haveInputErrors || haveWorkflowParameterErrors || haveSettingsErrors || haveConnectionErrors,
     [haveInputErrors, haveWorkflowParameterErrors, haveSettingsErrors, haveConnectionErrors]


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Fixes [#9412](https://github.com/Azure/LogicAppsUX/issues/9412) — In the VS Code Standard designer, changing a Response action's **Run after** settings (e.g. checking "Has failed" and unchecking "Is successful") was not persisted on Save, while the Azure portal worked correctly.

Root cause: the VS Code `DesignerCommandBar` (V1) captured the Redux store state **at render time** and the save mutation closed over that snapshot. The command bar only re-renders on a small set of subscribed values (e.g. the dirty flag), so once the workflow was already dirty, a subsequent edit did not trigger a re-render — leaving `designerState` stale. Save then serialized the stale snapshot and dropped the edit.

The fix moves `DesignerStore.getState()` **inside** the save mutation so serialization always uses current state. This matches the V2 command bar and the existing unit-test handlers, which already read fresh state at invocation time.

## Impact of Change
- **Users**: Run-after (and any other edits made while the workflow is already dirty) now save correctly from the VS Code Standard designer.
- **Developers**: Establishes the pattern of reading store state inside the mutation rather than at render time.
- **System**: No architectural or dependency changes; scoped to the VS Code React save path.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: `apps/vs-code-react` vitest — added a regression test that simulates an edit after the workflow is dirty, clicks Save, and asserts the fresh state is serialized. Verified it fails against the pre-fix code and passes with the fix.

## Contributors

## Screenshots/Videos
