### PR TITLE
fix(designer-v2): keep connector OAuth sign-in for managed MCP servers

### DIFF
--- a/libs/a2a-core/src/react/styles/index.css
+++ b/libs/a2a-core/src/react/styles/index.css
@@ -635,6 +635,12 @@
 	text-decoration: underline;
 }
 
+.markdownContent img {
+	max-width: 100%;
+	height: auto;
+	border-radius: var(--chat-radius-small);
+}
+
 .messageWrapper.user .markdownContent code {
 	background-color: rgba(255, 255, 255, 0.2);
 }

--- a/libs/designer-ui/src/lib/chatbot/chatbot.less
+++ b/libs/designer-ui/src/lib/chatbot/chatbot.less
@@ -47,6 +47,11 @@
     white-space: pre-wrap;
     word-break: break-all;
   }
+  img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
+  }
 }
 
 .msla-bubble-footer {

--- a/libs/designer-v2/src/lib/common/__test__/constants.spec.ts
+++ b/libs/designer-v2/src/lib/common/__test__/constants.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { connectorDeclaresOwnAuth, isManagedMcpConnector, usesMcpManagedIdentityFallback } from '../constants';
+
+const managedApiId = (name: string) => `/subscriptions/sub/providers/Microsoft.Web/locations/eastus2/managedApis/${name}`;
+
+describe('isManagedMcpConnector', () => {
+  it('should match connectors of type McpClient', () => {
+    expect(isManagedMcpConnector({ id: managedApiId('anything'), type: 'McpClient' })).toBe(true);
+  });
+
+  it('should match managed API connectors whose name contains mcp', () => {
+    expect(isManagedMcpConnector({ id: managedApiId('foundrygithubmcp') })).toBe(true);
+    expect(isManagedMcpConnector({ id: managedApiId('a365mcp') })).toBe(true);
+  });
+
+  it('should not match built-in connectors', () => {
+    expect(isManagedMcpConnector({ id: managedApiId('githubmcp'), properties: { capabilities: ['builtin'] } })).toBe(false);
+  });
+
+  it('should not match unrelated managed API connectors', () => {
+    expect(isManagedMcpConnector({ id: managedApiId('github') })).toBe(false);
+  });
+});
+
+describe('connectorDeclaresOwnAuth', () => {
+  it('should be true for multi-auth connectors', () => {
+    expect(
+      connectorDeclaresOwnAuth({
+        properties: { connectionParameterSets: { values: [{ name: 'oauth' }, { name: 'managedIdentity' }] } },
+      })
+    ).toBe(true);
+  });
+
+  it('should be true for single-auth connectors that declare connection parameters', () => {
+    expect(connectorDeclaresOwnAuth({ properties: { connectionParameters: { token: { type: 'oauthSetting' } } } })).toBe(true);
+  });
+
+  it('should be false when the connector declares no auth at all', () => {
+    expect(connectorDeclaresOwnAuth({ properties: { connectionParameters: {} } })).toBe(false);
+    expect(connectorDeclaresOwnAuth({ properties: { connectionParameterSets: { values: [] } } })).toBe(false);
+    expect(connectorDeclaresOwnAuth({ properties: {} })).toBe(false);
+    expect(connectorDeclaresOwnAuth({})).toBe(false);
+  });
+});
+
+describe('usesMcpManagedIdentityFallback', () => {
+  it('should be true for a managed MCP connector that declares no auth of its own', () => {
+    expect(usesMcpManagedIdentityFallback({ id: managedApiId('customservermcp'), properties: { capabilities: [] } })).toBe(true);
+  });
+
+  it('should be false for an OAuth-backed managed MCP connector', () => {
+    expect(
+      usesMcpManagedIdentityFallback({
+        id: managedApiId('foundrygithubmcp'),
+        properties: {
+          capabilities: [],
+          connectionParameters: { token: { type: 'oauthSetting' } },
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('should be false for a managed MCP connector that declares its own parameter sets', () => {
+    expect(
+      usesMcpManagedIdentityFallback({
+        id: managedApiId('stripemcp'),
+        properties: { capabilities: [], connectionParameterSets: { values: [{ name: 'oauth' }] } },
+      })
+    ).toBe(false);
+  });
+
+  it('should be false for connectors that are not managed MCP connectors', () => {
+    expect(usesMcpManagedIdentityFallback({ id: managedApiId('github'), properties: { capabilities: [] } })).toBe(false);
+  });
+});

--- a/libs/designer-v2/src/lib/common/constants.ts
+++ b/libs/designer-v2/src/lib/common/constants.ts
@@ -83,6 +83,40 @@ export const isManagedMcpConnector = (connector: { id?: string; type?: string; p
   return isMcp && !connector.properties?.capabilities?.includes('builtin');
 };
 
+/**
+ * Checks whether a connector declares how to authenticate on its own - either through multi-auth
+ * parameter sets, or through single-auth connection parameters such as an OAuth `token`
+ * (first-party connectors like GitHub work this way).
+ */
+export const connectorDeclaresOwnAuth = (connector: {
+  properties?: { connectionParameterSets?: { values?: unknown[] }; connectionParameters?: Record<string, unknown> };
+}): boolean => {
+  const connectorProperties = connector?.properties;
+  if (!connectorProperties) {
+    return false;
+  }
+  return (
+    (connectorProperties.connectionParameterSets?.values?.length ?? 0) > 0 ||
+    Object.keys(connectorProperties.connectionParameters ?? {}).length > 0
+  );
+};
+
+/**
+ * `isManagedMcpConnector` matches on the connector name, so OAuth-backed MCP connectors
+ * (e.g. `foundrygithubmcp`) qualify as well. Only connectors that declare no auth of their own fall
+ * back to the generic managed-identity based MCP auth; the rest must keep their own auth flow and
+ * must not have managed identity properties forced onto their connections.
+ */
+export const usesMcpManagedIdentityFallback = (connector: {
+  id?: string;
+  type?: string;
+  properties?: {
+    capabilities?: string[];
+    connectionParameterSets?: { values?: unknown[] };
+    connectionParameters?: Record<string, unknown>;
+  };
+}): boolean => isManagedMcpConnector(connector) && !connectorDeclaresOwnAuth(connector);
+
 export default {
   API_TIER: {
     PREMIUM: 'PREMIUM',

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
@@ -4,6 +4,7 @@ import Constants from '../../../../common/constants';
 import { getReactQueryClient } from '../../../ReactQueryProvider';
 import {
   getConnectionMappingForNode,
+  getConnectionPropertiesIfRequired,
   getLegacyConnectionReferenceKey,
   getManifestBasedConnectionMapping,
   isOpenApiConnectionType,
@@ -21,7 +22,10 @@ import {
   OperationManifestService,
   createItem,
   ConnectionReferenceKeyFormat,
+  ConnectionParameterTypes,
   InitLoggerService,
+  InitWorkflowService,
+  ResourceIdentityType,
 } from '@microsoft/logic-apps-shared';
 import type { LogicAppsV2, OperationManifest, Connector } from '@microsoft/logic-apps-shared';
 
@@ -355,3 +359,68 @@ function createDeferred<T>() {
   });
   return { promise, reject, resolve };
 }
+
+describe('getConnectionPropertiesIfRequired', () => {
+  const mcpConnectorId = '/subscriptions/sub/providers/Microsoft.Web/locations/eastus2/managedApis/foundrygithubmcp';
+  const oauthConnection: any = { id: '/connections/foundrygithubmcp', properties: { parameterValues: {} } };
+
+  beforeEach(() => {
+    InitWorkflowService({
+      getAppIdentity: () => ({ type: ResourceIdentityType.SYSTEM_ASSIGNED, principalId: 'principal', tenantId: 'tenant' }),
+      isExplicitAuthRequiredForManagedIdentity: () => true,
+    } as any);
+  });
+
+  it('should not force managed identity properties on an OAuth-backed managed MCP connector', () => {
+    const connector: any = {
+      id: mcpConnectorId,
+      properties: {
+        capabilities: [],
+        connectionParameters: { token: { type: 'oauthSetting', oAuthSettings: { identityProvider: 'oauth2pkce' } } },
+      },
+    };
+
+    expect(getConnectionPropertiesIfRequired(oauthConnection, connector)).toBeUndefined();
+  });
+
+  it('should add managed identity properties for a managed MCP connector that declares no auth of its own', () => {
+    const connector: any = { id: mcpConnectorId, properties: { capabilities: [] } };
+
+    expect(getConnectionPropertiesIfRequired(oauthConnection, connector)).toEqual({
+      authentication: { type: 'ManagedServiceIdentity' },
+    });
+  });
+
+  it('should return undefined for a non-MCP OAuth connector', () => {
+    const connector: any = {
+      id: '/subscriptions/sub/providers/Microsoft.Web/locations/eastus2/managedApis/github',
+      properties: { capabilities: [], connectionParameters: { token: { type: 'oauthSetting' } } },
+    };
+
+    expect(getConnectionPropertiesIfRequired(oauthConnection, connector)).toBeUndefined();
+  });
+
+  it('should still add managed identity properties when the MCP connection itself uses a managed identity', () => {
+    const connector: any = {
+      id: mcpConnectorId,
+      properties: {
+        capabilities: [],
+        connectionParameterSets: {
+          uiDefinition: {},
+          values: [
+            { name: 'oauth', uiDefinition: {}, parameters: { token: { type: 'oauthSetting' } } },
+            { name: 'managedIdentity', uiDefinition: {}, parameters: { identity: { type: ConnectionParameterTypes.managedIdentity } } },
+          ],
+        },
+      },
+    };
+    const msiConnection: any = {
+      id: '/connections/foundrygithubmcp',
+      properties: { parameterValues: {}, parameterValueSet: { name: 'managedIdentity', values: {} } },
+    };
+
+    expect(getConnectionPropertiesIfRequired(msiConnection, connector)).toEqual({
+      authentication: { type: 'ManagedServiceIdentity' },
+    });
+  });
+});

--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/connections.ts
@@ -1,4 +1,4 @@
-import Constants, { isManagedMcpConnector, MCP_AUTH_PROPERTY_KEYS } from '../../../common/constants';
+import Constants, { MCP_AUTH_PROPERTY_KEYS, usesMcpManagedIdentityFallback } from '../../../common/constants';
 import type { ApiHubAuthentication } from '../../../common/models/workflow';
 import { AgentUtils, isOpenApiSchemaVersion } from '../../../common/utilities/Utils';
 import type { DeserializedWorkflow } from '../../parsers/BJSWorkflow/BJSDeserializer';
@@ -330,11 +330,14 @@ export const updateNodeConnectionAndProperties = async (
   }
 };
 
-const getConnectionPropertiesIfRequired = (connection: Connection, connector: Connector): Record<string, any> | undefined => {
-  // For managed MCP connections, always include MSI auth properties if the Logic App has a managed identity.
-  // These connectors don't follow the standard multi-auth/single-auth MSI detection patterns.
+export const getConnectionPropertiesIfRequired = (connection: Connection, connector: Connector): Record<string, any> | undefined => {
+  // Managed MCP connectors that declare no auth of their own rely on the generic MCP auth parameter
+  // sets, which are managed identity based, so they always need MSI auth properties when the Logic
+  // App has a managed identity. They don't follow the standard multi-auth/single-auth MSI detection
+  // patterns. Connectors that declare their own auth (e.g. OAuth-backed `foundrygithubmcp`) must
+  // fall through to the standard detection so their credentials aren't replaced by an MSI token.
   if (
-    !isManagedMcpConnector(connector) &&
+    !usesMcpManagedIdentityFallback(connector) &&
     !isConnectionMultiAuthManagedIdentityType(connection, connector) &&
     !isConnectionSingleAuthManagedIdentityType(connection)
   ) {

--- a/libs/designer-v2/src/lib/ui/CustomNodes/components/card/__test__/actionCard.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/components/card/__test__/actionCard.spec.tsx
@@ -105,6 +105,19 @@ describe('ActionCard', () => {
     expect(screen.getAllByRole('progressbar').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('should keep the dynamic data spinner inline on the card, not in the indicator strip below it', () => {
+    render(<ActionCard {...defaultProps} icon="https://example.com/icon.svg" isLoadingDynamicData={true} />);
+    expect(screen.queryByTestId('card-indicator-badges')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('progressbar').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should not put the dynamic data spinner inside the indicator strip when other indicators are shown', () => {
+    render(<ActionCard {...defaultProps} isLoadingDynamicData={true} staticResultsEnabled={true} />);
+    const indicators = screen.getByTestId('card-indicator-badges');
+    expect(indicators).toBeInTheDocument();
+    expect(indicators.querySelector('[role="progressbar"]')).toBeNull();
+  });
+
   it('should render the static results indicator when staticResultsEnabled is true', () => {
     render(<ActionCard {...defaultProps} staticResultsEnabled={true} />);
     expect(screen.getByTestId('card-indicator-static-results')).toBeInTheDocument();

--- a/libs/designer-v2/src/lib/ui/CustomNodes/components/card/__test__/cardIndicatorBadges.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/components/card/__test__/cardIndicatorBadges.spec.tsx
@@ -32,17 +32,14 @@ describe('CardIndicatorBadges', () => {
     expect(screen.getByTestId('card-indicator-secure-inputs-outputs')).toBeInTheDocument();
   });
 
-  it('should render a spinner when dynamic data is loading', () => {
-    render(<CardIndicatorBadges isLoadingDynamicData={true} />);
-    expect(screen.getByTestId('card-indicator-loading-dynamic-data')).toBeInTheDocument();
-    expect(screen.getAllByRole('progressbar').length).toBeGreaterThanOrEqual(1);
+  it('should not render a loading indicator; the dynamic data spinner stays inline on the card', () => {
+    const { container } = render(<CardIndicatorBadges />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('card-indicator-loading-dynamic-data')).not.toBeInTheDocument();
   });
 
   it('should render every enabled indicator at once', () => {
-    render(
-      <CardIndicatorBadges comment="A comment" isLoadingDynamicData={true} isSecureInputsOutputs={true} staticResultsEnabled={true} />
-    );
-    expect(screen.getByTestId('card-indicator-loading-dynamic-data')).toBeInTheDocument();
+    render(<CardIndicatorBadges comment="A comment" isSecureInputsOutputs={true} staticResultsEnabled={true} />);
     expect(screen.getByTestId('card-indicator-static-results')).toBeInTheDocument();
     expect(screen.getByTestId('card-indicator-comment')).toBeInTheDocument();
     expect(screen.getByTestId('card-indicator-secure-inputs-outputs')).toBeInTheDocument();

--- a/libs/designer-v2/src/lib/ui/CustomNodes/components/card/actionCard.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/components/card/actionCard.tsx
@@ -178,9 +178,9 @@ export const ActionCard: React.FC<ActionCardProps> = ({
       ) : null}
       <div className={styles.icon}>{cardIcon}</div>
       <Text className={mergeClasses(styles.title, isScope && styles.scopeTitle)}>{title}</Text>
+      {isLoadingDynamicData ? <Spinner size={'extra-tiny'} /> : null}
       <CardIndicatorBadges
         comment={comment}
-        isLoadingDynamicData={isLoadingDynamicData}
         isSecureInputsOutputs={isSecureInputsOutputs}
         nodeIndex={nodeIndex}
         staticResultsEnabled={staticResultsEnabled}

--- a/libs/designer-v2/src/lib/ui/CustomNodes/components/card/cardIndicatorBadges.tsx
+++ b/libs/designer-v2/src/lib/ui/CustomNodes/components/card/cardIndicatorBadges.tsx
@@ -1,4 +1,4 @@
-import { Spinner, Tooltip } from '@fluentui/react-components';
+import { Tooltip } from '@fluentui/react-components';
 import type { FluentIcon } from '@fluentui/react-icons';
 import { BeakerFilled, CommentFilled, LockClosedFilled } from '@fluentui/react-icons';
 import { useMemo } from 'react';
@@ -7,7 +7,6 @@ import { useCardStyles } from './card.styles';
 
 export interface CardIndicatorBadgesProps {
   comment?: string;
-  isLoadingDynamicData?: boolean;
   isSecureInputsOutputs?: boolean;
   nodeIndex?: number;
   staticResultsEnabled?: boolean;
@@ -16,13 +15,11 @@ export interface CardIndicatorBadgesProps {
 interface Indicator {
   key: string;
   content: string;
-  Icon?: FluentIcon;
-  isSpinner?: boolean;
+  Icon: FluentIcon;
 }
 
 export const CardIndicatorBadges: React.FC<CardIndicatorBadgesProps> = ({
   comment,
-  isLoadingDynamicData,
   isSecureInputsOutputs,
   nodeIndex,
   staticResultsEnabled,
@@ -42,25 +39,12 @@ export const CardIndicatorBadges: React.FC<CardIndicatorBadgesProps> = ({
         id: 'byRkj+',
         description: 'This operation has secure inputs or outputs enabled.',
       }),
-      LOADING_DYNAMIC_DATA: intl.formatMessage({
-        defaultMessage: 'Loading dynamic data',
-        id: 'qMFpNH',
-        description: 'Loading dynamic data',
-      }),
     }),
     [intl]
   );
 
   const indicators = useMemo<Indicator[]>(() => {
     const result: Indicator[] = [];
-
-    if (isLoadingDynamicData) {
-      result.push({
-        key: 'loading-dynamic-data',
-        content: strings.LOADING_DYNAMIC_DATA,
-        isSpinner: true,
-      });
-    }
 
     if (staticResultsEnabled) {
       result.push({
@@ -87,7 +71,7 @@ export const CardIndicatorBadges: React.FC<CardIndicatorBadgesProps> = ({
     }
 
     return result;
-  }, [comment, isLoadingDynamicData, isSecureInputsOutputs, staticResultsEnabled, strings]);
+  }, [comment, isSecureInputsOutputs, staticResultsEnabled, strings]);
 
   if (indicators.length === 0) {
     return null;
@@ -95,7 +79,7 @@ export const CardIndicatorBadges: React.FC<CardIndicatorBadgesProps> = ({
 
   return (
     <div className={styles.indicators} data-testid="card-indicator-badges" data-automation-id="card-indicator-badges">
-      {indicators.map(({ key, content, Icon, isSpinner }) => (
+      {indicators.map(({ key, content, Icon }) => (
         <Tooltip key={key} relationship="label" withArrow positioning="below" content={content}>
           <span
             className={styles.indicator}
@@ -103,7 +87,7 @@ export const CardIndicatorBadges: React.FC<CardIndicatorBadgesProps> = ({
             data-automation-id={`card-indicator-${key}`}
             tabIndex={nodeIndex}
           >
-            {isSpinner ? <Spinner className={styles.spinner} size="extra-tiny" /> : Icon ? <Icon /> : null}
+            <Icon />
           </span>
         </Tooltip>
       ))}

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/__test__/createConnection.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/__test__/createConnection.spec.tsx
@@ -518,6 +518,86 @@ describe('ui/createConnection', () => {
     });
   });
 
+  describe('multi-auth managed identity picker', () => {
+    const oauthOnlyParameterSets: ConnectionParameterSets = {
+      uiDefinition: { displayName: 'Authentication type', description: 'Authentication type' },
+      values: [
+        {
+          name: 'certOauth',
+          uiDefinition: { displayName: 'OAuth', description: 'OAuth' },
+          parameters: {
+            token: {
+              type: 'oauthSetting',
+              uiDefinition: { displayName: 'Token', description: 'Token', tooltip: 'Token', constraints: { required: 'true' } },
+            },
+          },
+        },
+      ],
+    } as any;
+
+    const managedIdentityParameterSets: ConnectionParameterSets = {
+      uiDefinition: { displayName: 'Authentication type', description: 'Authentication type' },
+      values: [
+        {
+          name: 'oauthMI',
+          uiDefinition: { displayName: 'Managed identity', description: 'Managed identity' },
+          parameters: {
+            'token:managedIdentity': {
+              type: 'managedIdentity',
+              uiDefinition: {
+                displayName: 'Managed identity',
+                description: 'Managed identity',
+                tooltip: 'Managed identity',
+                constraints: { required: 'true' },
+              },
+            },
+          },
+        },
+      ],
+    } as any;
+
+    it('should not render the managed identity picker for an OAuth-only parameter set', () => {
+      const props: CreateConnectionProps = {
+        connector: baseConnector,
+        connectionParameterSets: oauthOnlyParameterSets,
+        enableManagedIdentityPicker: true,
+        checkOAuthCallback: vi.fn(),
+      };
+
+      renderer.render(<CreateConnection {...props} />);
+      const createConnection = findConnectionCreateDiv(renderer.getRenderOutput());
+
+      expect(findMultiAuthManagedIdentityPicker(createConnection)).toBeUndefined();
+    });
+
+    it('should render the managed identity picker when the selected parameter set declares a managed identity parameter', () => {
+      const props: CreateConnectionProps = {
+        connector: baseConnector,
+        connectionParameterSets: managedIdentityParameterSets,
+        enableManagedIdentityPicker: true,
+        checkOAuthCallback: vi.fn(),
+      };
+
+      renderer.render(<CreateConnection {...props} />);
+      const createConnection = findConnectionCreateDiv(renderer.getRenderOutput());
+
+      expect(findMultiAuthManagedIdentityPicker(createConnection)).toBeDefined();
+    });
+
+    it('should not render the managed identity picker when the caller has not opted in', () => {
+      const props: CreateConnectionProps = {
+        connector: baseConnector,
+        connectionParameterSets: managedIdentityParameterSets,
+        checkOAuthCallback: vi.fn(),
+      };
+
+      renderer.render(<CreateConnection {...props} />);
+      const createConnection = findConnectionCreateDiv(renderer.getRenderOutput());
+
+      expect(findMultiAuthManagedIdentityPicker(createConnection)).toBeUndefined();
+    });
+  });
+
   function findConnectionCreateDiv(createConnection: ReactElement) {
     return React.Children.toArray(createConnection.props.children).find(
       (child) => (child as ReactElement)?.props.className === 'msla-create-connection-container'
@@ -571,6 +651,15 @@ describe('ui/createConnection', () => {
 
   function findMultiAuthInput(createConnection: ReactElement) {
     return findInput(createConnection, 'connection-multi-auth-input');
+  }
+
+  function findMultiAuthManagedIdentityPicker(createConnection: ReactElement) {
+    const connectionsParamContainer = findConnectionsParamContainer(createConnection);
+    return React.Children.toArray(connectionsParamContainer.props.children).find((paramRow) =>
+      React.Children.toArray((paramRow as ReactElement)?.props?.children ?? []).some(
+        (child) => (child as ReactElement)?.props?.id === 'multi-auth-managed-identity-select'
+      )
+    ) as ReactElement | undefined;
   }
 
   function findInput(createConnection: ReactElement, inputDataTestId: string) {

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/createConnection/createConnection.tsx
@@ -407,14 +407,19 @@ export const CreateConnection = (props: CreateConnectionProps) => {
     return output ?? {};
   }, [enabledCapabilities, parametersByCapability]);
 
-  // Show MI picker only when explicitly enabled by the caller (e.g. MCP wizard) AND
-  // there are no visible parameters (form would be empty without it).
+  // This dropdown stands in for `managedIdentity` typed parameters, which `isParamVisible` hides.
+  // It is opt-in per caller (e.g. the MCP wizard) and only rendered when the selected parameter set
+  // actually declares such a parameter - an OAuth-only set also filters down to nothing visible, but
+  // it is served by the sign-in flow rather than by an identity picker.
   const isMultiAuthManagedIdentitySet = useMemo(() => {
     if (!props.enableManagedIdentityPicker || !isMultiAuth) {
       return false;
     }
-    return Object.keys(capabilityEnabledParameters ?? {}).length === 0;
-  }, [props.enableManagedIdentityPicker, isMultiAuth, capabilityEnabledParameters]);
+    if (Object.keys(capabilityEnabledParameters ?? {}).length > 0) {
+      return false;
+    }
+    return Object.values(multiAuthParams).some((parameter) => parameter?.type === ConnectionParameterTypes.managedIdentity);
+  }, [props.enableManagedIdentityPicker, isMultiAuth, capabilityEnabledParameters, multiAuthParams]);
 
   // Don't show name for simple connections
   const showNameInput = useMemo(() => {

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/mcpToolWizard.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/mcpToolWizard.spec.tsx
@@ -161,6 +161,50 @@ import {
 } from '../../../../../core/state/panel/panelSelectors';
 import { closeMcpToolWizard, setMcpWizardStep, setMcpWizardConnection } from '../../../../../core/state/panel/panelSlice';
 import { useConnectionsForConnector, useConnectionResource } from '../../../../../core/queries/connections';
+import { useConnector } from '../../../../../core/state/connection/connectionSelector';
+import { CreateConnectionInternal } from '../../../../panel/connectionsPanel/createConnection/createConnectionInternal';
+
+const mockUseConnector = vi.mocked(useConnector);
+const mockCreateConnectionInternal = vi.mocked(CreateConnectionInternal);
+
+const defaultMcpClientConnector = {
+  id: 'connectionProviders/mcpclient',
+  name: 'mcpclient',
+  properties: {
+    connectionParameters: {},
+  },
+};
+
+// Single-auth OAuth connector shape used by first-party managed connectors (e.g. GitHub):
+// no `connectionParameterSets`, auth declared through an `oauthSetting` connection parameter.
+const oauthConnector = {
+  id: '/subscriptions/x/providers/Microsoft.Web/locations/westus/managedApis/github',
+  name: 'github',
+  properties: {
+    connectionParameters: {
+      token: {
+        type: 'oauthSetting',
+        oAuthSettings: { identityProvider: 'github', clientId: 'client-id', scopes: [] },
+      },
+    },
+  },
+};
+
+const managedWizardState = (step: string): any => ({
+  ...mockWizardState,
+  step,
+  operation: {
+    ...mockWizardState.operation,
+    properties: {
+      ...mockWizardState.operation.properties,
+      operationKind: 'Managed',
+      api: {
+        ...mockWizardState.operation.properties.api,
+        id: '/subscriptions/x/providers/Microsoft.Web/customApis/managed-mcp',
+      },
+    },
+  },
+});
 
 const mockUseMcpToolWizard = vi.mocked(useMcpToolWizard);
 const mockUseMcpWizardStep = vi.mocked(useMcpWizardStep);
@@ -222,6 +266,7 @@ describe('McpToolWizard', () => {
       refetch: vi.fn(),
     } as any);
     mockUseConnectionResource.mockReturnValue({ data: undefined, isLoading: false } as any);
+    mockUseConnector.mockReturnValue({ data: defaultMcpClientConnector } as any);
   });
 
   describe('Connection Step', () => {
@@ -373,6 +418,39 @@ describe('McpToolWizard', () => {
       expect(primaryButton.disabled).toBe(true);
     });
 
+    test('should not warn or disable Next when the managed MCP connector uses its own OAuth auth', () => {
+      const mockConnections = [
+        {
+          id: 'conn-1',
+          name: 'connection-1',
+          properties: { displayName: 'Connection 1' },
+        },
+      ];
+
+      mockUseMcpToolWizard.mockReturnValue({ ...managedWizardState(MCP_WIZARD_STEP.CONNECTION), connectionId: 'conn-1' });
+      mockUseMcpWizardConnectionId.mockReturnValue('conn-1');
+      mockUseConnector.mockReturnValue({ data: oauthConnector } as any);
+      mockUseConnectionsForConnector.mockReturnValue({
+        data: mockConnections,
+        isLoading: false,
+        refetch: vi.fn(),
+      } as any);
+      mockUseConnectionResource.mockReturnValue({
+        data: { id: 'conn-1', properties: {} },
+        isLoading: false,
+      } as any);
+
+      render(<McpToolWizard />, { wrapper: createWrapper() });
+
+      expect(
+        screen.queryByText(
+          'This MCP connection has no resolvable managed identity. Re-create the connection and select a managed identity to load tools.'
+        )
+      ).toBeNull();
+      const primaryButton = screen.getByTestId('footer-button-primary') as HTMLButtonElement;
+      expect(primaryButton.disabled).toBe(false);
+    });
+
     test('should disable Next while full connection resource is still loading', () => {
       const mockConnections = [
         {
@@ -484,6 +562,66 @@ describe('McpToolWizard', () => {
       render(<McpToolWizard />, { wrapper: createWrapper() });
 
       expect(screen.queryByText('Create a new connection for the MCP server.')).toBeNull();
+    });
+
+    test('should not override connection parameter sets for built-in MCP servers', () => {
+      render(<McpToolWizard />, { wrapper: createWrapper() });
+
+      const props = mockCreateConnectionInternal.mock.calls[0][0] as any;
+      expect(props.connectionParameterSetsOverride).toBeUndefined();
+      expect(props.enableManagedIdentityPicker).toBe(false);
+    });
+
+    test('should override connection parameter sets for managed MCP servers whose connector declares no auth', () => {
+      mockUseMcpToolWizard.mockReturnValue(managedWizardState(MCP_WIZARD_STEP.CREATE_CONNECTION));
+      mockUseConnector.mockReturnValue({
+        data: {
+          id: '/subscriptions/x/providers/Microsoft.Web/customApis/managed-mcp',
+          name: 'managed-mcp',
+          properties: {},
+        },
+      } as any);
+
+      render(<McpToolWizard />, { wrapper: createWrapper() });
+
+      const props = mockCreateConnectionInternal.mock.calls[0][0] as any;
+      expect(props.connectionParameterSetsOverride?.values?.map((v: any) => v.name)).toEqual([
+        'None',
+        'Basic',
+        'Key',
+        'ManagedServiceIdentity',
+      ]);
+      expect(props.enableManagedIdentityPicker).toBe(true);
+    });
+
+    test('should not override connection parameter sets when the managed MCP connector declares its own OAuth auth', () => {
+      mockUseMcpToolWizard.mockReturnValue(managedWizardState(MCP_WIZARD_STEP.CREATE_CONNECTION));
+      mockUseConnector.mockReturnValue({ data: oauthConnector } as any);
+
+      render(<McpToolWizard />, { wrapper: createWrapper() });
+
+      const props = mockCreateConnectionInternal.mock.calls[0][0] as any;
+      expect(props.connectionParameterSetsOverride).toBeUndefined();
+      expect(props.enableManagedIdentityPicker).toBe(false);
+    });
+
+    test('should not override connection parameter sets when the managed MCP connector declares parameter sets', () => {
+      mockUseMcpToolWizard.mockReturnValue(managedWizardState(MCP_WIZARD_STEP.CREATE_CONNECTION));
+      mockUseConnector.mockReturnValue({
+        data: {
+          id: '/subscriptions/x/providers/Microsoft.Web/customApis/managed-mcp',
+          name: 'managed-mcp',
+          properties: {
+            connectionParameterSets: { uiDefinition: {}, values: [{ name: 'oauth', parameters: {} }] },
+          },
+        },
+      } as any);
+
+      render(<McpToolWizard />, { wrapper: createWrapper() });
+
+      const props = mockCreateConnectionInternal.mock.calls[0][0] as any;
+      expect(props.connectionParameterSetsOverride).toBeUndefined();
+      expect(props.enableManagedIdentityPicker).toBe(false);
     });
   });
 

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/mcpToolWizard.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/__test__/mcpToolWizard.spec.tsx
@@ -602,7 +602,6 @@ describe('McpToolWizard', () => {
 
       const props = mockCreateConnectionInternal.mock.calls[0][0] as any;
       expect(props.connectionParameterSetsOverride).toBeUndefined();
-      expect(props.enableManagedIdentityPicker).toBe(false);
     });
 
     test('should not override connection parameter sets when the managed MCP connector declares parameter sets', () => {
@@ -621,7 +620,18 @@ describe('McpToolWizard', () => {
 
       const props = mockCreateConnectionInternal.mock.calls[0][0] as any;
       expect(props.connectionParameterSetsOverride).toBeUndefined();
-      expect(props.enableManagedIdentityPicker).toBe(false);
+    });
+
+    test('should keep the managed identity picker available for managed MCP servers that declare their own auth', () => {
+      mockUseMcpToolWizard.mockReturnValue(managedWizardState(MCP_WIZARD_STEP.CREATE_CONNECTION));
+      mockUseConnector.mockReturnValue({ data: oauthConnector } as any);
+
+      render(<McpToolWizard />, { wrapper: createWrapper() });
+
+      // CreateConnection narrows this down to parameter sets that actually declare a
+      // `managedIdentity` parameter, so it stays enabled for every managed MCP server.
+      const props = mockCreateConnectionInternal.mock.calls[0][0] as any;
+      expect(props.enableManagedIdentityPicker).toBe(true);
     });
   });
 

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
@@ -39,9 +39,11 @@ import { useQuery } from '@tanstack/react-query';
 import { MCP_CLIENT_CONNECTOR_ID } from '../helpers';
 
 /**
- * Connection parameter sets for MCP servers. Used as a fallback when a custom connector
- * doesn't have its own connectionParameterSets, so users can select auth type
- * (None, Basic, Key, or Managed Identity) during connection creation.
+ * Connection parameter sets for MCP servers. Used as a fallback when a connector declares no
+ * authentication of its own, so users can select auth type (None, Basic, Key, or Managed Identity)
+ * during connection creation. Connectors that declare their own authentication (multi-auth
+ * parameter sets, or single-auth connection parameters such as an OAuth `token`) must keep their
+ * own connection experience instead.
  */
 const mcpConnectionParameterSets: ConnectionParameterSets = {
   uiDefinition: {
@@ -152,6 +154,30 @@ export const McpToolWizard = () => {
   const { data: connector } = useConnector(connectorId);
   const assistedConnectionProps = useMemo(() => (connector ? getAssistedConnectionProps(connector) : undefined), [connector]);
 
+  // A managed MCP server can be backed by a connector that already declares how to authenticate -
+  // either multi-auth parameter sets, or single-auth connection parameters such as an OAuth `token`
+  // (first-party connectors like GitHub work this way). Those connectors must keep their own
+  // connection experience; forcing the generic MCP auth parameter sets onto them replaces the
+  // sign-in dialog with a "None / Basic / Key / Managed identity" form and produces an
+  // unauthenticated connection.
+  const connectorDeclaresOwnAuth = useMemo(() => {
+    const connectorProperties = connector?.properties;
+    if (!connectorProperties) {
+      return false;
+    }
+    return (
+      (connectorProperties.connectionParameterSets?.values?.length ?? 0) > 0 ||
+      Object.keys(connectorProperties.connectionParameters ?? {}).length > 0
+    );
+  }, [connector]);
+
+  // Managed MCP servers whose connector declares no auth of its own rely on the MCP auth fallback
+  // (and therefore on a managed identity) to reach the server.
+  const usesMcpAuthFallback = useMemo(
+    () => isManagedMcpServer && !!connector && !connectorDeclaresOwnAuth,
+    [isManagedMcpServer, connector, connectorDeclaresOwnAuth]
+  );
+
   // Fetch connections for the appropriate connector
   const {
     data: connectionsData,
@@ -203,10 +229,11 @@ export const McpToolWizard = () => {
   // an undefined identity into addOperation.
   const isFetchingFullConnection = !!localConnectionId && !createdIdentity && isFullConnectionLoading;
 
-  // For managed MCP connectors the connection must surface an identity, otherwise listMcpTools
-  // returns 401. Surface a non-blocking warning + disable Next when we know the connection has
-  // resolved but no identity is available.
-  const needsManagedIdentityWarning = !!localConnectionId && !isFullConnectionLoading && !selectedIdentity && isManagedMcpServer;
+  // Connections created through the MCP auth fallback must surface an identity, otherwise
+  // listMcpTools returns 401. Surface a non-blocking warning + disable Next when we know the
+  // connection has resolved but no identity is available. Connectors with their own auth (OAuth,
+  // key, etc.) carry their credentials on the connection, so no identity is expected there.
+  const needsManagedIdentityWarning = !!localConnectionId && !isFullConnectionLoading && !selectedIdentity && usesMcpAuthFallback;
 
   useEffect(() => {
     if (currentStep === MCP_WIZARD_STEP.CREATE_CONNECTION) {
@@ -768,11 +795,11 @@ export const McpToolWizard = () => {
     // Managed MCP servers use the default Azure connection flow
     const connectionMetadata = isManagedMcpServer ? undefined : { type: ConnectionType.Mcp, required: true };
 
-    // For managed MCP servers (custom connectors), the connector from Azure API
-    // may not include connectionParameterSets (auth options). Provide MCP auth
-    // parameter sets as a fallback so users can select auth type (None, Basic,
-    // Managed Identity, etc.) when creating a connection.
-    const parameterSetsOverride = isManagedMcpServer ? mcpConnectionParameterSets : undefined;
+    // Managed MCP servers backed by a connector that declares no authentication of its own get the
+    // MCP auth parameter sets as a fallback, so users can pick an auth type (None, Basic, Key,
+    // Managed Identity). Connectors that do declare their own authentication keep their native
+    // experience - notably the OAuth sign-in dialog used by first-party connectors.
+    const parameterSetsOverride = usesMcpAuthFallback ? mcpConnectionParameterSets : undefined;
 
     return (
       <div className={classes.createConnectionContainer}>
@@ -789,7 +816,7 @@ export const McpToolWizard = () => {
           onConnectionCancelled={handleConnectionCancelled}
           description=" "
           connectionParameterSetsOverride={parameterSetsOverride}
-          enableManagedIdentityPicker={isManagedMcpServer}
+          enableManagedIdentityPicker={usesMcpAuthFallback}
         />
       </div>
     );

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
@@ -34,6 +34,7 @@ import {
 import { addOperation } from '../../../../core/actions/bjsworkflow/add';
 import { useMcpToolWizardStyles } from './styles/McpToolWizard.styles';
 import { useConnector } from '../../../../core/state/connection/connectionSelector';
+import { connectorDeclaresOwnAuth } from '../../../../common/constants';
 import type { Connection, ConnectionParameterSets, DiscoveryOperation, DiscoveryResultTypes } from '@microsoft/logic-apps-shared';
 import { useQuery } from '@tanstack/react-query';
 import { MCP_CLIENT_CONNECTOR_ID } from '../helpers';
@@ -160,22 +161,9 @@ export const McpToolWizard = () => {
   // connection experience; forcing the generic MCP auth parameter sets onto them replaces the
   // sign-in dialog with a "None / Basic / Key / Managed identity" form and produces an
   // unauthenticated connection.
-  const connectorDeclaresOwnAuth = useMemo(() => {
-    const connectorProperties = connector?.properties;
-    if (!connectorProperties) {
-      return false;
-    }
-    return (
-      (connectorProperties.connectionParameterSets?.values?.length ?? 0) > 0 ||
-      Object.keys(connectorProperties.connectionParameters ?? {}).length > 0
-    );
-  }, [connector]);
-
-  // Managed MCP servers whose connector declares no auth of its own rely on the MCP auth fallback
-  // (and therefore on a managed identity) to reach the server.
   const usesMcpAuthFallback = useMemo(
-    () => isManagedMcpServer && !!connector && !connectorDeclaresOwnAuth,
-    [isManagedMcpServer, connector, connectorDeclaresOwnAuth]
+    () => isManagedMcpServer && !!connector && !connectorDeclaresOwnAuth(connector),
+    [isManagedMcpServer, connector]
   );
 
   // Fetch connections for the appropriate connector

--- a/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/recommendation/browse/mcpToolWizard.tsx
@@ -789,6 +789,10 @@ export const McpToolWizard = () => {
     // experience - notably the OAuth sign-in dialog used by first-party connectors.
     const parameterSetsOverride = usesMcpAuthFallback ? mcpConnectionParameterSets : undefined;
 
+    // Opt every managed MCP server into the standalone managed identity dropdown. CreateConnection
+    // only renders it for a parameter set that actually declares a `managedIdentity` typed
+    // parameter, so connectors keeping their own OAuth sets are unaffected.
+
     return (
       <div className={classes.createConnectionContainer}>
         <CreateConnectionInternal
@@ -804,7 +808,7 @@ export const McpToolWizard = () => {
           onConnectionCancelled={handleConnectionCancelled}
           description=" "
           connectionParameterSetsOverride={parameterSetsOverride}
-          enableManagedIdentityPicker={usesMcpAuthFallback}
+          enableManagedIdentityPicker={isManagedMcpServer}
         />
       </div>
     );

--- a/libs/designer/src/lib/common/__test__/constants.spec.ts
+++ b/libs/designer/src/lib/common/__test__/constants.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { connectorDeclaresOwnAuth, isManagedMcpConnector, usesMcpManagedIdentityFallback } from '../constants';
+
+const managedApiId = (name: string) => `/subscriptions/sub/providers/Microsoft.Web/locations/eastus2/managedApis/${name}`;
+
+describe('isManagedMcpConnector', () => {
+  it('should match connectors of type McpClient', () => {
+    expect(isManagedMcpConnector({ id: managedApiId('anything'), type: 'McpClient' })).toBe(true);
+  });
+
+  it('should match managed API connectors whose name contains mcp', () => {
+    expect(isManagedMcpConnector({ id: managedApiId('foundrygithubmcp') })).toBe(true);
+    expect(isManagedMcpConnector({ id: managedApiId('a365mcp') })).toBe(true);
+  });
+
+  it('should not match built-in connectors', () => {
+    expect(isManagedMcpConnector({ id: managedApiId('githubmcp'), properties: { capabilities: ['builtin'] } })).toBe(false);
+  });
+
+  it('should not match unrelated managed API connectors', () => {
+    expect(isManagedMcpConnector({ id: managedApiId('github') })).toBe(false);
+  });
+});
+
+describe('connectorDeclaresOwnAuth', () => {
+  it('should be true for multi-auth connectors', () => {
+    expect(
+      connectorDeclaresOwnAuth({
+        properties: { connectionParameterSets: { values: [{ name: 'oauth' }, { name: 'managedIdentity' }] } },
+      })
+    ).toBe(true);
+  });
+
+  it('should be true for single-auth connectors that declare connection parameters', () => {
+    expect(connectorDeclaresOwnAuth({ properties: { connectionParameters: { token: { type: 'oauthSetting' } } } })).toBe(true);
+  });
+
+  it('should be false when the connector declares no auth at all', () => {
+    expect(connectorDeclaresOwnAuth({ properties: { connectionParameters: {} } })).toBe(false);
+    expect(connectorDeclaresOwnAuth({ properties: { connectionParameterSets: { values: [] } } })).toBe(false);
+    expect(connectorDeclaresOwnAuth({ properties: {} })).toBe(false);
+    expect(connectorDeclaresOwnAuth({})).toBe(false);
+  });
+});
+
+describe('usesMcpManagedIdentityFallback', () => {
+  it('should be true for a managed MCP connector that declares no auth of its own', () => {
+    expect(usesMcpManagedIdentityFallback({ id: managedApiId('customservermcp'), properties: { capabilities: [] } })).toBe(true);
+  });
+
+  it('should be false for an OAuth-backed managed MCP connector', () => {
+    expect(
+      usesMcpManagedIdentityFallback({
+        id: managedApiId('foundrygithubmcp'),
+        properties: {
+          capabilities: [],
+          connectionParameters: { token: { type: 'oauthSetting' } },
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('should be false for a managed MCP connector that declares its own parameter sets', () => {
+    expect(
+      usesMcpManagedIdentityFallback({
+        id: managedApiId('stripemcp'),
+        properties: { capabilities: [], connectionParameterSets: { values: [{ name: 'oauth' }] } },
+      })
+    ).toBe(false);
+  });
+
+  it('should be false for connectors that are not managed MCP connectors', () => {
+    expect(usesMcpManagedIdentityFallback({ id: managedApiId('github'), properties: { capabilities: [] } })).toBe(false);
+  });
+});

--- a/libs/designer/src/lib/common/constants.ts
+++ b/libs/designer/src/lib/common/constants.ts
@@ -83,6 +83,40 @@ export const isManagedMcpConnector = (connector: { id?: string; type?: string; p
   return isMcp && !connector.properties?.capabilities?.includes('builtin');
 };
 
+/**
+ * Checks whether a connector declares how to authenticate on its own - either through multi-auth
+ * parameter sets, or through single-auth connection parameters such as an OAuth `token`
+ * (first-party connectors like GitHub work this way).
+ */
+export const connectorDeclaresOwnAuth = (connector: {
+  properties?: { connectionParameterSets?: { values?: unknown[] }; connectionParameters?: Record<string, unknown> };
+}): boolean => {
+  const connectorProperties = connector?.properties;
+  if (!connectorProperties) {
+    return false;
+  }
+  return (
+    (connectorProperties.connectionParameterSets?.values?.length ?? 0) > 0 ||
+    Object.keys(connectorProperties.connectionParameters ?? {}).length > 0
+  );
+};
+
+/**
+ * `isManagedMcpConnector` matches on the connector name, so OAuth-backed MCP connectors
+ * (e.g. `foundrygithubmcp`) qualify as well. Only connectors that declare no auth of their own fall
+ * back to the generic managed-identity based MCP auth; the rest must keep their own auth flow and
+ * must not have managed identity properties forced onto their connections.
+ */
+export const usesMcpManagedIdentityFallback = (connector: {
+  id?: string;
+  type?: string;
+  properties?: {
+    capabilities?: string[];
+    connectionParameterSets?: { values?: unknown[] };
+    connectionParameters?: Record<string, unknown>;
+  };
+}): boolean => isManagedMcpConnector(connector) && !connectorDeclaresOwnAuth(connector);
+
 export default {
   API_TIER: {
     PREMIUM: 'PREMIUM',

--- a/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/__test__/connections.spec.ts
@@ -4,6 +4,7 @@ import Constants from '../../../../common/constants';
 import { getReactQueryClient } from '../../../ReactQueryProvider';
 import {
   getConnectionMappingForNode,
+  getConnectionPropertiesIfRequired,
   getLegacyConnectionReferenceKey,
   getManifestBasedConnectionMapping,
   isOpenApiConnectionType,
@@ -22,7 +23,10 @@ import {
   OperationManifestService,
   createItem,
   ConnectionReferenceKeyFormat,
+  ConnectionParameterTypes,
   InitLoggerService,
+  InitWorkflowService,
+  ResourceIdentityType,
 } from '@microsoft/logic-apps-shared';
 import type { LogicAppsV2, OperationManifest, Connector } from '@microsoft/logic-apps-shared';
 
@@ -369,3 +373,68 @@ function createDeferred<T>() {
   });
   return { promise, reject, resolve };
 }
+
+describe('getConnectionPropertiesIfRequired', () => {
+  const mcpConnectorId = '/subscriptions/sub/providers/Microsoft.Web/locations/eastus2/managedApis/foundrygithubmcp';
+  const oauthConnection: any = { id: '/connections/foundrygithubmcp', properties: { parameterValues: {} } };
+
+  beforeEach(() => {
+    InitWorkflowService({
+      getAppIdentity: () => ({ type: ResourceIdentityType.SYSTEM_ASSIGNED, principalId: 'principal', tenantId: 'tenant' }),
+      isExplicitAuthRequiredForManagedIdentity: () => true,
+    } as any);
+  });
+
+  it('should not force managed identity properties on an OAuth-backed managed MCP connector', () => {
+    const connector: any = {
+      id: mcpConnectorId,
+      properties: {
+        capabilities: [],
+        connectionParameters: { token: { type: 'oauthSetting', oAuthSettings: { identityProvider: 'oauth2pkce' } } },
+      },
+    };
+
+    expect(getConnectionPropertiesIfRequired(oauthConnection, connector)).toBeUndefined();
+  });
+
+  it('should add managed identity properties for a managed MCP connector that declares no auth of its own', () => {
+    const connector: any = { id: mcpConnectorId, properties: { capabilities: [] } };
+
+    expect(getConnectionPropertiesIfRequired(oauthConnection, connector)).toEqual({
+      authentication: { type: 'ManagedServiceIdentity' },
+    });
+  });
+
+  it('should return undefined for a non-MCP OAuth connector', () => {
+    const connector: any = {
+      id: '/subscriptions/sub/providers/Microsoft.Web/locations/eastus2/managedApis/github',
+      properties: { capabilities: [], connectionParameters: { token: { type: 'oauthSetting' } } },
+    };
+
+    expect(getConnectionPropertiesIfRequired(oauthConnection, connector)).toBeUndefined();
+  });
+
+  it('should still add managed identity properties when the MCP connection itself uses a managed identity', () => {
+    const connector: any = {
+      id: mcpConnectorId,
+      properties: {
+        capabilities: [],
+        connectionParameterSets: {
+          uiDefinition: {},
+          values: [
+            { name: 'oauth', uiDefinition: {}, parameters: { token: { type: 'oauthSetting' } } },
+            { name: 'managedIdentity', uiDefinition: {}, parameters: { identity: { type: ConnectionParameterTypes.managedIdentity } } },
+          ],
+        },
+      },
+    };
+    const msiConnection: any = {
+      id: '/connections/foundrygithubmcp',
+      properties: { parameterValues: {}, parameterValueSet: { name: 'managedIdentity', values: {} } },
+    };
+
+    expect(getConnectionPropertiesIfRequired(msiConnection, connector)).toEqual({
+      authentication: { type: 'ManagedServiceIdentity' },
+    });
+  });
+});

--- a/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/connections.ts
@@ -1,4 +1,4 @@
-import Constants, { isManagedMcpConnector, MCP_AUTH_PROPERTY_KEYS } from '../../../common/constants';
+import Constants, { MCP_AUTH_PROPERTY_KEYS, usesMcpManagedIdentityFallback } from '../../../common/constants';
 import type { ApiHubAuthentication } from '../../../common/models/workflow';
 import { AgentUtils, isOpenApiSchemaVersion } from '../../../common/utilities/Utils';
 import type { DeserializedWorkflow } from '../../parsers/BJSWorkflow/BJSDeserializer';
@@ -330,11 +330,14 @@ export const updateNodeConnectionAndProperties = async (
   }
 };
 
-const getConnectionPropertiesIfRequired = (connection: Connection, connector: Connector): Record<string, any> | undefined => {
-  // For managed MCP connections, always include MSI auth properties if the Logic App has a managed identity.
-  // These connectors don't follow the standard multi-auth/single-auth MSI detection patterns.
+export const getConnectionPropertiesIfRequired = (connection: Connection, connector: Connector): Record<string, any> | undefined => {
+  // Managed MCP connectors that declare no auth of their own rely on the generic MCP auth parameter
+  // sets, which are managed identity based, so they always need MSI auth properties when the Logic
+  // App has a managed identity. They don't follow the standard multi-auth/single-auth MSI detection
+  // patterns. Connectors that declare their own auth (e.g. OAuth-backed `foundrygithubmcp`) must
+  // fall through to the standard detection so their credentials aren't replaced by an MSI token.
   if (
-    !isManagedMcpConnector(connector) &&
+    !usesMcpManagedIdentityFallback(connector) &&
     !isConnectionMultiAuthManagedIdentityType(connection, connector) &&
     !isConnectionSingleAuthManagedIdentityType(connection)
   ) {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why

Fixes #9487.

Adding a managed MCP server (e.g. **Github MCP Server (MCP)**) from an Agent's *Add tool* flow showed a generic **Connection name / Authentication type: None / Managed identity** form instead of the connector's *"Sign in to create a connection to GitHub"* OAuth dialog. The connection that got created carried no credentials, so the Parameters step failed with:

```
MCP server returned HTTP 401 ... bad request: missing required Authorization header
```

Adding a regular action from the same `github` connector correctly showed the sign-in dialog, which is what made the MCP path look "incorrect".

**Root cause** — `mcpToolWizard.tsx` injected the generic MCP auth parameter sets for *every* managed MCP server:

```ts
const parameterSetsOverride = isManagedMcpServer ? mcpConnectionParameterSets : undefined;
```

`createConnectionInternal` applies that override whenever the connector has no `connectionParameterSets` of its own:

```ts
connector.properties.connectionParameterSets ?? connectionParameterSetsOverride
```

First-party OAuth connectors (github, office365, …) are **single-auth**: they declare no `connectionParameterSets` and instead expose `connectionParameters.token = { type: 'oauthSetting', … }`. So the override won, `isMultiAuth` flipped to `true`, the selected set defaulted to `None` (no params), `needsOAuth` returned `false`, and the sign-in button was replaced by the generic "Create" form.

The same flag also drove `needsManagedIdentityWarning`, which disables **Next** on the connection step whenever a managed MCP connection has no managed identity — i.e. for every OAuth-backed connection, even after the parameter-set problem is fixed.

**Fix** — only apply the MCP auth fallback when the connector declares no authentication of its own (neither `connectionParameterSets` nor `connectionParameters`). `parameterSetsOverride`, `enableManagedIdentityPicker`, and `needsManagedIdentityWarning` are all gated on that predicate.

**Regression window** — introduced by #9199 (`7872e2605`, *"(fix): Show managed identity picker for custom MCP connector connection creation"*). Before that commit no override existed and single-auth OAuth connectors fell through to the normal sign-in path. The scenario that PR targeted — MCP connectors that ship no auth metadata at all — is unaffected and covered by a new test.

### Second occurrence: MSI stamped onto OAuth MCP connections at save time

A HAR capture from a Standard Logic App showed the same assumption in a second place. The connection was created and consented through OAuth, but the draft save persisted it as a managed identity connection:

```json
"managedApiConnections": {
  "foundrygithubmcp": {
    "api": { "id": ".../managedApis/foundrygithubmcp" },
    "connection": { "id": ".../connections/foundrygithubmcp" },
    "authentication": { "type": "ManagedServiceIdentity" },
    "connectionRuntimeUrl": "https://....azure-apihub.net/apim/foundrygithubmcp/...",
    "connectionProperties": { "authentication": { "type": "ManagedServiceIdentity" } }
  }
}
```

The top-level `authentication` block is expected for Standard — that is how the runtime authenticates to the API Hub endpoint using the app identity plus its access policy. The `connectionProperties.authentication` block is not: it tells the connector runtime to call the backend with an MSI token instead of the stored OAuth credential.

It came from `getConnectionPropertiesIfRequired`, which short-circuited the standard MSI detection for any `isManagedMcpConnector(connector)`. That predicate matches on the connector name (`managedApis/*mcp*`), so `foundrygithubmcp` qualified despite being OAuth-only, and MSI properties were emitted unconditionally whenever the Logic App had an identity.

Introduced by #9052 (`3c210c53c`), present in both `libs/designer` and `libs/designer-v2`.

The `connectorDeclaresOwnAuth` predicate has been promoted out of `mcpToolWizard.tsx` into `common/constants.ts` alongside a new `usesMcpManagedIdentityFallback` helper, and `getConnectionPropertiesIfRequired` now uses it in both packages.

### Third occurrence: the managed identity picker was inferred from an empty form

`CreateConnection` decided whether to render the standalone managed identity dropdown by checking that the selected parameter set filtered down to zero visible parameters. An OAuth-only set also filters down to zero, because `isParamVisible` hides `oauthSetting` parameters. Combined with the wizard passing `enableManagedIdentityPicker={isManagedMcpServer}`, every managed MCP server whose connector ships an OAuth parameter set — `a365copilotchatmcp`, `a365teamsmcp`, `a365outlookmailmcp`, `jira` (its `oauth` set), `workiqonedrive`, `workiqsharepoint` — rendered a required **Managed identity** dropdown and disabled **Sign in** until an identity was picked.

The dropdown exists to stand in for `managedIdentity` typed parameters, which `isParamVisible` hides, so it is now driven by that signal on the selected set instead of by the empty-form proxy. With detection precise, the wizard opts every managed MCP server back in, which also covers a connector that ships its own managed identity parameter set.

Verified against the live catalog: of the 34 connectors returned by `apiOperations?$filter=mcpOnly eq true`, none declares a `managedIdentity` typed parameter today, and `microsoftlearndocsmcpserver` is the only one with no auth metadata at all — it still gets the fallback sets.

### Also in this PR (unrelated UI fixes)

**Chat markdown images overflow their bubble** — the assistant chat bubble styled `code` but never `img`, so a full-width image (for example a GitHub avatar in an agent reply) pushed past the bubble and forced a horizontal scrollbar. Added `max-width: 100%; height: auto; border-radius: 4px` to `.msla-bubble img` (designer-ui) and the equivalent `.markdownContent img` rule in a2a-core, which had the same gap.

**Dynamic-data spinner moved below the action card** — #9483 folded `isLoadingDynamicData` into the new `CardIndicatorBadges` strip. That strip is absolutely positioned below the card so it does not affect the ELK node size, which dragged the loading spinner out of the card along with it. Only the indicator badges were meant to move, so the spinner is restored to its original inline position after the node title.

## Impact of Change
- **Users**: Managed MCP servers backed by a connector with its own auth (GitHub, Office 365, Kusto, …) now show that connector's native connection experience — the OAuth sign-in dialog — instead of an auth-type form, and no longer produce 401s when loading tools. MCP connectors with no auth metadata keep the None/Basic/Key/Managed-identity fallback and the managed identity picker.
- **Developers**: No API change. `mcpConnectionParameterSets` is now a conditional fallback rather than an unconditional override; `connectorDeclaresOwnAuth` / `usesMcpManagedIdentityFallback` in `common/constants.ts` are the single predicates for MCP-specific auth handling across the wizard and the serializer.
- **System**: No new dependencies, no network or perf impact. Saved `connections.json` / `connections-draft.json` entries for OAuth-backed MCP connections no longer carry a bogus `connectionProperties.authentication` MSI block, so the runtime uses the stored OAuth credential as intended.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: `libs/designer` and `libs/designer-v2` vitest suites

New cases in `mcpToolWizard.spec.tsx`:
- built-in MCP server → no override, no managed identity picker
- managed MCP server whose connector declares no auth → fallback parameter sets `[None, Basic, Key, ManagedServiceIdentity]` + managed identity picker enabled (guards #9199)
- managed MCP server whose connector declares OAuth `connectionParameters` → no override, picker disabled
- managed MCP server whose connector declares its own `connectionParameterSets` → no override, picker disabled
- managed MCP server on an OAuth connector → no managed-identity warning and **Next** stays enabled

New cases in `common/__test__/constants.spec.ts` (both packages, 11 tests each):
- `isManagedMcpConnector` matches on type and on the `managedApis/*mcp*` name convention, and excludes built-ins
- `connectorDeclaresOwnAuth` is true for multi-auth parameter sets and for single-auth `connectionParameters`, false when neither is present
- `usesMcpManagedIdentityFallback` is true only for managed MCP connectors that declare no auth of their own

New cases in `bjsworkflow/__test__/connections.spec.ts` (both packages) for `getConnectionPropertiesIfRequired`:
- OAuth-backed managed MCP connector → no connection properties
- managed MCP connector with no auth metadata → MSI properties (guards #9052)
- non-MCP OAuth connector → no connection properties
- MCP connection whose selected parameter set is managed identity → MSI properties

`vitest run src/lib/ui/panel/recommendation/browse/__test__/mcpToolWizard.spec.tsx` → 21 passed. The one remaining failure (`No "CheckmarkLockRegular" export is defined on the "@fluentui/react-icons" mock`) reproduces on the unmodified branch and is unrelated to this change.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@AbodeSaafan (report + repro)

## Screenshots/Videos
See the repro video on #9487.

