### PR TITLE
perf(vscode): stop 15s extension-host freeze from telemetry masking

### DIFF
--- a/apps/vs-code-designer/src/app/utils/__test__/telemetry.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/telemetry.test.ts
@@ -63,4 +63,34 @@ describe('logSubscriptions', () => {
       { subscriptionId: 'sub2', tenantId: 'tenant2', isCustomCloud: false },
     ]);
   });
+
+  // Regression guard: vscode-azext-utils masks telemetry properties with \S+ / \S* regexes,
+  // which backtrack quadratically over a payload containing no whitespace. A compact
+  // JSON.stringify of a large subscription list is one giant \S+ token and cost ~15s of
+  // synchronous extension-host CPU. The invariant that prevents this is not "is it indented"
+  // (cosmetic) but "is every unbroken non-whitespace run short" (the actual cause).
+  test('should not emit long whitespace-free runs for a large subscription list', async () => {
+    const mockSubscriptions = Array.from({ length: 650 }, (_, i) => ({
+      subscriptionId: `00000000-aaaa-bbbb-cccc-${String(i).padStart(12, '0')}`,
+      tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+      isCustomCloud: false,
+    }));
+    ext.subscriptionProvider = {
+      isSignedIn: vi.fn().mockResolvedValue(true),
+      getSubscriptions: vi.fn().mockResolvedValue(mockSubscriptions),
+    } as any;
+    const context = {
+      telemetry: { measurements: {} as Record<string, number>, properties: {} },
+    } as any;
+
+    await logSubscriptions(context);
+    const serialized: string = context.telemetry.properties.subscriptions;
+
+    // No data may be lost or reshaped by the formatting change.
+    expect(JSON.parse(serialized)).toEqual(mockSubscriptions);
+
+    // Every whitespace-delimited token must stay short so masking remains linear.
+    const longestRun = serialized.split(/\s/).reduce((max, token) => Math.max(max, token.length), 0);
+    expect(longestRun).toBeLessThan(200);
+  });
 });

--- a/apps/vs-code-designer/src/app/utils/telemetry.ts
+++ b/apps/vs-code-designer/src/app/utils/telemetry.ts
@@ -48,7 +48,14 @@ export const logSubscriptions = async (context: IActionContext) => {
     const errorMessage = error instanceof Error ? error.message : isString(error) ? error : 'Unknown error';
     context.telemetry.properties.logSubscriptionsError = errorMessage;
   }
-  context.telemetry.properties.subscriptions = JSON.stringify(azureSubscriptions);
+  // NOTE: pretty-print (indent 1) is deliberate and load-bearing, not cosmetic.
+  // vscode-azext-utils masks every telemetry property with regexes built on \S+ / \S*.
+  // Compact JSON.stringify emits zero whitespace, so the whole payload is a single
+  // \S+ token and masking backtracks quadratically: ~650 subscriptions (~85KB) burned
+  // ~15s of synchronous CPU on the extension host, tripping VS Code's unresponsive
+  // detector and stalling every other extension. Indenting breaks the payload into
+  // short whitespace-delimited runs, making masking linear (~6ms) with identical data.
+  context.telemetry.properties.subscriptions = JSON.stringify(azureSubscriptions, null, 1);
 };
 
 export const logExtensionSettings = (context: IActionContext) => {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [x] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

Fixes a **~15 second synchronous freeze of the VS Code extension host** on activation, which trips VS Code's "unresponsive extension" detection and stalls every other extension in the window.

### Root cause

`logSubscriptions` serialized the full Azure subscription list with a compact `JSON.stringify`:

```ts
context.telemetry.properties.subscriptions = JSON.stringify(azureSubscriptions);
```

`vscode-azext-utils` masks **every** telemetry property before sending it, using regexes built on `\S+` / `\S*` (email, URL, and key patterns). Compact `JSON.stringify` emits **no whitespace**, so the entire payload is a single `\S+` token and the masker backtracks over it **quadratically**.

### Evidence

Captured a V8 CPU profile from a real extension host (`Developer: Show Running Extensions` reported the extension as Unresponsive):

| Frame | Self time | % of profile |
|---|---|---|
| **`maskUserInfo`** | **15,502ms** | **50.9%** |
| our bundle/dependency code | ~150ms | ~0.5% |

Reproduced independently. Cost is quadratic in payload length:

| Subscriptions | Compact | Indented (`null, 1`) | Speedup |
|---|---|---|---|
| 100 (13KB) | 324ms | 1.8ms | 184× |
| 400 (52KB) | 5,030ms | 3.6ms | 1400× |
| **650 (84.5KB)** | **13,138ms** | **5.7ms** | **2295×** |
| 1000 (130KB) | 32,567ms | 8.8ms | 3693× |

Compact quadruples per doubling of size; indented is linear.

### Fix

Serialize with `JSON.stringify(value, null, 1)`. Indentation breaks the payload into short whitespace-delimited runs, so masking stays linear.

**The telemetry schema does not change.** Whitespace is insignificant to every JSON parser (including Kusto `parse_json`); the round-trip was verified byte-identical at every size tested. No downstream query or dashboard is affected.

Worth noting: on this code path masking is a **no-op** anyway — the GUID-redacting regex only runs on the aggressive path used for `error`/`exception` keys, so subscription IDs were passing through unmodified. The 15.4s bought no privacy benefit.

### Why this surfaced now

`properties.subscriptions` was added in #6855 (2025-03-24), but was set from an **unawaited** call on an already-dispatched action context, so the property never actually shipped — dead code costing nothing. #8858 (2026-07-01, "fix unawaited log subscriptions") correctly rewrapped it in its own awaited `callWithTelemetryAndErrorHandling` action, arming a dormant landmine.

It only reproduces when all three hold: signed in (otherwise the payload is `[]`), **many** subscriptions (quadratic — 100 is an invisible 0.3s, ~300 crosses VS Code's ~3s unresponsive threshold, 650 is ~15s), and a build from #8858 onward. That is why CI and E2E never caught it.

An upstream issue will be filed against `vscode-azext-utils` — the quadratic masking affects every extension using `callWithTelemetryAndErrorHandling`.

## Impact of Change

- **Users**: Extension host no longer freezes for ~15s on activation for accounts with many Azure subscriptions; the "Azure Logic Apps (Standard) is unresponsive / prevented other extensions from running" warning is resolved. Other extensions in the window are no longer starved.
- **Developers**: None. One-line serialization change, no API change.
- **System**: Telemetry payload is ~12% larger in bytes (whitespace) but ~2295× cheaper to process. Content is unchanged and parses identically — no telemetry pipeline or dashboard changes required.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: local VS Code extension host (Windows), signed in to an account with a large subscription list

**Unit tests** — `apps/vs-code-designer/src/app/utils/__test__/telemetry.test.ts` (5 passing):
- Added a regression guard asserting no unbroken non-whitespace run exceeds 200 chars for a 650-subscription payload, plus a round-trip equality assertion so the formatting change cannot silently drop or reshape data.
- The guard encodes the *actual* cause rather than the cosmetic symptom, and was **verified to fail on the pre-fix code** (`expected 84501 to be less than 200` — confirming the whole 84.5KB payload was one token).
- The two pre-existing `logSubscriptions` assertions pass **unchanged on both versions**, independently confirming the schema is unaffected.

**Manual verification** — `Developer: Show Running Extensions`, same machine and account, with `logSubscriptions` fully enabled before and after:

| | Before | After |
|---|---|---|
| Logic Apps activation | 1363ms | 1439ms |
| Logic Apps profile | **5516.07ms** | none captured |
| Logic Apps status | ⚠️ Unresponsive | clean |

A fresh CPU profile after the fix shows `maskUserInfo` absent entirely; extension code totals ~440ms (1.4%).

Independent corroboration — unrelated extensions in the same window recovered on their own once the main thread was no longer held:

| Extension | Before | After |
|---|---|---|
| Azure Functions | ⚠️ Unresponsive, 3646ms | 943ms, clean |
| C# | 3962ms | 474ms |
| Azure Resources | 2510ms | 342ms |

Also validated: `npx biome check --write` clean; `npx tsup --config tsup.config.ts` reports 40 errors in 9 files, exactly the pre-existing baseline on `main` (0 new; neither changed file appears).

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
