### PR TITLE
fix(pipeline): remove temp branch pin left over from PR #9453 testing

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -21,10 +21,6 @@ resources:
     - repository: LogicAppsUX
       type: github
       name: Azure/LogicAppsUX
-      # TEMP (testing only, remove before merge): pin templates to this branch so test runs
-      # exercise the CFS changes in setup.yml. Without a ref, template references like
-      # `setup.yml@LogicAppsUX` resolve to the default branch (main), not the run branch.
-      ref: refs/heads/elaina/update-pipeline
       endpoint: LogicApps-VSCode-connection  # The service connection to use when accessing this repository
 
 parameters:


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
PR #9453 temporarily pinned the `LogicAppsUX` template repository resource in `.azure-pipelines/1esmain.yml` to `refs/heads/elaina/update-pipeline` so test runs would exercise the CFS registry changes in `setup.yml`. The pin was marked `TEMP (testing only, remove before merge)` but was accidentally left in when the PR merged. This PR removes the comment block and the `ref:` line, restoring the pre-#9453 behavior where template references like `setup.yml@LogicAppsUX` resolve to the default branch (`main`).

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: None.
- **Developers**: None.
- **System**: The 1ES release pipeline resolves its `@LogicAppsUX` templates from `main` again instead of the now-merged feature branch. Since `elaina/update-pipeline` was merged into `main`, both refs currently have identical template content, so there is no behavior change today — this removes the risk of the pipeline silently drifting or breaking if the feature branch is deleted or diverges.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Verified the diff exactly reverts the block to its pre-#9453 state (`git show 6fcbd144^:.azure-pipelines/1esmain.yml`); YAML-only change to the ADO pipeline resource definition, not exercised by GitHub CI.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
