### PR TITLE
perf(e2e): shard chat client suite and cache Playwright browsers

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,8 +26,29 @@ jobs:
           - recursive: true
             args: [--frozen-lockfile, --strict-peer-dependencies]
 
+    # Keyed on pnpm-lock.yaml because that is what pins @playwright/test, and a
+    # browser build is only valid for the Playwright version that requested it.
+    # No `restore-keys` on purpose: a prefix hit would restore browsers for a
+    # different Playwright version, report cache-hit != 'true', and then re-save
+    # that stale tree onto the new exact key.
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
     - name: Install Playwright Browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: pnpm run e2e:setup
+
+    # The cache restores browser binaries but not the apt packages they link
+    # against, so system deps still have to be reconciled on a hit. Nearly a
+    # no-op on the ubuntu-latest image.
+    - name: Install Playwright system dependencies
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: pnpm exec playwright install-deps chromium
+
     - name: Run Designer Playwright tests
       run: pnpm run test:e2e:designer --grep @mock --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       env:
@@ -71,6 +92,11 @@ jobs:
     name: Chat Client E2E Tests
     timeout-minutes: 90
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
@@ -83,13 +109,56 @@ jobs:
           - recursive: true
             args: [--frozen-lockfile, --strict-peer-dependencies]
 
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
     - name: Install Playwright Browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: pnpm run e2e:setup
+
+    - name: Install Playwright system dependencies
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: pnpm exec playwright install-deps chromium
+
     - name: Run Chat Client Playwright tests
-      run: pnpm run test:e2e:chatClient --grep @mock
+      run: pnpm run test:e2e:chatClient --grep @mock --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      env:
+        TEST_SHARDED: true
     - uses: actions/upload-artifact@v6
       if: always()
       with:
-        name: chat-client-playwright-report
-        path: playwright-report/
-        retention-days: 30
+        name: chat-client-playwright-report-${{ matrix.shardIndex }}
+        path: blob-report/
+        retention-days: 1
+
+  chat-client-report:
+    if: ${{ !cancelled() }}
+    needs: [chat-client-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24.x
+          package-manager-cache: false
+
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: all-blob-reports
+          pattern: chat-client-playwright-report-*
+          merge-multiple: true
+
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v6
+        with:
+          name: chat-client-playwright-report
+          path: playwright-report
+          retention-days: 30

--- a/e2e/chatClient/tests/features/sessions/chat-history.spec.ts
+++ b/e2e/chatClient/tests/features/sessions/chat-history.spec.ts
@@ -41,9 +41,6 @@ test.describe('Chat History Loading', { tag: '@mock' }, () => {
     await page.goto(`http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&withHistory=true`);
     await page.waitForLoadState('networkidle');
 
-    // Wait for sessions to load and render
-    await page.waitForTimeout(1000);
-
     // Should display "Chats" heading in sidebar
     await expect(page.getByRole('heading', { name: 'Chats' })).toBeVisible({ timeout: 5000 });
 
@@ -76,9 +73,6 @@ test.describe('Loading Messages for Historical Session', { tag: '@mock' }, () =>
     await page.goto(`http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&withHistory=true`);
     await page.waitForLoadState('networkidle');
 
-    // Wait for sessions to load
-    await page.waitForTimeout(1000);
-
     // Set up request listener for tasks/list BEFORE clicking
     const tasksListPromise = page.waitForRequest((request) => {
       const postData = request.postDataJSON();
@@ -105,16 +99,10 @@ test.describe('Loading Messages for Historical Session', { tag: '@mock' }, () =>
     await page.goto(`http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&multiSession=true&withHistory=true`);
     await page.waitForLoadState('networkidle');
 
-    // Wait for sessions to load
-    await page.waitForTimeout(1000);
-
     // Click on the second session (Bug Investigation) to load its messages
     const sessionItem = page.getByRole('group').filter({ hasText: 'Bug Investigation' }).filter({ hasText: '1/9/2025' });
     await expect(sessionItem).toBeVisible({ timeout: 5000 });
     await sessionItem.click();
-
-    // Wait for messages to load
-    await page.waitForTimeout(2000);
 
     // Verify historical messages from session-2 ("Bug Investigation") are visible
     await expect(page.getByText('Help me debug this timeout issue')).toBeVisible({ timeout: 5000 });
@@ -126,16 +114,10 @@ test.describe('Loading Messages for Historical Session', { tag: '@mock' }, () =>
     await page.goto(`http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&multiSession=true&withHistory=true`);
     await page.waitForLoadState('networkidle');
 
-    // Wait for sessions to load
-    await page.waitForTimeout(1000);
-
     // Click on the second session (Bug Investigation) to load its messages
     const sessionItem = page.getByRole('group').filter({ hasText: 'Bug Investigation' }).filter({ hasText: '1/9/2025' });
     await expect(sessionItem).toBeVisible({ timeout: 5000 });
     await sessionItem.click();
-
-    // Wait for messages to load
-    await page.waitForTimeout(2000);
 
     // Verify user message is visible
     await expect(page.getByText('Help me debug this timeout issue')).toBeVisible({ timeout: 5000 });
@@ -150,9 +132,6 @@ test.describe('Session Switching', { tag: '@mock' }, () => {
     // Enable multi-session mode to see session list
     await page.goto(`http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&multiSession=true&withHistory=true`);
     await page.waitForLoadState('networkidle');
-
-    // Wait for sessions to load
-    await page.waitForTimeout(1000);
 
     // Verify both sessions are visible
     const session1 = page.getByRole('group').filter({ hasText: 'Project Discussion' }).filter({ hasText: '1/10/2025' });
@@ -185,9 +164,6 @@ test.describe('Session Switching', { tag: '@mock' }, () => {
     await page.goto(`http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&multiSession=true&withHistory=true`);
     await page.waitForLoadState('networkidle');
 
-    // Wait for sessions to load
-    await page.waitForTimeout(1000);
-
     // Get session items by their visible text
     const session1 = page.getByRole('group').filter({ hasText: 'Project Discussion' }).filter({ hasText: '1/10/2025' });
     const session2 = page.getByRole('group').filter({ hasText: 'Bug Investigation' }).filter({ hasText: '1/9/2025' });
@@ -197,7 +173,6 @@ test.describe('Session Switching', { tag: '@mock' }, () => {
 
     // Click first session and verify its messages are displayed
     await session1.click();
-    await page.waitForTimeout(1000);
 
     // Verify first session's messages are visible (indicating it's active)
     await expect(page.getByText('Tell me about the project architecture')).toBeVisible({
@@ -207,7 +182,6 @@ test.describe('Session Switching', { tag: '@mock' }, () => {
 
     // Click second session and verify its messages are now displayed
     await session2.click();
-    await page.waitForTimeout(1000);
 
     // Verify second session's messages are visible (indicating it's now active)
     await expect(page.getByText('Help me debug this timeout issue')).toBeVisible({ timeout: 5000 });
@@ -261,9 +235,6 @@ test.describe('Chat History with Authentication', { tag: '@mock' }, () => {
     );
     await page.waitForLoadState('networkidle');
 
-    // Wait for sessions to load
-    await page.waitForTimeout(1000);
-
     // Set up request listener for tasks/list
     const tasksListPromise = page.waitForRequest((request) => {
       const postData = request.postDataJSON();
@@ -288,9 +259,6 @@ test.describe('Chat History Error Handling', { tag: '@mock' }, () => {
     await page.goto(`http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&errorHistory=true`);
     await page.waitForLoadState('networkidle');
 
-    // Wait a moment for the error to be handled
-    await page.waitForTimeout(1000);
-
     // App should still render even if contexts/list fails - should show "Start a new chat" button
     const newChatButton = page.getByRole('button', { name: /start a new chat/i });
     await expect(newChatButton).toBeVisible({ timeout: 5000 });
@@ -303,9 +271,6 @@ test.describe('Chat History Error Handling', { tag: '@mock' }, () => {
       `http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&multiSession=true&withHistory=true&errorTasks=true`
     );
     await page.waitForLoadState('networkidle');
-
-    // Wait for sessions to load
-    await page.waitForTimeout(1000);
 
     // Click on a session to trigger tasks/list
     const sessionItem = page.getByRole('group').filter({ hasText: 'Project Discussion' }).first();
@@ -328,9 +293,6 @@ test.describe('Creating New Chat with Existing History', { tag: '@mock' }, () =>
     await page.goto(`http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&multiSession=true&withHistory=true`);
     await page.waitForLoadState('networkidle');
 
-    // Wait for sessions to load
-    await page.waitForTimeout(1000);
-
     // Verify existing sessions are displayed
     const session1 = page.getByRole('group').filter({ hasText: 'Project Discussion' });
     await expect(session1).toBeVisible({ timeout: 5000 });
@@ -350,9 +312,6 @@ test.describe('Creating New Chat with Existing History', { tag: '@mock' }, () =>
     // Enable multiSession mode
     await page.goto(`http://localhost:3001/?agentCard=${encodeURIComponent(AGENT_CARD_URL)}&multiSession=true&withHistory=true`);
     await page.waitForLoadState('networkidle');
-
-    // Wait for sessions to load
-    await page.waitForTimeout(1000);
 
     // Click "New Chat" button
     const newChatButton = page.getByRole('button', { name: /new chat/i });

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "check": "biome check --write .",
     "compile:loc": "formatjs compile-folder --ast --format ./format.js \"Localize/lang\" \"libs/logic-apps-shared/src/intl/src/compiled-lang/\" ",
     "compile:loc:psuedo": "formatjs compile \"Localize/lang/strings.json\" --ast --format ./format.js --out-file \"libs/logic-apps-shared/src/intl/src/compiled-lang/strings.en-XA.json\" --pseudo-locale en-XA",
-    "e2e:setup": "playwright install --with-deps",
+    "e2e:setup": "playwright install --with-deps chromium",
     "extract": "formatjs extract \"libs/**/*.{ts,tsx}\" \"apps/vs-code-react/src/**/*.{ts,tsx}\" --ignore \"**/node_modules/**\" --ignore \"libs/**/*.{d,test,spec}.{ts,tsx}\" --ignore \"apps/vs-code-react/src/**/*.{d,test,spec}.{ts,tsx}\" --out-file Localize/lang/strings.json --format ./format.js",
     "generateArmToken": "node ./scripts/generateArmToken.js",
     "prepare": "husky || true",


### PR DESCRIPTION
## Commit Type

perf

## Risk Level

Low

## What & Why

The Playwright workflow takes ~6-7 min. Pulling per-job timings from a recent run on `main` (run `30500180094`) shows where it actually goes:

| Job | Duration | Test step | Tests | Sharded |
|---|---|---|---|---|
| **Chat Client E2E** | **314s** | 224s | **224** | **No** (2 workers) |
| designer shard 1/3 | 308s | 211s | ~29 | 3 x 2 workers |
| designer shard 2/3 | 277s | 186s | ~29 | " |
| designer shard 3/3 | 278s | 208s | ~29 | " |
| test (merge) | 18s | - | - | gated on shards |

Two problems fall out of that:

**1. Chat Client is the critical path and is unsharded.** It runs 224 tests on one runner with 2 workers, while the designer suite spreads 88 tests across 3 shards. `playwright.chatClient.config.ts` already handles `TEST_SHARDED` and emits blob reports, so the config side needed no changes - only the workflow was missing the matrix. This adds a 3-way shard plus a `chat-client-report` job that merges the blobs, mirroring the existing `designer-e2e-shards` / `test` pattern.

**2. Every job re-downloads browsers, and downloads too many.** Browser install was 35-56s per job (~4 min of runner time across the workflow). Two fixes:

- Cache `~/.cache/ms-playwright` keyed on `pnpm-lock.yaml`. Deliberately **no `restore-keys`**: a prefix hit would restore browsers built for a different Playwright version, report `cache-hit != 'true'`, and then re-save that stale tree. `.github/workflows/vscode-e2e.yml` documents this same trap. On a cache hit we still run `playwright install-deps chromium` so the apt-level deps are reconciled.
- `e2e:setup` was `playwright install --with-deps`, which with no browser argument installs chromium **and firefox and webkit**. All three Playwright configs (`playwright.config.ts`, `playwright.designer.config.ts`, `playwright.chatClient.config.ts`) declare only a `chromium` project - firefox/webkit are commented out - so roughly two thirds of every download was thrown away. Now installs `chromium` only.

Separately, this removes 15 redundant `waitForTimeout` calls from `chat-history.spec.ts`. Each sat between a `waitForLoadState('networkidle')` (or a click) and an auto-retrying `expect(...).toBeVisible()`, so the sleep only delayed a poll that was already going to wait. **To be clear, this one is a determinism change, not a measured speedup** - the full suite was 3.7m before and 4.0m after at 2 workers, i.e. noise. The serial single-file gain is real (65s -> 42s) but it disappears into worker parallelism.

I deliberately left every sleep that guards a *negative* assertion ("should still be visible", "didn't crash") or that sequences a `waitForRequest` listener. There the settle period **is** the test - deleting it makes the assertion pass before the thing being guarded against could even happen, which silently weakens the test rather than speeding it up. Anyone tempted to bulk-strip the remaining ~54 sleeps should know that trap; the giveaway comment usually sits *after* the sleep, not before it.

## Impact of Change

CI-only. No product/runtime code is touched.

- `.github/workflows/playwright.yml` - job names `designer-e2e-shards` and `test` are unchanged so existing branch protection checks keep resolving. `Chat Client E2E Tests` now reports as three matrix checks (`(1, 3)`, `(2, 3)`, `(3, 3)`) plus a new `chat-client-report` job, so **if the old unsuffixed `Chat Client E2E Tests` is in the required-checks list it will need updating** - otherwise it will wait forever on a check name that no longer exists.
- `package.json` - `e2e:setup` is also used by `real-e2e.yml`, which likewise only runs chromium.
- `chat-history.spec.ts` - test file only.

## Test Plan

**Verified on this PR's CI runs, not just locally.**

Chat client sharding - the critical path dropped from 314s to ~155s:

| Job | Before (main) | After |
|---|---|---|
| Chat Client E2E Tests (1, 3) | 314s (single job) | **151s** |
| Chat Client E2E Tests (2, 3) | - | **157s** |
| Chat Client E2E Tests (3, 3) | - | **155s** |
| chat-client-report (new merge job) | - | 20s |

Browser cache - confirmed working on the second run of `designer-e2e-shards (3, 3)`:

```
Cache Playwright browsers            -> success (3s)     <- restore hit
Install Playwright Browsers          -> skipped (0s)     <- download avoided
Install Playwright system deps       -> success (12s)
Post Cache Playwright browsers       -> success (0s)     <- exact-key hit, no re-save
```

So ~35-56s of browser download became ~15s. The `Post` step taking 0s is the confirmation that omitting `restore-keys` was right - an exact hit means no stale re-save. Cache entry is **251 MB**; with firefox+webkit it would have been roughly 3x that.

All jobs green: 3 chat client shards, 3 designer shards, `chat-client-report`, `test`.

One honest note: `designer-e2e-shards (3, 3)` failed on the first run, in `templates/app.spec.ts:71`. That is **a pre-existing flake on `main`, not a regression from this PR** - I checked the last 12 `main` runs and 3 failed, every one of them in `designer-e2e-shards (3, 3)` and in the same `templates/` specs (`createWorkflowPanel.spec.ts:45`, `app.spec.ts:71`, `app.spec.ts:27`). Re-running the shard passed. This PR touches no designer or template spec. Worth a separate issue.

Also verified locally:
- Full chat client suite, `--workers=2 --retries=0`: **224 passed**, both before and after the sleep removal.
- `chat-history.spec.ts` in isolation: 15/15 pass, 65s -> 42s.
- Confirmed all three Playwright configs declare only a chromium project before narrowing `e2e:setup`.

## Follow-ups (not in this PR)

- Designer is now the critical path (~250-290s). Bumping it from 3 to 5 shards is the obvious next step; left out to keep this reviewable.
- The `templates/` flake in shard 3 deserves its own investigation.
- The E2E web server runs Vite in **dev** mode, which is most of the ~10s-per-test bootstrap floor. Switching to `vite build` + `preview` would attack that directly and likely allow raising `workers` above 2.

## Contributors

@rllyy97

## Screenshots

N/A - CI configuration change.
