### PR TITLE
fix(DesignerV2): separate run selection from run details

### DIFF
--- a/libs/designer-v2/src/lib/ui/Designer.tsx
+++ b/libs/designer-v2/src/lib/ui/Designer.tsx
@@ -255,7 +255,7 @@ export const Designer = (props: DesignerProps) => {
             {hasUnsupportedMultipleTriggers ? (
               <MultiTriggerUnsupportedMessage
                 isStandard={isStandard}
-                onRunDetailsClick={canShowRunDetails ? () => HostService().openRun?.(runInstance!.id) : undefined}
+                onRunDetailsClick={canShowRunDetails ? () => HostService().openRunDetails?.(runInstance!.id) : undefined}
               />
             ) : (
               <DesignerReactFlow canvasRef={canvasRef}>

--- a/libs/designer-v2/src/lib/ui/__test__/Designer.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/__test__/Designer.spec.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
 
 const mockDispatch = vi.fn();
 let mockCanUndo = false;
@@ -14,6 +14,7 @@ let mockHasUnsupportedMultipleTriggers = false;
 let mockRunInstance: { id: string; name: string } | null = null;
 
 const mockOpenRun = vi.fn();
+const mockOpenRunDetails = vi.fn();
 
 vi.mock('../../core', () => ({
   openPanel: vi.fn((arg: unknown) => ({ type: 'openPanel', payload: arg })),
@@ -65,7 +66,7 @@ vi.mock('@microsoft/logic-apps-shared', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@microsoft/logic-apps-shared')>();
   return {
     ...actual,
-    HostService: () => ({ openRun: mockOpenRun }),
+    HostService: () => ({ openRun: mockOpenRun, openRunDetails: mockOpenRunDetails }),
   };
 });
 
@@ -144,6 +145,8 @@ import { Designer } from '../Designer';
 import { onUndoClick, onRedoClick } from '../../core';
 
 describe('Designer', () => {
+  afterEach(cleanup);
+
   beforeEach(() => {
     vi.clearAllMocks();
     hotkeysRegistrations.length = 0;
@@ -312,7 +315,7 @@ describe('Designer', () => {
       expect(screen.queryByTestId('run-details-button')).toBeNull();
     });
 
-    it('should show a Run details button for Consumption in monitoring/run-history mode and invoke HostService().openRun with the run id', () => {
+    it('should show a Run details button for Consumption in monitoring/run-history mode and invoke only HostService().openRunDetails', () => {
       mockHasUnsupportedMultipleTriggers = true;
       mockWorkflowKind = undefined; // Consumption
       mockIsMonitoringView = true;
@@ -322,7 +325,8 @@ describe('Designer', () => {
       expect(message.getAttribute('data-is-standard')).toBe('false');
       const button = screen.getByTestId('run-details-button');
       button.click();
-      expect(mockOpenRun).toHaveBeenCalledWith('/subscriptions/x/runs/run1');
+      expect(mockOpenRunDetails).toHaveBeenCalledWith('/subscriptions/x/runs/run1');
+      expect(mockOpenRun).not.toHaveBeenCalled();
     });
 
     it('should not show a Run details button for Standard in design/edit mode', () => {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/host.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/host.ts
@@ -17,6 +17,7 @@ export interface IHostService {
   openConnectionResource?(connectionId: string): void;
   openMonitorView?(resourceId: string, runName: string): void;
   openRun?(runId: string): void;
+  openRunDetails?(runId: string): void;
 }
 
 let service: IHostService;


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

This feature has not yet been implemented.  This is a required change after trying to test in Portal, no user impact.

## What & Why
<!-- Brief context: What does this change and why? -->
Run-history selection and the Consumption multi-trigger warning currently share `IHostService.openRun`, so a host cannot distinguish selecting a run in the designer from explicitly opening the legacy run-details blade. This change adds `openRunDetails` and uses it only for the multi-trigger message action, allowing `openRun` to remain dedicated to selecting a run on the designer canvas.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Selecting a run from run history remains in the designer; the legacy run-details blade is reserved for the multi-trigger warning action.
- **Developers**: Hosts can implement the optional `IHostService.openRunDetails` callback separately from `openRun`.
- **System**: No dependency or persistence changes; this is an additive optional host-service contract.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: `Designer.spec.tsx` (18 tests passed); `@microsoft/logic-apps-shared` and `@microsoft/logic-apps-designer-v2` `build:lib` completed successfully

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
Not applicable. This changes callback routing without altering visual layout.