### PR TITLE
revert(pipeline): roll back CFS registry config in setup.yml to unblock releases

### DIFF
--- a/.azure-pipelines/templates/setup.yml
+++ b/.azure-pipelines/templates/setup.yml
@@ -5,27 +5,8 @@ steps:
       versionSpec: '24.x'
     condition: succeeded()
 
-  # Route package restores through the CFS feed for pipeline builds only (SFI Network
-  # Isolation, MountainPass SR21). The checked-in root .npmrc stays on the public registry
-  # so local dev and GitHub Actions are unaffected. The config is inlined here (not read
-  # from a checked-in file) because the release job checks out a version tag before this
-  # template runs — older tags must still get the CFS registry.
-  - powershell: |
-      Add-Content .npmrc "`nregistry=https://pkgs.dev.azure.com/msazure/one/_packaging/one_PublicPackages/npm/registry/`nalways-auth=true`nignore-scripts=true"
-      Get-Content .npmrc
-    displayName: "Apply CFS registry config (pipeline only)"
-    condition: succeeded()
-
-  - task: NpmAuthenticate@0
-    displayName: "Authenticate with CFS npm feed"
-    inputs:
-      workingFile: .npmrc
-    condition: succeeded()
-
   - script: npm install -g pnpm
     displayName: "Install pnpm"
-    env:
-      npm_config_registry: https://pkgs.dev.azure.com/msazure/one/_packaging/one_PublicPackages/npm/registry/
     condition: succeeded()
 
   - script: pnpm install --frozen-lockfile --strict-peer-dependencies --recursive


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
The CFS registry routing added in #9453 breaks the ADO release pipeline at the very first install step. "Install pnpm" (`npm install -g pnpm`) now resolves against the CFS feed and fails with:

```
npm error code E401
npm error Unable to authenticate, your authentication token seems to be invalid.
```

so no pipeline run can get past setup. This PR rolls `.azure-pipelines/templates/setup.yml` back to its exact pre-#9453 state (removes the CFS registry append step, the `NpmAuthenticate@0` task, and the `npm_config_registry` override on the pnpm install) to unblock releases. The SFI Network Isolation (SR21) work can be re-landed once feed authentication is sorted out.

The other two files from #9453 are intentionally left as-is: the `1esmain.yml` branch pin was already reverted in #9474, and the `.npmrc` change was only a trailing-newline fix.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: None.
- **Developers**: None (local dev and GitHub Actions never used the CFS config).
- **System**: The ADO release pipeline restores packages from the public npm registry again, as it did before #9453. SR21/SFI compliance for the pipeline is deferred until the CFS auth issue is fixed.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Verified `setup.yml` is byte-identical to its pre-#9453 version (`git diff 6fcbd144^ -- .azure-pipelines/templates/setup.yml` is empty after the revert). Pipeline-only YAML change, not exercised by GitHub CI; validate by queueing a release pipeline run after merge.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
