### PR TITLE
fix(pipeline): route npm/pnpm restores through CFS in CI only (SFI SR21), keep public .npmrc for OSS

### DIFF
--- a/.azure-pipelines/templates/setup.yml
+++ b/.azure-pipelines/templates/setup.yml
@@ -5,11 +5,34 @@ steps:
       versionSpec: '24.x'
     condition: succeeded()
 
+  # SFI Network Isolation (SR21): route npm/pnpm restores through the internal CFS feed in CI
+  # only. The registry + auth are written to a file OUTSIDE the repo tree so the tracked .npmrc
+  # stays public (external `git clone && pnpm install` keeps working) and cannot be repointed by
+  # a PR to leak the injected token (cf. pnpm advisory GHSA-3qhv-2rgh-x77r).
+  - powershell: |
+      $ciNpmrc = Join-Path "$(Agent.TempDirectory)" "cfs.npmrc"
+      Set-Content -Path $ciNpmrc -Encoding ascii -Value @(
+        "registry=https://pkgs.dev.azure.com/msazure/one/_packaging/one_PublicPackages/npm/registry/",
+        "always-auth=true"
+      )
+      Write-Host "##vso[task.setvariable variable=CI_NPMRC]$ciNpmrc"
+    displayName: "Write CI-only CFS .npmrc"
+    condition: succeeded()
+
+  - task: NpmAuthenticate@0
+    displayName: "Authenticate with CFS npm feed"
+    inputs:
+      workingFile: $(CI_NPMRC)
+
   - script: npm install -g pnpm
     displayName: "Install pnpm"
+    env:
+      npm_config_userconfig: $(CI_NPMRC)
     condition: succeeded()
 
   - script: pnpm install --frozen-lockfile --strict-peer-dependencies --recursive
     displayName: "Install Dependencies with pnpm"
     workingDirectory: $(working_directory)
+    env:
+      npm_config_userconfig: $(CI_NPMRC)
     condition: succeeded()

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,8 @@
+# Public defaults so external `git clone && pnpm install` works without Microsoft-internal access.
+# SFI Network Isolation (SR21): the internal CFS registry + auth are injected at CI build time
+# only (see .azure-pipelines/templates/setup.yml), never committed here. Keeping the internal
+# feed out of the tracked .npmrc prevents credential exfiltration via fork PRs that could
+# repoint the registry (cf. pnpm advisory GHSA-3qhv-2rgh-x77r).
 auto-install-peers=true
 resolution-mode=highest
 ignore-workspace-root-check=true


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Route npm/pnpm package restores through Microsoft's Central Feed Service (CFS) for **SFI Network Isolation** compliance (AzRel Red Flag MountainPass SR21, IcM #839785749; deadline Aug 21, 2026) — **without breaking the open-source contributor flow**.

The internal CFS registry and its authentication are injected **at CI build time only**, in the official release pipeline (`1esmain.yml` → `templates/setup.yml`), via a `.npmrc` written **outside the repo tree** and consumed through `npm_config_userconfig`. The tracked root `.npmrc` keeps public defaults, so external `git clone && pnpm install` continues to work with no Microsoft-internal access.

### Why not commit the CFS registry to the tracked `.npmrc`
- A tracked root `.npmrc` is auto-loaded by **every** `pnpm install`, so committing the internal feed there makes external contributors and downstream consumers fail with **401** (they have no `msazure` ADO access) — this is a public repository.
- Committing `registry=<internal feed>` + `always-auth=true` alongside a pipeline that injects a live token is a **credential-exfiltration vector**: a change that repoints the registry can cause the injected token to be sent to another host during `install`. This is the class of issue pnpm hardened against in advisory **GHSA-3qhv-2rgh-x77r** (pnpm now ignores registry/credentials in a committed project `.npmrc`).

### Additional correctness fixes
- Preserve the existing pnpm settings (`auto-install-peers`, `resolution-mode`, `ignore-workspace-root-check`).
- Apply the registry override to the **actual `pnpm install --frozen-lockfile` step**, not only the `pnpm` bootstrap.
- No blanket `ignore-scripts=true` (would silently disable husky git hooks and native build scripts such as esbuild/playwright).

## Impact of Change
- **Users**: None — build pipeline change only.
- **Developers**: Local dev and external contributors are unaffected; the tracked `.npmrc` keeps public defaults. CI restores now flow through the CFS-backed feed (which mirrors npmjs.com via upstream sources).
- **System**: `setup.yml` writes a CI-only `.npmrc` to `$(Agent.TempDirectory)`, authenticates it with `NpmAuthenticate@0`, and points npm/pnpm at it via `npm_config_userconfig`.

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Validated on the official release pipeline; change is additive (CI-only auth + registry config). Confirm the CFS feed resolves the pinned `pnpm@9.1.3` and all lockfile tarballs under `--frozen-lockfile`.

## Open Question for SFI/CFS Owners
Is CI-only routing sufficient for the SR21 compliance signal, or is a committed repo-default registry required? For a **public** repo, the committed default must remain public; if a committed `registry=` line is mandated by the CFS adoption tooling, it should point at the public npm registry with CI layering the CFS override on top.

## Contributors
