### PR TITLE
fix(designer): skip listKeys for Managed Identity agent connections

### DIFF
--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/__test__/openAIConnector.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/__test__/openAIConnector.spec.tsx
@@ -181,6 +181,15 @@ const defaultProps: ConnectionParameterProps = {
   },
   setKeyValue: vi.fn(),
   operationParameterValues: { agentModelType: 'AzureOpenAI' },
+  parameterSet: {
+    name: 'Key',
+    parameters: {
+      cognitiveServiceAccountId: { type: 'string' },
+      openAIEndpoint: { type: 'string' },
+      openAIKey: { type: 'securestring' },
+    },
+    uiDefinition: { displayName: 'URL and key-based authentication' },
+  } as any,
 };
 
 const wrapper = ({ children }: { children: React.ReactNode }) => <IntlProvider locale="en">{children}</IntlProvider>;
@@ -355,6 +364,36 @@ describe('CustomOpenAIConnector', () => {
 
       // Verify the service was called
       expect(mockFetchAccountKeysById).toHaveBeenCalledWith(accountId);
+    });
+
+    it('does NOT fetch account keys (listKeys) when Managed Identity auth is selected', async () => {
+      mockFetchAccountById.mockResolvedValue({ properties: { endpoint: 'https://openai1.openai.azure.com/' } });
+      mockFetchAccountKeysById.mockResolvedValue({ key1: 'test-key-123' });
+
+      // Managed Identity auth set omits the `openAIKey` parameter, so no key fetch should occur.
+      const managedIdentityParameterSet = {
+        name: 'ManagedServiceIdentity',
+        parameters: {
+          cognitiveServiceAccountId: { type: 'string' },
+          openAIEndpoint: { type: 'string' },
+        },
+        uiDefinition: { displayName: 'Managed Service Identity' },
+      } as any;
+
+      const setKeyValue = vi.fn();
+      render(<CustomOpenAIConnector {...defaultProps} parameterSet={managedIdentityParameterSet} setKeyValue={setKeyValue} />, { wrapper });
+
+      const accountId = '/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.CognitiveServices/accounts/openai1';
+      await act(async () => {
+        capturedOnOptionSelect['openai-combobox']?.({}, { optionValue: accountId });
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      // Endpoint is still populated, but the key (listKeys) call must not be made.
+      expect(mockFetchAccountById).toHaveBeenCalledWith(accountId);
+      expect(setKeyValue).toHaveBeenCalledWith('openAIEndpoint', 'https://openai1.openai.azure.com/');
+      expect(mockFetchAccountKeysById).not.toHaveBeenCalled();
+      expect(setKeyValue).not.toHaveBeenCalledWith('openAIKey', expect.anything());
     });
 
     it('shows "Create new" link', () => {

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/__test__/openAIConnector.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/__test__/openAIConnector.spec.tsx
@@ -396,6 +396,23 @@ describe('CustomOpenAIConnector', () => {
       expect(setKeyValue).not.toHaveBeenCalledWith('openAIKey', expect.anything());
     });
 
+    it('still fetches account keys when no auth parameter set is provided (conservative fallback)', async () => {
+      mockFetchAccountById.mockResolvedValue({ properties: { endpoint: 'https://openai1.openai.azure.com/' } });
+      mockFetchAccountKeysById.mockResolvedValue({ key1: 'test-key-123' });
+
+      const setKeyValue = vi.fn();
+      render(<CustomOpenAIConnector {...defaultProps} parameterSet={undefined} setKeyValue={setKeyValue} />, { wrapper });
+
+      const accountId = '/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.CognitiveServices/accounts/openai1';
+      await act(async () => {
+        capturedOnOptionSelect['openai-combobox']?.({}, { optionValue: accountId });
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      // Without a known auth set we cannot tell it is keyless, so preserve the legacy fetch.
+      expect(mockFetchAccountKeysById).toHaveBeenCalledWith(accountId);
+    });
+
     it('shows "Create new" link', () => {
       render(<CustomOpenAIConnector {...defaultProps} />, { wrapper });
 

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/openAIConnector.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/openAIConnector.tsx
@@ -236,8 +236,8 @@ export const CustomOpenAIConnector = (props: ConnectionParameterProps) => {
       } catch (e: any) {
         LoggerService().log({
           level: LogEntryLevel.Error,
-          area: 'agent-connection-account-key',
-          message: 'Failed to fetch account key for cognitive service',
+          area: 'agent-connection-account-endpoint',
+          message: 'Failed to fetch account endpoint for cognitive service',
           error: e,
         });
         setErrorMessage(e.message ?? 'Failed to fetch account endpoint');
@@ -306,7 +306,9 @@ export const CustomOpenAIConnector = (props: ConnectionParameterProps) => {
   // The API key is only relevant to URL/key-based auth. Managed Identity (and other keyless
   // auth types) omit the `openAIKey` parameter, so fetching account keys (listKeys) for them
   // is unnecessary. Gate the key fetch on the selected auth set actually declaring `openAIKey`.
-  const authRequiresAccountKey = useMemo(() => !!parameterSet?.parameters?.['openAIKey'], [parameterSet]);
+  // When no auth set is available yet (undefined), fall back to the pre-existing fetch behavior
+  // so a key-based flow can never silently lose its auto-filled key.
+  const authRequiresAccountKey = useMemo(() => parameterSet == null || !!parameterSet.parameters?.['openAIKey'], [parameterSet]);
 
   const onSetOpenAIValues = useCallback(
     async (newValue: string) => {

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/openAIConnector.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/custom/openAIConnector.tsx
@@ -32,7 +32,7 @@ import constants from '../../../../../common/constants';
 const RefreshIcon = bundleIcon(ArrowClockwise16Regular, ArrowClockwise16Filled);
 
 export const CustomOpenAIConnector = (props: ConnectionParameterProps) => {
-  const { parameterKey, setKeyValue, setValue, parameter, operationParameterValues, parameterValues, value } = props;
+  const { parameterKey, setKeyValue, setValue, parameter, operationParameterValues, parameterValues, value, parameterSet } = props;
   const intl = useIntl();
   const styles = useStyles();
   const [parameterValue, setParameterValue] = useState<string>('');
@@ -303,13 +303,22 @@ export const CustomOpenAIConnector = (props: ConnectionParameterProps) => {
     refetchAPIManagementAccounts();
   }, [refetchAPIManagementAccounts]);
 
+  // The API key is only relevant to URL/key-based auth. Managed Identity (and other keyless
+  // auth types) omit the `openAIKey` parameter, so fetching account keys (listKeys) for them
+  // is unnecessary. Gate the key fetch on the selected auth set actually declaring `openAIKey`.
+  const authRequiresAccountKey = useMemo(() => !!parameterSet?.parameters?.['openAIKey'], [parameterSet]);
+
   const onSetOpenAIValues = useCallback(
     async (newValue: string) => {
       setLoadingAccountDetails(true);
-      await Promise.all([setAPIEndpoint(newValue), setAPIKey(newValue)]);
+      const tasks = [setAPIEndpoint(newValue)];
+      if (authRequiresAccountKey) {
+        tasks.push(setAPIKey(newValue));
+      }
+      await Promise.all(tasks);
       setLoadingAccountDetails(false);
     },
-    [setAPIEndpoint, setAPIKey]
+    [setAPIEndpoint, setAPIKey, authRequiresAccountKey]
   );
 
   const roleResourceId = useMemo(() => {

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/__test__/openAIConnector.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/__test__/openAIConnector.spec.tsx
@@ -404,6 +404,23 @@ describe('CustomOpenAIConnector', () => {
       expect(setKeyValue).not.toHaveBeenCalledWith('openAIKey', expect.anything());
     });
 
+    it('still fetches account keys when no auth parameter set is provided (conservative fallback)', async () => {
+      mockFetchAccountById.mockResolvedValue({ properties: { endpoint: 'https://openai1.openai.azure.com/' } });
+      mockFetchAccountKeysById.mockResolvedValue({ key1: 'test-key-123' });
+
+      const setKeyValue = vi.fn();
+      render(<CustomOpenAIConnector {...defaultProps} parameterSet={undefined} setKeyValue={setKeyValue} />, { wrapper });
+
+      const accountId = '/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.CognitiveServices/accounts/openai1';
+      await act(async () => {
+        capturedOnOptionSelect['openai-combobox']?.({}, { optionValue: accountId });
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      // Without a known auth set we cannot tell it is keyless, so preserve the legacy fetch.
+      expect(mockFetchAccountKeysById).toHaveBeenCalledWith(accountId);
+    });
+
     it('shows "Create new" link', () => {
       render(<CustomOpenAIConnector {...defaultProps} />, { wrapper });
 

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/__test__/openAIConnector.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/__test__/openAIConnector.spec.tsx
@@ -189,6 +189,15 @@ const defaultProps: ConnectionParameterProps = {
   },
   setKeyValue: vi.fn(),
   operationParameterValues: { agentModelType: 'AzureOpenAI' },
+  parameterSet: {
+    name: 'Key',
+    parameters: {
+      cognitiveServiceAccountId: { type: 'string' },
+      openAIEndpoint: { type: 'string' },
+      openAIKey: { type: 'securestring' },
+    },
+    uiDefinition: { displayName: 'URL and key-based authentication' },
+  } as any,
 };
 
 const wrapper = ({ children }: { children: React.ReactNode }) => <IntlProvider locale="en">{children}</IntlProvider>;
@@ -363,6 +372,36 @@ describe('CustomOpenAIConnector', () => {
 
       // Verify the service was called
       expect(mockFetchAccountKeysById).toHaveBeenCalledWith(accountId);
+    });
+
+    it('does NOT fetch account keys (listKeys) when Managed Identity auth is selected', async () => {
+      mockFetchAccountById.mockResolvedValue({ properties: { endpoint: 'https://openai1.openai.azure.com/' } });
+      mockFetchAccountKeysById.mockResolvedValue({ key1: 'test-key-123' });
+
+      // Managed Identity auth set omits the `openAIKey` parameter, so no key fetch should occur.
+      const managedIdentityParameterSet = {
+        name: 'ManagedServiceIdentity',
+        parameters: {
+          cognitiveServiceAccountId: { type: 'string' },
+          openAIEndpoint: { type: 'string' },
+        },
+        uiDefinition: { displayName: 'Managed Service Identity' },
+      } as any;
+
+      const setKeyValue = vi.fn();
+      render(<CustomOpenAIConnector {...defaultProps} parameterSet={managedIdentityParameterSet} setKeyValue={setKeyValue} />, { wrapper });
+
+      const accountId = '/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.CognitiveServices/accounts/openai1';
+      await act(async () => {
+        capturedOnOptionSelect['openai-combobox']?.({}, { optionValue: accountId });
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      // Endpoint is still populated, but the key (listKeys) call must not be made.
+      expect(mockFetchAccountById).toHaveBeenCalledWith(accountId);
+      expect(setKeyValue).toHaveBeenCalledWith('openAIEndpoint', 'https://openai1.openai.azure.com/');
+      expect(mockFetchAccountKeysById).not.toHaveBeenCalled();
+      expect(setKeyValue).not.toHaveBeenCalledWith('openAIKey', expect.anything());
     });
 
     it('shows "Create new" link', () => {

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/openAIConnector.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/openAIConnector.tsx
@@ -249,8 +249,8 @@ export const CustomOpenAIConnector = (props: ConnectionParameterProps) => {
       } catch (e: any) {
         LoggerService().log({
           level: LogEntryLevel.Error,
-          area: 'agent-connection-account-key',
-          message: 'Failed to fetch account key for cognitive service',
+          area: 'agent-connection-account-endpoint',
+          message: 'Failed to fetch account endpoint for cognitive service',
           error: e,
         });
         setErrorMessage(e.message ?? 'Failed to fetch account endpoint');
@@ -319,7 +319,9 @@ export const CustomOpenAIConnector = (props: ConnectionParameterProps) => {
   // The API key is only relevant to URL/key-based auth. Managed Identity (and other keyless
   // auth types) omit the `openAIKey` parameter, so fetching account keys (listKeys) for them
   // is unnecessary. Gate the key fetch on the selected auth set actually declaring `openAIKey`.
-  const authRequiresAccountKey = useMemo(() => !!parameterSet?.parameters?.['openAIKey'], [parameterSet]);
+  // When no auth set is available yet (undefined), fall back to the pre-existing fetch behavior
+  // so a key-based flow can never silently lose its auto-filled key.
+  const authRequiresAccountKey = useMemo(() => parameterSet == null || !!parameterSet.parameters?.['openAIKey'], [parameterSet]);
 
   const onSetOpenAIValues = useCallback(
     async (newValue: string) => {

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/openAIConnector.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/createConnection/custom/openAIConnector.tsx
@@ -33,8 +33,18 @@ import { getSubscriptionFromResource } from './cosmosConnector';
 const RefreshIcon = bundleIcon(ArrowClockwise16Regular, ArrowClockwise16Filled);
 
 export const CustomOpenAIConnector = (props: ConnectionParameterProps) => {
-  const { parameterKey, setKeyValue, setValue, parameter, operationParameterValues, parameterValues, value, cssOverrides, styleOverrides } =
-    props;
+  const {
+    parameterKey,
+    setKeyValue,
+    setValue,
+    parameter,
+    operationParameterValues,
+    parameterValues,
+    value,
+    parameterSet,
+    cssOverrides,
+    styleOverrides,
+  } = props;
   const intl = useIntl();
   const styles = useStyles();
   const [parameterValue, setParameterValue] = useState<string>(value ?? '');
@@ -306,13 +316,22 @@ export const CustomOpenAIConnector = (props: ConnectionParameterProps) => {
     refetchAPIManagementAccounts();
   }, [refetchAPIManagementAccounts]);
 
+  // The API key is only relevant to URL/key-based auth. Managed Identity (and other keyless
+  // auth types) omit the `openAIKey` parameter, so fetching account keys (listKeys) for them
+  // is unnecessary. Gate the key fetch on the selected auth set actually declaring `openAIKey`.
+  const authRequiresAccountKey = useMemo(() => !!parameterSet?.parameters?.['openAIKey'], [parameterSet]);
+
   const onSetOpenAIValues = useCallback(
     async (newValue: string) => {
       setLoadingAccountDetails(true);
-      await Promise.all([setAPIEndpoint(newValue), setAPIKey(newValue)]);
+      const tasks = [setAPIEndpoint(newValue)];
+      if (authRequiresAccountKey) {
+        tasks.push(setAPIKey(newValue));
+      }
+      await Promise.all(tasks);
       setLoadingAccountDetails(false);
     },
-    [setAPIEndpoint, setAPIKey]
+    [setAPIEndpoint, setAPIKey, authRequiresAccountKey]
   );
 
   const roleResourceId = useMemo(() => {


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why

When creating an **Agent / Azure OpenAI connection**, selecting a Cognitive Services account in the resource picker unconditionally fetched **both** the account endpoint **and** its account keys (`listKeys`) — regardless of the selected authentication type.

For **Managed Identity** auth there is no API key to populate (the MI auth set has no `openAIKey` parameter), so the `listKeys` call is pointless. A customer reported it firing on **every** MI connection create:

> "list keys call is still made each time you want to create a MI connection"

### Root cause

`onSetOpenAIValues` (the account-selection handler in `openAIConnector.tsx`) always ran `Promise.all([setAPIEndpoint(...), setAPIKey(...)])`. `setAPIKey` calls `fetchCognitiveServiceAccountKeysById` → `POST .../listKeys`. Per the agent connector manifest (`agentLoopConnector.ts`), only the `Key` ("URL and key-based") auth set declares an `openAIKey` parameter; the `ManagedServiceIdentity` set does not.

### Change

Gate the key fetch on whether the **selected** auth parameter set actually declares an `openAIKey` parameter:

```ts
const authRequiresAccountKey = useMemo(() => !!parameterSet?.parameters?.['openAIKey'], [parameterSet]);
// ...
const tasks = [setAPIEndpoint(newValue)];
if (authRequiresAccountKey) {
  tasks.push(setAPIKey(newValue));
}
await Promise.all(tasks);
```

- Manifest-driven (keys off the actual parameter set), not a hardcoded auth-set name — robust to future auth types.
- Managed Identity still gets its endpoint auto-filled; only `listKeys` is skipped.
- Applied identically to `libs/designer` and `libs/designer-v2`.

## Impact of Change
- **Users**: Creating a Managed Identity agent connection no longer makes an unnecessary (and previously customer-reported) `listKeys` call. URL/key-based auth is unchanged — the key is still auto-filled.
- **Developers**: `CustomOpenAIConnector` now reads `props.parameterSet` to decide whether to fetch keys.
- **System**: One fewer ARM call (`listKeys`) on MI connection create. No backend/runtime change.

## Test Plan
- [x] Unit tests added/updated
- [x] `openAIConnector.spec.tsx` (both `libs/designer` and `libs/designer-v2`): added a test asserting `listKeys` is **not** called when the Managed Identity auth set is selected (endpoint still populated); existing URL/key-based tests updated to supply the `Key` auth set and continue to assert the key is fetched. 29/29 pass each lib; `tsc` + biome clean.

## Contributors
<!-- N/A -->

## Screenshots/Videos
<!-- Network-call gating change (which ARM calls fire), not a visual/layout change. -->

<!-- validated: risk:low -->
