### PR TITLE
fix(ci): validate large-diff PRs via stdin (avoids E2BIG in pr-ai-validation)

### DIFF
--- a/.github/workflows/pr-ai-validation.yml
+++ b/.github/workflows/pr-ai-validation.yml
@@ -4,6 +4,11 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, labeled, unlabeled]
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to validate (manual runs only)'
+        required: false
+        type: string
 
 permissions:
   pull-requests: write
@@ -15,6 +20,9 @@ jobs:
   validate-pr:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+      COPILOT_CLI_VERSION: 1.0.72-0
     steps:
       - name: Check if contributor is trusted
         uses: actions/github-script@v8
@@ -57,16 +65,50 @@ jobs:
         with:
           sparse-checkout: prompts/copilot-pr-desc-check.md
 
+      - name: Cache Copilot CLI download
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: copilot-cli-${{ runner.os }}-${{ env.COPILOT_CLI_VERSION }}
+
       - name: Install Copilot CLI
-        run: npm install -g @github/copilot@latest
+        shell: bash
+        run: |
+          # @github/copilot is a thin loader; the real CLI is a large platform-native binary shipped as
+          # an optionalDependency. npm's optional-dep install is best-effort, so a transient registry/network
+          # blip can leave the binary missing/incomplete while npm still exits 0. Harden the install so a
+          # broken CLI is caught here rather than mid-validation:
+          #   - pin the version (reproducible; the ~/.npm cache above serves it offline on the happy path);
+          #   - retry the install and verify the binary actually runs (copilot --version) before proceeding;
+          #   - clear the npm cache between retries so a poisoned/partial artifact is not reused.
+          # (The oversized-prompt exit 126 is handled separately in the validation step via stdin.)
+          install_ok=0
+          for attempt in 1 2 3; do
+            if npm install -g "@github/copilot@${COPILOT_CLI_VERSION}" && copilot --version >/dev/null 2>&1; then
+              install_ok=1; break
+            fi
+            echo "::warning::Copilot CLI install/verify attempt ${attempt} failed; clearing cache and retrying..."
+            npm cache clean --force >/dev/null 2>&1 || true
+            sleep $((attempt * 5))
+          done
+          if [ "$install_ok" != "1" ]; then
+            echo "::warning::Copilot CLI could not be verified after 3 attempts; validation will fall back."
+          fi
 
       - name: Gather PR data
         id: gather
         uses: actions/github-script@v8
         with:
           script: |
-            const pr = context.payload.pull_request;
             const fs = require('fs');
+            let pr = context.payload.pull_request;
+            if (!pr) {
+              const num = Number(process.env.PR_NUMBER);
+              if (!num) { core.setFailed('No pull_request context and no pr_number input provided.'); return; }
+              pr = (await github.rest.pulls.get({
+                owner: context.repo.owner, repo: context.repo.repo, pull_number: num
+              })).data;
+            }
             const prData = {
               number: pr.number,
               title: pr.title,
@@ -116,19 +158,29 @@ jobs:
           MODELS="${COPILOT_MODELS:-claude-opus-4.8 claude-opus-4.6 gpt-5-mini}"
           RESULT=""; CLI_EXIT=1
           for MODEL in $MODELS; do
-            RESULT=$(timeout 90 copilot --yolo \
-              -p "$(cat /tmp/full-prompt.txt)" \
-              --model "$MODEL" 2>&1)
-            CLI_EXIT=$?
-            [ $CLI_EXIT -eq 0 ] && [ -n "$RESULT" ] && break
-            echo "::warning::Copilot model $MODEL failed (exit $CLI_EXIT) — trying next"
-            RESULT=""; CLI_EXIT=1
+            for try in 1 2; do
+              # Pass the prompt via stdin, NOT as a `-p "$(...)"` argv. On Linux a single argument is
+              # capped at MAX_ARG_STRLEN (128 KB); large-diff PRs push the combined prompt past that,
+              # making execve fail with E2BIG which surfaces as an instant exit 126 with no output.
+              # stdin has no such limit, so this validates PRs of any diff size.
+              RESULT=$(timeout 90 copilot --yolo \
+                --model "$MODEL" < /tmp/full-prompt.txt 2>&1)
+              CLI_EXIT=$?
+              if [ $CLI_EXIT -eq 0 ] && [ -n "$RESULT" ]; then break 2; fi
+              echo "::warning::Copilot model $MODEL attempt $try failed (exit $CLI_EXIT)"
+              # 126/127 = binary could not be executed (transient install/exec flake) — brief backoff and retry.
+              # Any other non-zero exit is deterministic for this model, so move on to the next one.
+              if [ $CLI_EXIT -eq 126 ] || [ $CLI_EXIT -eq 127 ]; then sleep 5; else break; fi
+            done
           done
           set -e
 
           if [ $CLI_EXIT -ne 0 ] || [ -z "$RESULT" ]; then
             echo "cli_success=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Copilot CLI exit $CLI_EXIT — using fallback"
+            echo "::warning::Copilot CLI unavailable (last exit $CLI_EXIT) — using fallback"
+            echo "----- Copilot CLI output (tail, for debugging) -----"
+            printf '%s\n' "$RESULT" | tail -n 25
+            echo "----------------------------------------------------"
           else
             echo "$RESULT" | python3 -c "
           import sys, json
@@ -156,7 +208,7 @@ jobs:
           LOGIC_APP_URL: ${{ vars.PR_VALIDATION_LOGIC_APP_URL }}
         with:
           script: |
-            const pr_number = context.payload.pull_request.number;
+            const pr_number = Number(process.env.PR_NUMBER);
             if (!process.env.LOGIC_APP_URL) {
               console.log('No Logic App URL configured either. Skipping validation.');
               return;
@@ -168,20 +220,19 @@ jobs:
                 body: JSON.stringify({ pr_id: pr_number })
               });
               if (!response.ok) {
-                if (response.status === 502) { console.log('Logic App Bad Gateway. Skipping.'); return; }
-                throw new Error(`API request failed with status ${response.status}`);
+                // Validator infrastructure is unavailable (e.g. 502/503/504). Validation could not run,
+                // which is not a defect in the PR — do not block it and do not post a false failure.
+                // The check fails only on an actual negative verdict (see "Post result and manage labels").
+                console.log(`Logic App unavailable (status ${response.status}). Skipping validation (non-blocking).`);
+                return;
               }
               const result = await response.json();
               const fs = require('fs');
               fs.writeFileSync('/tmp/validation-result.json', JSON.stringify(result));
             } catch (error) {
-              console.error('Fallback failed:', error.message);
-              await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: pr_number,
-                body: `## ❌ PR Validation Error\n\nBoth Copilot CLI and Logic App fallback failed.\n\nError: ${error.message}`
-              });
-              core.setFailed(`Validation error: ${error.message}`);
+              // Network error reaching the fallback — infrastructure unavailable, not a PR problem. Skip, don't block.
+              console.log(`Logic App fallback unreachable: ${error.message}. Skipping validation (non-blocking).`);
+              return;
             }
 
       - name: Post result and manage labels
@@ -192,7 +243,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const pr_number = context.payload.pull_request?.number;
+            const pr_number = Number(process.env.PR_NUMBER);
             if (!pr_number) return;
 
             const botCommentIdentifier = '## 🤖 AI PR Validation Report';


### PR DESCRIPTION
## Commit Type
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

The `pr-ai-validation` gate silently fails to validate large-diff PRs.

It builds the validation prompt (system prompt + PR metadata + `head -2000` of the diff) and passes it to the Copilot CLI as a single `-p "$(...)"` command-line argument. On Linux a single argv entry is capped at `MAX_ARG_STRLEN` (128 KB) regardless of the much larger total `ARG_MAX`. PRs with large generated diffs push the prompt past 128 KB, so `execve` fails with **E2BIG**, which surfaces as an immediate **exit 126 with empty output** on every run — deterministically, not intermittently. `copilot --version` still works (tiny args), which masks the cause and makes it look flaky. The gate then falls back to the Logic App and, on a gateway error, either skips to a vacuous green (502) or throws a red error (504) — so large PRs are never actually validated.

This passes the prompt via **stdin** (`copilot --yolo --model X < /tmp/full-prompt.txt`), which has no per-argument size limit, so the CLI validates PRs of any diff size. It also hardens the surrounding step: a uniform non-blocking skip on any infra-unavailable outcome (removing the 502/504 asymmetry), a pinned + cached CLI install with verify-and-retry, and a `workflow_dispatch` `pr_number` input for manual validation.

## Impact of Change
- **Users**: None — CI-only change, no product code.
- **Developers**: The PR-description gate now validates PRs of any size instead of failing on large diffs; infra outages produce a non-blocking skip rather than a spurious red.
- **System**: `pr-ai-validation.yml` delivers the prompt via stdin, uses a uniform fallback, and pins/caches the Copilot CLI install.

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: verified locally that a 150 KB prompt via stdin runs cleanly (exit 0) while the same content via `-p` argv triggers E2BIG on Linux; verified via `workflow_dispatch` that the CLI validates a full large diff end-to-end.

CI/workflow config only; no product code, so unit/E2E tests are not applicable.

## Contributors

## Screenshots/Videos
Not applicable — no UI changes.
