### PR TITLE
test(vscode): add regression test for node description persistence on save

### DIFF
--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -359,7 +359,7 @@ jobs:
           # Designer editing interactions: variables, extended view (parallel
           # branches / run-after), keyboard navigation.
           - shard: designer-interactions
-            scenario: p44-statelessvariables,p45-designerviewextended,p46-keyboardnav
+            scenario: p44-statelessvariables,p45-designerviewextended,p46-keyboardnav,p49-descriptionpersistence
             use_workspace_fixtures: true
             use_bundle_artifact: true
           # Multi-designer + dataMapper suite (manifest-multi) + bundle repair.

--- a/apps/vs-code-designer/src/test/ui/descriptionPersistence.test.ts
+++ b/apps/vs-code-designer/src/test/ui/descriptionPersistence.test.ts
@@ -235,13 +235,15 @@ describe('Description / Save-Persistence Tests', function () {
       assert.ok(marked, 'Should set the Compose description (edit #1, dirties the workflow)');
       await captureScreenshot(driver, 'linear-dirtied', EXPLICIT_SCREENSHOT_DIR);
 
-      // Edit #2 — change Compose2's run-after WHILE already dirty.
+      // Edit #2 — change Compose2's run-after WHILE already dirty. Flip it to
+      // "Has failed" ONLY (uncheck the default "Is successful"), so the test
+      // proves a non-default single status round-trips — not just an added one.
       const panelOpen = await openNodeSettingsPanel(driver, 'Compose2');
       assert.ok(panelOpen, 'Compose2 settings panel should open');
       const runAfterOpen = await openRunAfterSettings(driver);
       assert.ok(runAfterOpen, 'Run after section should open for Compose2');
-      const configured = await configureRunAfter(driver, ['Succeeded', 'Failed']);
-      assert.ok(configured, 'Should toggle Compose2 run-after to Succeeded + Failed while dirty');
+      const configured = await configureRunAfter(driver, ['Failed']);
+      assert.ok(configured, 'Should toggle Compose2 run-after to Failed only (Succeeded unchecked) while dirty');
       await captureScreenshot(driver, 'linear-runafter-configured', EXPLICIT_SCREENSHOT_DIR);
 
       const saved = await clickSaveButton(driver);
@@ -251,15 +253,19 @@ describe('Description / Save-Persistence Tests', function () {
 
       const wf = await readWorkflowJsonUntil(entry, (w) => {
         const statuses: string[] = w?.definition?.actions?.Compose2?.runAfter?.Compose ?? [];
-        return statuses.some((s) => s.toUpperCase() === 'FAILED');
+        const upper = statuses.map((s) => s.toUpperCase());
+        return upper.includes('FAILED') && !upper.includes('SUCCEEDED');
       });
 
       // Run-after statuses serialize as the canonical uppercase enum
-      // (e.g. FAILED); compare case-insensitively.
+      // (e.g. FAILED); compare case-insensitively. The edit flipped Compose2 to
+      // "Has failed" only, so the persisted set must be exactly {FAILED} — proving
+      // the default "Is successful" was removed and a non-default state persisted.
       const compose2RunAfter: string[] = (wf?.definition?.actions?.Compose2?.runAfter?.Compose ?? []).map((s: string) => s.toUpperCase());
-      assert.ok(
-        compose2RunAfter.includes('SUCCEEDED') && compose2RunAfter.includes('FAILED'),
-        `Compose2 run-after (edited while dirty) must persist Succeeded + Failed: ${JSON.stringify(
+      assert.deepStrictEqual(
+        [...compose2RunAfter].sort(),
+        ['FAILED'],
+        `Compose2 run-after (edited while dirty) must persist exactly Failed only: ${JSON.stringify(
           wf?.definition?.actions?.Compose2?.runAfter
         )}`
       );
@@ -307,12 +313,17 @@ describe('Description / Save-Persistence Tests', function () {
       await captureScreenshot(driver, 'parallel-dirtied', EXPLICIT_SCREENSHOT_DIR);
 
       // Edit #2 — change the parallel-branch join's run-after WHILE already dirty.
+      // Flip the Compose_A predecessor to "Has failed" ONLY (uncheck the default
+      // "Is successful"). The join then has one branch that is "Has failed"
+      // (Compose_A) and one that is "Is successful" (Compose_B) — proving a
+      // non-default single status persists per predecessor.
       const panelOpen = await openNodeSettingsPanel(driver, 'Compose_Join');
       assert.ok(panelOpen, 'Compose_Join settings panel should open');
       const runAfterOpen = await openRunAfterSettings(driver);
       assert.ok(runAfterOpen, 'Run after section should open for the parallel-branch join');
-      const configured = await configureRunAfter(driver, ['Succeeded', 'Failed']);
+      const configured = await configureRunAfter(driver, ['Failed']);
       console.log(`[descriptionPersistence] parallel configureRunAfter returned: ${configured}`);
+      assert.ok(configured, 'Should toggle Compose_A run-after to Failed only (Succeeded unchecked) while dirty');
       await captureScreenshot(driver, 'parallel-runafter-configured', EXPLICIT_SCREENSHOT_DIR);
 
       const saved = await clickSaveButton(driver);
@@ -322,8 +333,8 @@ describe('Description / Save-Persistence Tests', function () {
 
       const wf = await readWorkflowJsonUntil(entry, (w) => {
         const ra = w?.definition?.actions?.Compose_Join?.runAfter ?? {};
-        const statuses = [...(ra.Compose_A ?? []), ...(ra.Compose_B ?? [])];
-        return statuses.some((s: string) => s.toUpperCase() === 'FAILED');
+        const a = (ra.Compose_A ?? []).map((s: string) => s.toUpperCase());
+        return a.includes('FAILED') && !a.includes('SUCCEEDED');
       });
 
       const joinRunAfter = wf?.definition?.actions?.Compose_Join?.runAfter ?? {};
@@ -332,12 +343,21 @@ describe('Description / Save-Persistence Tests', function () {
         Object.prototype.hasOwnProperty.call(joinRunAfter, 'Compose_A') && Object.prototype.hasOwnProperty.call(joinRunAfter, 'Compose_B'),
         `Parallel-branch join must keep both predecessors in run-after: ${JSON.stringify(joinRunAfter)}`
       );
-      // The while-dirty run-after change (Failed) must persist on the join.
-      // Statuses serialize as the canonical uppercase enum; compare accordingly.
-      const joinStatuses = [...(joinRunAfter.Compose_A ?? []), ...(joinRunAfter.Compose_B ?? [])].map((s: string) => s.toUpperCase());
-      assert.ok(
-        joinStatuses.includes('FAILED'),
-        `Parallel-branch run-after change (Failed) must persist on the join: ${JSON.stringify(joinRunAfter)}`
+      // The while-dirty edit flipped the Compose_A predecessor to "Has failed"
+      // ONLY (default "Is successful" unchecked) — so it must persist as exactly
+      // {FAILED}. Statuses serialize as the canonical uppercase enum.
+      const composeAStatuses = (joinRunAfter.Compose_A ?? []).map((s: string) => s.toUpperCase());
+      assert.deepStrictEqual(
+        [...composeAStatuses].sort(),
+        ['FAILED'],
+        `Compose_A run-after must persist as Failed only (Succeeded unchecked): ${JSON.stringify(joinRunAfter)}`
+      );
+      // The other branch (Compose_B) must be left untouched — still just SUCCEEDED.
+      const composeBStatuses = (joinRunAfter.Compose_B ?? []).map((s: string) => s.toUpperCase());
+      assert.deepStrictEqual(
+        [...composeBStatuses].sort(),
+        ['SUCCEEDED'],
+        `Compose_B run-after must remain unchanged (Succeeded only): ${JSON.stringify(joinRunAfter)}`
       );
       // The earlier edit must also survive the same save.
       assert.strictEqual(

--- a/apps/vs-code-designer/src/test/ui/descriptionPersistence.test.ts
+++ b/apps/vs-code-designer/src/test/ui/descriptionPersistence.test.ts
@@ -251,12 +251,14 @@ describe('Description / Save-Persistence Tests', function () {
 
       const wf = await readWorkflowJsonUntil(entry, (w) => {
         const statuses: string[] = w?.definition?.actions?.Compose2?.runAfter?.Compose ?? [];
-        return statuses.includes('Failed');
+        return statuses.some((s) => s.toUpperCase() === 'FAILED');
       });
 
-      const compose2RunAfter: string[] = wf?.definition?.actions?.Compose2?.runAfter?.Compose ?? [];
+      // Run-after statuses serialize as the canonical uppercase enum
+      // (e.g. FAILED); compare case-insensitively.
+      const compose2RunAfter: string[] = (wf?.definition?.actions?.Compose2?.runAfter?.Compose ?? []).map((s: string) => s.toUpperCase());
       assert.ok(
-        compose2RunAfter.includes('Succeeded') && compose2RunAfter.includes('Failed'),
+        compose2RunAfter.includes('SUCCEEDED') && compose2RunAfter.includes('FAILED'),
         `Compose2 run-after (edited while dirty) must persist Succeeded + Failed: ${JSON.stringify(
           wf?.definition?.actions?.Compose2?.runAfter
         )}`
@@ -321,7 +323,7 @@ describe('Description / Save-Persistence Tests', function () {
       const wf = await readWorkflowJsonUntil(entry, (w) => {
         const ra = w?.definition?.actions?.Compose_Join?.runAfter ?? {};
         const statuses = [...(ra.Compose_A ?? []), ...(ra.Compose_B ?? [])];
-        return statuses.includes('Failed');
+        return statuses.some((s: string) => s.toUpperCase() === 'FAILED');
       });
 
       const joinRunAfter = wf?.definition?.actions?.Compose_Join?.runAfter ?? {};
@@ -331,9 +333,10 @@ describe('Description / Save-Persistence Tests', function () {
         `Parallel-branch join must keep both predecessors in run-after: ${JSON.stringify(joinRunAfter)}`
       );
       // The while-dirty run-after change (Failed) must persist on the join.
-      const joinStatuses = [...(joinRunAfter.Compose_A ?? []), ...(joinRunAfter.Compose_B ?? [])];
+      // Statuses serialize as the canonical uppercase enum; compare accordingly.
+      const joinStatuses = [...(joinRunAfter.Compose_A ?? []), ...(joinRunAfter.Compose_B ?? [])].map((s: string) => s.toUpperCase());
       assert.ok(
-        joinStatuses.includes('Failed'),
+        joinStatuses.includes('FAILED'),
         `Parallel-branch run-after change (Failed) must persist on the join: ${JSON.stringify(joinRunAfter)}`
       );
       // The earlier edit must also survive the same save.

--- a/apps/vs-code-designer/src/test/ui/descriptionPersistence.test.ts
+++ b/apps/vs-code-designer/src/test/ui/descriptionPersistence.test.ts
@@ -1,0 +1,354 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Description / save-persistence E2E tests.
+ *
+ * Regression coverage for the "serialize latest store state at save time" fix
+ * (#9412 / #9447) and the closely-related "Issue 2 – description not persisting"
+ * report. Both share one root cause: the V1 `DesignerCommandBar` used to serialize
+ * a render-time Redux snapshot inside its save mutation. Because the command bar
+ * only re-renders on a small set of subscribed values (like the dirty flag), an
+ * edit made while the workflow was *already dirty* (a description, a run-after
+ * change) did not re-render the command bar, so Save serialized stale state and
+ * dropped the edit from workflow.json. The fix reads `DesignerStore.getState()`
+ * fresh at save time.
+ *
+ * These tests drive the real designer in VS Code: seed a workflow, make a first
+ * edit to dirty it, then make a second edit *while already dirty*, save once, and
+ * assert the persisted workflow.json contains BOTH edits.
+ *
+ * Blocks:
+ *   1. Description persistence — dirty via an action description, then add a
+ *      trigger description while dirty; assert both descriptions persist.
+ *   2. Linear run-after — dirty via an action description, then change a
+ *      downstream action's run-after while dirty; assert both persist.
+ *   3. Parallel-branch run-after — a diamond (two parallel branches → a join);
+ *      dirty via a branch description, then change the join's run-after while
+ *      dirty; assert the parallel run-after change and the description persist.
+ *
+ * This file MUST run after Phase 4.1 (createWorkspace) has written the workspace
+ * manifest. It reuses the Standard / Stateful workspace, matching
+ * designerViewExtended.test.ts.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import * as assert from 'assert';
+import { Workbench, EditorView, type WebDriver, VSBrowser } from 'vscode-extension-tester';
+import { WORKSPACE_MANIFEST_PATH, loadWorkspaceManifest } from './workspaceManifest';
+import type { WorkspaceManifestEntry } from './workspaceManifest';
+import { sleep, captureScreenshot } from './helpers';
+import {
+  TEST_TIMEOUT,
+  DEPENDENCY_VALIDATION_TIMEOUT,
+  waitForDependencyValidation,
+  openDesignerForEntry,
+  clickSaveButton,
+  readWorkflowJson,
+  setNodeDescription,
+  openNodeSettingsPanel,
+  openRunAfterSettings,
+  configureRunAfter,
+} from './designerHelpers';
+
+const EXPLICIT_SCREENSHOT_DIR = path.join(
+  process.env.TEMP || process.cwd(),
+  'test-resources',
+  'screenshots',
+  'descriptionPersistence-explicit',
+  new Date().toISOString().replace(/[:.]/g, '-')
+);
+
+const SCHEMA = 'https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#';
+
+/** Write a workflow.json definition to the entry's workflow dir. */
+function seedWorkflow(entry: WorkspaceManifestEntry, actions: Record<string, unknown>): void {
+  const wjp = path.join(entry.wfDir, 'workflow.json');
+  fs.writeFileSync(
+    wjp,
+    JSON.stringify(
+      {
+        definition: {
+          $schema: SCHEMA,
+          actions,
+          contentVersion: '1.0.0.0',
+          outputs: {},
+          triggers: { manual: { type: 'Request', kind: 'Http', inputs: { schema: {} } } },
+        },
+        kind: 'Stateful',
+      },
+      null,
+      4
+    )
+  );
+}
+
+/**
+ * Poll-read workflow.json until the predicate is satisfied or the deadline
+ * elapses. Avoids a fixed sleep race between the save round-trip and the file
+ * write on disk.
+ */
+async function readWorkflowJsonUntil(entry: WorkspaceManifestEntry, predicate: (wf: any) => boolean, timeoutMs = 12_000): Promise<any> {
+  const deadline = Date.now() + timeoutMs;
+  let last: any;
+  while (Date.now() < deadline) {
+    try {
+      last = readWorkflowJson(entry.wfDir);
+      if (predicate(last)) {
+        return last;
+      }
+    } catch {
+      /* file mid-write; retry */
+    }
+    await sleep(500);
+  }
+  return last;
+}
+
+describe('Description / Save-Persistence Tests', function () {
+  this.timeout(TEST_TIMEOUT);
+
+  let driver: WebDriver;
+  let workbench: Workbench;
+  let manifest: WorkspaceManifestEntry[];
+
+  const getEntry = (): WorkspaceManifestEntry => {
+    const entry =
+      manifest.find((e) => e.appType === 'standard' && e.wfType === 'Stateful') || manifest.find((e) => e.appType === 'standard');
+    if (!entry) {
+      assert.fail('No matching Standard workspace entry found in manifest');
+    }
+    return entry as WorkspaceManifestEntry;
+  };
+
+  before(async function () {
+    this.timeout(DEPENDENCY_VALIDATION_TIMEOUT + 30_000);
+    fs.mkdirSync(EXPLICIT_SCREENSHOT_DIR, { recursive: true });
+    if (!fs.existsSync(WORKSPACE_MANIFEST_PATH)) {
+      assert.fail(`Workspace manifest not found at ${WORKSPACE_MANIFEST_PATH} - Phase 4.1 must run first`);
+      return;
+    }
+    manifest = loadWorkspaceManifest();
+    if (manifest.length === 0) {
+      assert.fail('Workspace manifest is empty - Phase 4.1 must create workspaces first');
+      return;
+    }
+    driver = VSBrowser.instance.driver;
+    workbench = new Workbench();
+    if (process.env.LA_E2E_SKIP_VALIDATION_WAIT === '1') {
+      console.log('[descriptionPersistence] Skipping dependency validation wait for UI-only scenario');
+    } else {
+      await waitForDependencyValidation(driver);
+    }
+  });
+
+  afterEach(async () => {
+    try {
+      await driver.switchTo().defaultContent();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await new EditorView().closeAllEditors();
+    } catch {
+      /* ignore */
+    }
+    await sleep(1000);
+  });
+
+  it('persists a trigger description added while the workflow was already dirty (Issue 2)', async () => {
+    const entry = getEntry();
+    seedWorkflow(entry, {
+      Compose: { type: 'Compose', inputs: 'OK', runAfter: {} },
+    });
+
+    const result = await openDesignerForEntry(workbench, driver, entry);
+    driver = VSBrowser.instance.driver;
+    assert.ok(result.success, `Designer should open — ${result.error}`);
+
+    const actionDescription = 'e2e action description';
+    const triggerDescription = 'e2e trigger description';
+
+    try {
+      await captureScreenshot(driver, 'desc-initial', EXPLICIT_SCREENSHOT_DIR);
+
+      // Edit #1 — add a description to the Compose action. This flips the
+      // workflow from clean → dirty (the command bar re-renders once here).
+      const actionSet = await setNodeDescription(driver, 'Compose', actionDescription);
+      assert.ok(actionSet, 'Should set the Compose action description (edit #1, dirties the workflow)');
+      await captureScreenshot(driver, 'desc-action-set', EXPLICIT_SCREENSHOT_DIR);
+
+      // Edit #2 — add a description to the trigger WHILE the workflow is already
+      // dirty. The dirty flag doesn't change, so the command bar does not
+      // re-render. This is the exact condition the fix addresses.
+      const triggerSet = await setNodeDescription(driver, 'manual', triggerDescription, { isTrigger: true });
+      assert.ok(triggerSet, 'Should set the trigger description (edit #2, made while already dirty)');
+      await captureScreenshot(driver, 'desc-trigger-set', EXPLICIT_SCREENSHOT_DIR);
+
+      // Save once. Both edits must be serialized from the latest store state.
+      const saved = await clickSaveButton(driver);
+      assert.ok(saved, 'Save should complete (button enabled means there were pending changes)');
+
+      await result.webview!.switchBack();
+
+      const wf = await readWorkflowJsonUntil(entry, (w) => w?.definition?.triggers?.manual?.description === triggerDescription);
+
+      assert.strictEqual(
+        wf?.definition?.triggers?.manual?.description,
+        triggerDescription,
+        `Trigger description (edited while dirty) must persist: ${JSON.stringify(wf?.definition?.triggers?.manual)}`
+      );
+      assert.strictEqual(
+        wf?.definition?.actions?.Compose?.description,
+        actionDescription,
+        `Action description (edit #1) must also persist: ${JSON.stringify(wf?.definition?.actions?.Compose)}`
+      );
+      console.log('[descriptionPersistence] Block 1 completed');
+    } finally {
+      try {
+        await result.webview!.switchBack();
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('persists a linear run-after change made while the workflow was already dirty (#9447)', async () => {
+    const entry = getEntry();
+    seedWorkflow(entry, {
+      Compose: { type: 'Compose', inputs: 'OK', runAfter: {} },
+      Compose2: { type: 'Compose', inputs: 'OK2', runAfter: { Compose: ['Succeeded'] } },
+    });
+
+    const result = await openDesignerForEntry(workbench, driver, entry);
+    driver = VSBrowser.instance.driver;
+    assert.ok(result.success, `Designer should open — ${result.error}`);
+
+    const dirtyMarker = 'e2e runafter dirty marker';
+
+    try {
+      await captureScreenshot(driver, 'linear-initial', EXPLICIT_SCREENSHOT_DIR);
+
+      // Edit #1 — dirty the workflow via a Compose description.
+      const marked = await setNodeDescription(driver, 'Compose', dirtyMarker);
+      assert.ok(marked, 'Should set the Compose description (edit #1, dirties the workflow)');
+      await captureScreenshot(driver, 'linear-dirtied', EXPLICIT_SCREENSHOT_DIR);
+
+      // Edit #2 — change Compose2's run-after WHILE already dirty.
+      const panelOpen = await openNodeSettingsPanel(driver, 'Compose2');
+      assert.ok(panelOpen, 'Compose2 settings panel should open');
+      const runAfterOpen = await openRunAfterSettings(driver);
+      assert.ok(runAfterOpen, 'Run after section should open for Compose2');
+      const configured = await configureRunAfter(driver, ['Succeeded', 'Failed']);
+      assert.ok(configured, 'Should toggle Compose2 run-after to Succeeded + Failed while dirty');
+      await captureScreenshot(driver, 'linear-runafter-configured', EXPLICIT_SCREENSHOT_DIR);
+
+      const saved = await clickSaveButton(driver);
+      assert.ok(saved, 'Save should complete');
+
+      await result.webview!.switchBack();
+
+      const wf = await readWorkflowJsonUntil(entry, (w) => {
+        const statuses: string[] = w?.definition?.actions?.Compose2?.runAfter?.Compose ?? [];
+        return statuses.includes('Failed');
+      });
+
+      const compose2RunAfter: string[] = wf?.definition?.actions?.Compose2?.runAfter?.Compose ?? [];
+      assert.ok(
+        compose2RunAfter.includes('Succeeded') && compose2RunAfter.includes('Failed'),
+        `Compose2 run-after (edited while dirty) must persist Succeeded + Failed: ${JSON.stringify(
+          wf?.definition?.actions?.Compose2?.runAfter
+        )}`
+      );
+      assert.strictEqual(
+        wf?.definition?.actions?.Compose?.description,
+        dirtyMarker,
+        `Compose description (edit #1) must also persist: ${JSON.stringify(wf?.definition?.actions?.Compose)}`
+      );
+      console.log('[descriptionPersistence] Block 2 completed');
+    } finally {
+      try {
+        await result.webview!.switchBack();
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('persists a run-after change on a parallel-branch join made while dirty', async () => {
+    const entry = getEntry();
+    // Diamond: manual → { Compose_A, Compose_B } (parallel, both run after the
+    // trigger) → Compose_Join (runs after both branches).
+    seedWorkflow(entry, {
+      Compose_A: { type: 'Compose', inputs: 'A', runAfter: {} },
+      Compose_B: { type: 'Compose', inputs: 'B', runAfter: {} },
+      Compose_Join: {
+        type: 'Compose',
+        inputs: 'JOIN',
+        runAfter: { Compose_A: ['Succeeded'], Compose_B: ['Succeeded'] },
+      },
+    });
+
+    const result = await openDesignerForEntry(workbench, driver, entry);
+    driver = VSBrowser.instance.driver;
+    assert.ok(result.success, `Designer should open — ${result.error}`);
+
+    const dirtyMarker = 'e2e parallel dirty marker';
+
+    try {
+      await captureScreenshot(driver, 'parallel-initial', EXPLICIT_SCREENSHOT_DIR);
+
+      // Edit #1 — dirty the workflow via a description on one parallel branch.
+      const marked = await setNodeDescription(driver, 'Compose_A', dirtyMarker);
+      assert.ok(marked, 'Should set the Compose_A description (edit #1, dirties the workflow)');
+      await captureScreenshot(driver, 'parallel-dirtied', EXPLICIT_SCREENSHOT_DIR);
+
+      // Edit #2 — change the parallel-branch join's run-after WHILE already dirty.
+      const panelOpen = await openNodeSettingsPanel(driver, 'Compose_Join');
+      assert.ok(panelOpen, 'Compose_Join settings panel should open');
+      const runAfterOpen = await openRunAfterSettings(driver);
+      assert.ok(runAfterOpen, 'Run after section should open for the parallel-branch join');
+      const configured = await configureRunAfter(driver, ['Succeeded', 'Failed']);
+      console.log(`[descriptionPersistence] parallel configureRunAfter returned: ${configured}`);
+      await captureScreenshot(driver, 'parallel-runafter-configured', EXPLICIT_SCREENSHOT_DIR);
+
+      const saved = await clickSaveButton(driver);
+      assert.ok(saved, 'Save should complete');
+
+      await result.webview!.switchBack();
+
+      const wf = await readWorkflowJsonUntil(entry, (w) => {
+        const ra = w?.definition?.actions?.Compose_Join?.runAfter ?? {};
+        const statuses = [...(ra.Compose_A ?? []), ...(ra.Compose_B ?? [])];
+        return statuses.includes('Failed');
+      });
+
+      const joinRunAfter = wf?.definition?.actions?.Compose_Join?.runAfter ?? {};
+      // The parallel structure (both predecessors) must be preserved.
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(joinRunAfter, 'Compose_A') && Object.prototype.hasOwnProperty.call(joinRunAfter, 'Compose_B'),
+        `Parallel-branch join must keep both predecessors in run-after: ${JSON.stringify(joinRunAfter)}`
+      );
+      // The while-dirty run-after change (Failed) must persist on the join.
+      const joinStatuses = [...(joinRunAfter.Compose_A ?? []), ...(joinRunAfter.Compose_B ?? [])];
+      assert.ok(
+        joinStatuses.includes('Failed'),
+        `Parallel-branch run-after change (Failed) must persist on the join: ${JSON.stringify(joinRunAfter)}`
+      );
+      // The earlier edit must also survive the same save.
+      assert.strictEqual(
+        wf?.definition?.actions?.Compose_A?.description,
+        dirtyMarker,
+        `Compose_A description (edit #1) must also persist: ${JSON.stringify(wf?.definition?.actions?.Compose_A)}`
+      );
+      console.log('[descriptionPersistence] Block 3 completed');
+    } finally {
+      try {
+        await result.webview!.switchBack();
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+});

--- a/apps/vs-code-designer/src/test/ui/designerHelpers.ts
+++ b/apps/vs-code-designer/src/test/ui/designerHelpers.ts
@@ -3017,7 +3017,21 @@ export async function openNodeSettingsPanel(driver: WebDriver, nodeText: string)
     if (exactNode.length > 0) {
       await driver.actions().move({ origin: exactNode[0] }).click().perform();
       await sleep(1500);
-      console.log(`[openNodeSettingsPanel] Clicked exact node "${nodeText}"`);
+      // A canvas "+" add-action context menu sometimes opens on/near the click;
+      // dismiss any stray floating popover so it can't cover the details panel.
+      const panelNode = await driver.executeScript<string>(
+        `
+        const menus = Array.from(document.querySelectorAll('[role="menu"], .fui-MenuPopover'));
+        for (const m of menus) {
+          if (!m.closest('.msla-panel-container') && !m.closest('[id^="msla-node-details-panel"]')) {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', keyCode: 27, bubbles: true }));
+          }
+        }
+        const header = document.querySelector('.msla-panel-card-header, [class*="msla-panel"] [class*="title"]');
+        return header ? (header.textContent || '').trim().slice(0, 60) : '(no panel header)';
+        `
+      );
+      console.log(`[openNodeSettingsPanel] Clicked exact node "${nodeText}" (panel header: ${panelNode})`);
       return true;
     }
 
@@ -3160,55 +3174,90 @@ export async function setNodeDescription(
  */
 export async function openRunAfterSettings(driver: WebDriver): Promise<boolean> {
   try {
-    const clickRunAfterHeader = async (): Promise<boolean> => {
-      const headers = await driver.findElements(
-        By.css(
-          '.msla-setting-section-header, [data-automation-id*="runAfter"], [data-automation-id*="run-after"], [aria-label*="Run after"], [aria-label*="Run After"]'
-        )
+    // 0. Dismiss any stray overlay (e.g. a canvas "+" add-action context menu)
+    //    that could be covering the node details panel and swallowing clicks.
+    await driver.executeScript(
+      `
+      const menus = Array.from(document.querySelectorAll('[role="menu"], .fui-MenuPopover'));
+      for (const m of menus) {
+        // Only dismiss floating popovers, never the panel itself.
+        if (!m.closest('.msla-panel-container') && !m.closest('[id^="msla-node-details-panel"]')) {
+          const evt = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', keyCode: 27, bubbles: true });
+          document.dispatchEvent(evt);
+        }
+      }
+      `
+    );
+    await sleep(300);
+
+    // 1. Activate the "Settings" tab. Run-after config lives under it. Panel tabs
+    //    render as Fluent <Tab role="tab"> inside #msla-node-details-panel-<id>,
+    //    with the localized title as text ("Settings"). Poll because the panel
+    //    can take a moment to mount its TabList after the node click.
+    let settingsTabClicked = false;
+    for (let attempt = 0; attempt < 10 && !settingsTabClicked; attempt++) {
+      const result = await driver.executeScript<{ clicked: boolean; panels: number; tabTitles: string[] }>(
+        `
+        const panels = document.querySelectorAll('[id^="msla-node-details-panel"]').length;
+        const tabs = Array.from(document.querySelectorAll('[role="tab"]'));
+        const tabTitles = tabs.map((t) => (t.textContent || '').trim()).filter(Boolean);
+        const tab = tabs.find((t) => (t.textContent || '').trim().toLowerCase().startsWith('settings'));
+        if (tab) {
+          tab.scrollIntoView({ block: 'center' });
+          tab.click();
+          return { clicked: true, panels, tabTitles };
+        }
+        return { clicked: false, panels, tabTitles };
+        `
       );
-      for (const header of headers) {
-        const text = await header.getText().catch(() => '');
-        const ariaLabel = await header.getAttribute('aria-label').catch(() => '');
-        if (`${text} ${ariaLabel}`.toLowerCase().includes('run after')) {
-          await driver.executeScript('arguments[0].scrollIntoView({ block: "center" });', header).catch(() => undefined);
-          await driver.actions().move({ origin: header }).click().perform();
-          await sleep(1000);
-          console.log('[openRunAfterSettings] Opened Run after section');
-          return true;
-        }
+      if (result.clicked) {
+        settingsTabClicked = true;
+        break;
       }
+      if (attempt === 0 || attempt === 9) {
+        console.log(`[openRunAfterSettings] attempt ${attempt + 1}: panels=${result.panels} tabs=[${result.tabTitles.join('|')}]`);
+      }
+      await sleep(600);
+    }
+    if (!settingsTabClicked) {
+      console.log('[openRunAfterSettings] Settings tab not found');
       return false;
-    };
-
-    if (await clickRunAfterHeader()) {
-      return true;
     }
+    await sleep(800);
 
-    // Try finding by text content
-    const runAfterButtons = await driver.findElements(By.xpath('//button[contains(., "Run after") or contains(., "Run After")]'));
-    if (runAfterButtons.length > 0) {
-      await runAfterButtons[0].click();
-      await sleep(1000);
-      console.log('[openRunAfterSettings] Opened Run after via text match');
-      return true;
-    }
-
-    // Try the tab/pivot pattern used in the designer, then expand the Run after section within Settings.
-    const tabs = await driver.findElements(By.css('[role="tab"]'));
-    for (const tab of tabs) {
-      const text = await tab.getText().catch(() => '');
-      if (text.toLowerCase().includes('settings')) {
-        await tab.click();
-        await sleep(1000);
-        console.log('[openRunAfterSettings] Opened Settings tab');
-        if (await clickRunAfterHeader()) {
-          return true;
+    // 2. Expand the "Run after" section header if its body is not yet mounted.
+    //    The section body (and therefore the predecessor `.msla-run-after-edge-header`
+    //    rows) only render while the section is expanded, so click the header
+    //    `button.msla-setting-section-header` (text = "Run after") when collapsed.
+    for (let attempt = 0; attempt < 4; attempt++) {
+      const state = await driver.executeScript<{ hasBody: boolean; clickedHeader: boolean; headers: string[] }>(
+        `
+        const hasBody = !!document.querySelector('.msla-run-after-edge-header');
+        const headerEls = Array.from(document.querySelectorAll('button.msla-setting-section-header'));
+        const headers = headerEls.map((h) => (h.textContent || '').trim()).filter(Boolean);
+        if (hasBody) { return { hasBody: true, clickedHeader: false, headers }; }
+        const header = headerEls.find((h) => (h.textContent || '').toLowerCase().includes('run after'));
+        if (header) {
+          header.scrollIntoView({ block: 'center' });
+          header.click();
+          return { hasBody: false, clickedHeader: true, headers };
         }
+        return { hasBody: false, clickedHeader: false, headers };
+        `
+      );
+      if (state.hasBody) {
+        console.log('[openRunAfterSettings] Run after section is open');
+        return true;
       }
+      if (!state.clickedHeader) {
+        console.log(`[openRunAfterSettings] Run after header not found; section headers=[${state.headers.join('|')}]`);
+      }
+      await sleep(800);
     }
 
-    console.log('[openRunAfterSettings] Run After section not found');
-    return false;
+    const opened = await driver.executeScript<boolean>('return !!document.querySelector(".msla-run-after-edge-header");');
+    console.log(`[openRunAfterSettings] Run after section open=${opened} after retries`);
+    return opened;
   } catch (e: any) {
     console.log(`[openRunAfterSettings] Error: ${e.message}`);
     return false;
@@ -3216,214 +3265,145 @@ export async function openRunAfterSettings(driver: WebDriver): Promise<boolean> 
 }
 
 /**
- * Toggle run-after status checkboxes for a given list of statuses.
+ * Toggle run-after status checkboxes for a given list of statuses on the node
+ * settings panel that is currently open.
+ *
+ * DOM contract (libs/designer run-after components):
+ *  - Each predecessor renders a `.msla-run-after-edge-header` containing a
+ *    `<button>` whose aria-label starts with "Expand" when collapsed / "Collapse"
+ *    when expanded. The status checkboxes only mount while the predecessor is
+ *    expanded, so every collapsed predecessor must be expanded first.
+ *  - Status checkboxes are Fluent v9 Checkboxes inside `.msla-run-after-statuses`,
+ *    labelled "Is successful" (Succeeded), "Has timed out" (TimedOut),
+ *    "Is skipped" (Skipped) and "Has failed" (Failed). A status is `disabled`
+ *    when the action runs after the trigger, or when it is the only checked
+ *    status (you cannot remove the last run-after status).
+ *
  * Statuses can be: 'Succeeded', 'Failed', 'Skipped', 'TimedOut'.
  */
 export async function configureRunAfter(driver: WebDriver, statuses: string[]): Promise<boolean> {
+  const statusLabels: Record<string, string> = {
+    Succeeded: 'Is successful',
+    TimedOut: 'Has timed out',
+    Skipped: 'Is skipped',
+    Failed: 'Has failed',
+  };
+  const desired = statuses.map((status) => status.toLowerCase());
   try {
-    const desired = new Set(statuses.map((status) => status.toLowerCase()));
-    const statusLabels: Record<string, string> = {
-      Succeeded: 'Is successful',
-      Failed: 'Has failed',
-      Skipped: 'Is skipped',
-      TimedOut: 'Has timed out',
-    };
-    const allStatuses = Object.keys(statusLabels);
-    const getStates = async () =>
+    // Ensure the Run after section is open (idempotent — safe if already open).
+    await openRunAfterSettings(driver);
+
+    // Expand every collapsed predecessor so its status checkboxes mount. Only
+    // `.msla-run-after-edge-header` buttons whose aria-label starts with "expand"
+    // are clicked, so we never touch canvas "+" add buttons or other controls.
+    const expandInfo = await driver.executeScript<{ headers: number; expanded: number }>(
+      `
+      const headers = Array.from(document.querySelectorAll('.msla-run-after-edge-header'));
+      let expanded = 0;
+      for (const h of headers) {
+        const btn = h.querySelector('button');
+        if (!btn) { continue; }
+        const aria = (btn.getAttribute('aria-label') || '').trim().toLowerCase();
+        if (aria.indexOf('expand') === 0) {
+          btn.scrollIntoView({ block: 'center' });
+          btn.click();
+          expanded++;
+        }
+      }
+      return { headers: headers.length, expanded };
+      `
+    );
+    console.log(`[configureRunAfter] predecessors=${expandInfo.headers} expanded=${expandInfo.expanded}`);
+    await sleep(600);
+
+    // Toggle checkboxes to match the desired set. Re-run because Fluent
+    // re-renders the checkbox inputs on each change (stale element references).
+    const toggleOnce = async () =>
       driver.executeScript<{
         found: string[];
         checked: Record<string, boolean>;
         disabled: Record<string, boolean>;
+        clicked: string[];
         diagnostics: string[];
       }>(
         `
-        const labels = arguments[0];
+        const desired = arguments[0];
+        const labelById = arguments[1];
         const found = [];
         const checked = {};
         const disabled = {};
+        const clicked = [];
         const diagnostics = [];
-        const usedControls = [];
-        function getRoot() {
-          const roots = Array.from(document.querySelectorAll('[role="tabpanel"], [data-automation-id*="runAfter"], [data-automation-id*="run-after"], .msla-setting-section, .msla-panel'));
-          const root = roots.find((root) => {
-            const text = (root.textContent || '').toLowerCase();
-            return text.includes('run after') && (text.includes('has failed') || text.includes('is successful') || text.includes('has timed out'));
-          });
-          if (!root) {
-            diagnostics.push('run-after status root not found');
-          }
-          return root;
+        const groups = Array.from(document.querySelectorAll('.msla-run-after-statuses'));
+        if (groups.length === 0) {
+          diagnostics.push('no .msla-run-after-statuses mounted');
+          return { found, checked, disabled, clicked, diagnostics };
         }
-        function findControl(label) {
-          const lowerLabel = String(label).toLowerCase();
-          const root = getRoot();
-          if (!root) {
-            diagnostics.push(String(label) + ': no run-after root');
-            return null;
-          }
-          const candidates = Array.from(
-            root.querySelectorAll(
-              'input[type="checkbox"], [role="checkbox"], label, .fui-Checkbox, [class*="fui-Checkbox"], [class*="Checkbox__label"]'
-            )
-          );
-          for (const el of candidates) {
-            const checkboxContainer = el.closest('.fui-Checkbox, [class*="fui-Checkbox"], label');
-            const text = [
-              el.getAttribute('aria-label') || '',
-              el.getAttribute('title') || '',
-              checkboxContainer?.textContent || '',
-              el.textContent || '',
-              el.parentElement?.textContent || '',
-            ].join(' ').toLowerCase();
-            if (!text.includes(lowerLabel)) {
-              continue;
-            }
-            let node = el;
-            for (let depth = 0; node && depth < 6; depth++) {
-              const input = node instanceof HTMLInputElement ? node : node.querySelector?.('input[type="checkbox"]');
-              const roleCheckbox = node.getAttribute?.('role') === 'checkbox' ? node : node.querySelector?.('[role="checkbox"]');
-              const control = input || roleCheckbox;
-              if (control) {
-                if (usedControls.includes(control)) {
-                  diagnostics.push(String(label) + ': duplicate control');
-                  return null;
-                }
-                usedControls.push(control);
-                return { control, input: input instanceof HTMLInputElement ? input : null };
+        function findInput(labelText) {
+          const lower = String(labelText).toLowerCase();
+          for (const group of groups) {
+            const boxes = Array.from(group.querySelectorAll('.fui-Checkbox, [class*="fui-Checkbox"]'));
+            for (const box of boxes) {
+              if ((box.textContent || '').toLowerCase().includes(lower)) {
+                const input = box.querySelector('input[type="checkbox"]');
+                if (input) { return input; }
               }
-              node = node.parentElement;
+            }
+            const labels = Array.from(group.querySelectorAll('label'));
+            for (const lbl of labels) {
+              if ((lbl.textContent || '').toLowerCase().includes(lower)) {
+                const forId = lbl.getAttribute('for');
+                if (forId) {
+                  const byId = document.getElementById(forId);
+                  if (byId) { return byId; }
+                }
+                const near = lbl.querySelector('input[type="checkbox"]') || (lbl.parentElement && lbl.parentElement.querySelector('input[type="checkbox"]'));
+                if (near) { return near; }
+              }
             }
           }
-          diagnostics.push(String(label) + ': not found');
           return null;
         }
-        for (const [status, label] of Object.entries(labels)) {
-          const match = findControl(label);
-          if (!match) {
+        for (const id of Object.keys(labelById)) {
+          const input = findInput(labelById[id]);
+          if (!input) {
+            diagnostics.push(id + ': checkbox not found');
             continue;
           }
-          found.push(status);
-          checked[status] = match.input ? match.input.checked : match.control.getAttribute('aria-checked') === 'true';
-          disabled[status] = match.input ? match.input.disabled : match.control.getAttribute('aria-disabled') === 'true';
+          found.push(id);
+          checked[id] = !!input.checked;
+          disabled[id] = !!input.disabled;
+          const want = desired.indexOf(id.toLowerCase()) !== -1;
+          if (want !== input.checked) {
+            if (input.disabled) {
+              diagnostics.push(id + ': disabled, cannot toggle');
+              continue;
+            }
+            input.scrollIntoView({ block: 'center' });
+            input.click();
+            clicked.push(id);
+          }
         }
-        if (found.length === 0) {
-          diagnostics.push('body=' + (document.body.textContent || '').slice(0, 1000));
-        }
-        return { found, checked, disabled, diagnostics };
-      `,
+        return { found, checked, disabled, clicked, diagnostics };
+        `,
+        desired,
         statusLabels
       );
-    const expandCollapsedRunAfterRows = async () =>
-      driver.executeScript<number>(
-        `
-        let clicked = 0;
-        const candidates = Array.from(document.querySelectorAll('button, [role="button"], [aria-expanded="false"]'));
-        for (const el of candidates) {
-          const text = [
-            el.getAttribute('aria-label') || '',
-            el.textContent || '',
-            el.parentElement?.textContent || '',
-            el.parentElement?.parentElement?.textContent || '',
-          ].join(' ').toLowerCase();
-          const looksExpandable =
-            text.includes('expand') || text.includes('run after') || text.includes('manual') || text.includes('response');
-          if (!looksExpandable) {
-            continue;
-          }
-          try {
-            el.scrollIntoView({ block: 'center', inline: 'center' });
-            el.click();
-            clicked++;
-          } catch {
-            // Keep trying other candidate expanders.
-          }
-        }
-        return clicked;
-      `
-      );
-    const clickStatus = async (status: string) =>
-      driver.executeScript<boolean>(
-        `
-      const label = arguments[1];
-      function getRoot() {
-        const roots = Array.from(document.querySelectorAll('[role="tabpanel"], [data-automation-id*="runAfter"], [data-automation-id*="run-after"], .msla-setting-section, .msla-panel'));
-        return roots.find((root) => {
-          const text = (root.textContent || '').toLowerCase();
-          return text.includes('run after') && (text.includes('has failed') || text.includes('is successful') || text.includes('has timed out'));
-        });
-      }
-      const lowerLabel = String(label).toLowerCase();
-      const root = getRoot();
-      if (!root) {
-        return false;
-      }
-      const candidates = Array.from(root.querySelectorAll('input[type="checkbox"], [role="checkbox"], label, .fui-Checkbox, [class*="fui-Checkbox"], [class*="Checkbox__label"]'));
-      for (const el of candidates) {
-        const checkboxContainer = el.closest('.fui-Checkbox, [class*="fui-Checkbox"], label');
-        const text = [
-          el.getAttribute('aria-label') || '',
-          el.getAttribute('title') || '',
-          checkboxContainer?.textContent || '',
-          el.textContent || '',
-          el.parentElement?.textContent || '',
-        ].join(' ').toLowerCase();
-        if (!text.includes(lowerLabel)) {
-          continue;
-        }
-        let node = el;
-        for (let depth = 0; node && depth < 6; depth++) {
-          const input = node instanceof HTMLInputElement ? node : node.querySelector?.('input[type="checkbox"]');
-          const roleCheckbox = node.getAttribute?.('role') === 'checkbox' ? node : node.querySelector?.('[role="checkbox"]');
-          const control = input || roleCheckbox;
-          if (!control) {
-            node = node.parentElement;
-            continue;
-          }
-          const disabled = input instanceof HTMLInputElement ? input.disabled : control.getAttribute('aria-disabled') === 'true';
-          if (disabled) {
-            return false;
-          }
-          control.scrollIntoView({ block: 'center', inline: 'center' });
-          control.click();
-          return true;
-        }
-      }
-        return false;
-    `,
-        status,
-        statusLabels[status as keyof typeof statusLabels]
-      );
 
-    let states = await getStates();
-    if (states.found.length === 0) {
-      const expanded = await expandCollapsedRunAfterRows();
-      console.log(`[configureRunAfter] Expanded ${expanded} collapsed run-after candidate(s) before checkbox query`);
-      await sleep(800);
-      states = await getStates();
-    }
-    for (const status of allStatuses) {
-      if (desired.has(status.toLowerCase()) && !states.checked[status]) {
-        await clickStatus(status);
-        await sleep(400);
-      }
+    let state = await toggleOnce();
+    for (let pass = 0; pass < 3 && state.clicked.length > 0; pass++) {
+      await sleep(400);
+      state = await toggleOnce();
     }
 
-    states = await getStates();
-    for (const status of allStatuses) {
-      if (!desired.has(status.toLowerCase()) && states.checked[status]) {
-        await clickStatus(status);
-        await sleep(400);
-      }
-    }
-
-    states = await getStates();
-    const matchesDesired = allStatuses.every((status) => !!states.checked[status] === desired.has(status.toLowerCase()));
+    const allIds = Object.keys(statusLabels);
+    const matches = allIds.every((id) => state.found.includes(id) && state.checked[id] === (desired.indexOf(id.toLowerCase()) !== -1));
     console.log(
-      `[configureRunAfter] Found=${states.found.join(',')} checked=${JSON.stringify(states.checked)} diagnostics=${JSON.stringify(
-        states.diagnostics
-      )}`
+      `[configureRunAfter] found=${state.found.join(',')} checked=${JSON.stringify(state.checked)} disabled=${JSON.stringify(
+        state.disabled
+      )} diagnostics=${JSON.stringify(state.diagnostics)}`
     );
-    return allStatuses.every((status) => states.found.includes(status)) && matchesDesired;
+    return matches;
   } catch (e: any) {
     console.log(`[configureRunAfter] Error: ${e.message}`);
     return false;

--- a/apps/vs-code-designer/src/test/ui/designerHelpers.ts
+++ b/apps/vs-code-designer/src/test/ui/designerHelpers.ts
@@ -37,6 +37,7 @@
  *   - selectDropdownInPanel: Select a dropdown option in the settings panel
  *   - addParallelBranch: Add a parallel branch on the canvas
  *   - openNodeSettingsPanel: Click a node to open its settings
+ *   - setNodeDescription: Set a node's description/comment in the panel header
  *   - openRunAfterSettings: Navigate to the Run After section
  *   - configureRunAfter: Toggle run-after status checkboxes
  *   - focusCanvasNode: Click to focus a specific node
@@ -3049,6 +3050,106 @@ export async function openNodeSettingsPanel(driver: WebDriver, nodeText: string)
     return false;
   } catch (e: any) {
     console.log(`[openNodeSettingsPanel] Error: ${e.message}`);
+    return false;
+  }
+}
+
+/**
+ * Set a node's description (the "comment" in the panel header).
+ *
+ * The description editor is a Fluent `TextField multiline` → a real
+ * `<textarea aria-label="Description">` (placeholder "Add a description") inside
+ * `.msla-panel-comment-container`. For triggers the box is always visible when
+ * the node panel opens. For actions it is hidden until revealed via the panel
+ * header overflow menu ("More commands" → "Add a description").
+ *
+ * Typing fires the Fluent `onChange` → `commentChange` → `setNodeDescription`
+ * Redux action, so the value lands on `workflow.operations[nodeId].description`
+ * and serializes to `definition.{triggers|actions}.<name>.description`.
+ */
+export async function setNodeDescription(
+  driver: WebDriver,
+  nodeText: string,
+  description: string,
+  opts: { isTrigger?: boolean } = {}
+): Promise<boolean> {
+  try {
+    const opened = await openNodeSettingsPanel(driver, nodeText);
+    if (!opened) {
+      console.log(`[setNodeDescription] Could not open panel for "${nodeText}"`);
+      return false;
+    }
+
+    const findDescriptionTextarea = async (): Promise<WebElement | null> => {
+      const selectors = [
+        'textarea[aria-label="Description"]',
+        '.msla-panel-comment-container textarea',
+        'textarea[placeholder="Add a description"]',
+      ];
+      for (const selector of selectors) {
+        const els = await driver.findElements(By.css(selector));
+        for (const el of els) {
+          if (await el.isDisplayed().catch(() => false)) {
+            return el;
+          }
+        }
+      }
+      return null;
+    };
+
+    let textarea = await findDescriptionTextarea();
+
+    // For actions the description box is hidden until revealed via the
+    // panel-header overflow menu. Triggers always show it, so only reveal
+    // when the textarea isn't already present.
+    if (!textarea && !opts.isTrigger) {
+      const moreButtons = await driver.findElements(
+        By.css('[data-automation-id="msla-panel-header-more-options"], button[aria-label="More commands"]')
+      );
+      if (moreButtons.length > 0) {
+        await driver.actions().move({ origin: moreButtons[0] }).click().perform();
+        await sleep(800);
+        const menuItems = await driver.findElements(By.css('[role="menuitem"]'));
+        for (const item of menuItems) {
+          const itemText = `${await item.getText().catch(() => '')} ${await item.getAttribute('title').catch(() => '')}`;
+          if (itemText.toLowerCase().includes('description') || itemText.toLowerCase().includes('comment')) {
+            await driver.actions().move({ origin: item }).click().perform();
+            await sleep(800);
+            break;
+          }
+        }
+      }
+      // Poll for the textarea to appear after revealing it.
+      const revealDeadline = Date.now() + 5000;
+      while (!textarea && Date.now() < revealDeadline) {
+        textarea = await findDescriptionTextarea();
+        if (!textarea) {
+          await sleep(300);
+        }
+      }
+    }
+
+    if (!textarea) {
+      console.log(`[setNodeDescription] Description textarea not found for "${nodeText}"`);
+      return false;
+    }
+
+    // Focus via the Selenium Actions API so React registers the interaction,
+    // clear any existing value, then type. The description box is a plain
+    // <textarea>, so sendKeys works directly (no Lexical contenteditable path).
+    await driver.actions().move({ origin: textarea }).click().perform();
+    await sleep(300);
+    await textarea.sendKeys(Key.chord(Key.CONTROL, 'a'));
+    await textarea.sendKeys(Key.DELETE);
+    await textarea.sendKeys(description);
+    await sleep(500);
+
+    const finalValue = await textarea.getAttribute('value').catch(() => '');
+    const ok = finalValue === description;
+    console.log(`[setNodeDescription] Set "${nodeText}" description → "${finalValue}" (match=${ok})`);
+    return ok;
+  } catch (e: any) {
+    console.log(`[setNodeDescription] Error: ${e.message}`);
     return false;
   }
 }

--- a/apps/vs-code-designer/src/test/ui/run-e2e.ts
+++ b/apps/vs-code-designer/src/test/ui/run-e2e.ts
@@ -1393,6 +1393,7 @@ async function main(): Promise<void> {
   const phase4Files = [testFile('statelessVariables.test.js')];
   const phase5Files = [testFile('designerViewExtended.test.js')];
   const phase6Files = [testFile('keyboardNavigation.test.js')];
+  const phase9Files = [testFile('descriptionPersistence.test.js')];
 
   const phase7Files = [testFile('demo.test.js'), testFile('smoke.test.js'), testFile('standalone.test.js'), testFile('dataMapper.test.js')];
 
@@ -1556,6 +1557,13 @@ async function main(): Promise<void> {
       testFile: phase6Files[0],
       workspaceSpec: { appType: 'standard', wfType: 'Stateful' },
       settings: { validateDependencies: false, autoStartDesignTime: true },
+    },
+    {
+      id: 'p49-descriptionpersistence',
+      testFile: phase9Files[0],
+      workspaceSpec: { appType: 'standard', wfType: 'Stateful' },
+      settings: { validateDependencies: false, autoStartDesignTime: false },
+      env: { LA_E2E_SKIP_VALIDATION_WAIT: '1' },
     },
 
     // Phase 4.7 — designer-shell smoke + dataMapper. dataMapper.test.ts
@@ -2485,6 +2493,10 @@ namespace ${namespaceName}
       await prepareFreshSession('phase6-only');
       exits.push(await runPhase('Phase 4.6: keyboardNavigation', phase6Files, { resources: wsResources }));
 
+      await new Promise((r) => setTimeout(r, 3000));
+      await prepareFreshSession('phase9-only');
+      exits.push(await runPhase('Phase 4.9: descriptionPersistence', phase9Files, { resources: wsResources }));
+
       const finalExit = Math.max(...exits);
       console.log(`\n=== New tests results: ${exits.map((c, i) => `4.${i + 3}=${c}`).join(', ')} → exit ${finalExit} ===`);
       process.exit(finalExit);
@@ -2716,9 +2728,13 @@ namespace ${namespaceName}
       await prepareFreshSession('phase6-shard');
       exits.push(await runPhase('Phase 4.6: keyboardNavigation', phase6Files, { resources: wsResources }));
 
+      await new Promise((r) => setTimeout(r, 3000));
+      await prepareFreshSession('phase9-shard');
+      exits.push(await runPhase('Phase 4.9: descriptionPersistence', phase9Files, { resources: wsResources }));
+
       const finalExit = Math.max(...exits);
       console.log(
-        `\n=== Newtests shard results: 4.1=${exits[0]}, 4.3=${exits[1]}, 4.4=${exits[2]}, 4.5=${exits[3]}, 4.6=${exits[4]} → exit ${finalExit} ===`
+        `\n=== Newtests shard results: 4.1=${exits[0]}, 4.3=${exits[1]}, 4.4=${exits[2]}, 4.5=${exits[3]}, 4.6=${exits[4]}, 4.9=${exits[5]} → exit ${finalExit} ===`
       );
       process.exit(finalExit);
     }
@@ -2858,6 +2874,13 @@ namespace ${namespaceName}
     const phase6Exit = await runPhase('Phase 4.6: keyboardNavigation', phase6Files, { resources: phase2Resources });
     if (phase6Exit !== 0) {
       console.log(`\n⚠ Phase 4.6 exited with code ${phase6Exit} — continuing`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    await prepareFreshSession('phase9');
+    const phase9Exit = await runPhase('Phase 4.9: descriptionPersistence', phase9Files, { resources: phase2Resources });
+    if (phase9Exit !== 0) {
+      console.log(`\n⚠ Phase 4.9 exited with code ${phase9Exit} — continuing`);
     }
 
     await new Promise((resolve) => setTimeout(resolve, 3000));

--- a/apps/vs-code-designer/src/test/ui/run-e2e.ts
+++ b/apps/vs-code-designer/src/test/ui/run-e2e.ts
@@ -677,6 +677,20 @@ async function main(): Promise<void> {
       throw new Error(`${prereq} must be listed in extensionDependencies because the E2E extension activation requires it.`);
     }
   }
+  // Transitive dependencies that the VS Code CLI's --install-extension does NOT
+  // reliably auto-resolve. Installing ms-dotnettools.csdevkit pulls in
+  // ms-dotnettools.csharp, but csharp's own dependency
+  // ms-dotnettools.vscode-dotnet-runtime is not always installed (observed on
+  // Windows). Without it, the C#/C# Dev Kit extensions fail to activate
+  // ("depends on an unknown 'ms-dotnettools.vscode-dotnet-runtime' extension"),
+  // which cascades into the Azure Logic Apps extension never finishing
+  // activation — so azureLogicAppsStandard.createWorkspace / Open Designer are
+  // never registered. Install these explicitly to guarantee activation.
+  const transitiveE2eDependencies = ['ms-dotnettools.vscode-dotnet-runtime'];
+  const allE2eDependencies = [
+    ...extDeps,
+    ...transitiveE2eDependencies.filter((dep) => !extDeps.some((d) => d.toLowerCase() === dep.toLowerCase())),
+  ];
   const extDirName = `${pkgJson.publisher}.${pkgJson.name}-${pkgJson.version}`;
   const ourExtTarget = path.join(extDir, extDirName);
 
@@ -739,11 +753,11 @@ async function main(): Promise<void> {
     }
   };
 
-  if (extDeps.length > 0) {
-    console.log(`\n=== Step 2: Install ${extDeps.length} extension dependencies ===`);
+  if (allE2eDependencies.length > 0) {
+    console.log(`\n=== Step 2: Install ${allE2eDependencies.length} extension dependencies ===`);
 
     const depsToInstall: string[] = [];
-    for (const dep of extDeps) {
+    for (const dep of allE2eDependencies) {
       removeInvalidExtensionEntries(dep);
       const alreadyInstalled = !!findValidInstalledExtension(dep);
 
@@ -803,7 +817,7 @@ async function main(): Promise<void> {
       rebuildExtensionsJson(extDir);
     }
 
-    const missingDeps = extDeps.filter((dep) => !findValidInstalledExtension(dep));
+    const missingDeps = allE2eDependencies.filter((dep) => !findValidInstalledExtension(dep));
     if (missingDeps.length > 0) {
       throw new Error(`Missing E2E extension prerequisite(s): ${missingDeps.join(', ')}. Install/retry before running UI E2E tests.`);
     }

--- a/apps/vs-code-react/src/app/designer/DesignerCommandBar/__test__/index.test.tsx
+++ b/apps/vs-code-react/src/app/designer/DesignerCommandBar/__test__/index.test.tsx
@@ -161,4 +161,48 @@ describe('DesignerCommandBar (V1) save path', () => {
     expect(mockSerializeWorkflow.mock.calls[0][0]).toBe(freshState);
     expect(mockSerializeWorkflow.mock.calls[0][0]).toHaveProperty('marker', 'fresh');
   });
+
+  it('serializes a node description edited after the workflow was already dirty (issue #2 – description not persisting)', async () => {
+    // Serialize using the description from the live store state so we can assert the edit
+    // survives all the way into the posted save message, mirroring the real serializer which
+    // reads rootState.workflow.operations[id].description.
+    mockSerializeWorkflow.mockImplementation(async (state: any) => ({
+      definition: {
+        triggers: {
+          manualTrigger: { type: 'Request', description: state.workflow.operations?.manualTrigger?.description },
+        },
+        actions: {
+          Compose: { type: 'Compose', description: state.workflow.operations?.Compose?.description },
+        },
+      },
+      parameters: {},
+      connectionReferences: {},
+    }));
+
+    render(<DesignerCommandBar {...defaultProps} />);
+
+    // The workflow is already dirty (mockDesignerIsDirty = true), so the command bar does not
+    // re-render when the user adds a description. setNodeDescription writes the value onto
+    // workflow.operations[id]. Simulate that post-render edit on the live store state.
+    currentStoreState = {
+      ...baseState,
+      workflow: {
+        ...baseState.workflow,
+        operations: {
+          manualTrigger: { description: 'trigger description' },
+          Compose: { description: 'action description' },
+        },
+      },
+    };
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => expect(mockPostMessage).toHaveBeenCalled());
+
+    const saveMessage = mockPostMessage.mock.calls.find(([msg]) => msg?.command === 'save')?.[0];
+    expect(saveMessage).toBeDefined();
+    expect(saveMessage.definition.triggers.manualTrigger.description).toBe('trigger description');
+    expect(saveMessage.definition.actions.Compose.description).toBe('action description');
+  });
 });

--- a/apps/vs-code-react/src/app/designer/DesignerCommandBar/__test__/index.test.tsx
+++ b/apps/vs-code-react/src/app/designer/DesignerCommandBar/__test__/index.test.tsx
@@ -162,11 +162,13 @@ describe('DesignerCommandBar (V1) save path', () => {
     expect(mockSerializeWorkflow.mock.calls[0][0]).toHaveProperty('marker', 'fresh');
   });
 
-  it('serializes a node description edited after the workflow was already dirty (issue #2 – description not persisting)', async () => {
+  it('serializes a node description edited after the workflow was already dirty (description persistence regression, #9447)', async () => {
     // Serialize using the description from the live store state so we can assert the edit
     // survives all the way into the posted save message, mirroring the real serializer which
-    // reads rootState.workflow.operations[id].description.
-    mockSerializeWorkflow.mockImplementation(async (state: any) => ({
+    // reads rootState.workflow.operations[id].description. Scoped to this test via
+    // mockImplementationOnce so it does not leak into later tests (clearAllMocks does not
+    // reset implementations).
+    mockSerializeWorkflow.mockImplementationOnce(async (state: any) => ({
       definition: {
         triggers: {
           manualTrigger: { type: 'Request', description: state.workflow.operations?.manualTrigger?.description },


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [x] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Adds a regression test guarding node **description** persistence on save in the VS Code designer (V1 `DesignerCommandBar`).

This locks in the fix from #9447. Before that fix, the V1 command bar serialized a render-time Redux snapshot inside its save mutation. Because the command bar only re-renders on a small set of subscribed values (e.g. the dirty flag), a description added to a trigger/action **while the workflow was already dirty** did not trigger a re-render, so Save serialized stale state and the description was dropped from `workflow.json`. The test simulates exactly that scenario and asserts the posted `save` message carries the descriptions.

## Impact of Change
- **Users**: None — test-only change, no product behavior modified.
- **Developers**: Fails if `DesignerCommandBar` ever regresses to serializing a captured render-time snapshot instead of the latest store state at save time.
- **System**: None.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: `vitest run` DesignerCommandBar suite — 36 passed (36); `biome check` clean

## Contributors
@lambrianmsft

## Screenshots/Videos
N/A — no visual changes.