### PR TITLE
fix(designer-v2): allow removing an agent's last handoff, add handoff E2E coverage

### DIFF
--- a/e2e/designer/agentic/handoff.spec.ts
+++ b/e2e/designer/agentic/handoff.spec.ts
@@ -47,6 +47,66 @@ const getAgentToolNames = async (page: Page, agentId: string): Promise<string[]>
   return Object.keys(await getAgentTools(page, agentId)).sort();
 };
 
+// `addAgentHandoff` adds the tool and edge synchronously but populates the handoff action's `inputs`
+// from an unawaited `initializeOperationDetails`, so the tool key shows up in the serialized workflow
+// before its payload does. Always poll this whole shape rather than the tool names alone, otherwise
+// assertions on the payload race initialization.
+const getHandoffToolShape = async (page: Page, agentId: string, toolId: string) => {
+  const tool = (await getAgentTools(page, agentId))[toolId];
+  if (!tool) {
+    return null;
+  }
+  const actionIds = Object.keys(tool.actions ?? {});
+  const action = actionIds.length === 1 ? tool.actions[actionIds[0]] : undefined;
+  return {
+    description: tool.description,
+    actionCount: actionIds.length,
+    actionIdIsGenerated: actionIds.length === 1 ? /^handoff_[a-z0-9]{8}$/i.test(actionIds[0]) : false,
+    // Handoffs created at runtime currently serialize as `AgentHandOff` while ones read from a
+    // definition round-trip as `AgentHandoff`, so compare case-insensitively.
+    type: typeof action?.type === 'string' ? action.type.toLowerCase() : action?.type,
+    inputs: action?.inputs,
+  };
+};
+
+const fixtureHandoffs = [
+  {
+    agentId: 'TriageAgent',
+    toolId: 'handoff_from_TriageAgent_to_SalesAgent_tool',
+    actionId: 'handoff_from_TriageAgent_to_SalesAgent',
+    target: 'SalesAgent',
+    description: 'Hand off to sales agent who can fulfill sales requests such as ordering a product.',
+  },
+  {
+    agentId: 'TriageAgent',
+    toolId: 'handoff_from_TriageAgent_to_RefundAgent_tool',
+    actionId: 'handoff_from_TriageAgent_to_RefundAgent',
+    target: 'RefundAgent',
+    description: 'Hand off to refund agent who can fulfill refund requests.',
+  },
+  {
+    agentId: 'SalesAgent',
+    toolId: 'handoff_from_SalesAgent_to_TriageAgent_tool',
+    actionId: 'handoff_from_SalesAgent_to_TriageAgent',
+    target: 'TriageAgent',
+    description: 'Hand off to triage agent who can check if there are any further help needed.',
+  },
+  {
+    agentId: 'RefundAgent',
+    toolId: 'handoff_from_RefundAgent_to_TriageAgent_tool',
+    actionId: 'handoff_from_RefundAgent_to_TriageAgent',
+    target: 'TriageAgent',
+    description: 'Hand off to triage agent who can check if there are any further help needed.',
+  },
+  {
+    agentId: 'RefundAgent',
+    toolId: 'handoff_from_RefundAgent_to_SalesAgent_tool',
+    actionId: 'handoff_from_RefundAgent_to_SalesAgent',
+    target: 'SalesAgent',
+    description: 'Hand off to sales agent who can fulfill refund requests.',
+  },
+];
+
 test.describe(
   'Agent handoff tests',
   {
@@ -75,19 +135,30 @@ test.describe(
         'handoff_from_TriageAgent_to_RefundAgent_tool',
         'handoff_from_TriageAgent_to_SalesAgent_tool',
       ]);
-
-      // The tool description and the inner AgentHandoff action (including its target) round-trip.
-      const toSales = triageTools.handoff_from_TriageAgent_to_SalesAgent_tool;
-      expect(toSales.description).toBe('Hand off to sales agent who can fulfill sales requests such as ordering a product.');
-      expect(toSales.actions.handoff_from_TriageAgent_to_SalesAgent.type).toMatch(/^AgentHandoff$/i);
-      expect(toSales.actions.handoff_from_TriageAgent_to_SalesAgent.inputs).toEqual({ name: 'SalesAgent' });
-
-      const toRefund = triageTools.handoff_from_TriageAgent_to_RefundAgent_tool;
-      expect(toRefund.description).toBe('Hand off to refund agent who can fulfill refund requests.');
-      expect(toRefund.actions.handoff_from_TriageAgent_to_RefundAgent.inputs).toEqual({ name: 'RefundAgent' });
-
       // A handoff tool and a regular tool coexist on the same agent without either being dropped.
       expect(await getAgentToolNames(page, 'SalesAgent')).toEqual(['handoff_from_SalesAgent_to_TriageAgent_tool', 'place_order']);
+      expect(await getAgentToolNames(page, 'RefundAgent')).toEqual([
+        'handoff_from_RefundAgent_to_SalesAgent_tool',
+        'handoff_from_RefundAgent_to_TriageAgent_tool',
+      ]);
+
+      // Every fixture handoff keeps its description and its inner AgentHandoff action, id, and target.
+      for (const handoff of fixtureHandoffs) {
+        const tool = (await getAgentTools(page, handoff.agentId))[handoff.toolId];
+        expect(tool.description, `description of ${handoff.toolId}`).toBe(handoff.description);
+        expect(Object.keys(tool.actions), `actions of ${handoff.toolId}`).toEqual([handoff.actionId]);
+        expect(tool.actions[handoff.actionId].type, `type of ${handoff.actionId}`).toMatch(/^AgentHandoff$/i);
+        expect(tool.actions[handoff.actionId].inputs, `inputs of ${handoff.actionId}`).toEqual({ name: handoff.target });
+      }
+
+      // The non-handoff tool on SalesAgent round-trips untouched alongside the handoff tools.
+      const placeOrder = (await getAgentTools(page, 'SalesAgent')).place_order;
+      expect(placeOrder.description).toBe('Place the order');
+      expect(Object.keys(placeOrder.actions)).toEqual([
+        'set_order_parameters',
+        'resetset_state_variable_from_sales_to_triage',
+        'complete_order',
+      ]);
     });
 
     test('Selecting an agent in the handoff selector adds a handoff tool, edge, and tab entry', async ({ page }) => {
@@ -103,19 +174,24 @@ test.describe(
       await expect(handoffEntryHeader(page, 'RefundAgent')).toBeVisible();
       await expect(handoffEntryHeader(page, 'TriageAgent')).toBeVisible();
 
-      await expect
-        .poll(() => getAgentToolNames(page, 'SalesAgent'))
-        .toEqual(['handoff_from_SalesAgent_to_TriageAgent_tool', 'handoff_to_RefundAgent_from_SalesAgent', 'place_order']);
-
       // generateHandoffToolName() names the tool `handoff_to_<target>_from_<source>`, and the inner
-      // action gets a generated `handoff_<guid>` id whose only input is the target agent name.
-      const tools = await getAgentTools(page, 'SalesAgent');
-      const added = tools.handoff_to_RefundAgent_from_SalesAgent;
-      const addedActionIds = Object.keys(added.actions);
-      expect(addedActionIds).toHaveLength(1);
-      expect(addedActionIds[0]).toMatch(/^handoff_[a-z0-9]{8}$/i);
-      expect(added.actions[addedActionIds[0]].type).toMatch(/^AgentHandoff$/i);
-      expect(added.actions[addedActionIds[0]].inputs).toEqual({ name: 'RefundAgent' });
+      // action gets a generated `handoff_<guid>` id whose only input is the target agent name. Poll
+      // the whole payload, since `inputs` is filled in asynchronously after the tool itself appears.
+      await expect
+        .poll(() => getHandoffToolShape(page, 'SalesAgent', 'handoff_to_RefundAgent_from_SalesAgent'))
+        .toEqual({
+          description: '',
+          actionCount: 1,
+          actionIdIsGenerated: true,
+          type: 'agenthandoff',
+          inputs: { name: 'RefundAgent' },
+        });
+
+      expect(await getAgentToolNames(page, 'SalesAgent')).toEqual([
+        'handoff_from_SalesAgent_to_TriageAgent_tool',
+        'handoff_to_RefundAgent_from_SalesAgent',
+        'place_order',
+      ]);
     });
 
     test('Deleting a handoff entry removes its tool and edge while leaving other tools intact', async ({ page }) => {
@@ -135,6 +211,22 @@ test.describe(
       await expect.poll(() => getAgentToolNames(page, 'RefundAgent')).toEqual(['handoff_from_RefundAgent_to_TriageAgent_tool']);
       // Deleting a handoff on one agent must not touch tools on another agent.
       expect(await getAgentToolNames(page, 'SalesAgent')).toEqual(['handoff_from_SalesAgent_to_TriageAgent_tool', 'place_order']);
+    });
+
+    test('Unchecking an agents only handoff removes it', async ({ page }) => {
+      await GoToMockWorkflowV2(page, 'Handoff A2A');
+
+      // SalesAgent has exactly one handoff, so unchecking it drives `checkedItems` to zero — the
+      // boundary the selector used to bail out of, which made the last handoff unremovable.
+      await openHandoffTab(page, 'card-salesagent');
+      await expect(handoffEntryHeader(page, 'TriageAgent')).toBeVisible();
+
+      await toggleAgentInSelector(page, 'TriageAgent');
+
+      await expect(agentEdge(page, 'SalesAgent', 'TriageAgent')).toHaveCount(0);
+      await expect(handoffEntryHeader(page, 'TriageAgent')).toHaveCount(0);
+      // The agent's non-handoff tool is left alone.
+      await expect.poll(() => getAgentToolNames(page, 'SalesAgent')).toEqual(['place_order']);
     });
 
     test('Unchecking an agent in the selector removes the handoff and flags the target as unreachable', async ({ page }) => {

--- a/e2e/designer/agentic/handoff.spec.ts
+++ b/e2e/designer/agentic/handoff.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { GoToMockWorkflowV2 } from '../utils/GoToWorkflow';
+import { getSerializedWorkflowFromStateV2 } from '../utils/designerFunctions';
+
+// Handoffs are the agent-to-agent control transfer mechanism in agentic workflows. Each handoff is
+// stored as a tool subgraph on the source agent whose only action is an `AgentHandoff` pointing at the
+// target agent, and the designer renders it as a direct agent-to-agent edge rather than a tool node.
+// The add/remove thunks live in libs/designer-v2/src/lib/core/actions/bjsworkflow/handoff.ts and the UI
+// in libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/handoffTab.
+
+const agentEdge = (page: Page, sourceId: string, targetId: string): Locator =>
+  page.locator(`[data-testid="rf__edge-${sourceId}-${targetId}"]`);
+
+const handoffEntryHeader = (page: Page, targetAgentName: string): Locator =>
+  page.getByRole('button', { name: targetAgentName, exact: true });
+
+const deleteHandoffButton = (page: Page, targetAgentName: string): Locator =>
+  handoffEntryHeader(page, targetAgentName).locator('xpath=following-sibling::button[@aria-label="Delete handoff"]');
+
+const openHandoffTab = async (page: Page, agentCardTestId: string) => {
+  // Close any panel that is already open so the canvas returns to full width, then re-fit. Adding or
+  // removing a handoff re-layouts the graph, and a node can end up underneath the Standalone toolbox
+  // nub, which would swallow the click.
+  const closePanelButton = page.getByRole('button', { name: 'Close', exact: true });
+  if ((await closePanelButton.count()) > 0) {
+    await closePanelButton.first().click();
+  }
+  await page.getByLabel('Zoom view to fit').click({ force: true });
+
+  await page.getByTestId(agentCardTestId).click();
+  await page.getByRole('tab', { name: 'Handoffs' }).click();
+  await expect(page.getByRole('button', { name: 'Select agents' })).toBeVisible();
+};
+
+const toggleAgentInSelector = async (page: Page, targetAgentName: string) => {
+  await page.getByRole('button', { name: 'Select agents' }).click();
+  await page.getByRole('menuitemcheckbox', { name: targetAgentName, exact: true }).click();
+  await page.keyboard.press('Escape');
+};
+
+const getAgentTools = async (page: Page, agentId: string): Promise<Record<string, any>> => {
+  const serialized: any = await getSerializedWorkflowFromStateV2(page);
+  return serialized.definition.actions[agentId].tools ?? {};
+};
+
+const getAgentToolNames = async (page: Page, agentId: string): Promise<string[]> => {
+  return Object.keys(await getAgentTools(page, agentId)).sort();
+};
+
+test.describe(
+  'Agent handoff tests',
+  {
+    tag: '@mock',
+  },
+  () => {
+    test('Handoff tools deserialize into agent-to-agent edges and survive a serialization round-trip', async ({ page }) => {
+      await GoToMockWorkflowV2(page, 'Handoff A2A');
+
+      // Every handoff in the fixture becomes a direct edge between the two agents. Bidirectional pairs
+      // are drawn as a single overlapping spline, so assert the edge exists in the graph rather than
+      // that each direction paints its own visible line.
+      await expect(agentEdge(page, 'TriageAgent', 'SalesAgent')).toBeAttached();
+      await expect(agentEdge(page, 'TriageAgent', 'RefundAgent')).toBeAttached();
+      await expect(agentEdge(page, 'SalesAgent', 'TriageAgent')).toBeAttached();
+      await expect(agentEdge(page, 'RefundAgent', 'TriageAgent')).toBeAttached();
+      await expect(agentEdge(page, 'RefundAgent', 'SalesAgent')).toBeAttached();
+
+      // Handoff tools are folded into those edges, so they must not surface as tool nodes on the
+      // canvas. A non-handoff tool on the same agent (`place_order`) still does.
+      await expect(page.locator('[data-testid="rf__node-place_order"]')).toBeVisible();
+      await expect(page.locator('[data-testid^="rf__node-handoff_"]')).toHaveCount(0);
+
+      const triageTools = await getAgentTools(page, 'TriageAgent');
+      expect(Object.keys(triageTools).sort()).toEqual([
+        'handoff_from_TriageAgent_to_RefundAgent_tool',
+        'handoff_from_TriageAgent_to_SalesAgent_tool',
+      ]);
+
+      // The tool description and the inner AgentHandoff action (including its target) round-trip.
+      const toSales = triageTools.handoff_from_TriageAgent_to_SalesAgent_tool;
+      expect(toSales.description).toBe('Hand off to sales agent who can fulfill sales requests such as ordering a product.');
+      expect(toSales.actions.handoff_from_TriageAgent_to_SalesAgent.type).toMatch(/^AgentHandoff$/i);
+      expect(toSales.actions.handoff_from_TriageAgent_to_SalesAgent.inputs).toEqual({ name: 'SalesAgent' });
+
+      const toRefund = triageTools.handoff_from_TriageAgent_to_RefundAgent_tool;
+      expect(toRefund.description).toBe('Hand off to refund agent who can fulfill refund requests.');
+      expect(toRefund.actions.handoff_from_TriageAgent_to_RefundAgent.inputs).toEqual({ name: 'RefundAgent' });
+
+      // A handoff tool and a regular tool coexist on the same agent without either being dropped.
+      expect(await getAgentToolNames(page, 'SalesAgent')).toEqual(['handoff_from_SalesAgent_to_TriageAgent_tool', 'place_order']);
+    });
+
+    test('Selecting an agent in the handoff selector adds a handoff tool, edge, and tab entry', async ({ page }) => {
+      await GoToMockWorkflowV2(page, 'Handoff A2A');
+
+      await openHandoffTab(page, 'card-salesagent');
+      await expect(agentEdge(page, 'SalesAgent', 'RefundAgent')).toHaveCount(0);
+
+      await toggleAgentInSelector(page, 'RefundAgent');
+
+      // The new handoff shows up on the canvas and in the Handoffs tab.
+      await expect(agentEdge(page, 'SalesAgent', 'RefundAgent')).toBeAttached();
+      await expect(handoffEntryHeader(page, 'RefundAgent')).toBeVisible();
+      await expect(handoffEntryHeader(page, 'TriageAgent')).toBeVisible();
+
+      await expect
+        .poll(() => getAgentToolNames(page, 'SalesAgent'))
+        .toEqual(['handoff_from_SalesAgent_to_TriageAgent_tool', 'handoff_to_RefundAgent_from_SalesAgent', 'place_order']);
+
+      // generateHandoffToolName() names the tool `handoff_to_<target>_from_<source>`, and the inner
+      // action gets a generated `handoff_<guid>` id whose only input is the target agent name.
+      const tools = await getAgentTools(page, 'SalesAgent');
+      const added = tools.handoff_to_RefundAgent_from_SalesAgent;
+      const addedActionIds = Object.keys(added.actions);
+      expect(addedActionIds).toHaveLength(1);
+      expect(addedActionIds[0]).toMatch(/^handoff_[a-z0-9]{8}$/i);
+      expect(added.actions[addedActionIds[0]].type).toMatch(/^AgentHandoff$/i);
+      expect(added.actions[addedActionIds[0]].inputs).toEqual({ name: 'RefundAgent' });
+    });
+
+    test('Deleting a handoff entry removes its tool and edge while leaving other tools intact', async ({ page }) => {
+      await GoToMockWorkflowV2(page, 'Handoff A2A');
+
+      await openHandoffTab(page, 'card-refundagent');
+      await expect(agentEdge(page, 'RefundAgent', 'SalesAgent')).toBeAttached();
+
+      await deleteHandoffButton(page, 'SalesAgent').click();
+
+      await expect(agentEdge(page, 'RefundAgent', 'SalesAgent')).toHaveCount(0);
+      await expect(handoffEntryHeader(page, 'SalesAgent')).toHaveCount(0);
+      // The agent's other handoff is untouched.
+      await expect(handoffEntryHeader(page, 'TriageAgent')).toBeVisible();
+      await expect(agentEdge(page, 'RefundAgent', 'TriageAgent')).toBeAttached();
+
+      await expect.poll(() => getAgentToolNames(page, 'RefundAgent')).toEqual(['handoff_from_RefundAgent_to_TriageAgent_tool']);
+      // Deleting a handoff on one agent must not touch tools on another agent.
+      expect(await getAgentToolNames(page, 'SalesAgent')).toEqual(['handoff_from_SalesAgent_to_TriageAgent_tool', 'place_order']);
+    });
+
+    test('Unchecking an agent in the selector removes the handoff and flags the target as unreachable', async ({ page }) => {
+      await GoToMockWorkflowV2(page, 'Handoff A2A');
+
+      // RefundAgent is only reachable through TriageAgent's handoff, so removing it strands the agent.
+      await openHandoffTab(page, 'card-triageagent');
+      await toggleAgentInSelector(page, 'RefundAgent');
+
+      await expect(agentEdge(page, 'TriageAgent', 'RefundAgent')).toHaveCount(0);
+      await expect(handoffEntryHeader(page, 'RefundAgent')).toHaveCount(0);
+      await expect.poll(() => getAgentToolNames(page, 'TriageAgent')).toEqual(['handoff_from_TriageAgent_to_SalesAgent_tool']);
+
+      await openHandoffTab(page, 'card-refundagent');
+      await expect(page.getByText('Agent is unreachable in flow structure')).toBeVisible();
+
+      // SalesAgent still has an inbound handoff from TriageAgent, so it is not flagged.
+      await openHandoffTab(page, 'card-salesagent');
+      await expect(page.getByText('Agent is unreachable in flow structure')).toHaveCount(0);
+    });
+
+    test('Editing a handoff description serializes onto the handoff tool', async ({ page }) => {
+      await GoToMockWorkflowV2(page, 'Handoff A2A');
+
+      await openHandoffTab(page, 'card-salesagent');
+
+      const description = page.locator('#handoff_from_SalesAgent_to_TriageAgent_tool-description');
+      await expect(description).toHaveValue('Hand off to triage agent who can check if there are any further help needed.');
+
+      await description.fill('Hand back to triage once the sale is complete.');
+      await description.blur();
+
+      await expect
+        .poll(async () => (await getAgentTools(page, 'SalesAgent')).handoff_from_SalesAgent_to_TriageAgent_tool.description)
+        .toBe('Hand back to triage once the sale is complete.');
+    });
+  }
+);

--- a/e2e/designer/notes.spec.ts
+++ b/e2e/designer/notes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { GoToMockWorkflow } from './utils/GoToWorkflow';
+import { GoToMockWorkflowV2 } from './utils/GoToWorkflow';
 
 test.describe(
   'Designer notes tests',
@@ -12,10 +12,7 @@ test.describe(
       const pageErrors: string[] = [];
       page.on('pageerror', (error) => pageErrors.push(error.message));
 
-      await page.goto('/v2');
-      // The v2 route pulls in a large module graph; give the dev server time to serve it.
-      await page.getByText('Local', { exact: true }).waitFor({ state: 'visible', timeout: 3 * 60 * 1000 });
-      await GoToMockWorkflow(page, 'Notes In Metadata');
+      await GoToMockWorkflowV2(page, 'Notes In Metadata');
 
       await expect(page.getByTestId('card-check_for_entra_security_alerts')).toBeVisible();
       await expect(page.getByTestId('card-initialize_variable')).toBeVisible();

--- a/e2e/designer/utils/GoToWorkflow.ts
+++ b/e2e/designer/utils/GoToWorkflow.ts
@@ -20,6 +20,13 @@ export const GoToMockWorkflow = async (page: Page, workflowName: string) => {
   await page.getByLabel('Zoom view to fit').click({ force: true });
 };
 
+export const GoToMockWorkflowV2 = async (page: Page, workflowName: string) => {
+  await page.goto('/v2');
+  // The v2 route pulls in a large module graph; give the dev server time to serve it.
+  await page.getByText('Local', { exact: true }).waitFor({ state: 'visible', timeout: 3 * 60 * 1000 });
+  await GoToMockWorkflow(page, workflowName);
+};
+
 export const LoadRunFile = async (page: Page, runName: string) => {
   await page.getByRole('button', { name: 'Toolbox' }).click();
   await page.getByRole('heading', { name: '▼ Context Settings' }).click();

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/handoffTab/HandoffSelector.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/handoffTab/HandoffSelector.tsx
@@ -97,9 +97,6 @@ export const HandoffSelector = ({ agentId, readOnly }: { agentId: string; readOn
           });
         }}
         onCheckedValueChange={(_e, data) => {
-          if (data.checkedItems.length === 0) {
-            return;
-          }
           const newItems = data.checkedItems.filter((x) => !selectedIds.includes(x));
           const removedItems = selectedIds.filter((x) => !data.checkedItems.includes(x));
           removedItems.forEach(removeHandoff);

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/handoffTab/__test__/handoffSelector.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/handoffTab/__test__/handoffSelector.spec.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+
+const mockDispatch = vi.fn();
+
+let handoffActions: { toolId: string; targetId: string }[] = [];
+let allAgentIds: string[] = [];
+let selectedPanelNodeId = 'SalesAgent';
+
+vi.mock('react-redux', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-redux')>();
+  return {
+    ...actual,
+    useDispatch: () => mockDispatch,
+  };
+});
+
+vi.mock('@microsoft/logic-apps-shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@microsoft/logic-apps-shared')>();
+  return {
+    ...actual,
+    LoggerService: () => ({ log: vi.fn() }),
+  };
+});
+
+vi.mock('../../../../../../core/state/workflow/workflowSelectors', () => ({
+  useAllAgentIds: () => allAgentIds,
+  useHandoffActionsForAgent: () => handoffActions,
+  useNodeDisplayName: (id: string) => id,
+}));
+
+vi.mock('../../../../../../core', () => ({
+  useOperationPanelSelectedNodeId: () => selectedPanelNodeId,
+}));
+
+vi.mock('../../../../../../core/state/operation/operationSelector', () => ({
+  useOperationVisuals: () => ({ iconUri: 'icon.png' }),
+}));
+
+vi.mock('../../../../../../core/actions/bjsworkflow/handoff', () => ({
+  addAgentHandoff: vi.fn((payload) => ({ type: 'addAgentHandoff', payload })),
+  removeAgentHandoff: vi.fn((payload) => ({ type: 'removeAgentHandoff', payload })),
+}));
+
+import { addAgentHandoff, removeAgentHandoff } from '../../../../../../core/actions/bjsworkflow/handoff';
+import { HandoffSelector } from '../HandoffSelector';
+
+const renderSelector = (agentId = 'SalesAgent', readOnly = false) =>
+  render(
+    <IntlProvider locale="en" messages={{}}>
+      <HandoffSelector agentId={agentId} readOnly={readOnly} />
+    </IntlProvider>
+  );
+
+const openSelector = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('button', { name: /select agents/i }));
+  return screen.findAllByRole('menuitemcheckbox');
+};
+
+describe('HandoffSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allAgentIds = ['TriageAgent', 'SalesAgent', 'RefundAgent'];
+    handoffActions = [];
+    selectedPanelNodeId = 'SalesAgent';
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('lists every agent except the one the panel is open on', async () => {
+    const user = userEvent.setup();
+    renderSelector();
+
+    const items = await openSelector(user);
+    expect(items.map((item) => item.textContent)).toEqual(['TriageAgent', 'RefundAgent']);
+  });
+
+  it('checks the agents that already have a handoff', async () => {
+    handoffActions = [{ toolId: 'handoff_to_TriageAgent_from_SalesAgent', targetId: 'TriageAgent' }];
+    const user = userEvent.setup();
+    renderSelector();
+
+    const items = await openSelector(user);
+    expect(items.map((item) => item.getAttribute('aria-checked'))).toEqual(['true', 'false']);
+  });
+
+  it('adds a handoff when an unchecked agent is selected', async () => {
+    const user = userEvent.setup();
+    renderSelector();
+
+    const items = await openSelector(user);
+    await user.click(items[1]);
+
+    expect(addAgentHandoff).toHaveBeenCalledWith({ sourceId: 'SalesAgent', targetId: 'RefundAgent' });
+    expect(removeAgentHandoff).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'addAgentHandoff',
+      payload: { sourceId: 'SalesAgent', targetId: 'RefundAgent' },
+    });
+  });
+
+  it('removes only the unchecked handoff when several are selected', async () => {
+    handoffActions = [
+      { toolId: 'handoff_to_TriageAgent_from_SalesAgent', targetId: 'TriageAgent' },
+      { toolId: 'handoff_to_RefundAgent_from_SalesAgent', targetId: 'RefundAgent' },
+    ];
+    const user = userEvent.setup();
+    renderSelector();
+
+    const items = await openSelector(user);
+    await user.click(items[0]);
+
+    expect(removeAgentHandoff).toHaveBeenCalledTimes(1);
+    expect(removeAgentHandoff).toHaveBeenCalledWith({
+      agentId: 'SalesAgent',
+      toolId: 'handoff_to_TriageAgent_from_SalesAgent',
+    });
+    expect(addAgentHandoff).not.toHaveBeenCalled();
+  });
+
+  // Regression test: the handler used to bail out whenever `checkedItems` became empty, which made an
+  // agent's last handoff impossible to remove from this menu.
+  it('removes the handoff when the only checked agent is unchecked', async () => {
+    handoffActions = [{ toolId: 'handoff_to_TriageAgent_from_SalesAgent', targetId: 'TriageAgent' }];
+    const user = userEvent.setup();
+    renderSelector();
+
+    const items = await openSelector(user);
+    await user.click(items[0]);
+
+    expect(removeAgentHandoff).toHaveBeenCalledWith({
+      agentId: 'SalesAgent',
+      toolId: 'handoff_to_TriageAgent_from_SalesAgent',
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'removeAgentHandoff',
+      payload: { agentId: 'SalesAgent', toolId: 'handoff_to_TriageAgent_from_SalesAgent' },
+    });
+  });
+
+  it('filters the agent list by the search text', async () => {
+    const user = userEvent.setup();
+    renderSelector();
+
+    await user.click(screen.getByRole('button', { name: /select agents/i }));
+    await user.type(screen.getByPlaceholderText('Filter agents'), 'Refund');
+
+    const items = await screen.findAllByRole('menuitemcheckbox');
+    expect(items.map((item) => item.textContent)).toEqual(['RefundAgent']);
+  });
+
+  it('disables the agent options when read only', async () => {
+    const user = userEvent.setup();
+    renderSelector('SalesAgent', true);
+
+    const items = await openSelector(user);
+    for (const item of items) {
+      expect(item.getAttribute('aria-disabled')).toBe('true');
+    }
+  });
+});


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Agent handoffs are a designer-v2-only feature and had zero E2E coverage. Handoffs are stored as tool subgraphs on the source agent (an `AgentHandoff` action pointing at the target), rendered as agent-to-agent edges instead of tool nodes, and mutated through `addAgentHandoff` / `removeAgentHandoff`. None of the deserialize → mutate → serialize path was exercised, and the `HandoffA2A.json` mock workflow existed but was referenced by no spec.

**Bug fix.** Writing the removal coverage surfaced a real defect. `HandoffSelector`'s `onCheckedValueChange` bailed out early whenever `checkedItems` became empty:

```ts
if (data.checkedItems.length === 0) {
  return;
}
```

So unchecking an agent's **only** handoff silently did nothing — the last handoff could only be removed via the per-entry delete button. The guard has been there since designer-v2 was introduced (#8128) and wasn't guarding anything; the zero-selection case computes removals correctly like any other. Removing it fixes the boundary. The new test was confirmed to fail before the fix and pass after.

**E2E coverage.** Adds `e2e/designer/agentic/handoff.spec.ts` (6 tests, `@mock`, all on `/v2`):

- **Deserialization + round-trip** — all five fixture handoffs become `rf__edge-<source>-<target>` graph edges, handoff tools do not render as tool nodes (while the sibling non-handoff `place_order` tool does), and the description, action id, action type, and target of every handoff across all three agents round-trip — as does `place_order` and its three inner actions.
- **Add** — checking an agent in the Handoffs tab "Select agents" menu creates the edge, the tab entry, and a `handoff_to_<target>_from_<source>` tool whose single generated `handoff_<guid>` action targets the right agent.
- **Delete** — the per-entry delete button removes exactly that tool and edge, leaving the agent's other handoff and other agents' tools untouched.
- **Zero-selection boundary** — unchecking an agent's only handoff removes it and leaves its non-handoff tool alone (regression test for the fix above).
- **Uncheck + unreachable warning** — unchecking an agent removes the handoff, and the now-stranded target surfaces "Agent is unreachable in flow structure" while a still-reachable agent does not.
- **Description editing** — editing a handoff description serializes onto the handoff tool.

Two behaviors worth flagging to reviewers, both accommodated rather than asserted-as-correct so the tests don't cement them:

1. Bidirectional handoff pairs render as a single overlapping spline, so the reverse-direction edge element has an empty bounding box. Edge assertions use `toBeAttached()` rather than `toBeVisible()`.
2. Newly created handoffs serialize with `type: 'AgentHandOff'` (capital `O`) while pre-existing ones round-trip as `'AgentHandoff'`. The type assertions are case-insensitive.

Post-add assertions poll the complete serialized handoff payload rather than just the tool key, because `addAgentHandoff` adds the tool synchronously but fills `inputs.name` via an unawaited `initializeOperationDetails` — asserting the payload immediately after the key appears would race initialization.

Also extracts the duplicated `/v2` navigation (goto + long wait for the module graph to load + `GoToMockWorkflow`) into `GoToMockWorkflowV2` and reuses it from `notes.spec.ts`.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Unchecking an agent's last handoff in the Handoffs tab selector now removes it, instead of silently doing nothing. No other behavior changes.
- **Developers**: New `GoToMockWorkflowV2` helper for `/v2` mock specs; new `e2e/designer/agentic/` folder for agentic designer specs.
- **System**: One guard removed from a designer-v2 event handler. Adds 6 tests to the `@mock` Playwright designer suite (~1 min wall clock, sharded across the existing 3 CI shards).

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Standalone designer `/v2` route against the `Handoff A2A` mock workflow, Chromium

`e2e/designer/agentic/handoff.spec.ts` — 6/6 passing, and 12/12 with `--repeat-each=2` to check for flakiness. `e2e/designer/notes.spec.ts` re-run after the helper refactor and still passing. The zero-selection test was run against the unpatched `HandoffSelector` first and failed as expected (`rf__edge-SalesAgent-TriageAgent` still present after unchecking), then passed with the fix applied.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
N/A — the only product change is removing a no-op early return; there is no visual change.
