### PR TITLE
Fix multi-trigger unsupported notice overflowing narrow Designer V2 canvas

### DIFF
--- a/libs/designer-ui/src/lib/multiTriggerUnsupportedMessage/__test__/multiTriggerUnsupportedMessage.spec.tsx
+++ b/libs/designer-ui/src/lib/multiTriggerUnsupportedMessage/__test__/multiTriggerUnsupportedMessage.spec.tsx
@@ -53,4 +53,23 @@ describe('MultiTriggerUnsupportedMessage', () => {
     expect(screen.queryByText(/use run details/i)).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /run details/i })).not.toBeInTheDocument();
   });
+
+  it('should allow the centered wrapper and the MessageBar to shrink below their natural content width so they stay within a narrow canvas (e.g. beside an open RunHistoryPanel/drawer) instead of overflowing it', () => {
+    const onRunDetailsClick = vi.fn();
+    renderWithIntl(<MultiTriggerUnsupportedMessage isStandard={false} onRunDetailsClick={onRunDetailsClick} />);
+
+    // The MessageBar itself must be allowed to shrink below its `maxWidth: 480px` so it can fit
+    // inside canvases narrower than 480px.
+    const messageBar = screen.getByRole('group');
+    expect(getComputedStyle(messageBar).minWidth).toBe('0');
+    expect(getComputedStyle(messageBar).maxWidth).toBe('480px');
+
+    // The outer centered flex container: without `min-width: 0` a flex item's automatic minimum
+    // size defaults to its content's min-content/max-content size, which would prevent it (and the
+    // MessageBar inside it) from ever becoming narrower than the room needed to render its content
+    // on one line -- causing overflow past a narrow canvas region instead of wrapping/shrinking.
+    const root = messageBar.parentElement as HTMLElement;
+    expect(root).toBeTruthy();
+    expect(getComputedStyle(root).minWidth).toBe('0');
+  });
 });

--- a/libs/designer-ui/src/lib/multiTriggerUnsupportedMessage/styles.ts
+++ b/libs/designer-ui/src/lib/multiTriggerUnsupportedMessage/styles.ts
@@ -7,11 +7,23 @@ export const useMultiTriggerUnsupportedMessageStyles = makeStyles({
     justifyContent: 'center',
     width: '100%',
     height: '100%',
+    // Without an explicit minWidth, a flex item's automatic minimum size defaults to its content's
+    // min-content size. Since the MessageBar below has no fixed width of its own, that would let this
+    // container (and therefore the MessageBar) grow to fit its widest unwrapped line instead of
+    // shrinking to whatever space is actually available -- e.g. the narrower canvas region left over
+    // when a RunHistoryPanel/drawer is open beside the designer. minWidth: 0 allows this flex item to
+    // shrink to fit the available width so its content can wrap/reflow instead of overflowing.
+    minWidth: 0,
     padding: tokens.spacingHorizontalXXL,
     boxSizing: 'border-box',
   },
   content: {
     width: '100%',
     maxWidth: '480px',
+    // Same reasoning as `root`: allow the MessageBar itself to shrink below its natural content
+    // width so its title/body text and action button wrap/reflow within a narrow canvas instead of
+    // overflowing it.
+    minWidth: 0,
+    boxSizing: 'border-box',
   },
 });


### PR DESCRIPTION
## Summary

Follow-up to #9494 (package 5.988.0). Ref IcM **51000001179344**.

In Azure Portal Consumption Run history, on a narrow canvas (RunHistoryPanel/drawer open, e.g. ~392px of a ~762px viewport), the centered `MultiTriggerUnsupportedMessage` MessageBar overflows past the right edge of the visible canvas region instead of shrinking/wrapping.

## Root cause

`MultiTriggerUnsupportedMessage`'s wrapper is a centered flex container, and the `MessageBar` inside it has `width: 100%` / `maxWidth: 480px`. Neither element had an explicit `minWidth`, so both defaulted to the CSS flex-item automatic minimum size (`min-width: auto`), which resolves to the element's **unwrapped content width**. With no fixed width constraint reaching the `MessageBar`, its grid layout never got a reason to wrap the title/body text onto multiple lines, so the whole box rendered at (or near) its natural single-line width and overflowed the narrower canvas region left over once the RunHistoryPanel is open — instead of shrinking to fit and letting its content wrap.

## Fix

Set `minWidth: 0` on both:
- the outer centered flex wrapper (`root`)
- the `MessageBar` itself (`content`)

This lets both elements shrink to whatever width is actually available (down to `maxWidth: 480px` at normal widths, narrower when squeezed by the drawer), allowing the title/body text and the "Run details" button to wrap/reflow naturally instead of overflowing. No overflow/clipping is introduced — the fix relies on native flex shrink + the MessageBar's existing `layout="multiline"` wrapping behavior, not `overflow: hidden`.

Centered presentation at normal widths, the 480px max width, and all existing Consumption/Standard messaging + Run Details behavior are unchanged.

## Files changed
- `libs/designer-ui/src/lib/multiTriggerUnsupportedMessage/styles.ts` — added `minWidth: 0` to `root` and `content`, with comments explaining the flex/grid min-size interaction.
- `libs/designer-ui/src/lib/multiTriggerUnsupportedMessage/__test__/multiTriggerUnsupportedMessage.spec.tsx` — new test asserting `minWidth: 0` and `maxWidth: 480px` are applied to the wrapper and MessageBar via `getComputedStyle`.

## Validation
- `pnpm exec vitest run src/lib/multiTriggerUnsupportedMessage/__test__/multiTriggerUnsupportedMessage.spec.tsx` (designer-ui) — 4/4 passed.
- `npx biome check --write` on changed files — clean, no fixes needed.
- Pre-commit hooks (i18n extract, eslint --fix, biome) ran clean on commit.

## Accessibility / localization notes
- No change to semantics, roles, or ARIA labeling — `MessageBar`'s `role="group"`, title/body structure, and the `Run details` button are untouched.
- The fix is purely a sizing constraint; it does not affect high-contrast styling, focus order, or announcement behavior (`useAnnounce`).
- Longer localized strings will now wrap onto additional lines within the MessageBar instead of overflowing, which is the intended behavior for both narrow canvases and long translations.

## Scope note
This does **not** touch Portal's `AgentUpsellBanner` (already fixed in Portal commit `b0ee44a4` by gating it to Workflow view) — this PR is scoped entirely to the shared `@microsoft/designer-ui` component per the investigation.

## Will Portal need a new package release?
**Yes.** Portal only consumes the built `@microsoft/logic-apps-designer-v2` / `@microsoft/designer-ui` packages (via `<Designer/>`); it does not build this code from source. This change requires a new package publish/version bump before Portal can pick up the fix.