### PR TITLE
fix(designer-v2): don't crash when definition.metadata.notes holds arbitrary content

### DIFF
--- a/__mocks__/workflows/NotesInMetadata.json
+++ b/__mocks__/workflows/NotesInMetadata.json
@@ -1,0 +1,48 @@
+{
+  "definition": {
+    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+      "notes": {
+        "purpose": "Poll Microsoft Entra ID Protection risk detections and post medium/high-risk alerts to the configured Microsoft Teams group chat.",
+        "validNote": {
+          "content": "This is a **real** designer note.",
+          "color": "#FFFBCC",
+          "metadata": {
+            "position": { "x": -350, "y": 0 },
+            "width": 200,
+            "height": 140
+          }
+        }
+      }
+    },
+    "triggers": {
+      "Check_for_Entra_security_alerts": {
+        "type": "Recurrence",
+        "recurrence": {
+          "frequency": "Minute",
+          "interval": 5,
+          "timeZone": "W. Europe Standard Time"
+        }
+      }
+    },
+    "actions": {
+      "Initialize_variable": {
+        "runAfter": {},
+        "type": "InitializeVariable",
+        "inputs": {
+          "variables": [
+            {
+              "name": "riskCount",
+              "type": "integer",
+              "value": 0
+            }
+          ]
+        }
+      }
+    },
+    "outputs": {}
+  },
+  "connectionReferences": {},
+  "parameters": {}
+}

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/ConsumptionSerializationHelpers.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Services/ConsumptionSerializationHelpers.ts
@@ -1,5 +1,5 @@
 import { isOpenApiSchemaVersion } from '@microsoft/logic-apps-designer';
-import { clone } from '@microsoft/logic-apps-shared';
+import { clone, mergeDesignerNotes } from '@microsoft/logic-apps-shared';
 
 ///////////////////////////////////////////////////////////////////////////////
 // This was mostly copied straight from what we have in portal
@@ -35,7 +35,9 @@ export const convertDesignerWorkflowToConsumptionWorkflow = async (_workflow: an
     if (!workflow.definition.metadata) {
       workflow.definition.metadata = {};
     }
-    workflow.definition.metadata.notes = workflow.notes;
+    // `definition.metadata.notes` predates designer notes and may hold unrelated user content, so
+    // merge rather than replace to avoid deleting it on save (see #9466).
+    workflow.definition.metadata.notes = mergeDesignerNotes(workflow.definition.metadata.notes, workflow.notes);
     delete workflow.notes;
   }
 

--- a/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
+++ b/apps/Standalone/src/designer/app/AzureLogicAppsDesigner/Utilities/Workflow.ts
@@ -1,5 +1,6 @@
 import type { ConnectionAndAppSetting, ConnectionsData, NotesData, ParametersData } from '../Models/Workflow';
 import { isOpenApiSchemaVersion, type ConnectionReferences } from '@microsoft/logic-apps-designer';
+import { sanitizeNotes } from '@microsoft/logic-apps-shared';
 
 export class WorkflowUtility {
   public static convertToCanonicalFormat(value: string): string {
@@ -136,7 +137,9 @@ export const getDataForConsumption = (data: any) => {
   const connectionReferences = formatConnectionReferencesForConsumption(connections);
   const parameters: ParametersData = formatWorkflowParametersForConsumption(properties);
   // TODO: Move notes out of metadata once backend is updated
-  const notes: NotesData = properties?.definition?.metadata?.notes;
+  // `definition.metadata.notes` may contain arbitrary user-authored content, so only well-formed
+  // notes are kept — see https://github.com/Azure/LogicAppsUX/issues/9466
+  const notes: NotesData = sanitizeNotes(properties?.definition?.metadata?.notes);
 
   return { workflow, connectionReferences, parameters, notes };
 };

--- a/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
+++ b/apps/Standalone/src/designer/app/LocalDesigner/LogicAppSelector/LogicAppSelector.tsx
@@ -17,6 +17,7 @@ const fileOptions = [
   // { key: 'straightLine.json', text: 'Straight Line' },
   { key: 'simpleBigworkflow.json', text: 'Simple Big Workflow' },
   { key: 'UnicodeKeys.json', text: 'Unicode Keys' },
+  { key: 'NotesInMetadata.json', text: 'Notes In Metadata' },
 
   // Agent
   { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },

--- a/apps/Standalone/src/designer/app/LocalDesigner/localDesignerV2.tsx
+++ b/apps/Standalone/src/designer/app/LocalDesigner/localDesignerV2.tsx
@@ -191,6 +191,7 @@ const connectionParameterEditorService = new CustomConnectionParameterEditorServ
 export const LocalDesigner = () => {
   const {
     workflowDefinition,
+    notes,
     parameters,
     isReadOnly,
     isMonitoringView,
@@ -245,6 +246,7 @@ export const LocalDesigner = () => {
             definition: workflowDefinition,
             connectionReferences: connections,
             parameters: parameters,
+            notes: notes,
             kind: workflowKind,
           }}
           runInstance={runInstance}

--- a/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
+++ b/apps/Standalone/src/designer/state/workflowLoadingSlice.ts
@@ -14,6 +14,7 @@ export interface WorkflowLoadingState {
   workflowName?: string;
   runId?: string;
   workflowDefinition: LogicAppsV2.WorkflowDefinition | null;
+  notes: Record<string, any> | undefined;
   runInstance: LogicAppsV2.RunInstanceDefinition | null;
   connections: ConnectionReferences;
   isReadOnly: boolean;
@@ -45,6 +46,7 @@ export interface WorkflowLoadingState {
 const initialState: WorkflowLoadingState = {
   appId: undefined,
   workflowDefinition: null,
+  notes: undefined,
   parameters: {},
   runInstance: null,
   connections: {},
@@ -73,6 +75,7 @@ const initialState: WorkflowLoadingState = {
 
 type WorkflowPayload = {
   workflowDefinition: LogicAppsV2.WorkflowDefinition;
+  notes: Record<string, any> | undefined;
   connectionReferences: ConnectionReferences;
   parameters: Record<string, WorkflowParameter>;
   runFiles: any[];
@@ -96,6 +99,8 @@ export const loadWorkflow = createAsyncThunk('workflowLoadingState/loadWorkflow'
   const wf = await import(`../../../../../__mocks__/workflows/${fileName}.json`);
   return {
     workflowDefinition: wf.definition as LogicAppsV2.WorkflowDefinition,
+    // Notes are stored on the definition metadata, which is user-writable and may not be well-formed
+    notes: wf?.notes ?? wf?.definition?.metadata?.notes,
     connectionReferences: wf.connections as ConnectionReferences,
     parameters: wf?.parameters ?? wf?.definition?.parameters ?? {},
     workflowKind: wf?.kind,
@@ -198,6 +203,7 @@ export const workflowLoadingSlice = createSlice({
       state.isMonitoringView = lastWorkflow.isMonitoringView;
       // Clear these state values, they get built with the other values
       state.workflowDefinition = null;
+      state.notes = undefined;
       state.runInstance = null;
       state.connections = {};
     },
@@ -232,6 +238,7 @@ export const workflowLoadingSlice = createSlice({
         return;
       }
       state.workflowDefinition = action.payload?.workflowDefinition;
+      state.notes = action.payload?.notes;
       state.connections = action.payload?.connectionReferences ?? {};
       state.parameters = action.payload?.parameters ?? {};
       state.runFiles = action.payload?.runFiles ?? [];
@@ -239,6 +246,7 @@ export const workflowLoadingSlice = createSlice({
     });
     builder.addCase(loadWorkflow.rejected, (state) => {
       state.workflowDefinition = null;
+      state.notes = undefined;
       state.parameters = {};
     });
     builder.addCase(loadRun.fulfilled, (state, action: PayloadAction<RunPayload | null>) => {

--- a/e2e/designer/notes.spec.ts
+++ b/e2e/designer/notes.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { GoToMockWorkflow } from './utils/GoToWorkflow';
+
+test.describe(
+  'Designer notes tests',
+  {
+    tag: '@mock',
+  },
+  async () => {
+    // Regression test for https://github.com/Azure/LogicAppsUX/issues/9466
+    test('Malformed entries in definition.metadata.notes do not crash the designer', async ({ page }) => {
+      const pageErrors: string[] = [];
+      page.on('pageerror', (error) => pageErrors.push(error.message));
+
+      await page.goto('/v2');
+      // The v2 route pulls in a large module graph; give the dev server time to serve it.
+      await page.getByText('Local', { exact: true }).waitFor({ state: 'visible', timeout: 3 * 60 * 1000 });
+      await GoToMockWorkflow(page, 'Notes In Metadata');
+
+      await expect(page.getByTestId('card-check_for_entra_security_alerts')).toBeVisible();
+      await expect(page.getByTestId('card-initialize_variable')).toBeVisible();
+
+      // The well-formed note still renders, the arbitrary user content is dropped.
+      await expect(page.locator('[data-testid="rf__node-validNote"]')).toBeVisible();
+      await expect(page.locator('[data-testid="rf__node-purpose"]')).toHaveCount(0);
+
+      expect(pageErrors).toEqual([]);
+    });
+  }
+);

--- a/libs/designer-v2/src/lib/core/state/notes/__test__/notesSlice.spec.ts
+++ b/libs/designer-v2/src/lib/core/state/notes/__test__/notesSlice.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import reducer, { initialState, initializeNotes, updateNote, deleteNote } from '../notesSlice';
+import type { NotesState } from '../notesSlice';
+import type { Note } from '../../../../common/models/workflow';
+
+const buildNote = (overrides: Partial<Note> = {}): Note => ({
+  content: 'A note',
+  color: '#FFFBCC',
+  metadata: { position: { x: 10, y: 20 }, width: 200, height: 140 },
+  ...overrides,
+});
+
+describe('notesSlice', () => {
+  describe('initializeNotes', () => {
+    it('loads well-formed notes', () => {
+      const notes = { note1: buildNote() };
+      const state = reducer(initialState, initializeNotes(notes));
+      expect(state.notes).toEqual(notes);
+    });
+
+    // https://github.com/Azure/LogicAppsUX/issues/9466 - `definition.metadata.notes` can hold
+    // arbitrary user-authored content which used to crash the designer on load.
+    it('drops entries that are not notes', () => {
+      const state = reducer(
+        initialState,
+        initializeNotes({
+          purpose: 'Poll Microsoft Entra ID Protection risk detections.',
+        } as any)
+      );
+      expect(state.notes).toEqual({});
+    });
+
+    it('handles an undefined payload', () => {
+      const state = reducer({ ...initialState, notes: { note1: buildNote() } }, initializeNotes(undefined));
+      expect(state.notes).toEqual({});
+    });
+
+    it('backfills missing metadata so position updates cannot crash', () => {
+      const state = reducer(initialState, initializeNotes({ note1: { content: 'No metadata' } as any }));
+      expect(state.notes['note1'].metadata.position).toEqual({ x: 0, y: 0 });
+
+      const updated = reducer(state, updateNote({ id: 'note1', note: { metadata: { position: { x: 5, y: 6 } } } }));
+      expect(updated.notes['note1'].metadata.position).toEqual({ x: 5, y: 6 });
+    });
+  });
+
+  describe('updateNote', () => {
+    const stateWithNote = (): NotesState => ({ ...initialState, notes: { note1: buildNote() } });
+
+    it('merges partial positions with the existing position', () => {
+      const state = reducer(stateWithNote(), updateNote({ id: 'note1', note: { metadata: { position: { x: 99 } } } }));
+      expect(state.notes['note1'].metadata.position).toEqual({ x: 99, y: 20 });
+    });
+
+    it('ignores updates for unknown notes', () => {
+      const state = reducer(stateWithNote(), updateNote({ id: 'missing', note: { metadata: { position: { x: 1, y: 2 } } } }));
+      expect(state.notes['missing']).toBeUndefined();
+    });
+
+    it('does not throw when the stored note has no metadata', () => {
+      const state: NotesState = { ...initialState, notes: { note1: { content: 'x', color: '#FFF' } as Note } };
+      expect(() => reducer(state, updateNote({ id: 'note1', note: { metadata: { position: { x: 1, y: 2 } } } }))).not.toThrow();
+    });
+  });
+
+  describe('deleteNote', () => {
+    it('removes the note', () => {
+      const state = reducer({ ...initialState, notes: { note1: buildNote() } }, deleteNote('note1'));
+      expect(state.notes).toEqual({});
+    });
+  });
+});

--- a/libs/designer-v2/src/lib/core/state/notes/__test__/notesSlice.spec.ts
+++ b/libs/designer-v2/src/lib/core/state/notes/__test__/notesSlice.spec.ts
@@ -57,6 +57,18 @@ describe('notesSlice', () => {
       expect(state.notes['missing']).toBeUndefined();
     });
 
+    it('does not mark the workflow dirty when the note is unknown', () => {
+      const state = reducer(stateWithNote(), updateNote({ id: 'missing', note: { metadata: { position: { x: 1, y: 2 } } } }));
+      expect(state.isDirty).toBe(false);
+      expect(state.changeCount).toBe(0);
+    });
+
+    it('marks the workflow dirty when the note exists', () => {
+      const state = reducer(stateWithNote(), updateNote({ id: 'note1', note: { content: 'Updated' } }));
+      expect(state.isDirty).toBe(true);
+      expect(state.changeCount).toBe(1);
+    });
+
     it('does not throw when the stored note has no metadata', () => {
       const state: NotesState = { ...initialState, notes: { note1: { content: 'x', color: '#FFF' } as Note } };
       expect(() => reducer(state, updateNote({ id: 'note1', note: { metadata: { position: { x: 1, y: 2 } } } }))).not.toThrow();

--- a/libs/designer-v2/src/lib/core/state/notes/notesSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/notes/notesSlice.ts
@@ -18,6 +18,11 @@ export const initialState: NotesState = {
   changeCount: 0,
 };
 
+const markDirty = (state: NotesState) => {
+  state.isDirty = true;
+  state.changeCount += 1;
+};
+
 const notesSlice = createSlice({
   name: 'notes',
   initialState,
@@ -41,6 +46,8 @@ const notesSlice = createSlice({
     updateNote: (state, action: PayloadAction<{ id: string; note: DeepPartial<Note> }>) => {
       const note = state.notes[action.payload.id];
       if (!note) {
+        // React Flow can emit measurement events for nodes that are no longer in state; ignoring
+        // them here keeps the workflow from being marked dirty by a no-op.
         return;
       }
       if (action.payload.note?.color) {
@@ -68,6 +75,7 @@ const notesSlice = createSlice({
           note.metadata.height = action.payload.note.metadata.height;
         }
       }
+      markDirty(state);
     },
     deleteNote: (state, action: PayloadAction<string>) => {
       delete state.notes[action.payload];
@@ -79,10 +87,7 @@ const notesSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(resetWorkflowState, () => initialState);
     builder.addCase(setStateAfterUndoRedo, (_, action: PayloadAction<UndoRedoPartialRootState>) => action.payload.notes);
-    builder.addMatcher(isAnyOf(addNote, updateNote, deleteNote), (state) => {
-      state.isDirty = true;
-      state.changeCount += 1;
-    });
+    builder.addMatcher(isAnyOf(addNote, deleteNote), markDirty);
   },
 });
 

--- a/libs/designer-v2/src/lib/core/state/notes/notesSlice.ts
+++ b/libs/designer-v2/src/lib/core/state/notes/notesSlice.ts
@@ -2,9 +2,8 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice, isAnyOf } from '@reduxjs/toolkit';
 import { resetWorkflowState, setStateAfterUndoRedo } from '../global';
 import type { UndoRedoPartialRootState } from '../undoRedo/undoRedoTypes';
-import { type DeepPartial, guid } from '@microsoft/logic-apps-shared';
+import { type DeepPartial, DEFAULT_NOTE_COLOR, DEFAULT_NOTE_SIZE, guid, sanitizeNotes } from '@microsoft/logic-apps-shared';
 import type { XYPosition } from '@xyflow/react';
-import { DEFAULT_NOTE_SIZE } from '../../../core/utils/graph';
 import type { Note } from '../../../common/models/workflow';
 
 export interface NotesState {
@@ -23,13 +22,15 @@ const notesSlice = createSlice({
   name: 'notes',
   initialState,
   reducers: {
-    initializeNotes: (state, action: PayloadAction<Record<string, Note>>) => {
-      state.notes = action.payload;
+    initializeNotes: (state, action: PayloadAction<Record<string, Note> | undefined>) => {
+      // `definition.metadata.notes` is user-writable and may hold arbitrary content, so anything
+      // that isn't a well-formed note is dropped here rather than crashing the designer on load.
+      state.notes = sanitizeNotes(action.payload);
     },
     addNote: (state, action: PayloadAction<XYPosition>) => {
       state.notes[guid()] = {
         content: '',
-        color: '#FFFBCC',
+        color: DEFAULT_NOTE_COLOR,
         metadata: {
           position: action.payload,
           width: DEFAULT_NOTE_SIZE.width,
@@ -38,26 +39,33 @@ const notesSlice = createSlice({
       };
     },
     updateNote: (state, action: PayloadAction<{ id: string; note: DeepPartial<Note> }>) => {
+      const note = state.notes[action.payload.id];
+      if (!note) {
+        return;
+      }
       if (action.payload.note?.color) {
-        state.notes[action.payload.id].color = action.payload.note.color;
+        note.color = action.payload.note.color;
       }
       if (action.payload.note?.content !== undefined) {
-        state.notes[action.payload.id].content = action.payload.note.content;
+        note.content = action.payload.note.content;
       }
       if (action.payload.note?.metadata) {
+        if (!note.metadata) {
+          note.metadata = { position: { x: 0, y: 0 }, width: DEFAULT_NOTE_SIZE.width, height: DEFAULT_NOTE_SIZE.height };
+        }
         if (action.payload.note.metadata.position) {
-          const existing = state.notes[action.payload.id].metadata.position;
+          const existing = note.metadata.position;
           const pos = action.payload.note.metadata.position;
-          state.notes[action.payload.id].metadata.position = {
+          note.metadata.position = {
             x: pos.x ?? existing.x,
             y: pos.y ?? existing.y,
           };
         }
         if (action.payload.note.metadata.width) {
-          state.notes[action.payload.id].metadata.width = action.payload.note.metadata.width;
+          note.metadata.width = action.payload.note.metadata.width;
         }
         if (action.payload.note.metadata.height) {
-          state.notes[action.payload.id].metadata.height = action.payload.note.metadata.height;
+          note.metadata.height = action.payload.note.metadata.height;
         }
       }
     },

--- a/libs/designer-v2/src/lib/core/utils/graph.ts
+++ b/libs/designer-v2/src/lib/core/utils/graph.ts
@@ -10,6 +10,7 @@ import {
   WORKFLOW_EDGE_TYPES,
   WORKFLOW_NODE_TYPES,
   getRecordEntry,
+  DEFAULT_NOTE_SIZE as SHARED_DEFAULT_NOTE_SIZE,
 } from '@microsoft/logic-apps-shared';
 import type { WorkflowEdgeType, WorkflowNodeType } from '@microsoft/logic-apps-shared';
 import type { ElkExtendedEdge, ElkNode } from 'elkjs';
@@ -42,10 +43,7 @@ export const DEFAULT_NODE_SIZE = {
   height: 40,
 };
 
-export const DEFAULT_NOTE_SIZE = {
-  width: 200,
-  height: 140,
-};
+export const DEFAULT_NOTE_SIZE = SHARED_DEFAULT_NOTE_SIZE;
 
 // Creating generic layout nodes and edges below
 

--- a/libs/designer-v2/src/lib/core/utils/graph.ts
+++ b/libs/designer-v2/src/lib/core/utils/graph.ts
@@ -10,7 +10,6 @@ import {
   WORKFLOW_EDGE_TYPES,
   WORKFLOW_NODE_TYPES,
   getRecordEntry,
-  DEFAULT_NOTE_SIZE as SHARED_DEFAULT_NOTE_SIZE,
 } from '@microsoft/logic-apps-shared';
 import type { WorkflowEdgeType, WorkflowNodeType } from '@microsoft/logic-apps-shared';
 import type { ElkExtendedEdge, ElkNode } from 'elkjs';
@@ -42,8 +41,6 @@ export const DEFAULT_NODE_SIZE = {
   width: 200,
   height: 40,
 };
-
-export const DEFAULT_NOTE_SIZE = SHARED_DEFAULT_NOTE_SIZE;
 
 // Creating generic layout nodes and edges below
 

--- a/libs/designer-v2/src/lib/ui/CustomNodes/NoteNode/index.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/NoteNode/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import type { NodeProps } from '@xyflow/react';
 import { Button, Card, mergeClasses, Textarea } from '@fluentui/react-components';
 import { useIntl } from 'react-intl';
-import { isUndefinedOrEmptyString } from '@microsoft/logic-apps-shared';
+import { DEFAULT_NOTE_COLOR, isUndefinedOrEmptyString } from '@microsoft/logic-apps-shared';
 
 import type { AppDispatch } from '../../../core';
 import { deleteNote, updateNote } from '../../../core/state/notes/notesSlice';
@@ -67,7 +67,7 @@ const NoteNode = ({ id, dragging }: NodeProps) => {
       <Card
         className={mergeClasses(styles.noteCard, dragging && styles.draggingNote)}
         style={{
-          backgroundColor: noteData?.color || '#FFFBCC',
+          backgroundColor: noteData?.color || DEFAULT_NOTE_COLOR,
           width: noteData?.metadata?.width ?? 200,
           resize: isReadOnly ? 'none' : 'horizontal',
         }}

--- a/libs/designer-v2/src/lib/ui/CustomNodes/NoteNode/index.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/NoteNode/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import type { NodeProps } from '@xyflow/react';
 import { Button, Card, mergeClasses, Textarea } from '@fluentui/react-components';
 import { useIntl } from 'react-intl';
-import { DEFAULT_NOTE_COLOR, isUndefinedOrEmptyString } from '@microsoft/logic-apps-shared';
+import { DEFAULT_NOTE_COLOR, DEFAULT_NOTE_SIZE, isUndefinedOrEmptyString } from '@microsoft/logic-apps-shared';
 
 import type { AppDispatch } from '../../../core';
 import { deleteNote, updateNote } from '../../../core/state/notes/notesSlice';
@@ -68,7 +68,7 @@ const NoteNode = ({ id, dragging }: NodeProps) => {
         className={mergeClasses(styles.noteCard, dragging && styles.draggingNote)}
         style={{
           backgroundColor: noteData?.color || DEFAULT_NOTE_COLOR,
-          width: noteData?.metadata?.width ?? 200,
+          width: noteData?.metadata?.width ?? DEFAULT_NOTE_SIZE.width,
           resize: isReadOnly ? 'none' : 'horizontal',
         }}
       >

--- a/libs/designer-v2/src/lib/ui/DesignerReactFlow.tsx
+++ b/libs/designer-v2/src/lib/ui/DesignerReactFlow.tsx
@@ -19,6 +19,7 @@ import {
   guid,
   removeIdTag,
   WORKFLOW_NODE_TYPES,
+  DEFAULT_NOTE_SIZE,
   type WorkflowNodeType,
 } from '@microsoft/logic-apps-shared';
 import { useDispatch } from 'react-redux';
@@ -33,7 +34,7 @@ import { clearPanel, expandDiscoveryPanel, setNodeSelection } from '../core/stat
 import { useOperationPanelSelectedNodeIds } from '../core/state/panel/panelSelectors';
 import { addOperationRunAfter, removeOperationRunAfter } from '../core/actions/bjsworkflow/runafter';
 import { useClampPan, useIsA2AWorkflow } from '../core/state/designerView/designerViewSelectors';
-import { DEFAULT_NODE_SIZE, DEFAULT_NOTE_SIZE } from '../core/utils/graph';
+import { DEFAULT_NODE_SIZE } from '../core/utils/graph';
 import { DraftEdge } from './connections/draftEdge';
 import { useIsDarkMode, useReadOnly } from '../core/state/designerOptions/designerOptionsSelectors';
 import { useLayout } from '../core/graphlayout';

--- a/libs/designer-v2/src/lib/ui/__test__/DesignerReactFlow.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/__test__/DesignerReactFlow.spec.tsx
@@ -96,7 +96,6 @@ vi.mock('../../core/graphlayout', () => ({
 
 vi.mock('../../core/utils/graph', () => ({
   DEFAULT_NODE_SIZE: { width: 200, height: 40 },
-  DEFAULT_NOTE_SIZE: { width: 250, height: 100 },
 }));
 
 vi.mock('../../core/utils/designerLayoutHelpers', () => ({

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/notes.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/notes.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_NOTE_COLOR, DEFAULT_NOTE_SIZE, sanitizeNotes } from '../notes';
+
+describe('lib/helpers/notes', () => {
+  describe('sanitizeNotes', () => {
+    it('returns an empty record for non-object input', () => {
+      expect(sanitizeNotes(undefined)).toEqual({});
+      expect(sanitizeNotes(null)).toEqual({});
+      expect(sanitizeNotes('notes')).toEqual({});
+      expect(sanitizeNotes([{ content: 'a' }])).toEqual({});
+    });
+
+    it('keeps well-formed notes untouched', () => {
+      const notes = {
+        note1: {
+          content: 'Hello',
+          color: '#FFFFFF',
+          metadata: { position: { x: -350, y: 120 }, width: 300, height: 200 },
+        },
+      };
+      expect(sanitizeNotes(notes)).toEqual(notes);
+    });
+
+    // https://github.com/Azure/LogicAppsUX/issues/9466
+    it('drops user-authored metadata that is not a note', () => {
+      expect(
+        sanitizeNotes({
+          purpose: 'Poll Microsoft Entra ID Protection risk detections.',
+          owner: { team: 'identity' },
+          tags: ['a', 'b'],
+          count: 4,
+          nothing: null,
+        })
+      ).toEqual({});
+    });
+
+    it('keeps valid notes alongside foreign metadata', () => {
+      const sanitized = sanitizeNotes({
+        purpose: 'Some user-authored string',
+        note1: { content: 'Real note', color: '#FF0000', metadata: { position: { x: 1, y: 2 }, width: 10, height: 20 } },
+      });
+      expect(Object.keys(sanitized)).toEqual(['note1']);
+    });
+
+    it('fills in defaults for partial notes', () => {
+      expect(sanitizeNotes({ note1: { content: 'Partial' } })).toEqual({
+        note1: {
+          content: 'Partial',
+          color: DEFAULT_NOTE_COLOR,
+          metadata: {
+            position: { x: 0, y: 0 },
+            width: DEFAULT_NOTE_SIZE.width,
+            height: DEFAULT_NOTE_SIZE.height,
+          },
+        },
+      });
+    });
+
+    it('replaces non-finite or non-numeric dimensions with defaults', () => {
+      const sanitized = sanitizeNotes({
+        note1: {
+          content: 'Bad numbers',
+          metadata: { position: { x: Number.NaN, y: '12' }, width: null, height: Number.POSITIVE_INFINITY },
+        },
+      });
+      expect(sanitized['note1'].metadata).toEqual({
+        position: { x: 0, y: 0 },
+        width: DEFAULT_NOTE_SIZE.width,
+        height: DEFAULT_NOTE_SIZE.height,
+      });
+    });
+  });
+});

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/notes.spec.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/__test__/notes.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { DEFAULT_NOTE_COLOR, DEFAULT_NOTE_SIZE, sanitizeNotes } from '../notes';
+import { DEFAULT_NOTE_COLOR, DEFAULT_NOTE_SIZE, mergeDesignerNotes, sanitizeNotes } from '../notes';
 
 describe('lib/helpers/notes', () => {
   describe('sanitizeNotes', () => {
@@ -68,6 +68,43 @@ describe('lib/helpers/notes', () => {
         width: DEFAULT_NOTE_SIZE.width,
         height: DEFAULT_NOTE_SIZE.height,
       });
+    });
+  });
+
+  describe('mergeDesignerNotes', () => {
+    const designerNote = {
+      content: 'Real note',
+      color: DEFAULT_NOTE_COLOR,
+      metadata: { position: { x: 1, y: 2 }, width: 10, height: 20 },
+    };
+
+    // https://github.com/Azure/LogicAppsUX/issues/9466 - saving must not delete metadata the
+    // designer never owned.
+    it('preserves foreign entries that sanitizeNotes drops', () => {
+      const merged = mergeDesignerNotes(
+        {
+          purpose: 'Poll Microsoft Entra ID Protection risk detections.',
+          owner: { team: 'identity' },
+          note1: { content: 'Stale content' },
+        },
+        { note1: designerNote }
+      );
+
+      expect(merged).toEqual({
+        purpose: 'Poll Microsoft Entra ID Protection risk detections.',
+        owner: { team: 'identity' },
+        note1: designerNote,
+      });
+    });
+
+    it('drops designer notes that are no longer present', () => {
+      const merged = mergeDesignerNotes({ purpose: 'keep me', note1: { content: 'Deleted note' } }, {});
+      expect(merged).toEqual({ purpose: 'keep me' });
+    });
+
+    it('handles missing or non-object existing notes', () => {
+      expect(mergeDesignerNotes(undefined, { note1: designerNote })).toEqual({ note1: designerNote });
+      expect(mergeDesignerNotes('nope', {})).toEqual({});
     });
   });
 });

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/index.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/index.ts
@@ -10,6 +10,7 @@ export * from './hooks';
 export * from './http';
 export * from './logicapps';
 export * from './navigator';
+export * from './notes';
 export * from './operations';
 export * from './recurrence';
 export * from './run';

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/notes.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/notes.ts
@@ -1,0 +1,57 @@
+import type { Note } from '../models/workflow';
+
+export const DEFAULT_NOTE_SIZE = {
+  width: 200,
+  height: 140,
+};
+
+export const DEFAULT_NOTE_COLOR = '#FFFBCC';
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const toFiniteNumber = (value: unknown, fallback: number): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+
+/**
+ * Normalizes an untrusted `notes` record into designer notes.
+ *
+ * Designer notes are persisted under `definition.metadata.notes`, a location that predates the
+ * feature and may already hold arbitrary user-authored content. Entries that don't look like a
+ * note are dropped, and partial notes are filled in with defaults, so downstream code can rely on
+ * `content`, `color` and `metadata` always being present.
+ */
+export const sanitizeNotes = (notes: unknown): Record<string, Note> => {
+  if (!isPlainObject(notes)) {
+    return {};
+  }
+
+  const sanitized: Record<string, Note> = {};
+  for (const [id, value] of Object.entries(notes)) {
+    // A note always serializes with a string `content`; anything else is foreign metadata.
+    if (!isPlainObject(value) || typeof value['content'] !== 'string') {
+      continue;
+    }
+
+    const rawMetadata = value['metadata'];
+    const metadata = isPlainObject(rawMetadata) ? rawMetadata : {};
+    const rawPosition = metadata['position'];
+    const position = isPlainObject(rawPosition) ? rawPosition : {};
+    const color = value['color'];
+
+    sanitized[id] = {
+      content: value['content'],
+      color: typeof color === 'string' ? color : DEFAULT_NOTE_COLOR,
+      metadata: {
+        position: {
+          x: toFiniteNumber(position['x'], 0),
+          y: toFiniteNumber(position['y'], 0),
+        },
+        width: toFiniteNumber(metadata['width'], DEFAULT_NOTE_SIZE.width),
+        height: toFiniteNumber(metadata['height'], DEFAULT_NOTE_SIZE.height),
+      },
+    };
+  }
+
+  return sanitized;
+};

--- a/libs/logic-apps-shared/src/utils/src/lib/helpers/notes.ts
+++ b/libs/logic-apps-shared/src/utils/src/lib/helpers/notes.ts
@@ -13,6 +13,10 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 const toFiniteNumber = (value: unknown, fallback: number): number =>
   typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 
+// A note always serializes with a string `content`; anything else is foreign metadata.
+const isNoteLike = (value: unknown): value is Record<string, unknown> & { content: string } =>
+  isPlainObject(value) && typeof value['content'] === 'string';
+
 /**
  * Normalizes an untrusted `notes` record into designer notes.
  *
@@ -28,8 +32,7 @@ export const sanitizeNotes = (notes: unknown): Record<string, Note> => {
 
   const sanitized: Record<string, Note> = {};
   for (const [id, value] of Object.entries(notes)) {
-    // A note always serializes with a string `content`; anything else is foreign metadata.
-    if (!isPlainObject(value) || typeof value['content'] !== 'string') {
+    if (!isNoteLike(value)) {
       continue;
     }
 
@@ -54,4 +57,26 @@ export const sanitizeNotes = (notes: unknown): Record<string, Note> => {
   }
 
   return sanitized;
+};
+
+/**
+ * Merges designer notes back into an untrusted `notes` record for persistence.
+ *
+ * `sanitizeNotes` drops entries that aren't well-formed notes, so writing the designer's notes
+ * straight back over `definition.metadata.notes` would silently delete that foreign content.
+ * Foreign entries are carried over untouched, while designer notes the user deleted are dropped
+ * because they were well-formed on load and are absent from `designerNotes`.
+ */
+export const mergeDesignerNotes = (existingNotes: unknown, designerNotes: Record<string, Note>): Record<string, unknown> => {
+  const merged: Record<string, unknown> = {};
+
+  if (isPlainObject(existingNotes)) {
+    for (const [id, value] of Object.entries(existingNotes)) {
+      if (!isNoteLike(value)) {
+        merged[id] = value;
+      }
+    }
+  }
+
+  return { ...merged, ...designerNotes };
 };


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

Fixes #9466 — Consumption Designer V2 crashes on load with `t.metadata is undefined`.

**Root cause.** Designer notes are persisted under `definition.metadata.notes`, a location that is user-writable and predates the notes feature, so it can already hold arbitrary content. The workflow in the issue has:

```json
"metadata": {
  "notes": { "purpose": "Poll Microsoft Entra ID Protection for risky users..." }
}
```

Designer V2 loaded that record verbatim into the notes slice (`initializeNotes(notes ?? {})`), so `state.notes['purpose']` was a plain string. React Flow renders a note node for every entry and immediately emits dimension/position changes on mount; `DesignerReactFlow` dispatches those as `updateNote`, and the reducer did `state.notes[id].metadata.position` unguarded → `TypeError: t.metadata is undefined` → the React error boundary tears down the whole designer. Designer V1 is unaffected because it has no notes slice.

**Fix.**
- New `sanitizeNotes` helper in `@microsoft/logic-apps-shared` (alongside shared `DEFAULT_NOTE_SIZE` / `DEFAULT_NOTE_COLOR`). It keeps only entries that are objects with a string `content` — which every serialized note has, since the serializer already drops empty-content notes — and backfills defaults for missing `color`/`metadata`/`position`/`width`/`height`.
- `initializeNotes` now sanitizes its payload, so **every host is protected** (portal, VS Code, standalone) regardless of how notes are handed to the designer.
- `updateNote` now bails out for unknown ids and backfills `metadata` if it's missing, so a stray dispatch can't throw. It also no longer marks the slice dirty when the id is unknown, so a stale React Flow event can't enable Save or add undo history for a no-op.
- New `mergeDesignerNotes` helper preserves foreign `definition.metadata.notes` entries on save. Sanitizing on load means the designer no longer tracks non-note content, and the consumption serializer previously replaced the whole `metadata.notes` object — which would have deleted it. Merging carries foreign entries through untouched while still dropping designer notes the user removed.
- The Standalone consumption data path (`getDataForConsumption`) sanitizes on load and `convertDesignerWorkflowToConsumptionWorkflow` merges on save, mirroring the portal's data-shaping code.
- Deduped the note size/color constants that were previously literal-duplicated in `graph.ts` and `NoteNode`. `DEFAULT_NOTE_SIZE` is now imported from the shared package directly rather than re-exported through `graph.ts`.

## Impact of Change
- **Users**: Consumption workflows with pre-existing `metadata.notes` content now open in Designer V2 instead of crashing to a blank page. Their custom metadata is preserved across a save round-trip.
- **Developers**: New exported helpers `sanitizeNotes` and `mergeDesignerNotes`, plus `DEFAULT_NOTE_SIZE` / `DEFAULT_NOTE_COLOR`, in `@microsoft/logic-apps-shared`. `DEFAULT_NOTE_SIZE` is no longer exported from `designer-v2/core/utils/graph` — import it from the shared package.
- **System**: Touches shared runtime code in `logic-apps-shared`, Redux state-management logic in `notesSlice`, and the consumption save path, hence Medium risk. No perf or dependency impact; sanitization is a single pass over the notes record at load.

## Test Plan
- [x] Unit tests added/updated — 19 tests (`notes.spec.ts` for `sanitizeNotes` and `mergeDesignerNotes`, `notesSlice.spec.ts` for `initializeNotes`/`updateNote` including dirty-state bookkeeping), all passing.
- [x] E2E tests added/updated — `e2e/designer/notes.spec.ts` (`@mock`) loads the new `NotesInMetadata` mock workflow on `/v2` and asserts the cards render, the well-formed note renders, the bogus `purpose` entry does not, and no page errors are raised. Verified it **fails** without the fix and passes with it.
- [x] Manual testing completed — reproduced in the standalone designer with Playwright against the local dev server:
  - **Without the fix**: canvas renders empty, console shows `TypeError: Cannot set properties of undefined` thrown from `updateNote` in `notesSlice.ts`, dispatched from `DesignerReactFlow` via React Flow's `ResizeObserver` → `updateNodeInternals` → `triggerNodeChanges`. This is the un-minified form of the reported `t.metadata is undefined`.
  - **With the fix**: the Recurrence trigger, the Initialize variable action and the single well-formed note all render; zero console errors; the bogus `purpose` entry produces no node (`rf__node-purpose` absent, `rf__node-validNote` present).
- [x] Tested in: Standalone designer V2 (`/v2`, local mock workflow), Chromium.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
No visual changes — behavior only. See the Test Plan for the before/after observed in the standalone designer.