### PR TITLE
fix(vscode): exclude local-only settings from portal deploy

### DIFF
--- a/apps/vs-code-designer/src/app/commands/appSettings/__test__/uploadAppSettings.test.ts
+++ b/apps/vs-code-designer/src/app/commands/appSettings/__test__/uploadAppSettings.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import {
+  inlineCodeNodeExecutablePathKey,
+  workflowLocationKey,
+  workflowResourceGroupNameKey,
+  workflowSubscriptionIdKey,
+  workflowTenantIdKey,
+} from '../../../../constants';
+import { getLocalSettingsJson } from '../../../utils/appSettings/localSettings';
+import { getLocalSettingsFile } from '../getLocalSettingsFile';
+import { uploadAppSettings } from '../uploadAppSettings';
+import { confirmOverwriteSettings } from '@microsoft/vscode-azext-azureappservice';
+
+vi.mock('../../../../localize', () => ({
+  localize: (_key: string, defaultValue: string, ...args: unknown[]) =>
+    defaultValue.replace(/{(\d+)}/g, (_match, index) => String(args[Number(index)] ?? '')),
+}));
+
+vi.mock('../getLocalSettingsFile', () => ({
+  getLocalSettingsFile: vi.fn(),
+}));
+
+vi.mock('../../../utils/appSettings/localSettings', () => ({
+  getLocalSettingsJson: vi.fn(),
+}));
+
+vi.mock('@microsoft/vscode-azext-azureappservice', () => ({
+  // Mimic the real behavior: copy the (already filtered) source settings onto the target.
+  confirmOverwriteSettings: vi.fn(async (_context: unknown, source: Record<string, string>, target: Record<string, string>) => {
+    Object.assign(target, source);
+  }),
+}));
+
+vi.mock('@microsoft/vscode-azext-azureappsettings', () => ({
+  AppSettingsTreeItem: { contextValue: 'appSettings' },
+}));
+
+describe('uploadAppSettings', () => {
+  let context: any;
+  let updateApplicationSettings: Mock;
+  let node: any;
+
+  const portalSubscriptionId = 'real-portal-subscription-id';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context = { telemetry: { properties: {}, measurements: {} } };
+    (getLocalSettingsFile as Mock).mockResolvedValue('D:\\workspace\\LogicApp\\local.settings.json');
+
+    updateApplicationSettings = vi.fn();
+    const client = {
+      fullName: 'my-logic-app',
+      // Portal already has the correct platform-provided subscription id.
+      listApplicationSettings: vi.fn(async () => ({ properties: { [workflowSubscriptionIdKey]: portalSubscriptionId } })),
+      updateApplicationSettings,
+    };
+    node = { clientProvider: { createClient: vi.fn(async () => client) } };
+  });
+
+  const getUploadedProperties = (): Record<string, string> => updateApplicationSettings.mock.calls[0][0].properties;
+
+  it('excludes name-matched settings like the inline-code node executable path', async () => {
+    (getLocalSettingsJson as Mock).mockResolvedValue({
+      Values: {
+        FUNCTIONS_WORKER_RUNTIME: 'node',
+        [inlineCodeNodeExecutablePathKey]: 'C:\\Users\\dev\\.azurelogicapps\\dependencies\\NodeJs\\node.exe',
+      },
+    });
+
+    await uploadAppSettings(context, node, undefined, [inlineCodeNodeExecutablePathKey]);
+
+    const uploaded = getUploadedProperties();
+    expect(uploaded[inlineCodeNodeExecutablePathKey]).toBeUndefined();
+    expect(uploaded.FUNCTIONS_WORKER_RUNTIME).toBe('node');
+    expect(confirmOverwriteSettings).toHaveBeenCalled();
+  });
+
+  it('skips empty WORKFLOWS_* connector settings so they do not overwrite portal values', async () => {
+    (getLocalSettingsJson as Mock).mockResolvedValue({
+      Values: {
+        [workflowSubscriptionIdKey]: '',
+        [workflowTenantIdKey]: '',
+        [workflowResourceGroupNameKey]: '   ',
+        [workflowLocationKey]: '',
+        FUNCTIONS_WORKER_RUNTIME: 'node',
+      },
+    });
+
+    await uploadAppSettings(context, node, undefined, []);
+
+    const uploaded = getUploadedProperties();
+    // Empty local sentinels must not be uploaded...
+    expect(uploaded[workflowTenantIdKey]).toBeUndefined();
+    expect(uploaded[workflowResourceGroupNameKey]).toBeUndefined();
+    expect(uploaded[workflowLocationKey]).toBeUndefined();
+    // ...and the portal's real subscription id must be preserved.
+    expect(uploaded[workflowSubscriptionIdKey]).toBe(portalSubscriptionId);
+    expect(uploaded.FUNCTIONS_WORKER_RUNTIME).toBe('node');
+  });
+
+  it('uploads WORKFLOWS_* connector settings when they have real values', async () => {
+    (getLocalSettingsJson as Mock).mockResolvedValue({
+      Values: {
+        [workflowSubscriptionIdKey]: 'local-subscription-id',
+        [workflowTenantIdKey]: 'local-tenant-id',
+      },
+    });
+
+    await uploadAppSettings(context, node, undefined, []);
+
+    const uploaded = getUploadedProperties();
+    expect(uploaded[workflowSubscriptionIdKey]).toBe('local-subscription-id');
+    expect(uploaded[workflowTenantIdKey]).toBe('local-tenant-id');
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/appSettings/__test__/uploadAppSettings.test.ts
+++ b/apps/vs-code-designer/src/app/commands/appSettings/__test__/uploadAppSettings.test.ts
@@ -112,4 +112,35 @@ describe('uploadAppSettings', () => {
     expect(uploaded[workflowSubscriptionIdKey]).toBe('local-subscription-id');
     expect(uploaded[workflowTenantIdKey]).toBe('local-tenant-id');
   });
+
+  it('excludes settings matched by a RegExp exclusion without throwing', async () => {
+    (getLocalSettingsJson as Mock).mockResolvedValue({
+      Values: {
+        'SomeReference-connectionKey': 'secret',
+        FUNCTIONS_WORKER_RUNTIME: 'node',
+      },
+    });
+
+    // A RegExp exclusion must be handled directly; passing it into `new RegExp(regexp, 'i')` throws.
+    await expect(uploadAppSettings(context, node, undefined, [/-connectionKey$/])).resolves.not.toThrow();
+
+    const uploaded = getUploadedProperties();
+    expect(uploaded['SomeReference-connectionKey']).toBeUndefined();
+    expect(uploaded.FUNCTIONS_WORKER_RUNTIME).toBe('node');
+  });
+
+  it('matches RegExp exclusions case-insensitively', async () => {
+    (getLocalSettingsJson as Mock).mockResolvedValue({
+      Values: {
+        REMOTEDEBUGGINGVERSION: 'VS2022',
+        FUNCTIONS_WORKER_RUNTIME: 'node',
+      },
+    });
+
+    await uploadAppSettings(context, node, undefined, [/remotedebuggingversion/]);
+
+    const uploaded = getUploadedProperties();
+    expect(uploaded.REMOTEDEBUGGINGVERSION).toBeUndefined();
+    expect(uploaded.FUNCTIONS_WORKER_RUNTIME).toBe('node');
+  });
 });

--- a/apps/vs-code-designer/src/app/commands/appSettings/uploadAppSettings.ts
+++ b/apps/vs-code-designer/src/app/commands/appSettings/uploadAppSettings.ts
@@ -2,7 +2,14 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { localSettingsFileName, logicAppFilter } from '../../../constants';
+import {
+  localSettingsFileName,
+  logicAppFilter,
+  workflowLocationKey,
+  workflowResourceGroupNameKey,
+  workflowSubscriptionIdKey,
+  workflowTenantIdKey,
+} from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { getLocalSettingsJson } from '../../utils/appSettings/localSettings';
@@ -52,18 +59,26 @@ export async function uploadAppSettings(
       remoteSettings.properties = {};
     }
 
-    if (exclude) {
-      Object.keys(localSettings.Values).forEach((settingName) => {
-        if (
-          exclude.some((exclusion) =>
-            isString(exclusion) ? settingName.toLowerCase() === exclusion.toLowerCase() : settingName.match(new RegExp(exclusion, 'i'))
-          )
-        ) {
-          delete localSettings.Values?.[settingName];
-          excludedAppSettings.push(settingName);
-        }
-      });
-    }
+    // Azure connector settings hold an empty-string sentinel locally when Azure connectors are
+    // disabled (or the user cancels the sign-in wizard). Uploading the empty value would overwrite
+    // the correct platform-provided value in the portal and break managed-connection resolution,
+    // so skip these keys whenever their local value is empty.
+    const skipWhenEmptySettings = [workflowSubscriptionIdKey, workflowTenantIdKey, workflowResourceGroupNameKey, workflowLocationKey];
+
+    Object.keys(localSettings.Values).forEach((settingName) => {
+      const isExcludedByName =
+        exclude?.some((exclusion) =>
+          isString(exclusion) ? settingName.toLowerCase() === exclusion.toLowerCase() : settingName.match(new RegExp(exclusion, 'i'))
+        ) ?? false;
+      const isEmptyConnectorSetting =
+        skipWhenEmptySettings.some((key) => key.toLowerCase() === settingName.toLowerCase()) &&
+        (localSettings.Values?.[settingName] ?? '').trim() === '';
+
+      if (isExcludedByName || isEmptyConnectorSetting) {
+        delete localSettings.Values?.[settingName];
+        excludedAppSettings.push(settingName);
+      }
+    });
 
     ext.outputChannel.appendLog(localize('uploadingSettings', 'Uploading settings...'), { resourceName: client.fullName });
     await confirmOverwriteSettings(context, localSettings.Values, remoteSettings.properties, client.fullName);

--- a/apps/vs-code-designer/src/app/commands/appSettings/uploadAppSettings.ts
+++ b/apps/vs-code-designer/src/app/commands/appSettings/uploadAppSettings.ts
@@ -67,9 +67,16 @@ export async function uploadAppSettings(
 
     Object.keys(localSettings.Values).forEach((settingName) => {
       const isExcludedByName =
-        exclude?.some((exclusion) =>
-          isString(exclusion) ? settingName.toLowerCase() === exclusion.toLowerCase() : settingName.match(new RegExp(exclusion, 'i'))
-        ) ?? false;
+        exclude?.some((exclusion) => {
+          if (isString(exclusion)) {
+            return settingName.toLowerCase() === exclusion.toLowerCase();
+          }
+          // `exclusion` is already a RegExp. Passing a RegExp into `new RegExp(pattern, flags)`
+          // throws a TypeError, so reuse it directly and only re-create it to add the
+          // case-insensitive flag when it is missing.
+          const caseInsensitiveExclusion = exclusion.ignoreCase ? exclusion : new RegExp(exclusion.source, `${exclusion.flags}i`);
+          return caseInsensitiveExclusion.test(settingName);
+        }) ?? false;
       const isEmptyConnectorSetting =
         skipWhenEmptySettings.some((key) => key.toLowerCase() === settingName.toLowerCase()) &&
         (localSettings.Values?.[settingName] ?? '').trim() === '';

--- a/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
@@ -24,6 +24,7 @@ import {
   customDirectory,
   workflowAuthenticationMethodKey,
   ProjectDirectoryPathKey,
+  inlineCodeNodeExecutablePathKey,
 } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
@@ -95,6 +96,10 @@ async function deploy(
     ProjectDirectoryPathKey,
     workflowAuthenticationMethodKey,
     'REMOTEDEBUGGINGVERSION',
+    // Local-debug-only: absolute path to the local Node.js binary used by the inline-code
+    // language worker. Deploying it points the cloud worker at a non-existent local path,
+    // which hangs "Execute JavaScript Code" actions in a Running state indefinitely.
+    inlineCodeNodeExecutablePathKey,
   ];
   const deployPaths = await getDeployFsPath(actionContext, target);
   const context: IDeployContext = Object.assign(actionContext, deployPaths, { defaultAppSetting: 'defaultFunctionAppToDeploy' });


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
On deploy, `uploadAppSettings` pushes `local.settings.json` values to the portal. Some values are local-only and must not be deployed:

- **`languageWorkers__node__defaultExecutablePath`** — an absolute path to the developer's local Node.js binary, set during pre-debug (PR #9164) so the inline-code language worker resolves locally. In the cloud that path does not exist, so the Node worker never starts and **Execute JavaScript Code** actions hang in a **Running** state indefinitely (ADO #10109800). Added to the deploy `settingsToExclude` list.
- **Empty `WORKFLOWS_*` connector sentinels** (`WORKFLOWS_SUBSCRIPTION_ID`, `WORKFLOWS_TENANT_ID`, `WORKFLOWS_RESOURCE_GROUP_NAME`, `WORKFLOWS_LOCATION_NAME`) — empty locally when Azure connectors are disabled/cancelled. Azure sets correct values on provisioning, but uploading the empty sentinel overwrote them and broke managed-connection resolution. `uploadAppSettings` now skips these keys when empty; non-empty values still upload.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Deploying a project using the inline "Execute JavaScript Code" action (or with Azure connectors disabled locally) no longer breaks the workflow in the portal.
- **Developers**: `settingsToExclude` in `deploy.ts` gains the inline-code node path; `uploadAppSettings` gains value-aware skipping of empty `WORKFLOWS_*` settings.
- **System**: No architectural change; only narrows what is uploaded on deploy.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: VS Code Standard Logic App deploy; verified excluded settings do not appear in uploaded app settings

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft

## Screenshots/Videos
<!-- Visual changes only -->
N/A