### PR TITLE
fix(test-utils): make fluentui-react-icons vitest mock reliably intercept

### DIFF
--- a/libs/designer-ui/src/lib/card/__test__/__snapshots__/cardfooter.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/card/__test__/__snapshots__/cardfooter.spec.tsx.snap
@@ -23,21 +23,11 @@ exports[`lib/card/cardfooter > should render with a comment icon 1`] = `
         }
       }
     >
-      <svg
-        aria-hidden={true}
-        className="panel-card-v2-badge active ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
+      <span
+        className="panel-card-v2-badge active"
+        data-icon-name="CommentRegular"
         role="button"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M10.48 13.84h4.92c.9 0 1.6-.71 1.6-1.56V5.57C17 4.7 16.3 4 15.4 4H4.6C3.7 4 3 4.71 3 5.57v6.7c0 .86.7 1.57 1.6 1.57h1.6V17l4.28-3.16ZM6.8 17.8a1 1 0 0 1-1.4-.2.98.98 0 0 1-.2-.59v-2.17h-.6A2.58 2.58 0 0 1 2 12.28V5.57A2.58 2.58 0 0 1 4.6 3h10.8C16.84 3 18 4.15 18 5.57v6.7a2.58 2.58 0 0 1-2.6 2.57h-4.59L6.8 17.8Z"
-          fill="currentColor"
-        />
-      </svg>
+      />
     </div>
   </div>
 </div>
@@ -62,21 +52,11 @@ exports[`lib/card/cardfooter > should render with a connection icon 1`] = `
         }
       }
     >
-      <svg
-        aria-hidden={true}
-        className="panel-card-v2-badge active ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
+      <span
+        className="panel-card-v2-badge active"
+        data-icon-name="LinkMultipleRegular"
         role="button"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1 8a4 4 0 0 1 4-4h6a4 4 0 0 1 0 8H9.5a.5.5 0 0 1 0-1H11a3 3 0 1 0 0-6H5a3 3 0 0 0-.87 5.87 5 5 0 0 0-.13 1A4 4 0 0 1 1 8Zm17 4a3 3 0 0 0-2.13-2.87c.08-.32.12-.66.13-1A4 4 0 0 1 15 16H9a4 4 0 0 1 0-8h1.5a.5.5 0 0 1 0 1H9a3 3 0 1 0 0 6h6a3 3 0 0 0 3-3Z"
-          fill="currentColor"
-        />
-      </svg>
+      />
     </div>
   </div>
 </div>
@@ -101,21 +81,11 @@ exports[`lib/card/cardfooter > should render with a lock icon 1`] = `
         }
       }
     >
-      <svg
-        aria-hidden={true}
-        className="panel-card-v2-badge active ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
+      <span
+        className="panel-card-v2-badge active"
+        data-icon-name="LockClosedRegular"
         role="button"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M10 13a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM6 6h1V5a3 3 0 0 1 6 0v1h1a3 3 0 0 1 3 3v6a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V9a3 3 0 0 1 3-3Zm4-3a2 2 0 0 0-2 2v1h4V5a2 2 0 0 0-2-2Zm6 6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v6c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V9Z"
-          fill="currentColor"
-        />
-      </svg>
+      />
     </div>
   </div>
 </div>
@@ -140,21 +110,11 @@ exports[`lib/card/cardfooter > should render with a testing icon 1`] = `
         }
       }
     >
-      <svg
-        aria-hidden={true}
-        className="panel-card-v2-badge active ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
+      <span
+        className="panel-card-v2-badge active"
+        data-icon-name="BeakerRegular"
         role="button"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M14 3a.5.5 0 0 1 0 1h-1v4.68c0 .58.15 1.15.42 1.66l2.4 4.45A1.5 1.5 0 0 1 14.5 17h-9a1.5 1.5 0 0 1-1.32-2.21l2.4-4.44a3.5 3.5 0 0 0 .41-1.66V4H6a.5.5 0 0 1 0-1h8ZM8 4v4.69a4.5 4.5 0 0 1-.54 2.13L6.82 12h6.36l-.64-1.18A4.5 4.5 0 0 1 12 8.68V4H8Zm5.72 9H6.28l-1.22 2.26a.5.5 0 0 0 .44.74h9a.5.5 0 0 0 .44-.74L13.72 13Z"
-          fill="currentColor"
-        />
-      </svg>
+      />
     </div>
   </div>
 </div>
@@ -167,22 +127,12 @@ exports[`lib/card/cardfooter > should render with an inactive connection icon 1`
   <div
     className="msla-badges"
   >
-    <svg
+    <span
       aria-label="Connection required"
-      className="panel-card-v2-badge inactive ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-      fill="currentColor"
-      height="1em"
-      role="img"
+      className="panel-card-v2-badge inactive"
+      data-icon-name="LinkMultipleRegular"
       tabIndex={0}
-      viewBox="0 0 20 20"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M1 8a4 4 0 0 1 4-4h6a4 4 0 0 1 0 8H9.5a.5.5 0 0 1 0-1H11a3 3 0 1 0 0-6H5a3 3 0 0 0-.87 5.87 5 5 0 0 0-.13 1A4 4 0 0 1 1 8Zm17 4a3 3 0 0 0-2.13-2.87c.08-.32.12-.66.13-1A4 4 0 0 1 15 16H9a4 4 0 0 1 0-8h1.5a.5.5 0 0 1 0 1H9a3 3 0 1 0 0 6h6a3 3 0 0 0 3-3Z"
-        fill="currentColor"
-      />
-    </svg>
+    />
   </div>
 </div>
 `;

--- a/libs/designer-ui/src/lib/colorizer/__test__/__snapshots__/colorizer.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/colorizer/__test__/__snapshots__/colorizer.spec.tsx.snap
@@ -18,7 +18,7 @@ exports[`lib/colorizer > should render 1`] = `
       <Button
         appearance="subtle"
         aria-label="Copy the value of 'start time' to the clipboard"
-        icon={<CompoundIcon />}
+        icon={<ForwardRef />}
         onClick={[Function]}
       />
     </Tooltip>
@@ -154,7 +154,7 @@ exports[`lib/colorizer > should render when utc time format props are given 1`] 
       <Button
         appearance="subtle"
         aria-label="Switch 'start time' to the local time"
-        icon={<CompoundIcon />}
+        icon={<ForwardRef />}
         onClick={[Function]}
       />
     </Tooltip>
@@ -165,7 +165,7 @@ exports[`lib/colorizer > should render when utc time format props are given 1`] 
       <Button
         appearance="subtle"
         aria-label="Copy the value of 'start time' to the clipboard"
-        icon={<CompoundIcon />}
+        icon={<ForwardRef />}
         onClick={[Function]}
       />
     </Tooltip>

--- a/libs/designer-ui/src/lib/copyinputcontrol/__test__/__snapshots__/copyinputcontrol.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/copyinputcontrol/__test__/__snapshots__/copyinputcontrol.spec.tsx.snap
@@ -31,34 +31,9 @@ exports[`lib/copyinputcontrol > should construct the copyinputcontrol correctly 
     <span
       className="fui-Button__icon rywnvv2 ___hix1za0_wgffxm0 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M5.5 4.63V17.25c0 1.8 1.46 3.25 3.25 3.25h8.62c-.31.88-1.15 1.5-2.13 1.5H8.75A4.75 4.75 0 0 1 4 17.25V6.75c0-.98.63-1.81 1.5-2.12ZM17.75 2C18.99 2 20 3 20 4.25v13c0 1.24-1 2.25-2.25 2.25h-9c-1.24 0-2.25-1-2.25-2.25v-13C6.5 3.01 7.5 2 8.75 2h9Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M5.5 4.63V17.25c0 1.8 1.46 3.25 3.25 3.25h8.62c-.31.88-1.15 1.5-2.13 1.5H8.75A4.75 4.75 0 0 1 4 17.25V6.75c0-.98.63-1.81 1.5-2.12ZM17.75 2C18.99 2 20 3 20 4.25v13c0 1.24-1 2.25-2.25 2.25h-9c-1.24 0-2.25-1-2.25-2.25v-13C6.5 3.01 7.5 2 8.75 2h9Zm0 1.5h-9a.75.75 0 0 0-.75.75v13c0 .41.34.75.75.75h9c.41 0 .75-.34.75-.75v-13a.75.75 0 0 0-.75-.75Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
   </button>
 </div>
@@ -95,34 +70,9 @@ exports[`lib/copyinputcontrol > should render basic CopyInputControl without age
     <span
       className="fui-Button__icon rywnvv2 ___hix1za0_wgffxm0 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M5.5 4.63V17.25c0 1.8 1.46 3.25 3.25 3.25h8.62c-.31.88-1.15 1.5-2.13 1.5H8.75A4.75 4.75 0 0 1 4 17.25V6.75c0-.98.63-1.81 1.5-2.12ZM17.75 2C18.99 2 20 3 20 4.25v13c0 1.24-1 2.25-2.25 2.25h-9c-1.24 0-2.25-1-2.25-2.25v-13C6.5 3.01 7.5 2 8.75 2h9Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M5.5 4.63V17.25c0 1.8 1.46 3.25 3.25 3.25h8.62c-.31.88-1.15 1.5-2.13 1.5H8.75A4.75 4.75 0 0 1 4 17.25V6.75c0-.98.63-1.81 1.5-2.12ZM17.75 2C18.99 2 20 3 20 4.25v13c0 1.24-1 2.25-2.25 2.25h-9c-1.24 0-2.25-1-2.25-2.25v-13C6.5 3.01 7.5 2 8.75 2h9Zm0 1.5h-9a.75.75 0 0 0-.75.75v13c0 .41.34.75.75.75h9c.41 0 .75-.34.75-.75v-13a.75.75 0 0 0-.75-.75Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
   </button>
 </div>
@@ -159,34 +109,9 @@ exports[`lib/copyinputcontrol > should render with popup button when showAgentVi
     <span
       className="fui-Button__icon rywnvv2 ___hix1za0_wgffxm0 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M5.5 4.63V17.25c0 1.8 1.46 3.25 3.25 3.25h8.62c-.31.88-1.15 1.5-2.13 1.5H8.75A4.75 4.75 0 0 1 4 17.25V6.75c0-.98.63-1.81 1.5-2.12ZM17.75 2C18.99 2 20 3 20 4.25v13c0 1.24-1 2.25-2.25 2.25h-9c-1.24 0-2.25-1-2.25-2.25v-13C6.5 3.01 7.5 2 8.75 2h9Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M5.5 4.63V17.25c0 1.8 1.46 3.25 3.25 3.25h8.62c-.31.88-1.15 1.5-2.13 1.5H8.75A4.75 4.75 0 0 1 4 17.25V6.75c0-.98.63-1.81 1.5-2.12ZM17.75 2C18.99 2 20 3 20 4.25v13c0 1.24-1 2.25-2.25 2.25h-9c-1.24 0-2.25-1-2.25-2.25v-13C6.5 3.01 7.5 2 8.75 2h9Zm0 1.5h-9a.75.75 0 0 0-.75.75v13c0 .41.34.75.75.75h9c.41 0 .75-.34.75-.75v-13a.75.75 0 0 0-.75-.75Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
   </button>
   <button
@@ -202,20 +127,9 @@ exports[`lib/copyinputcontrol > should render with popup button when showAgentVi
     <span
       className="fui-Button__icon rywnvv2 ___hix1za0_wgffxm0 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M6.25 3A3.25 3.25 0 0 0 3 6.25v11.5C3 19.55 4.46 21 6.25 21h11.5c1.8 0 3.25-1.46 3.25-3.25V6.25C21 4.45 19.54 3 17.75 3H6.25ZM19.5 7h-15v-.75c0-.97.78-1.75 1.75-1.75h11.5c.97 0 1.75.78 1.75 1.75V7Zm-15 1.5h15v9.25c0 .97-.78 1.75-1.75 1.75H6.25c-.97 0-1.75-.78-1.75-1.75V8.5Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-icon-name="Window24Regular"
+      />
     </span>
   </button>
 </div>
@@ -253,34 +167,9 @@ exports[`lib/copyinputcontrol > should set the aria-labelledby attribute 1`] = `
     <span
       className="fui-Button__icon rywnvv2 ___hix1za0_wgffxm0 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M5.5 4.63V17.25c0 1.8 1.46 3.25 3.25 3.25h8.62c-.31.88-1.15 1.5-2.13 1.5H8.75A4.75 4.75 0 0 1 4 17.25V6.75c0-.98.63-1.81 1.5-2.12ZM17.75 2C18.99 2 20 3 20 4.25v13c0 1.24-1 2.25-2.25 2.25h-9c-1.24 0-2.25-1-2.25-2.25v-13C6.5 3.01 7.5 2 8.75 2h9Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M5.5 4.63V17.25c0 1.8 1.46 3.25 3.25 3.25h8.62c-.31.88-1.15 1.5-2.13 1.5H8.75A4.75 4.75 0 0 1 4 17.25V6.75c0-.98.63-1.81 1.5-2.12ZM17.75 2C18.99 2 20 3 20 4.25v13c0 1.24-1 2.25-2.25 2.25h-9c-1.24 0-2.25-1-2.25-2.25v-13C6.5 3.01 7.5 2 8.75 2h9Zm0 1.5h-9a.75.75 0 0 0-.75.75v13c0 .41.34.75.75.75h9c.41 0 .75-.34.75-.75v-13a.75.75 0 0 0-.75-.75Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
   </button>
 </div>

--- a/libs/designer-ui/src/lib/editor/initializevariable/__test__/__snapshots__/VariableEditor.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/editor/initializevariable/__test__/__snapshots__/VariableEditor.spec.tsx.snap
@@ -17,34 +17,9 @@ exports[`VariableEditor > renders correctly with empty variables 1`] = `
         <span
           class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M8.3 4.3a1 1 0 0 0 0 1.4l6.29 6.3-6.3 6.3a1 1 0 1 0 1.42 1.4l7-7a1 1 0 0 0 0-1.4l-7-7a1 1 0 0 0-1.42 0Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M8.47 4.22c-.3.3-.3.77 0 1.06L15.19 12l-6.72 6.72a.75.75 0 1 0 1.06 1.06l7.25-7.25c.3-.3.3-.77 0-1.06L9.53 4.22a.75.75 0 0 0-1.06 0Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
         New Variable
       </button>
@@ -70,34 +45,9 @@ exports[`VariableEditor > renders correctly with single variable 1`] = `
         <span
           class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M8.3 4.3a1 1 0 0 0 0 1.4l6.29 6.3-6.3 6.3a1 1 0 1 0 1.42 1.4l7-7a1 1 0 0 0 0-1.4l-7-7a1 1 0 0 0-1.42 0Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M8.47 4.22c-.3.3-.3.77 0 1.06L15.19 12l-6.72 6.72a.75.75 0 1 0 1.06 1.06l7.25-7.25c.3-.3.3-.77 0-1.06L9.53 4.22a.75.75 0 0 0-1.06 0Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
         testVariable
       </button>
@@ -123,34 +73,9 @@ exports[`VariableEditor > renders correctly with single variable with Token 1`] 
         <span
           class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M8.3 4.3a1 1 0 0 0 0 1.4l6.29 6.3-6.3 6.3a1 1 0 1 0 1.42 1.4l7-7a1 1 0 0 0 0-1.4l-7-7a1 1 0 0 0-1.42 0Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M8.47 4.22c-.3.3-.3.77 0 1.06L15.19 12l-6.72 6.72a.75.75 0 1 0 1.06 1.06l7.25-7.25c.3-.3.3-.77 0-1.06L9.53 4.22a.75.75 0 0 0-1.06 0Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
         testVariable
       </button>

--- a/libs/designer-ui/src/lib/monitoring/retrypanel/__test__/__snapshots__/retrypanel.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/retrypanel/__test__/__snapshots__/retrypanel.spec.tsx.snap
@@ -24,34 +24,9 @@ exports[`lib/monitoring/retrypanel > should render 1`] = `
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
         <div
@@ -77,34 +52,9 @@ exports[`lib/monitoring/retrypanel > should render 1`] = `
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -162,34 +112,9 @@ exports[`lib/monitoring/retrypanel > should render 1`] = `
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -255,34 +180,9 @@ exports[`lib/monitoring/retrypanel > should render 1`] = `
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5V6h14v-.5Zm0 4.1V7H3v7.5A2.5 2.5 0 0 0 5.5 17h4.1A5.5 5.5 0 0 1 17 9.6ZM14.5 19a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h4.1c-.16-.32-.3-.65-.4-1H5.5A1.5 1.5 0 0 1 4 14.5V7h12v2.2c.35.1.68.24 1 .4V5.5ZM5.5 4h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Zm9 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
                 <button
@@ -298,34 +198,9 @@ exports[`lib/monitoring/retrypanel > should render 1`] = `
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -391,34 +266,9 @@ exports[`lib/monitoring/retrypanel > should render 1`] = `
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5V6h14v-.5Zm0 4.1V7H3v7.5A2.5 2.5 0 0 0 5.5 17h4.1A5.5 5.5 0 0 1 17 9.6ZM14.5 19a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h4.1c-.16-.32-.3-.65-.4-1H5.5A1.5 1.5 0 0 1 4 14.5V7h12v2.2c.35.1.68.24 1 .4V5.5ZM5.5 4h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Zm9 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
                 <button
@@ -434,34 +284,9 @@ exports[`lib/monitoring/retrypanel > should render 1`] = `
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -527,34 +352,9 @@ exports[`lib/monitoring/retrypanel > should render 1`] = `
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -620,34 +420,9 @@ exports[`lib/monitoring/retrypanel > should render 1`] = `
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -709,34 +484,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
         <div
@@ -762,34 +512,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -847,34 +572,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -940,34 +640,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5V6h14v-.5Zm0 4.1V7H3v7.5A2.5 2.5 0 0 0 5.5 17h4.1A5.5 5.5 0 0 1 17 9.6ZM14.5 19a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h4.1c-.16-.32-.3-.65-.4-1H5.5A1.5 1.5 0 0 1 4 14.5V7h12v2.2c.35.1.68.24 1 .4V5.5ZM5.5 4h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Zm9 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
                 <button
@@ -983,34 +658,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -1076,34 +726,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5V6h14v-.5Zm0 4.1V7H3v7.5A2.5 2.5 0 0 0 5.5 17h4.1A5.5 5.5 0 0 1 17 9.6ZM14.5 19a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h4.1c-.16-.32-.3-.65-.4-1H5.5A1.5 1.5 0 0 1 4 14.5V7h12v2.2c.35.1.68.24 1 .4V5.5ZM5.5 4h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Zm9 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
                 <button
@@ -1119,34 +744,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -1212,34 +812,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -1305,34 +880,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -1398,34 +948,9 @@ exports[`lib/monitoring/retrypanel > should render a service request ID when ava
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -1487,34 +1012,9 @@ exports[`lib/monitoring/retrypanel > should render an end time and duration when
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
         <div
@@ -1540,34 +1040,9 @@ exports[`lib/monitoring/retrypanel > should render an end time and duration when
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -1625,34 +1100,9 @@ exports[`lib/monitoring/retrypanel > should render an end time and duration when
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -1718,34 +1168,9 @@ exports[`lib/monitoring/retrypanel > should render an end time and duration when
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5V6h14v-.5Zm0 4.1V7H3v7.5A2.5 2.5 0 0 0 5.5 17h4.1A5.5 5.5 0 0 1 17 9.6ZM14.5 19a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h4.1c-.16-.32-.3-.65-.4-1H5.5A1.5 1.5 0 0 1 4 14.5V7h12v2.2c.35.1.68.24 1 .4V5.5ZM5.5 4h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Zm9 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
                 <button
@@ -1761,34 +1186,9 @@ exports[`lib/monitoring/retrypanel > should render an end time and duration when
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -1854,34 +1254,9 @@ exports[`lib/monitoring/retrypanel > should render an end time and duration when
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5V6h14v-.5Zm0 4.1V7H3v7.5A2.5 2.5 0 0 0 5.5 17h4.1A5.5 5.5 0 0 1 17 9.6ZM14.5 19a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h4.1c-.16-.32-.3-.65-.4-1H5.5A1.5 1.5 0 0 1 4 14.5V7h12v2.2c.35.1.68.24 1 .4V5.5ZM5.5 4h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Zm9 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
                 <button
@@ -1897,34 +1272,9 @@ exports[`lib/monitoring/retrypanel > should render an end time and duration when
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -1990,34 +1340,9 @@ exports[`lib/monitoring/retrypanel > should render an end time and duration when
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -2083,34 +1408,9 @@ exports[`lib/monitoring/retrypanel > should render an end time and duration when
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -2172,34 +1472,9 @@ exports[`lib/monitoring/retrypanel > should render an error when available 1`] =
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
         <div
@@ -2225,34 +1500,9 @@ exports[`lib/monitoring/retrypanel > should render an error when available 1`] =
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -2353,34 +1603,9 @@ exports[`lib/monitoring/retrypanel > should render an error when available 1`] =
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -2446,34 +1671,9 @@ exports[`lib/monitoring/retrypanel > should render an error when available 1`] =
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5V6h14v-.5Zm0 4.1V7H3v7.5A2.5 2.5 0 0 0 5.5 17h4.1A5.5 5.5 0 0 1 17 9.6ZM14.5 19a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h4.1c-.16-.32-.3-.65-.4-1H5.5A1.5 1.5 0 0 1 4 14.5V7h12v2.2c.35.1.68.24 1 .4V5.5ZM5.5 4h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Zm9 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
                 <button
@@ -2489,34 +1689,9 @@ exports[`lib/monitoring/retrypanel > should render an error when available 1`] =
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -2582,34 +1757,9 @@ exports[`lib/monitoring/retrypanel > should render an error when available 1`] =
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5V6h14v-.5Zm0 4.1V7H3v7.5A2.5 2.5 0 0 0 5.5 17h4.1A5.5 5.5 0 0 1 17 9.6ZM14.5 19a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h4.1c-.16-.32-.3-.65-.4-1H5.5A1.5 1.5 0 0 1 4 14.5V7h12v2.2c.35.1.68.24 1 .4V5.5ZM5.5 4h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Zm9 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm-.5-6.5a.5.5 0 0 1 1 0V14h1a.5.5 0 0 1 0 1h-1.5a.5.5 0 0 1-.5-.5v-2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
                 <button
@@ -2625,34 +1775,9 @@ exports[`lib/monitoring/retrypanel > should render an error when available 1`] =
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -2718,34 +1843,9 @@ exports[`lib/monitoring/retrypanel > should render an error when available 1`] =
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -2811,34 +1911,9 @@ exports[`lib/monitoring/retrypanel > should render an error when available 1`] =
                   <span
                     className="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden={true}
-                      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>

--- a/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/raw.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/raw.spec.tsx.snap
@@ -37,34 +37,9 @@ exports[`ui/monitoring/values/_raw > should render 1`] = `
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -133,34 +108,9 @@ exports[`ui/monitoring/values/_raw > should rendered a zero-width space if value
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>

--- a/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/values.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/values.spec.tsx.snap
@@ -89,34 +89,9 @@ exports[`ui/monitoring/values/value > should render a decimal value 1`] = `
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -544,34 +519,9 @@ exports[`ui/monitoring/values/value > should render a number value 1`] = `
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -640,34 +590,9 @@ exports[`ui/monitoring/values/value > should render a raw value 1`] = `
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -736,34 +661,9 @@ exports[`ui/monitoring/values/value > should render an XML value 1`] = `
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>

--- a/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/xml.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/monitoring/values/__test__/__snapshots__/xml.spec.tsx.snap
@@ -37,34 +37,9 @@ exports[`ui/monitoring/values/xml > should render XML 1`] = `
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -133,34 +108,9 @@ exports[`ui/monitoring/values/xml > should render XML with encoded UTF-8 Chinese
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -229,34 +179,9 @@ exports[`ui/monitoring/values/xml > should render XML without the UTF-8 byte ord
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -325,34 +250,9 @@ exports[`ui/monitoring/values/xml > should render a zero-width space if value is
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>

--- a/libs/designer-ui/src/lib/pager/__test__/__snapshots__/pager.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/pager/__test__/__snapshots__/pager.spec.tsx.snap
@@ -24,34 +24,9 @@ exports[`lib/pager > Snapshots > should match snapshot for default pager 1`] = `
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
       <div
@@ -95,34 +70,9 @@ exports[`lib/pager > Snapshots > should match snapshot for default pager 1`] = `
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -154,34 +104,9 @@ exports[`lib/pager > Snapshots > should match snapshot for disabled state (singl
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
       <div
@@ -225,34 +150,9 @@ exports[`lib/pager > Snapshots > should match snapshot for disabled state (singl
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -284,34 +184,9 @@ exports[`lib/pager > Snapshots > should match snapshot for pager with clickable 
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
       <div
@@ -362,34 +237,9 @@ exports[`lib/pager > Snapshots > should match snapshot for pager with clickable 
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -436,34 +286,9 @@ exports[`lib/pager > Snapshots > should match snapshot for pager with count disp
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
       <div
@@ -507,34 +332,9 @@ exports[`lib/pager > Snapshots > should match snapshot for pager with count disp
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -567,34 +367,9 @@ exports[`lib/pager > Snapshots > should match snapshot for pager with failed ite
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
       <div
@@ -614,50 +389,15 @@ exports[`lib/pager > Snapshots > should match snapshot for pager with failed ite
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
-        <svg
-          aria-hidden={true}
-          className="___17azqa9_19j06cy f1w7gpdv fez10in f1euv43f f1mybs0q f1hcrxcs f1aehjj5 f1vgc2s3 f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 2a3 3 0 0 0-3 3c0 2.23.79 5.2 1.22 6.69.24.79.97 1.31 1.78 1.31s1.54-.52 1.78-1.31C12.2 10.2 13 7.25 13 5a3 3 0 0 0-3-3Zm0 12a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          className="___27ei560_kknnmb0 f1euv43f f1mybs0q f1hcrxcs f1aehjj5 f1vgc2s3"
+          data-icon-name="ImportantFilled"
+        />
       </div>
       <div
         className="___mwxu0x0_0000000 f1d2rq10 f22iagw f122n59 f19jf40t"
@@ -703,50 +443,15 @@ exports[`lib/pager > Snapshots > should match snapshot for pager with failed ite
           <span
             className="fui-Button__icon rywnvv2"
           >
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
-        <svg
-          aria-hidden={true}
-          className="___6ow4e00_13vhdas f1w7gpdv fez10in f1euv43f f1mybs0q f1hcrxcs f1aehjj5 f1e31b4d f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 2a3 3 0 0 0-3 3c0 2.23.79 5.2 1.22 6.69.24.79.97 1.31 1.78 1.31s1.54-.52 1.78-1.31C12.2 10.2 13 7.25 13 5a3 3 0 0 0-3-3Zm0 12a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          className="___1dp8gus_q1pg110 f1euv43f f1mybs0q f1hcrxcs f1aehjj5 f1e31b4d"
+          data-icon-name="ImportantFilled"
+        />
       </div>
       <button
         aria-label="Next"
@@ -762,34 +467,9 @@ exports[`lib/pager > Snapshots > should match snapshot for pager with failed ite
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -821,34 +501,9 @@ exports[`lib/pager > Snapshots > should match snapshot for readonly pager 1`] = 
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.27 15.8a.75.75 0 0 1-1.06-.03l-5-5.25a.75.75 0 0 1 0-1.04l5-5.25a.75.75 0 1 1 1.08 1.04L7.8 10l4.5 4.73c.29.3.28.78-.02 1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
       <div
@@ -874,34 +529,9 @@ exports[`lib/pager > Snapshots > should match snapshot for readonly pager 1`] = 
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>

--- a/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheader.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/panelheader/__test__/__snapshots__/panelheader.spec.tsx.snap
@@ -69,34 +69,9 @@ exports[`lib/panel/panelHeader/main > should render 1`] = `
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m3.9 4.05.07-.08a.75.75 0 0 1 .98-.07l.08.07L10 8.94l4.97-4.97a.75.75 0 0 1 .98-.07l.08.07c.27.27.3.68.07.98l-.07.08L11.06 10l4.97 4.97c.27.27.3.68.07.98l-.07.08a.75.75 0 0 1-.98.07l-.08-.07L10 11.06l-4.97 4.97a.75.75 0 0 1-.98.07l-.08-.07a.75.75 0 0 1-.07-.98l.07-.08L8.94 10 3.97 5.03a.75.75 0 0 1-.07-.98l.07-.08-.07.08Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -173,34 +148,9 @@ exports[`lib/panel/panelHeader/main > should render with panel header buttons 1`
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m3.9 4.05.07-.08a.75.75 0 0 1 .98-.07l.08.07L10 8.94l4.97-4.97a.75.75 0 0 1 .98-.07l.08.07c.27.27.3.68.07.98l-.07.08L11.06 10l4.97 4.97c.27.27.3.68.07.98l-.07.08a.75.75 0 0 1-.98.07l-.08-.07L10 11.06l-4.97 4.97a.75.75 0 0 1-.98.07l-.08-.07a.75.75 0 0 1-.07-.98l.07-.08L8.94 10 3.97 5.03a.75.75 0 0 1-.07-.98l.07-.08-.07.08Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -216,34 +166,9 @@ exports[`lib/panel/panelHeader/main > should render with panel header buttons 1`
       <span
         className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.25 6a7 7 0 1 1-1.24 3.57A.53.53 0 0 0 2.5 9a.47.47 0 0 0-.48.44L2 10a8 8 0 1 0 1.5-4.66V3.5a.5.5 0 0 0-1 0v3c0 .28.22.5.5.5h3a.5.5 0 0 0 0-1H4.25Zm5.24.88A1 1 0 0 0 8 7.75v4.5a1 1 0 0 0 1.5.87l3.99-2.25a1 1 0 0 0 0-1.74l-4-2.25Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.25 6a7 7 0 1 1-1.24 3.57A.53.53 0 0 0 2.5 9a.47.47 0 0 0-.48.44L2 10a8 8 0 1 0 1.5-4.66V3.5a.5.5 0 0 0-1 0v3c0 .28.22.5.5.5h3a.5.5 0 0 0 0-1H4.25ZM8 7.75a1 1 0 0 1 1.5-.87l3.99 2.25a1 1 0 0 1 0 1.74l-4 2.25A1 1 0 0 1 8 12.25v-4.5ZM13 10 9 7.75v4.5L13 10Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
       Submit from this action
     </button>
@@ -256,34 +181,9 @@ exports[`lib/panel/panelHeader/main > should render with panel header buttons 1`
       <span
         className="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
     </button>
   </div>
@@ -369,34 +269,9 @@ exports[`lib/panel/panelHeader/main > should render with panel header menu 1`] =
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12 8a2 2 0 1 1 0-4 2 2 0 0 1 0 4Zm0 6a2 2 0 1 1 0-4 2 2 0 0 1 0 4Zm-2 4a2 2 0 1 0 4 0 2 2 0 0 0-4 0Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12 7.75a1.75 1.75 0 1 1 0-3.5 1.75 1.75 0 0 1 0 3.5Zm0 6a1.75 1.75 0 1 1 0-3.5 1.75 1.75 0 0 1 0 3.5ZM10.25 18a1.75 1.75 0 1 0 3.5 0 1.75 1.75 0 0 0-3.5 0Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
       <button
@@ -415,34 +290,9 @@ exports[`lib/panel/panelHeader/main > should render with panel header menu 1`] =
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m3.9 4.05.07-.08a.75.75 0 0 1 .98-.07l.08.07L10 8.94l4.97-4.97a.75.75 0 0 1 .98-.07l.08.07c.27.27.3.68.07.98l-.07.08L11.06 10l4.97 4.97c.27.27.3.68.07.98l-.07.08a.75.75 0 0 1-.98.07l-.08-.07L10 11.06l-4.97 4.97a.75.75 0 0 1-.98.07l-.08-.07a.75.75 0 0 1-.07-.98l.07-.08L8.94 10 3.97 5.03a.75.75 0 0 1-.07-.98l.07-.08-.07.08Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -519,34 +369,9 @@ exports[`lib/panel/panelHeader/main > should render with panel header trigger in
         <span
           className="fui-Button__icon rywnvv2"
         >
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m3.9 4.05.07-.08a.75.75 0 0 1 .98-.07l.08.07L10 8.94l4.97-4.97a.75.75 0 0 1 .98-.07l.08.07c.27.27.3.68.07.98l-.07.08L11.06 10l4.97 4.97c.27.27.3.68.07.98l-.07.08a.75.75 0 0 1-.98.07l-.08-.07L10 11.06l-4.97 4.97a.75.75 0 0 1-.98.07l-.08-.07a.75.75 0 0 1-.07-.98l.07-.08L8.94 10 3.97 5.03a.75.75 0 0 1-.07-.98l.07-.08-.07.08Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden={true}
-            className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -597,20 +422,9 @@ exports[`lib/panel/panelHeader/main > should render with panel header trigger in
           <span
             className="fui-Button__icon rywnvv2 ___hix1za0_wgffxm0 fe5j1ua fjamq6b f64fuq3 fbaiahx"
           >
-            <svg
-              aria-hidden={true}
-              className="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-icon-name="DismissRegular"
+            />
           </span>
         </button>
       </div>
@@ -633,34 +447,9 @@ exports[`lib/panel/panelHeader/main > should render with panel header trigger in
       <span
         className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.25 6a7 7 0 1 1-1.24 3.57A.53.53 0 0 0 2.5 9a.47.47 0 0 0-.48.44L2 10a8 8 0 1 0 1.5-4.66V3.5a.5.5 0 0 0-1 0v3c0 .28.22.5.5.5h3a.5.5 0 0 0 0-1H4.25Zm5.24.88A1 1 0 0 0 8 7.75v4.5a1 1 0 0 0 1.5.87l3.99-2.25a1 1 0 0 0 0-1.74l-4-2.25Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.25 6a7 7 0 1 1-1.24 3.57A.53.53 0 0 0 2.5 9a.47.47 0 0 0-.48.44L2 10a8 8 0 1 0 1.5-4.66V3.5a.5.5 0 0 0-1 0v3c0 .28.22.5.5.5h3a.5.5 0 0 0 0-1H4.25ZM8 7.75a1 1 0 0 1 1.5-.87l3.99 2.25a1 1 0 0 1 0 1.74l-4 2.25A1 1 0 0 1 8 12.25v-4.5ZM13 10 9 7.75v4.5L13 10Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
       Submit from this action
     </button>
@@ -673,34 +462,9 @@ exports[`lib/panel/panelHeader/main > should render with panel header trigger in
       <span
         className="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 20 20"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
     </button>
   </div>

--- a/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/__test__/__snapshots__/operationSearchHeader.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/panel/recommendationpanel/operationSearchHeader/__test__/__snapshots__/operationSearchHeader.spec.tsx.snap
@@ -76,20 +76,9 @@ exports[`OperationSearchHeader > renders correctly with isTriggerNode=false 1`] 
         <span
           class="fui-Button__icon rywnvv2 fui-MenuButton__icon"
         >
-          <svg
-            aria-hidden="true"
-            class="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.5 13h5a.5.5 0 0 1 .09 1H7.5a.5.5 0 0 1-.09-1h5.09-5Zm-2-4h9a.5.5 0 0 1 .09 1H5.5a.5.5 0 0 1-.09-1h9.09-9Zm-2-4h13a.5.5 0 0 1 .09 1H3.5a.5.5 0 0 1-.09-1H16.5h-13Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-icon-name="FilterRegular"
+          />
         </span>
       </button>
     </div>
@@ -174,20 +163,9 @@ exports[`OperationSearchHeader > renders correctly with isTriggerNode=true 1`] =
         <span
           class="fui-Button__icon rywnvv2 fui-MenuButton__icon"
         >
-          <svg
-            aria-hidden="true"
-            class="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.5 13h5a.5.5 0 0 1 .09 1H7.5a.5.5 0 0 1-.09-1h5.09-5Zm-2-4h9a.5.5 0 0 1 .09 1H5.5a.5.5 0 0 1-.09-1h9.09-9Zm-2-4h13a.5.5 0 0 1 .09 1H3.5a.5.5 0 0 1-.09-1H16.5h-13Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-icon-name="FilterRegular"
+          />
         </span>
       </button>
     </div>
@@ -271,20 +249,9 @@ exports[`OperationSearchHeader > renders correctly with search term and filters 
         <span
           class="fui-Button__icon rywnvv2 fui-MenuButton__icon"
         >
-          <svg
-            aria-hidden="true"
-            class="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.5 13h5a.5.5 0 0 1 .09 1H7.5a.5.5 0 0 1-.09-1h5.09-5Zm-2-4h9a.5.5 0 0 1 .09 1H5.5a.5.5 0 0 1-.09-1h9.09-9Zm-2-4h13a.5.5 0 0 1 .09 1H3.5a.5.5 0 0 1-.09-1H16.5h-13Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-icon-name="FilterRegular"
+          />
         </span>
       </button>
     </div>

--- a/libs/designer-ui/src/lib/templates/__test__/__snapshots__/templatesPanelHeader.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/templates/__test__/__snapshots__/templatesPanelHeader.spec.tsx.snap
@@ -92,20 +92,9 @@ exports[`ui/templates/templatesPanelHeader > should render with all props 1`] = 
         onKeyDown={[Function]}
         type="button"
       >
-        <svg
-          aria-hidden={true}
-          className="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M14 8c0 .41-.34.75-.75.75H4.46l3.29 2.94a.75.75 0 1 1-1 1.12L2 8.56a.75.75 0 0 1 0-1.12L6.75 3.2a.75.75 0 1 1 1 1.12L4.46 7.25h8.79c.41 0 .75.34.75.75Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-icon-name="ArrowLeft16Filled"
+        />
         Back to template library
       </button>
     </div>
@@ -142,20 +131,9 @@ exports[`ui/templates/templatesPanelHeader > should render with back button when
         onKeyDown={[Function]}
         type="button"
       >
-        <svg
-          aria-hidden={true}
-          className="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M14 8c0 .41-.34.75-.75.75H4.46l3.29 2.94a.75.75 0 1 1-1 1.12L2 8.56a.75.75 0 0 1 0-1.12L6.75 3.2a.75.75 0 1 1 1 1.12L4.46 7.25h8.79c.41 0 .75.34.75.75Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-icon-name="ArrowLeft16Filled"
+        />
         Back to template library
       </button>
     </div>

--- a/libs/designer-ui/src/lib/workflowparameters/__tests__/__snapshots__/workflowparameter.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/workflowparameters/__tests__/__snapshots__/workflowparameter.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`ui/workflowparameters/workflowparameter > should construct. 1`] = `
       className="___r7kt3y0_0000000 fqerorx"
       data-automation-id="id-parameter-heading-button"
       data-testid="id-parameter-heading-button"
-      icon={<CompoundIcon />}
+      icon={<ForwardRef />}
       id="id"
       onClick={[Function]}
       style={
@@ -50,7 +50,7 @@ exports[`ui/workflowparameters/workflowparameter > should construct. 1`] = `
           <Button
             appearance="subtle"
             aria-label="Delete parameter"
-            icon={<CompoundIcon />}
+            icon={<ForwardRef />}
             onClick={[Function]}
             style={
               {

--- a/libs/designer-ui/src/lib/workflowparameters/__tests__/__snapshots__/workflowparameters.spec.tsx.snap
+++ b/libs/designer-ui/src/lib/workflowparameters/__tests__/__snapshots__/workflowparameters.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`ui/workflowparameters/workflowparameters > should construct. 1`] = `
     <Button
       appearance="subtle"
       aria-label="Close panel"
-      icon={<CompoundIcon />}
+      icon={<ForwardRef />}
       onClick={[Function]}
     />
   </div>
@@ -22,7 +22,7 @@ exports[`ui/workflowparameters/workflowparameters > should construct. 1`] = `
     className="___1xjmln6_0000000 f1asdtw4"
   >
     <Button
-      icon={<CompoundIcon />}
+      icon={<ForwardRef />}
       onClick={[Function]}
     >
       Create parameter

--- a/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/TimelineHeader.test.tsx
+++ b/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/TimelineHeader.test.tsx
@@ -83,9 +83,14 @@ describe('TimelineHeader', () => {
   });
 
   it('should render timeline icon in both expanded and collapsed states', () => {
+    // Only count rendered host elements (e.g. the icon's <span>/<svg>), not the wrapping
+    // component instance, which also carries the same className prop and would otherwise
+    // be double-counted by findAllByProps.
+    const isHostElement = (instance: { type: unknown }) => typeof instance.type === 'string';
+
     // Test expanded
     const expandedComponent = renderWithIntl(defaultProps);
-    const expandedIcons = expandedComponent.root.findAllByProps({ className: 'timeline-icon' });
+    const expandedIcons = expandedComponent.root.findAllByProps({ className: 'timeline-icon' }).filter(isHostElement);
     expect(expandedIcons).toHaveLength(1);
 
     // Test collapsed
@@ -93,7 +98,7 @@ describe('TimelineHeader', () => {
       ...defaultProps,
       isExpanded: false,
     });
-    const collapsedIcons = collapsedComponent.root.findAllByProps({ className: 'timeline-icon' });
+    const collapsedIcons = collapsedComponent.root.findAllByProps({ className: 'timeline-icon' }).filter(isHostElement);
     expect(collapsedIcons).toHaveLength(1);
   });
 

--- a/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineButtons.test.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineButtons.test.tsx.snap
@@ -13,34 +13,9 @@ exports[`TimelineButtons > should render collapsed (not expanded) 1`] = `
     <span
       className="fui-Button__icon rywnvv2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.2 12.27a.75.75 0 0 1 .03-1.06l5.25-5a.75.75 0 0 1 1.04 0l5.25 5a.75.75 0 0 1-1.04 1.08L10 7.8l-4.73 4.5a.75.75 0 0 1-1.06-.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.15 12.35a.5.5 0 0 1 0-.7L9.6 6.16a.55.55 0 0 1 .78 0l5.46 5.49a.5.5 0 0 1-.7.7L10 7.2l-5.15 5.16a.5.5 0 0 1-.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
   </button>
   <button
@@ -52,34 +27,9 @@ exports[`TimelineButtons > should render collapsed (not expanded) 1`] = `
     <span
       className="fui-Button__icon rywnvv2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.8 7.73c.28.3.27.78-.03 1.06l-5.25 5a.75.75 0 0 1-1.04 0l-5.25-5a.75.75 0 0 1 1.04-1.08L10 12.2l4.73-4.5a.75.75 0 0 1 1.06.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
   </button>
 </div>
@@ -98,34 +48,9 @@ exports[`TimelineButtons > should render with default props 1`] = `
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.2 12.27a.75.75 0 0 1 .03-1.06l5.25-5a.75.75 0 0 1 1.04 0l5.25 5a.75.75 0 0 1-1.04 1.08L10 7.8l-4.73 4.5a.75.75 0 0 1-1.06-.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.15 12.35a.5.5 0 0 1 0-.7L9.6 6.16a.55.55 0 0 1 .78 0l5.46 5.49a.5.5 0 0 1-.7.7L10 7.2l-5.15 5.16a.5.5 0 0 1-.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Previous task
   </button>
@@ -138,34 +63,9 @@ exports[`TimelineButtons > should render with default props 1`] = `
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.8 7.73c.28.3.27.78-.03 1.06l-5.25 5a.75.75 0 0 1-1.04 0l-5.25-5a.75.75 0 0 1 1.04-1.08L10 12.2l4.73-4.5a.75.75 0 0 1 1.06.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Next task
   </button>
@@ -185,34 +85,9 @@ exports[`TimelineButtons > should render with disabled buttons when fetching rep
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.2 12.27a.75.75 0 0 1 .03-1.06l5.25-5a.75.75 0 0 1 1.04 0l5.25 5a.75.75 0 0 1-1.04 1.08L10 7.8l-4.73 4.5a.75.75 0 0 1-1.06-.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.15 12.35a.5.5 0 0 1 0-.7L9.6 6.16a.55.55 0 0 1 .78 0l5.46 5.49a.5.5 0 0 1-.7.7L10 7.2l-5.15 5.16a.5.5 0 0 1-.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Previous task
   </button>
@@ -225,34 +100,9 @@ exports[`TimelineButtons > should render with disabled buttons when fetching rep
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.8 7.73c.28.3.27.78-.03 1.06l-5.25 5a.75.75 0 0 1-1.04 0l-5.25-5a.75.75 0 0 1 1.04-1.08L10 12.2l4.73-4.5a.75.75 0 0 1 1.06.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Next task
   </button>
@@ -272,34 +122,9 @@ exports[`TimelineButtons > should render with disabled buttons when no repetitio
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.2 12.27a.75.75 0 0 1 .03-1.06l5.25-5a.75.75 0 0 1 1.04 0l5.25 5a.75.75 0 0 1-1.04 1.08L10 7.8l-4.73 4.5a.75.75 0 0 1-1.06-.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.15 12.35a.5.5 0 0 1 0-.7L9.6 6.16a.55.55 0 0 1 .78 0l5.46 5.49a.5.5 0 0 1-.7.7L10 7.2l-5.15 5.16a.5.5 0 0 1-.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Previous task
   </button>
@@ -312,34 +137,9 @@ exports[`TimelineButtons > should render with disabled buttons when no repetitio
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.8 7.73c.28.3.27.78-.03 1.06l-5.25 5a.75.75 0 0 1-1.04 0l-5.25-5a.75.75 0 0 1 1.04-1.08L10 12.2l4.73-4.5a.75.75 0 0 1 1.06.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Next task
   </button>
@@ -359,34 +159,9 @@ exports[`TimelineButtons > should render with disabled next button at last task 
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.2 12.27a.75.75 0 0 1 .03-1.06l5.25-5a.75.75 0 0 1 1.04 0l5.25 5a.75.75 0 0 1-1.04 1.08L10 7.8l-4.73 4.5a.75.75 0 0 1-1.06-.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.15 12.35a.5.5 0 0 1 0-.7L9.6 6.16a.55.55 0 0 1 .78 0l5.46 5.49a.5.5 0 0 1-.7.7L10 7.2l-5.15 5.16a.5.5 0 0 1-.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Previous task
   </button>
@@ -399,34 +174,9 @@ exports[`TimelineButtons > should render with disabled next button at last task 
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.8 7.73c.28.3.27.78-.03 1.06l-5.25 5a.75.75 0 0 1-1.04 0l-5.25-5a.75.75 0 0 1 1.04-1.08L10 12.2l4.73-4.5a.75.75 0 0 1 1.06.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Next task
   </button>
@@ -446,34 +196,9 @@ exports[`TimelineButtons > should render with disabled previous button at first 
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.2 12.27a.75.75 0 0 1 .03-1.06l5.25-5a.75.75 0 0 1 1.04 0l5.25 5a.75.75 0 0 1-1.04 1.08L10 7.8l-4.73 4.5a.75.75 0 0 1-1.06-.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.15 12.35a.5.5 0 0 1 0-.7L9.6 6.16a.55.55 0 0 1 .78 0l5.46 5.49a.5.5 0 0 1-.7.7L10 7.2l-5.15 5.16a.5.5 0 0 1-.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Previous task
   </button>
@@ -486,34 +211,9 @@ exports[`TimelineButtons > should render with disabled previous button at first 
     <span
       className="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.8 7.73c.28.3.27.78-.03 1.06l-5.25 5a.75.75 0 0 1-1.04 0l-5.25-5a.75.75 0 0 1 1.04-1.08L10 12.2l4.73-4.5a.75.75 0 0 1 1.06.02Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Next task
   </button>

--- a/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineContent.test.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineContent.test.tsx.snap
@@ -107,20 +107,10 @@ exports[`TimelineContent > should render error carets for failed repetitions 1`]
   <div
     className="error-caret-container"
   >
-    <svg
-      aria-hidden={true}
-      className="error-caret ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-      fill="currentColor"
-      height="1em"
-      viewBox="0 0 20 20"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M13 14.2a1 1 0 0 1-1.63.78l-4.72-3.81a1.5 1.5 0 0 1 0-2.34l4.72-3.81A1 1 0 0 1 13 5.8v8.4Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span
+      className="error-caret"
+      data-icon-name="CaretLeftFilled"
+    />
     <div />
   </div>
 </div>
@@ -198,11 +188,8 @@ exports[`TimelineContent > should render no repetitions state 1`] = `
     }
   }
 >
-  <svg
-    aria-hidden={true}
-    className="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-    fill="currentColor"
-    height="1em"
+  <span
+    data-icon-name="BorderNoneRegular"
     style={
       {
         "color": "var(--colorNeutralForeground3)",
@@ -210,15 +197,7 @@ exports[`TimelineContent > should render no repetitions state 1`] = `
         "width": "30px",
       }
     }
-    viewBox="0 0 20 20"
-    width="1em"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M8 3.5c0-.28.22-.5.5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5Zm-2.46.55a2 2 0 0 0-1.5 1.55.5.5 0 0 1-.59.4.5.5 0 0 1-.38-.66 3 3 0 0 1 2.34-2.29.5.5 0 0 1 .6.4.5.5 0 0 1-.47.6Zm0 11.9a2 2 0 0 1-1.5-1.55.5.5 0 0 0-.59-.4.5.5 0 0 0-.38.66 3 3 0 0 0 2.34 2.29.5.5 0 0 0 .6-.4.5.5 0 0 0-.47-.6Zm9.05-12.9a3 3 0 0 1 2.36 2.36.5.5 0 0 1-.4.6.5.5 0 0 1-.6-.47 2 2 0 0 0-1.55-1.5.5.5 0 0 1-.4-.59.5.5 0 0 1 .6-.4Zm-.13 12.9a2 2 0 0 0 1.5-1.55.5.5 0 0 1 .59-.4.5.5 0 0 1 .38.66 3 3 0 0 1-2.34 2.29.5.5 0 0 1-.6-.4.5.5 0 0 1 .47-.6ZM16 11.5a.5.5 0 0 0 1 0v-3a.5.5 0 0 0-1 0v3ZM3.5 12a.5.5 0 0 1-.5-.5v-3a.5.5 0 0 1 1 0v3a.5.5 0 0 1-.5.5Zm5 4a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1h-3Z"
-      fill="currentColor"
-    />
-  </svg>
+  />
   <span
     className="fui-Text ___g0or4u0_dhwpsw0 fk6fouc fkhj508 f1i3iumi fl43uef fpgzoln f1w7gpdv f6juhto f1gl81tg f2jf649"
     style={
@@ -243,11 +222,8 @@ exports[`TimelineContent > should render no repetitions state when collapsed 1`]
     }
   }
 >
-  <svg
-    aria-hidden={true}
-    className="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-    fill="currentColor"
-    height="1em"
+  <span
+    data-icon-name="BorderNoneRegular"
     style={
       {
         "color": "var(--colorNeutralForeground3)",
@@ -255,15 +231,7 @@ exports[`TimelineContent > should render no repetitions state when collapsed 1`]
         "width": "30px",
       }
     }
-    viewBox="0 0 20 20"
-    width="1em"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M8 3.5c0-.28.22-.5.5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5Zm-2.46.55a2 2 0 0 0-1.5 1.55.5.5 0 0 1-.59.4.5.5 0 0 1-.38-.66 3 3 0 0 1 2.34-2.29.5.5 0 0 1 .6.4.5.5 0 0 1-.47.6Zm0 11.9a2 2 0 0 1-1.5-1.55.5.5 0 0 0-.59-.4.5.5 0 0 0-.38.66 3 3 0 0 0 2.34 2.29.5.5 0 0 0 .6-.4.5.5 0 0 0-.47-.6Zm9.05-12.9a3 3 0 0 1 2.36 2.36.5.5 0 0 1-.4.6.5.5 0 0 1-.6-.47 2 2 0 0 0-1.55-1.5.5.5 0 0 1-.4-.59.5.5 0 0 1 .6-.4Zm-.13 12.9a2 2 0 0 0 1.5-1.55.5.5 0 0 1 .59-.4.5.5 0 0 1 .38.66 3 3 0 0 1-2.34 2.29.5.5 0 0 1-.6-.4.5.5 0 0 1 .47-.6ZM16 11.5a.5.5 0 0 0 1 0v-3a.5.5 0 0 0-1 0v3ZM3.5 12a.5.5 0 0 1-.5-.5v-3a.5.5 0 0 1 1 0v3a.5.5 0 0 1-.5.5Zm5 4a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1h-3Z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </div>
 `;
 
@@ -340,20 +308,10 @@ exports[`TimelineContent > should render with default props 1`] = `
   >
     <div />
     <div />
-    <svg
-      aria-hidden={true}
-      className="error-caret ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-      fill="currentColor"
-      height="1em"
-      viewBox="0 0 20 20"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M13 14.2a1 1 0 0 1-1.63.78l-4.72-3.81a1.5 1.5 0 0 1 0-2.34l4.72-3.81A1 1 0 0 1 13 5.8v8.4Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span
+      className="error-caret"
+      data-icon-name="CaretLeftFilled"
+    />
   </div>
 </div>
 `;
@@ -489,20 +447,10 @@ exports[`TimelineContent > should render with multiple task groups 1`] = `
     <div />
     <div />
     <div />
-    <svg
-      aria-hidden={true}
-      className="error-caret ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-      fill="currentColor"
-      height="1em"
-      viewBox="0 0 20 20"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M13 14.2a1 1 0 0 1-1.63.78l-4.72-3.81a1.5 1.5 0 0 1 0-2.34l4.72-3.81A1 1 0 0 1 13 5.8v8.4Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span
+      className="error-caret"
+      data-icon-name="CaretLeftFilled"
+    />
   </div>
 </div>
 `;

--- a/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineGroup.test.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineGroup.test.tsx.snap
@@ -23,34 +23,9 @@ exports[`TimelineGroup > should render as collapsed group initially 1`] = `
     <span
       className="fui-Button__icon rywnvv2 ___14u6ce1_ubi7uv0 f1nizpg2 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.3 4.3a1 1 0 0 0 0 1.4l6.29 6.3-6.3 6.3a1 1 0 1 0 1.42 1.4l7-7a1 1 0 0 0 0-1.4l-7-7a1 1 0 0 0-1.42 0Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.47 4.22c-.3.3-.3.77 0 1.06L15.19 12l-6.72 6.72a.75.75 0 1 0 1.06 1.06l7.25-7.25c.3-.3.3-.77 0-1.06L9.53 4.22a.75.75 0 0 0-1.06 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Task #1
   </button>
@@ -80,34 +55,9 @@ exports[`TimelineGroup > should render as expanded group when taskId matches tra
     <span
       className="fui-Button__icon rywnvv2 ___14u6ce1_ubi7uv0 f1nizpg2 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.3 4.3a1 1 0 0 0 0 1.4l6.29 6.3-6.3 6.3a1 1 0 1 0 1.42 1.4l7-7a1 1 0 0 0 0-1.4l-7-7a1 1 0 0 0-1.42 0Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.47 4.22c-.3.3-.3.77 0 1.06L15.19 12l-6.72 6.72a.75.75 0 1 0 1.06 1.06l7.25-7.25c.3-.3.3-.77 0-1.06L9.53 4.22a.75.75 0 0 0-1.06 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Task #1
   </button>
@@ -199,34 +149,9 @@ exports[`TimelineGroup > should render with default props when timeline is expan
     <span
       className="fui-Button__icon rywnvv2 ___14u6ce1_ubi7uv0 f1nizpg2 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.3 4.3a1 1 0 0 0 0 1.4l6.29 6.3-6.3 6.3a1 1 0 1 0 1.42 1.4l7-7a1 1 0 0 0 0-1.4l-7-7a1 1 0 0 0-1.42 0Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.47 4.22c-.3.3-.3.77 0 1.06L15.19 12l-6.72 6.72a.75.75 0 1 0 1.06 1.06l7.25-7.25c.3-.3.3-.77 0-1.06L9.53 4.22a.75.75 0 0 0-1.06 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Task #1
   </button>
@@ -256,34 +181,9 @@ exports[`TimelineGroup > should render with different task number 1`] = `
     <span
       className="fui-Button__icon rywnvv2 ___14u6ce1_ubi7uv0 f1nizpg2 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.3 4.3a1 1 0 0 0 0 1.4l6.29 6.3-6.3 6.3a1 1 0 1 0 1.42 1.4l7-7a1 1 0 0 0 0-1.4l-7-7a1 1 0 0 0-1.42 0Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.47 4.22c-.3.3-.3.77 0 1.06L15.19 12l-6.72 6.72a.75.75 0 1 0 1.06 1.06l7.25-7.25c.3-.3.3-.77 0-1.06L9.53 4.22a.75.75 0 0 0-1.06 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Task #6
   </button>
@@ -313,34 +213,9 @@ exports[`TimelineGroup > should render with empty repetitions 1`] = `
     <span
       className="fui-Button__icon rywnvv2 ___14u6ce1_ubi7uv0 f1nizpg2 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Task #1
   </button>
@@ -370,34 +245,9 @@ exports[`TimelineGroup > should render with no selected repetition 1`] = `
     <span
       className="fui-Button__icon rywnvv2 ___14u6ce1_ubi7uv0 f1nizpg2 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.3 4.3a1 1 0 0 0 0 1.4l6.29 6.3-6.3 6.3a1 1 0 1 0 1.42 1.4l7-7a1 1 0 0 0 0-1.4l-7-7a1 1 0 0 0-1.42 0Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.47 4.22c-.3.3-.3.77 0 1.06L15.19 12l-6.72 6.72a.75.75 0 1 0 1.06 1.06l7.25-7.25c.3-.3.3-.77 0-1.06L9.53 4.22a.75.75 0 0 0-1.06 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Task #1
   </button>
@@ -427,34 +277,9 @@ exports[`TimelineGroup > should render with single repetition 1`] = `
     <span
       className="fui-Button__icon rywnvv2 ___14u6ce1_ubi7uv0 f1nizpg2 fe5j1ua fjamq6b f64fuq3 fbaiahx"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.3 4.3a1 1 0 0 0 0 1.4l6.29 6.3-6.3 6.3a1 1 0 1 0 1.42 1.4l7-7a1 1 0 0 0 0-1.4l-7-7a1 1 0 0 0-1.42 0Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M8.47 4.22c-.3.3-.3.77 0 1.06L15.19 12l-6.72 6.72a.75.75 0 1 0 1.06 1.06l7.25-7.25c.3-.3.3-.77 0-1.06L9.53 4.22a.75.75 0 0 0-1.06 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
     Task #1
   </button>

--- a/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineHeader.test.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/MonitoringTimeline/__tests__/__snapshots__/TimelineHeader.test.tsx.snap
@@ -11,20 +11,10 @@ exports[`TimelineHeader > should not render title text when collapsed 1`] = `
     }
   }
 >
-  <svg
-    aria-hidden={true}
-    className="timeline-icon ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-    fill="currentColor"
-    height="1em"
-    viewBox="0 0 20 20"
-    width="1em"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M3.5 3C2.67 3 2 3.67 2 4.5v4c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-4c0-.83-.67-1.5-1.5-1.5h-9ZM3 4.5c0-.28.22-.5.5-.5h9c.28 0 .5.22.5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-4Zm.5 6.5c-.83 0-1.5.67-1.5 1.5v4c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-4c0-.83-.67-1.5-1.5-1.5h-9ZM3 12.5c0-.28.22-.5.5-.5h9c.28 0 .5.22.5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-4Zm14-.06a2 2 0 0 1-1-3.88 2 2 0 0 1 1 3.88ZM16.5 3c.28 0 .5.22.5.5v4.04a3.02 3.02 0 0 0-1 0V3.5c0-.28.22-.5.5-.5Zm0 10.5c-.17 0-.34-.01-.5-.04v4.04a.5.5 0 0 0 1 0v-4.04c-.16.03-.33.04-.5.04Z"
-      fill="currentColor"
-    />
-  </svg>
+  <span
+    className="timeline-icon"
+    data-icon-name="TimelineRegular"
+  />
 </div>
 `;
 
@@ -39,20 +29,10 @@ exports[`TimelineHeader > should render when collapsed 1`] = `
     }
   }
 >
-  <svg
-    aria-hidden={true}
-    className="timeline-icon ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-    fill="currentColor"
-    height="1em"
-    viewBox="0 0 20 20"
-    width="1em"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M3.5 3C2.67 3 2 3.67 2 4.5v4c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-4c0-.83-.67-1.5-1.5-1.5h-9ZM3 4.5c0-.28.22-.5.5-.5h9c.28 0 .5.22.5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-4Zm.5 6.5c-.83 0-1.5.67-1.5 1.5v4c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-4c0-.83-.67-1.5-1.5-1.5h-9ZM3 12.5c0-.28.22-.5.5-.5h9c.28 0 .5.22.5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-4Zm14-.06a2 2 0 0 1-1-3.88 2 2 0 0 1 1 3.88ZM16.5 3c.28 0 .5.22.5.5v4.04a3.02 3.02 0 0 0-1 0V3.5c0-.28.22-.5.5-.5Zm0 10.5c-.17 0-.34-.01-.5-.04v4.04a.5.5 0 0 0 1 0v-4.04c-.16.03-.33.04-.5.04Z"
-      fill="currentColor"
-    />
-  </svg>
+  <span
+    className="timeline-icon"
+    data-icon-name="TimelineRegular"
+  />
 </div>
 `;
 
@@ -68,20 +48,10 @@ exports[`TimelineHeader > should render with default props when expanded 1`] = `
     }
   }
 >
-  <svg
-    aria-hidden={true}
-    className="timeline-icon ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
-    fill="currentColor"
-    height="1em"
-    viewBox="0 0 20 20"
-    width="1em"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M3.5 3C2.67 3 2 3.67 2 4.5v4c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-4c0-.83-.67-1.5-1.5-1.5h-9ZM3 4.5c0-.28.22-.5.5-.5h9c.28 0 .5.22.5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-4Zm.5 6.5c-.83 0-1.5.67-1.5 1.5v4c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-4c0-.83-.67-1.5-1.5-1.5h-9ZM3 12.5c0-.28.22-.5.5-.5h9c.28 0 .5.22.5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-4Zm14-.06a2 2 0 0 1-1-3.88 2 2 0 0 1 1 3.88ZM16.5 3c.28 0 .5.22.5.5v4.04a3.02 3.02 0 0 0-1 0V3.5c0-.28.22-.5.5-.5Zm0 10.5c-.17 0-.34-.01-.5-.04v4.04a.5.5 0 0 0 1 0v-4.04c-.16.03-.33.04-.5.04Z"
-      fill="currentColor"
-    />
-  </svg>
+  <span
+    className="timeline-icon"
+    data-icon-name="TimelineRegular"
+  />
   <span
     className="fui-Text ___g0or4u0_dhwpsw0 fk6fouc fkhj508 f1i3iumi fl43uef fpgzoln f1w7gpdv f6juhto f1gl81tg f2jf649"
     style={
@@ -100,34 +70,9 @@ exports[`TimelineHeader > should render with default props when expanded 1`] = `
     <span
       className="fui-Button__icon rywnvv2"
     >
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4 10a6 6 0 0 1 9.97-4.5h-1.22a.75.75 0 0 0 0 1.5h3c.41 0 .75-.34.75-.75v-3a.75.75 0 0 0-1.5 0v1.16a7.5 7.5 0 1 0 2.5 5.31.75.75 0 0 0-1.5.06V10a6 6 0 0 1-12 0Z"
-          fill="currentColor"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 20 20"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4 10a6 6 0 0 1 10.47-4H12.5a.5.5 0 0 0 0 1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-1 0v1.6a7 7 0 1 0 1.98 4.36.5.5 0 1 0-1 .08L16 10a6 6 0 0 1-12 0Z"
-          fill="currentColor"
-        />
-      </svg>
+      <span
+        data-testid="fluent-icon"
+      />
     </span>
   </button>
 </div>

--- a/libs/designer-v2/src/lib/ui/menuItems/__test__/__snapshots__/collapseMenuItem.spec.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/menuItems/__test__/__snapshots__/collapseMenuItem.spec.tsx.snap
@@ -14,34 +14,9 @@ exports[`lib/ui/menuItems/collapseMenuItem > should render correctly when isColl
   <span
     className="fui-MenuItem__icon ro9koqv"
   >
-    <svg
-      aria-hidden={true}
-      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-      fill="currentColor"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M10.5 12.5a1 1 0 0 1 1 .89V21a1 1 0 0 1-2 .12V15.9l-5.8 5.8a1 1 0 0 1-1.31.08l-.1-.08a1 1 0 0 1-.08-1.32l.08-.1 5.79-5.78H3a1 1 0 0 1-.12-2h7.62Zm3-10.5a1 1 0 0 1 1 .88V8.1l5.8-5.8a1 1 0 0 1 1.31-.08l.1.08a1 1 0 0 1 .08 1.32l-.08.1-5.8 5.8H21a1 1 0 0 1 .12 1.99H13.5a1 1 0 0 1-1-.88V3a1 1 0 0 1 1-1Z"
-        fill="currentColor"
-      />
-    </svg>
-    <svg
-      aria-hidden={true}
-      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-      fill="currentColor"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M10.25 13c.41 0 .75.34.75.75v7.5a.75.75 0 0 1-1.5 0v-5.69l-6.22 6.22a.75.75 0 1 1-1.06-1.06l6.22-6.22H2.75a.75.75 0 0 1 0-1.5h7.5ZM20.72 2.22a.75.75 0 1 1 1.06 1.06L15.56 9.5h5.69a.75.75 0 0 1 0 1.5h-7.5a.75.75 0 0 1-.75-.75v-7.5a.75.75 0 0 1 1.5 0v5.69l6.22-6.22Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span
+      data-testid="fluent-icon"
+    />
   </span>
   <span
     className="fui-MenuItem__content r1ls86vo"
@@ -65,34 +40,9 @@ exports[`lib/ui/menuItems/collapseMenuItem > should render correctly when isColl
   <span
     className="fui-MenuItem__icon ro9koqv"
   >
-    <svg
-      aria-hidden={true}
-      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-      fill="currentColor"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M7.67 14.92a1 1 0 0 1 1.41 1.42L6.41 19H8a1 1 0 0 1 1 .89V20a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-4a1 1 0 1 1 2 0v1.6l2.67-2.68ZM16 21a1 1 0 1 1 0-2h1.59l-2.67-2.66a1 1 0 0 1-.08-1.32l.08-.1a1 1 0 0 1 1.42 0L19 17.6V16a1 1 0 0 1 .89-.99H20a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-4ZM8 3a1 1 0 0 1 0 2H6.42l2.66 2.67a1 1 0 0 1 .09 1.32l-.09.1a1 1 0 0 1-1.41 0L5 6.4V8a1 1 0 0 1-.88 1H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h4Zm12 0a1 1 0 0 1 1 1v4a1 1 0 1 1-2 0V6.41l-2.66 2.67a1 1 0 0 1-1.32.09l-.1-.09a1 1 0 0 1 0-1.41L17.6 5H16a1 1 0 0 1-.99-.88V4a1 1 0 0 1 1-1h4Z"
-        fill="currentColor"
-      />
-    </svg>
-    <svg
-      aria-hidden={true}
-      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-      fill="currentColor"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M7.6 15.35a.75.75 0 0 1 1.06 1.06l-3.1 3.1h2.19c.38 0 .7.28.74.64l.01.1c0 .42-.34.75-.75.75h-4a.75.75 0 0 1-.75-.75v-4a.75.75 0 0 1 1.5 0v2.2l3.1-3.1ZM16.25 21a.75.75 0 0 1 0-1.5h2.2l-3.1-3.09a.75.75 0 0 1-.07-.98l.07-.08c.3-.3.77-.3 1.06 0l3.1 3.1v-2.2c0-.38.28-.69.64-.74h.1c.42 0 .75.33.75.74v4c0 .42-.33.75-.75.75h-4ZM7.75 3a.75.75 0 0 1 0 1.5H5.56l3.1 3.1c.26.26.29.68.07.97l-.07.09c-.3.29-.77.29-1.07 0L4.5 5.56v2.19c0 .38-.28.7-.65.74l-.1.01A.75.75 0 0 1 3 7.75v-4c0-.41.34-.75.75-.75h4Zm12.5 0c.42 0 .75.34.75.75v4a.75.75 0 0 1-1.5 0v-2.2l-3.09 3.1a.75.75 0 0 1-.98.08l-.08-.07a.75.75 0 0 1 0-1.07l3.1-3.09h-2.2a.75.75 0 0 1-.74-.65v-.1c0-.41.33-.75.74-.75h4Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span
+      data-testid="fluent-icon"
+    />
   </span>
   <span
     className="fui-MenuItem__content r1ls86vo"

--- a/libs/designer-v2/src/lib/ui/menuItems/__test__/__snapshots__/pinMenuItem.spec.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/menuItems/__test__/__snapshots__/pinMenuItem.spec.tsx.snap
@@ -14,34 +14,9 @@ exports[`lib/ui/menuItems/pinMenuItem > should render for actions if pinned=fals
   <span
     className="fui-MenuItem__icon ro9koqv"
   >
-    <svg
-      aria-hidden={true}
-      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-      fill="currentColor"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="m21.07 7.76-4.83-4.83a2.75 2.75 0 0 0-4.4.72L9.4 8.52a.75.75 0 0 1-.42.37L4.8 10.33a1.25 1.25 0 0 0-.48 2.07l3.1 3.1L3 19.94V21h1.06l4.44-4.44 3.1 3.1c.66.66 1.77.4 2.07-.47l1.44-4.17c.06-.18.2-.33.37-.42l4.87-2.44a2.75 2.75 0 0 0 .72-4.4Z"
-        fill="currentColor"
-      />
-    </svg>
-    <svg
-      aria-hidden={true}
-      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-      fill="currentColor"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="m16.24 2.93 4.83 4.83a2.75 2.75 0 0 1-.72 4.4l-4.87 2.44a.75.75 0 0 0-.37.42l-1.44 4.17a1.25 1.25 0 0 1-2.07.48l-3.1-3.1L4.06 21H3v-1.06l4.44-4.44-3.1-3.1c-.66-.66-.4-1.77.47-2.07l4.17-1.44c.18-.06.34-.2.42-.37l2.44-4.87a2.75 2.75 0 0 1 4.4-.72Zm3.77 5.89-4.83-4.83c-.6-.6-1.62-.44-2 .33l-2.44 4.87c-.26.52-.72.93-1.27 1.12l-3.8 1.3 6.71 6.71 1.31-3.79c.2-.55.6-1.01 1.12-1.27l4.87-2.44c.77-.38.93-1.4.33-2Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span
+      data-testid="fluent-icon"
+    />
   </span>
   <span
     className="fui-MenuItem__content r1ls86vo"
@@ -65,34 +40,9 @@ exports[`lib/ui/menuItems/pinMenuItem > should render for actions if pinned=true
   <span
     className="fui-MenuItem__icon ro9koqv"
   >
-    <svg
-      aria-hidden={true}
-      className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-      fill="currentColor"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M3.28 2.22a.75.75 0 0 0-1.06 1.06l5.9 5.9-3.3 1.15a1.25 1.25 0 0 0-.49 2.07l3.1 3.1L3 19.94V21h1.06l4.44-4.44 3.1 3.1c.66.66 1.77.4 2.07-.47l1.14-3.31 5.91 5.9a.75.75 0 0 0 1.06-1.06L3.28 2.22Zm17.07 9.94-3.34 1.67L10.17 7l1.67-3.34a2.75 2.75 0 0 1 4.4-.72l4.83 4.83a2.75 2.75 0 0 1-.72 4.4Z"
-        fill="currentColor"
-      />
-    </svg>
-    <svg
-      aria-hidden={true}
-      className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-      fill="currentColor"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M3.28 2.22a.75.75 0 0 0-1.06 1.06l5.9 5.9-3.3 1.15a1.25 1.25 0 0 0-.49 2.07l3.1 3.1L3 19.94V21h1.06l4.44-4.44 3.1 3.1c.66.66 1.77.4 2.07-.47l1.14-3.31 5.91 5.9a.75.75 0 0 0 1.06-1.06L3.28 2.22ZM13.64 14.7l-1.26 3.62-6.7-6.7 3.62-1.26 4.34 4.34Zm6.04-3.88-3.78 1.9L17 13.82l3.34-1.67a2.75 2.75 0 0 0 .72-4.4l-4.83-4.83a2.75 2.75 0 0 0-4.4.72l-1.67 3.34 1.12 1.11 1.89-3.78c.38-.77 1.4-.93 2-.33l4.83 4.83c.6.6.44 1.62-.33 2Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span
+      data-testid="fluent-icon"
+    />
   </span>
   <span
     className="fui-MenuItem__content r1ls86vo"

--- a/libs/designer-v2/src/lib/ui/panel/agentChat/__tests__/__snapshots__/agentChatHeader.spec.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/panel/agentChat/__tests__/__snapshots__/agentChatHeader.spec.tsx.snap
@@ -38,34 +38,9 @@ exports[`AgentChatHeader > renders correctly and matches snapshot when showing s
       <span
         className="fui-Button__icon rywnvv2"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.5 2C2.67 2 2 2.67 2 3.5v9c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-9c0-.83-.67-1.5-1.5-1.5h-9Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.5 3c.28 0 .5.22.5.5v9a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-9c0-.28.22-.5.5-.5h9Zm-9-1C2.67 2 2 2.67 2 3.5v9c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-9c0-.83-.67-1.5-1.5-1.5h-9Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
     </button>
     <button
@@ -80,34 +55,9 @@ exports[`AgentChatHeader > renders correctly and matches snapshot when showing s
       <span
         className="fui-Button__icon rywnvv2"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.5 8a4.5 4.5 0 0 1 7.85-3h-1.6a.75.75 0 0 0 0 1.5h3c.41 0 .75-.34.75-.75v-3a.75.75 0 0 0-1.5 0v.78a6 6 0 1 0 1.94 5.32.75.75 0 0 0-1.49-.2A4.5 4.5 0 0 1 3.5 8Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3 8a5 5 0 0 1 9-3h-2a.5.5 0 0 0 0 1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-1 0v1.53A5.99 5.99 0 0 0 2 8a6 6 0 0 0 11.98.54.5.5 0 0 0-1-.08A5 5 0 0 1 3 8Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
     </button>
     <button
@@ -122,34 +72,9 @@ exports[`AgentChatHeader > renders correctly and matches snapshot when showing s
       <span
         className="fui-Button__icon rywnvv2"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.7 4.26a.75.75 0 1 1 1.1-1.02l4 4.25c.27.29.27.73 0 1.02l-4 4.25a.75.75 0 1 1-1.1-1.02L11.23 8 7.7 4.26Zm-4 0a.75.75 0 1 1 1.1-1.02l4 4.25c.27.29.27.73 0 1.02l-4 4.25a.75.75 0 1 1-1.1-1.02L7.23 8 3.7 4.26Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.65 3.85a.5.5 0 1 1 .7-.7l4.5 4.5c.2.2.2.5 0 .7l-4.5 4.5a.5.5 0 0 1-.7-.7L11.79 8 7.65 3.85Zm-4 0a.5.5 0 1 1 .7-.7l4.5 4.5c.2.2.2.5 0 .7l-4.5 4.5a.5.5 0 0 1-.7-.7L7.79 8 3.65 3.85Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
     </button>
   </div>
@@ -194,34 +119,9 @@ exports[`AgentChatHeader > renders correctly and matches snapshot with dark mode
       <span
         className="fui-Button__icon rywnvv2"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.5 8a4.5 4.5 0 0 1 7.85-3h-1.6a.75.75 0 0 0 0 1.5h3c.41 0 .75-.34.75-.75v-3a.75.75 0 0 0-1.5 0v.78a6 6 0 1 0 1.94 5.32.75.75 0 0 0-1.49-.2A4.5 4.5 0 0 1 3.5 8Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3 8a5 5 0 0 1 9-3h-2a.5.5 0 0 0 0 1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-1 0v1.53A5.99 5.99 0 0 0 2 8a6 6 0 0 0 11.98.54.5.5 0 0 0-1-.08A5 5 0 0 1 3 8Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
     </button>
     <button
@@ -236,34 +136,9 @@ exports[`AgentChatHeader > renders correctly and matches snapshot with dark mode
       <span
         className="fui-Button__icon rywnvv2"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.7 4.26a.75.75 0 1 1 1.1-1.02l4 4.25c.27.29.27.73 0 1.02l-4 4.25a.75.75 0 1 1-1.1-1.02L11.23 8 7.7 4.26Zm-4 0a.75.75 0 1 1 1.1-1.02l4 4.25c.27.29.27.73 0 1.02l-4 4.25a.75.75 0 1 1-1.1-1.02L7.23 8 3.7 4.26Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.65 3.85a.5.5 0 1 1 .7-.7l4.5 4.5c.2.2.2.5 0 .7l-4.5 4.5a.5.5 0 0 1-.7-.7L11.79 8 7.65 3.85Zm-4 0a.5.5 0 1 1 .7-.7l4.5 4.5c.2.2.2.5 0 .7l-4.5 4.5a.5.5 0 0 1-.7-.7L7.79 8 3.65 3.85Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
     </button>
   </div>
@@ -308,34 +183,9 @@ exports[`AgentChatHeader > renders correctly when dark mode is on 1`] = `
       <span
         className="fui-Button__icon rywnvv2"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.5 8a4.5 4.5 0 0 1 7.85-3h-1.6a.75.75 0 0 0 0 1.5h3c.41 0 .75-.34.75-.75v-3a.75.75 0 0 0-1.5 0v.78a6 6 0 1 0 1.94 5.32.75.75 0 0 0-1.49-.2A4.5 4.5 0 0 1 3.5 8Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3 8a5 5 0 0 1 9-3h-2a.5.5 0 0 0 0 1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-1 0v1.53A5.99 5.99 0 0 0 2 8a6 6 0 0 0 11.98.54.5.5 0 0 0-1-.08A5 5 0 0 1 3 8Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
     </button>
     <button
@@ -350,34 +200,9 @@ exports[`AgentChatHeader > renders correctly when dark mode is on 1`] = `
       <span
         className="fui-Button__icon rywnvv2"
       >
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.7 4.26a.75.75 0 1 1 1.1-1.02l4 4.25c.27.29.27.73 0 1.02l-4 4.25a.75.75 0 1 1-1.1-1.02L11.23 8 7.7 4.26Zm-4 0a.75.75 0 1 1 1.1-1.02l4 4.25c.27.29.27.73 0 1.02l-4 4.25a.75.75 0 1 1-1.1-1.02L7.23 8 3.7 4.26Z"
-            fill="currentColor"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-          fill="currentColor"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.65 3.85a.5.5 0 1 1 .7-.7l4.5 4.5c.2.2.2.5 0 .7l-4.5 4.5a.5.5 0 0 1-.7-.7L11.79 8 7.65 3.85Zm-4 0a.5.5 0 1 1 .7-.7l4.5 4.5c.2.2.2.5 0 .7l-4.5 4.5a.5.5 0 0 1-.7-.7L7.79 8 3.65 3.85Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span
+          data-testid="fluent-icon"
+        />
       </span>
     </button>
   </div>

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__tests__/__snapshots__/inputsPanel.spec.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__tests__/__snapshots__/inputsPanel.spec.tsx.snap
@@ -20,34 +20,9 @@ exports[`InputsPanel > should render error state 1`] = `
         <span
           class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
         Inputs
       </button>
@@ -59,34 +34,9 @@ exports[`InputsPanel > should render error state 1`] = `
         <span
           class="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -120,34 +70,9 @@ exports[`InputsPanel > should render error state 1`] = `
                 <span
                   class="fui-Button__icon rywnvv2"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                    fill="currentColor"
-                    height="1em"
-                    viewBox="0 0 20 20"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                    fill="currentColor"
-                    height="1em"
-                    viewBox="0 0 20 20"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                      fill="currentColor"
-                    />
-                  </svg>
+                  <span
+                    data-testid="fluent-icon"
+                  />
                 </span>
               </button>
             </div>
@@ -199,34 +124,9 @@ exports[`InputsPanel > should render loading state 1`] = `
         <span
           class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
         Inputs
       </button>
@@ -238,34 +138,9 @@ exports[`InputsPanel > should render loading state 1`] = `
         <span
           class="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -299,34 +174,9 @@ exports[`InputsPanel > should render loading state 1`] = `
                 <span
                   class="fui-Button__icon rywnvv2"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                    fill="currentColor"
-                    height="1em"
-                    viewBox="0 0 20 20"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                    fill="currentColor"
-                    height="1em"
-                    viewBox="0 0 20 20"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                      fill="currentColor"
-                    />
-                  </svg>
+                  <span
+                    data-testid="fluent-icon"
+                  />
                 </span>
               </button>
             </div>
@@ -378,34 +228,9 @@ exports[`InputsPanel > should render the InputsPanel with inputs 1`] = `
         <span
           class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
         Inputs
       </button>
@@ -417,34 +242,9 @@ exports[`InputsPanel > should render the InputsPanel with inputs 1`] = `
         <span
           class="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
       </button>
     </div>
@@ -478,34 +278,9 @@ exports[`InputsPanel > should render the InputsPanel with inputs 1`] = `
                 <span
                   class="fui-Button__icon rywnvv2"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                    fill="currentColor"
-                    height="1em"
-                    viewBox="0 0 20 20"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                    fill="currentColor"
-                    height="1em"
-                    viewBox="0 0 20 20"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                      fill="currentColor"
-                    />
-                  </svg>
+                  <span
+                    data-testid="fluent-icon"
+                  />
                 </span>
               </button>
             </div>
@@ -557,34 +332,9 @@ exports[`InputsPanel > should render the InputsPanel with no inputs 1`] = `
         <span
           class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
         >
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-              fill="currentColor"
-            />
-          </svg>
-          <svg
-            aria-hidden="true"
-            class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-              fill="currentColor"
-            />
-          </svg>
+          <span
+            data-testid="fluent-icon"
+          />
         </span>
         Inputs
       </button>

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__tests__/__snapshots__/outputsPanel.spec.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/monitoringTab/__tests__/__snapshots__/outputsPanel.spec.tsx.snap
@@ -23,34 +23,9 @@ exports[`OutputsPanel > Should render OutputsPanel with error state 1`] = `
             <span
               class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
             >
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span
+                data-testid="fluent-icon"
+              />
             </span>
             Outputs
           </button>
@@ -62,34 +37,9 @@ exports[`OutputsPanel > Should render OutputsPanel with error state 1`] = `
             <span
               class="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
             >
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                fill="currentColor"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                fill="currentColor"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span
+                data-testid="fluent-icon"
+              />
             </span>
           </button>
         </div>
@@ -123,34 +73,9 @@ exports[`OutputsPanel > Should render OutputsPanel with error state 1`] = `
                     <span
                       class="fui-Button__icon rywnvv2"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                        fill="currentColor"
-                        height="1em"
-                        viewBox="0 0 20 20"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <svg
-                        aria-hidden="true"
-                        class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                        fill="currentColor"
-                        height="1em"
-                        viewBox="0 0 20 20"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                          fill="currentColor"
-                        />
-                      </svg>
+                      <span
+                        data-testid="fluent-icon"
+                      />
                     </span>
                   </button>
                 </div>
@@ -200,34 +125,9 @@ exports[`OutputsPanel > Should render OutputsPanel with error state 1`] = `
           <span
             class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
           >
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
           Outputs
         </button>
@@ -239,34 +139,9 @@ exports[`OutputsPanel > Should render OutputsPanel with error state 1`] = `
           <span
             class="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
           >
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -300,34 +175,9 @@ exports[`OutputsPanel > Should render OutputsPanel with error state 1`] = `
                   <span
                     class="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -434,34 +284,9 @@ exports[`OutputsPanel > Should render OutputsPanel with loading state 1`] = `
             <span
               class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
             >
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span
+                data-testid="fluent-icon"
+              />
             </span>
             Outputs
           </button>
@@ -473,34 +298,9 @@ exports[`OutputsPanel > Should render OutputsPanel with loading state 1`] = `
             <span
               class="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
             >
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                fill="currentColor"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                fill="currentColor"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span
+                data-testid="fluent-icon"
+              />
             </span>
           </button>
         </div>
@@ -534,34 +334,9 @@ exports[`OutputsPanel > Should render OutputsPanel with loading state 1`] = `
                     <span
                       class="fui-Button__icon rywnvv2"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                        fill="currentColor"
-                        height="1em"
-                        viewBox="0 0 20 20"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <svg
-                        aria-hidden="true"
-                        class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                        fill="currentColor"
-                        height="1em"
-                        viewBox="0 0 20 20"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                          fill="currentColor"
-                        />
-                      </svg>
+                      <span
+                        data-testid="fluent-icon"
+                      />
                     </span>
                   </button>
                 </div>
@@ -611,34 +386,9 @@ exports[`OutputsPanel > Should render OutputsPanel with loading state 1`] = `
           <span
             class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
           >
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
           Outputs
         </button>
@@ -650,34 +400,9 @@ exports[`OutputsPanel > Should render OutputsPanel with loading state 1`] = `
           <span
             class="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
           >
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -711,34 +436,9 @@ exports[`OutputsPanel > Should render OutputsPanel with loading state 1`] = `
                   <span
                     class="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -845,34 +545,9 @@ exports[`OutputsPanel > Should render OutputsPanel with no outputs 1`] = `
             <span
               class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
             >
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span
+                data-testid="fluent-icon"
+              />
             </span>
             Outputs
           </button>
@@ -922,34 +597,9 @@ exports[`OutputsPanel > Should render OutputsPanel with no outputs 1`] = `
           <span
             class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
           >
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
           Outputs
         </button>
@@ -1056,34 +706,9 @@ exports[`OutputsPanel > Should render OutputsPanel with outputs 1`] = `
             <span
               class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
             >
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span
+                data-testid="fluent-icon"
+              />
             </span>
             Outputs
           </button>
@@ -1095,34 +720,9 @@ exports[`OutputsPanel > Should render OutputsPanel with outputs 1`] = `
             <span
               class="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
             >
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                fill="currentColor"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                fill="currentColor"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span
+                data-testid="fluent-icon"
+              />
             </span>
           </button>
         </div>
@@ -1156,34 +756,9 @@ exports[`OutputsPanel > Should render OutputsPanel with outputs 1`] = `
                     <span
                       class="fui-Button__icon rywnvv2"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                        fill="currentColor"
-                        height="1em"
-                        viewBox="0 0 20 20"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <svg
-                        aria-hidden="true"
-                        class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                        fill="currentColor"
-                        height="1em"
-                        viewBox="0 0 20 20"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                          fill="currentColor"
-                        />
-                      </svg>
+                      <span
+                        data-testid="fluent-icon"
+                      />
                     </span>
                   </button>
                 </div>
@@ -1233,34 +808,9 @@ exports[`OutputsPanel > Should render OutputsPanel with outputs 1`] = `
           <span
             class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
           >
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
           Outputs
         </button>
@@ -1272,34 +822,9 @@ exports[`OutputsPanel > Should render OutputsPanel with outputs 1`] = `
           <span
             class="fui-Button__icon rywnvv2 ___1yz413i_pen21v0 f1a695kz"
           >
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.73 4.2a.75.75 0 0 1 1.06.03l5 5.25c.28.3.28.75 0 1.04l-5 5.25a.75.75 0 1 1-1.08-1.04L12.2 10l-4.5-4.73a.75.75 0 0 1 .02-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
         </button>
       </div>
@@ -1333,34 +858,9 @@ exports[`OutputsPanel > Should render OutputsPanel with outputs 1`] = `
                   <span
                     class="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>
@@ -1584,34 +1084,9 @@ exports[`OutputsPanel > Should render OutputsPanel without uri 1`] = `
             <span
               class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
             >
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <svg
-                aria-hidden="true"
-                class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span
+                data-testid="fluent-icon"
+              />
             </span>
             Outputs
           </button>
@@ -1646,34 +1121,9 @@ exports[`OutputsPanel > Should render OutputsPanel without uri 1`] = `
                     <span
                       class="fui-Button__icon rywnvv2"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                        fill="currentColor"
-                        height="1em"
-                        viewBox="0 0 20 20"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <svg
-                        aria-hidden="true"
-                        class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                        fill="currentColor"
-                        height="1em"
-                        viewBox="0 0 20 20"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                          fill="currentColor"
-                        />
-                      </svg>
+                      <span
+                        data-testid="fluent-icon"
+                      />
                     </span>
                   </button>
                 </div>
@@ -1723,34 +1173,9 @@ exports[`OutputsPanel > Should render OutputsPanel without uri 1`] = `
           <span
             class="fui-Button__icon rywnvv2 ___963sj20_1qpm2bl f1nizpg2"
           >
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.3 8.3a1 1 0 0 1 1.4 0l6.3 6.29 6.3-6.3a1 1 0 1 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-7-7a1 1 0 0 1 0-1.42Z"
-                fill="currentColor"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.22 8.47c.3-.3.77-.3 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25c-.3.3-.77.3-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z"
-                fill="currentColor"
-              />
-            </svg>
+            <span
+              data-testid="fluent-icon"
+            />
           </span>
           Outputs
         </button>
@@ -1785,34 +1210,9 @@ exports[`OutputsPanel > Should render OutputsPanel without uri 1`] = `
                   <span
                     class="fui-Button__icon rywnvv2"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6 4c0-1.1.9-2 2-2h6a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-                      fill="currentColor"
-                      height="1em"
-                      viewBox="0 0 20 20"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 2a2 2 0 0 0-2 2v10c0 1.1.9 2 2 2h6a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8ZM7 4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V4ZM4 6a2 2 0 0 1 1-1.73V14.5A2.5 2.5 0 0 0 7.5 17h6.23A2 2 0 0 1 12 18H7.5A3.5 3.5 0 0 1 4 14.5V6Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span
+                      data-testid="fluent-icon"
+                    />
                   </span>
                 </button>
               </div>

--- a/libs/designer-v2/src/lib/ui/settings/__tests__/__snapshots__/advancedSettingsMessage.spec.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/settings/__tests__/__snapshots__/advancedSettingsMessage.spec.tsx.snap
@@ -19,36 +19,10 @@ exports[`AdvancedSettingsMessage Component > should render correctly and match s
     target="_blank"
   >
     Guideline for agent advanced parameters
-    <svg
-      aria-hidden="true"
-      class="fui-Icon-filled ___yt8pzc0_14cuo7n fjseox fez10in f1dd5bof"
-      fill="currentColor"
-      height="12"
+    <span
+      data-testid="fluent-icon"
       style="position: relative; top: 2px; left: 2px;"
-      viewBox="0 0 12 12"
-      width="12"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M1 3c0-1.1.9-2 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2V7a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1v1a2 2 0 0 1-2-2V3Zm3 6c0 1.1.9 2 2 2h3a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2v1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1V4a2 2 0 0 0-2 2v3Z"
-        fill="currentColor"
-      />
-    </svg>
-    <svg
-      aria-hidden="true"
-      class="fui-Icon-regular ___9ctc0p0_17npts5 f1w7gpdv fez10in f1dd5bof"
-      fill="currentColor"
-      height="12"
-      style="position: relative; top: 2px; left: 2px;"
-      viewBox="0 0 12 12"
-      width="12"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M1 3.25C1 2 2 1 3.25 1h2.5c1.22 0 2.2.96 2.25 2.16v2.68a2.25 2.25 0 0 1-1.5 2.03V3.25a.75.75 0 0 0-.75-.75h-2.5a.75.75 0 0 0-.75.75v2.5c0 .33.2.6.5.71v1.53a2.25 2.25 0 0 1-2-2.24v-2.5Zm3 5.5C4 9.99 5 11 6.25 11h2.5C9.99 11 11 10 11 8.75v-2.5c0-1.16-.88-2.11-2-2.24v1.53c.3.1.5.38.5.71v2.5c0 .41-.34.75-.75.75h-2.5a.75.75 0 0 1-.75-.75V4.13C4.63 4.43 4 5.27 4 6.25v2.5Z"
-        fill="currentColor"
-      />
-    </svg>
+    />
   </a>
 </div>
 `;

--- a/libs/designer-v2/src/lib/ui/settings/__tests__/__snapshots__/settingsection.spec.tsx.snap
+++ b/libs/designer-v2/src/lib/ui/settings/__tests__/__snapshots__/settingsection.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`ui/settings/settingsection > should construct 1`] = `
       appearance="subtle"
       aria-label="Collapsed Sample Setting Section, Select to expand"
       className="msla-setting-section-header"
-      icon={<CompoundIcon />}
+      icon={<ForwardRef />}
       onClick={[Function]}
     >
       Sample Setting Section

--- a/libs/shared-test-utils/fluentui-react-icons-mock.ts
+++ b/libs/shared-test-utils/fluentui-react-icons-mock.ts
@@ -23,6 +23,15 @@ vi.mock('@fluentui/react-icons', () => {
           return createElement('span', { ...props, ref, 'data-testid': 'fluent-icon' });
         });
       },
+      // Custom (non-generated) icons in the codebase call `wrapIcon(Icon, displayName)` at module
+      // evaluation time to produce a component with the same shape as Fluent's generated icons.
+      // Keep it callable and render the real Icon so these hand-authored icons still work, without
+      // pulling in Fluent's generated SVG exports (which is what this mock exists to avoid).
+      wrapIcon: (Icon: (props: unknown) => unknown, displayName?: string) => {
+        const component = forwardRef((props, ref) => createElement(Icon as never, { ...(props as object), ref }));
+        component.displayName = displayName ?? (Icon as { displayName?: string }).displayName ?? Icon.name;
+        return component;
+      },
     },
     {
       get(target: Record<string, unknown>, prop: string) {

--- a/libs/shared-test-utils/fluentui-react-icons-mock.ts
+++ b/libs/shared-test-utils/fluentui-react-icons-mock.ts
@@ -34,6 +34,27 @@ vi.mock('@fluentui/react-icons', () => {
         }
         return cache[prop];
       },
+      has(target: Record<string, unknown>, prop: string | symbol) {
+        // Symbols (e.g. Symbol.toStringTag) and `then` must fall through to the real
+        // target so the mocked namespace isn't mistaken for a thenable by dynamic import
+        // interop, and so built-in symbol checks behave normally.
+        if (typeof prop === 'symbol' || prop === 'then') {
+          return prop in target;
+        }
+        return true;
+      },
+      getOwnPropertyDescriptor(target: Record<string, unknown>, prop: string | symbol) {
+        if (prop in target) {
+          return Object.getOwnPropertyDescriptor(target, prop);
+        }
+        if (typeof prop === 'symbol') {
+          return undefined;
+        }
+        if (!cache[prop]) {
+          cache[prop] = createStub(prop);
+        }
+        return { configurable: true, enumerable: true, value: cache[prop], writable: true };
+      },
     }
   );
 });

--- a/libs/shared-test-utils/package.json
+++ b/libs/shared-test-utils/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "peerDependencies": {
     "react": ">=18"
+  },
+  "devDependencies": {
+    "@fluentui/react-icons": "^2.0.224"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1676,6 +1676,10 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+    devDependencies:
+      '@fluentui/react-icons':
+        specifier: ^2.0.224
+        version: 2.0.315(react@18.3.1)
 
   libs/vscode-extension:
     dependencies:


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope

## What & Why

`libs/shared-test-utils/fluentui-react-icons-mock.ts` mocks `@fluentui/react-icons` in every consuming package''s `vitest.config.ts` `setupFiles` to avoid importing hundreds of real SVG icon modules in tests. It had **two independent, compounding bugs** that meant it was not actually doing this anywhere in CI:

1. **`libs/shared-test-utils` had no dependency on `@fluentui/react-icons`.** `vi.mock(''@fluentui/react-icons'', factory)` resolves the specifier the same way Node resolution would - relative to the *calling file''s own* location. Since the setup file lives in `shared-test-utils`, and that package declared no such dependency (and pnpm''s default, non-hoisted layout only symlinks each workspace package''s own declared deps into its own `node_modules`), the specifier could never resolve to the *same physical module* that real consumers (e.g. `designer-ui`, `designer-v2`) import. Result: **the mock factory was never invoked** - confirmed via temporary debug logging that never printed - and tests were quietly rendering real `<svg>` icon markup the whole time. Fixed by adding `@fluentui/react-icons` as a `devDependency` of `shared-test-utils`, which (thanks to the repo''s `resolution-mode=highest` in `.npmrc`) resolves to the exact same physical copy already used elsewhere (verified identical symlink targets via `Get-Item -ExpandProperty Target`).

2. **The mock''s `Proxy` only implemented a `get` trap.** Once interception actually works (e.g. under a hoisted `node_modules` layout, which is how this bug was originally surfaced), Vitest''s mocked-module export validation also uses `has` / `getOwnPropertyDescriptor`. A `get`-only proxy falls through to the underlying target (`{ bundleIcon }`) for those, so Vitest concluded every other icon name "doesn''t exist" and threw `No "<IconName>" export is defined on the "@fluentui/react-icons" mock`. Fixed by adding `has` and `getOwnPropertyDescriptor` traps that mirror `get`''s lazy-stub-creation logic - special-casing symbols and the string `then` to fall through to the real target, so the mocked module isn''t mistaken for a thenable by dynamic `import()` interop.

Both fixes were necessary together: fixing only #2 without #1 is a no-op under CI''s default pnpm layout (confirmed empirically - re-ran tests with only the Proxy trap fix applied, no behavior change, until the dependency fix was also added).

### The tricky part: snapshots

Since the mock was never actually intercepting, dozens of committed snapshots across `designer-ui` and `designer-v2` had baked in **real inline `<svg>` markup** for icons owned by our own components. Now that the mock genuinely intercepts, those render as the mock''s documented stub (`<span data-icon-name="IconName" />`) instead. This PR **deliberately regenerates every affected snapshot** - this is the bulk of the diff and is expected/intentional, not a regression.

Notably, `@fluentui/react-components`''s own *internal* built-in icons (e.g. SearchBox''s search/dismiss icons) are **not** stubbed and correctly remain real SVGs - they resolve via that library''s own separate dependency edge to `@fluentui/react-icons`, which is outside this mock''s intended scope (the mock exists to avoid pulling in hundreds of icons imported by *our* code, not to stub third-party internals).

`libs/designer` (v1) also wires this setup file into its `vitest.config.ts`, but has zero snapshots containing real icon SVG markup, so there was nothing to regenerate there.

### Incidental fix: `TimelineHeader.test.tsx`

Regenerating designer-v2 snapshots exposed one real (non-snapshot) test regression: `TimelineHeader.test.tsx`''s "should render timeline icon in both expanded and collapsed states" test used `findAllByProps({ className: ''timeline-icon'' })` and expected exactly 1 match. The mock''s stub is a `forwardRef` that spreads `className` directly onto its rendered `<span>`, so `react-test-renderer` matched **both** the wrapper component instance and its host `<span>` (both carry the identical `className` prop) - 2 matches instead of 1. Real Fluent icons avoid this because they internally `mergeClasses()` a base class onto the passed `className`, so the host element''s actual class differs from the raw prop. Fixed by filtering `findAllByProps` results to host elements only (`typeof instance.type === ''string''`).

## Impact of Change
- **Users**: None - test-infrastructure only, no user-facing behavior changes.
- **Developers**: Any future test asserting on the exact rendered SVG markup of an icon owned by our own code (rather than snapshotting) will now need to account for the stub instead of a real SVG - none were found in this sweep, but this is the tradeoff of the mock now actually working. Large snapshot diff (30 files) is expected and intentional - hundreds of real inline SVGs collapse into compact `data-icon-name` stub spans.
- **System**: None - no production/runtime code paths change.

## Test Plan
- [x] Unit tests added/updated (snapshot regeneration + `TimelineHeader.test.tsx` assertion fix)
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: local Windows dev machine, both pnpm `node_modules` layouts reasoned about (see below)

Details:
- `libs/designer-ui`: full suite, 118 files / 1075 tests - all pass.
- `libs/designer-v2`: full suite, 183 files / 2167 tests - 182 files / 2166 tests pass; 1 pre-existing, unrelated failure (`quickViewPanel.spec.tsx`, confirmed present on `main` without this change).
- `libs/designer` (v1): full suite, 178 files / 2227 tests - same 1 pre-existing `quickViewPanel.spec.tsx` failure (duplicated file), everything else passes; no snapshots to regenerate (none contained icon SVG markup).
- Targeted suites called out in the task: `libs/designer-v2` -> `src/lib/ui/panel/recommendation` (156 tests, all pass) and `libs/designer-ui` -> `operationSearchHeader` (8 tests, all pass).
- Spot-checked all other consumers of the shared mock: `libs/chatbot` (54 tests), `libs/data-mapper-v2` (220 tests), `libs/data-mapper` (216 tests, one unrelated infra flake on `@fluentui/utilities` module fetch that passed cleanly in isolation), `libs/a2a-core` (705 tests), `libs/logic-apps-shared` (966 tests) - all pass, no affected snapshots. `apps/iframe-app` could not run because `@microsoft/logic-apps-chat`''s `dist/` isn''t built in this environment - a pre-existing, unrelated build-order gap, not caused by this change.
- Validated under **both** pnpm `node_modules` layouts: the default (non-hoisted) layout, which is what CI uses and where this repo''s install succeeded normally on this machine (no long-path issue encountered), and manually confirmed the root cause/fix reasoning is layout-independent by construction - the fix is a `package.json` dependency declaration, not a runtime workaround, so it resolves correctly regardless of hoisting.
- `npx biome check --write` run on all changed source files (never `--unsafe`).

## Follow-ups from review

**Lockfile contamination (fixed):** the previous `pnpm-lock.yaml` diff in this PR contained ~230 unrelated resolution rewrites, pointing dependencies at this machine's corporate `pkgs.visualstudio.com`/`packagefeedproxy.microsoft.io` registry mirror and downgrading `sha512` integrity hashes to `sha1`. This was a side effect of running `pnpm install` on a machine whose global npm/pnpm config overrides the registry - it rewrote resolutions for every package `pnpm` happened to touch, not just the one dependency this PR adds. Fixed by restoring `pnpm-lock.yaml` to `main`'s exact content (`git checkout origin/main -- pnpm-lock.yaml`) and hand-editing in only the legitimate 4-line addition (the `libs/shared-test-utils` `devDependencies` entry for `@fluentui/react-icons@^2.0.224`, resolving to `2.0.315(react@18.3.1)` - the same version already resolved elsewhere in the repo for that specifier range). `git diff origin/main -- pnpm-lock.yaml` now shows exactly that 4-line addition and nothing else. Re-ran `operationSearchHeader` tests against the corrected lockfile (node_modules untouched) to confirm the fix still works: 8/8 pass.

**Did any non-snapshot assertions break?** Yes, one: `TimelineHeader.test.tsx` (already covered above and fixed in this PR) - a `findAllByProps({ className: 'timeline-icon' })` call that matched both the mock's wrapper and its host `<span>`. Beyond that, I specifically grepped every spec file under `designer`, `designer-ui`, and `designer-v2` for assertions on `svg`, `path`, `viewBox`, `role="img"`, or Fluent-generated class names. The only `role="img"` matches found are in `StatusIndicator.spec.tsx` and `TreeActionItem.spec.tsx` under `designer-v2`'s `runTreeView` - these assert on plain `<img src=".../status_success_small.svg">` elements from static SVG file imports, unrelated to `@fluentui/react-icons` or this mock. No other non-snapshot assertions broke.

**Startup-time measurement:** I initially skipped this rather than backfill a justification. A second reviewer ran the A/B measurement independently on the icon-heavy `libs/designer-v2/src/lib/ui/MonitoringTimeline` suite, everything else held equal:
- **A** = mock intercepting (this PR's fix in place, renders stubs)
- **B** = setup file replaced with `export {}` (no mock, real SVG modules load)

Two rounds each:

| | A (intercepting) | B (no mock) | delta |
|---|---|---|---|
| wall | 73.9s / 63.5s → ~68.7s | 95.6s / 74.2s → ~84.9s | ~19% faster |
| collect | 61.0s / 47.3s → ~54.1s | 92.6s / 63.7s → ~78.2s | ~31% faster |
| transform | 6.6s / 5.7s → ~6.1s | 12.7s / 9.9s → ~11.3s | ~46% faster |

Caveat: run-to-run noise on that machine was large (B ranged 74-96s across rounds), so treat `wall` as indicative rather than precise. But the direction was consistent both rounds, and `collect`/`transform` - the two metrics the mock directly acts on (module loading cost) - improved substantially every time. **Conclusion: keep interception on** - the snapshot churn is worth it.

Two side observations from that A/B independently corroborate the root-cause diagnosis:
- In variant **B**, all 50 tests passed against **main's currently-committed snapshots** - direct runtime proof the mock has been inert in CI until now (not just an inference from grepping for inline SVG markup in `.snap` files).
- In variant **A**, exactly the 22 snapshot tests failed - the same set this PR regenerates. Nothing unexpected broke.

**A note on the `designer-e2e-shards (3, 3)` CI failure:** this is unrelated to this PR. The job log shows every failure is a button enable/disable timing assertion in `e2e/templates/createWorkflowPanel.spec.ts` (`getByRole('button', { name: 'update' | 'create' })` timing out on `toBeEnabled`/`toBeDisabled`) - nothing touches icons, SVGs, or anything this mock reaches. Playwright E2E drives the built Standalone app in a real browser process, which never loads vitest's `setupFiles` - so the mock isn't even in that code path. Independently confirmed the same job (`Playwright Tests - Real APIs`) is currently failing on `main` too (two separate runs today), so this area is already flaky regardless of this branch. This PR's entire diff is a test-mock file, regenerated snapshots, a `private: true` test-utils `package.json`, and a 4-line lockfile addition (a devDependency that resolves to a version already present elsewhere in the tree) - none of that ships to the app bundle, so there's no path by which it could affect a browser E2E run.

## Contributors
@rllyy97

## Screenshots/Videos
N/A - test-infrastructure change only, no UI/behavior change. (Snapshot diffs are the closest analog - real `<svg>` markup becomes `<span data-icon-name="..." />` stubs.)



