### PR TITLE
fix(iframe-app): restore chat history order and timestamps

### DIFF
--- a/apps/iframe-app/src/components/IframeWrapper.tsx
+++ b/apps/iframe-app/src/components/IframeWrapper.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
-import { ChatWidget, type IdentityProvider, type ChatWidgetProps, type StorageConfig } from '@microsoft/logic-apps-chat';
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { ChatWidget, type ChatMessage, type IdentityProvider, type ChatWidgetProps, type StorageConfig } from '@microsoft/logic-apps-chat';
 import { MultiSessionChat } from './MultiSessionChat/MultiSessionChat';
 import { LoadingDisplay } from './LoadingDisplay';
 import { LoginPrompt } from './LoginPrompt';
@@ -27,7 +27,7 @@ export function IframeWrapper({ config }: IframeWrapperProps) {
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [loginError, setLoginError] = useState<string | null>(null);
   const [userName, setUserName] = useState<string | undefined>(props.userName);
-  const chatHistoryRef = useRef<ChatHistoryData | null>(null);
+  const [chatHistory, setChatHistory] = useState<ChatHistoryData | null>(null);
 
   // Check if we should wait for postMessage
   const params = new URLSearchParams(window.location.search);
@@ -81,7 +81,7 @@ export function IframeWrapper({ config }: IframeWrapperProps) {
 
   // Handle chat history received from parent blade
   const handleChatHistoryReceived = useCallback((history: ChatHistoryData) => {
-    chatHistoryRef.current = history;
+    setChatHistory(history);
   }, []);
 
   // Check authentication status on mount
@@ -181,6 +181,19 @@ export function IframeWrapper({ config }: IframeWrapperProps) {
     };
   }, [agentCardData, apiKey, propsWithAuth.apiKey, oboUserToken, propsWithAuth.oboUserToken]);
 
+  const initialMessages = useMemo<ChatMessage[] | undefined>(
+    () =>
+      chatHistory?.messages.map((message) => ({
+        id: message.id,
+        role: message.role,
+        content: message.content,
+        timestamp: message.timestamp instanceof Date ? message.timestamp : new Date(message.timestamp),
+        metadata: message.metadata,
+      })),
+    [chatHistory]
+  );
+  const initialContextId = chatHistory?.contextId || contextId;
+
   // Show loading states
   if (expectPostMessage && isWaitingForAgentCard) {
     return <LoadingDisplay title="Waiting for Configuration" message="Waiting for agent card data via postMessage..." />;
@@ -226,9 +239,6 @@ export function IframeWrapper({ config }: IframeWrapperProps) {
   // For single-session mode, determine the initial context ID
   const sessionKey = propsWithAuth.sessionKey || 'default';
 
-  // Use contextId from URL config, or from chat history received via postMessage
-  const initialContextId = contextId || chatHistoryRef.current?.contextId;
-
   return (
     <FluentProvider theme={theme}>
       <ChatWidget
@@ -239,6 +249,7 @@ export function IframeWrapper({ config }: IframeWrapperProps) {
         sessionKey={sessionKey}
         storageConfig={storageConfig}
         initialContextId={initialContextId}
+        initialMessages={initialMessages}
       />
     </FluentProvider>
   );

--- a/apps/iframe-app/src/components/__tests__/IframeWrapper.test.tsx
+++ b/apps/iframe-app/src/components/__tests__/IframeWrapper.test.tsx
@@ -258,6 +258,7 @@ describe('IframeWrapper', () => {
 
   it('should handle chat history from Frame Blade', async () => {
     const { useFrameBlade } = await import('../../lib/hooks/useFrameBlade');
+    const { ChatWidget } = await import('@microsoft/logic-apps-chat');
 
     let capturedHistoryCallback: ((history: any) => void) | undefined;
 
@@ -289,6 +290,12 @@ describe('IframeWrapper', () => {
           content: 'Test message',
           timestamp: '2024-01-01T00:00:00Z',
         },
+        {
+          id: 'msg-2',
+          role: 'assistant',
+          content: 'Test response',
+          timestamp: '2024-01-01T00:00:05Z',
+        },
       ],
     };
 
@@ -299,9 +306,16 @@ describe('IframeWrapper', () => {
       }
     });
 
-    // Verify contextId is handled (not stored in localStorage, but passed as initialContextId prop)
-    // The actual verification happens when the component re-renders with the contextId
-    expect(chatHistory.contextId).toBe('test-context-123');
+    expect(ChatWidget).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        initialContextId: 'test-context-123',
+        initialMessages: [
+          expect.objectContaining({ id: 'msg-1', role: 'user', timestamp: new Date('2024-01-01T00:00:00Z') }),
+          expect.objectContaining({ id: 'msg-2', role: 'assistant', timestamp: new Date('2024-01-01T00:00:05Z') }),
+        ],
+      }),
+      {}
+    );
   });
 
   it('should pass contextId from URL config to ChatWidget', async () => {

--- a/libs/a2a-core/src/api/history-transformers.test.ts
+++ b/libs/a2a-core/src/api/history-transformers.test.ts
@@ -132,7 +132,7 @@ describe('History Transformers', () => {
         id: 'msg-123',
         role: 'assistant', // Transformed from 'agent'
         content: [{ type: 'text', text: 'Hello, how can I help?' }],
-        timestamp: new Date('10/29/2025 2:00:00 PM'),
+        timestamp: new Date('2025-10-29T14:00:00Z'),
         contextId: 'context-789',
       });
     });
@@ -167,7 +167,7 @@ describe('History Transformers', () => {
       const result = transformMessage(serverMessage);
 
       expect(result.timestamp).toBeInstanceOf(Date);
-      expect(result.timestamp.toISOString()).toBe(new Date('10/29/2025 3:30:45 PM').toISOString());
+      expect(result.timestamp.toISOString()).toBe('2025-10-29T15:30:45.000Z');
     });
   });
 
@@ -396,6 +396,80 @@ describe('History Transformers', () => {
       // Should be sorted to chronological order
       expect(result[0].id).toBe('msg-1'); // Earlier message first
       expect(result[1].id).toBe('msg-2'); // Later message second
+    });
+
+    it('should preserve task exchanges when message timestamps are equal', () => {
+      const timestamp = '10/29/2025 12:00:00 PM';
+      const createMessage = (messageId: string, taskId: string, role: 'user' | 'agent'): ServerMessage => ({
+        messageId,
+        taskId,
+        contextId: 'context-1',
+        role,
+        parts: [{ kind: 'text', text: messageId }],
+        metadata: { timestamp },
+        kind: 'message',
+      });
+      const createTask = (taskId: string, userMessageId: string, agentMessageId: string): ServerTask => {
+        const agentMessage = createMessage(agentMessageId, taskId, 'agent');
+        const userMessage = createMessage(userMessageId, taskId, 'user');
+        const taskStatus = {
+          state: 'completed',
+          message: agentMessage,
+          timestamp,
+        };
+
+        return {
+          id: taskId,
+          contextId: 'context-1',
+          taskStatus,
+          status: taskStatus,
+          history: [agentMessage, userMessage],
+          kind: 'task',
+        };
+      };
+      const serverTasks = [createTask('task-1', 'user-1', 'agent-1'), createTask('task-2', 'user-2', 'agent-2')];
+
+      const result = transformTasksToMessages(serverTasks);
+
+      expect(result.map((message) => message.id)).toEqual(['user-1', 'agent-1', 'user-2', 'agent-2']);
+    });
+
+    it('should keep messages chronological when task times overlap', () => {
+      const createMessage = (messageId: string, taskId: string, role: 'user' | 'agent', timestamp: string): ServerMessage => ({
+        messageId,
+        taskId,
+        contextId: 'context-1',
+        role,
+        parts: [{ kind: 'text', text: messageId }],
+        metadata: { timestamp },
+        kind: 'message',
+      });
+      const createTask = (taskId: string, userTime: string, agentTime: string): ServerTask => {
+        const agentMessage = createMessage(`${taskId}-agent`, taskId, 'agent', agentTime);
+        const userMessage = createMessage(`${taskId}-user`, taskId, 'user', userTime);
+        const taskStatus = {
+          state: 'completed',
+          message: agentMessage,
+          timestamp: agentTime,
+        };
+
+        return {
+          id: taskId,
+          contextId: 'context-1',
+          taskStatus,
+          status: taskStatus,
+          history: [agentMessage, userMessage],
+          kind: 'task',
+        };
+      };
+      const serverTasks = [
+        createTask('task-1', '10/29/2025 12:00:00 PM', '10/29/2025 12:10:00 PM'),
+        createTask('task-2', '10/29/2025 12:05:00 PM', '10/29/2025 12:06:00 PM'),
+      ];
+
+      const result = transformTasksToMessages(serverTasks);
+
+      expect(result.map((message) => message.id)).toEqual(['task-1-user', 'task-2-user', 'task-2-agent', 'task-1-agent']);
     });
   });
 

--- a/libs/a2a-core/src/api/history-transformers.ts
+++ b/libs/a2a-core/src/api/history-transformers.ts
@@ -45,30 +45,35 @@ export const transformContext = (serverContext: ServerContext): ChatSession => {
  * @returns Array of messages in chronological order
  */
 export const transformTasksToMessages = (serverTasks: ServerTask[]): Message[] => {
-  const messages: Message[] = [];
-
-  // Flatten all task histories
-  for (const task of serverTasks) {
+  const messages = serverTasks.flatMap((task, taskIndex) => {
     const taskState = task.taskStatus?.state;
-    for (const serverMessage of task.history) {
-      messages.push(transformMessage(serverMessage, taskState));
-    }
-  }
-
-  // Sort by timestamp to ensure chronological order
-  // This handles cases where history arrays might be reverse chronological
-  // When timestamps are equal, ensure user messages come before assistant messages
-  messages.sort((a, b) => {
-    const timeDiff = a.timestamp.getTime() - b.timestamp.getTime();
-    if (timeDiff !== 0) {
-      return timeDiff;
-    }
-    // Same timestamp: user messages (role='user') should come before assistant messages
-    // user=0, assistant=1, so 'user' sorts before 'assistant'
-    return a.role === 'user' ? -1 : b.role === 'user' ? 1 : 0;
+    const taskTime = parseServerDate(task.taskStatus.timestamp).getTime();
+    return task.history.map((serverMessage, messageIndex) => ({
+      message: transformMessage(serverMessage, taskState),
+      taskIndex,
+      taskTime,
+      messageIndex,
+    }));
   });
 
-  return messages;
+  messages.sort((firstEntry, secondEntry) => {
+    const timeDifference = firstEntry.message.timestamp.getTime() - secondEntry.message.timestamp.getTime();
+    if (timeDifference !== 0) {
+      return timeDifference;
+    }
+
+    if (firstEntry.taskIndex !== secondEntry.taskIndex) {
+      return firstEntry.taskTime - secondEntry.taskTime || firstEntry.taskIndex - secondEntry.taskIndex;
+    }
+
+    if (firstEntry.message.role !== secondEntry.message.role) {
+      return firstEntry.message.role === 'user' ? -1 : 1;
+    }
+
+    return firstEntry.messageIndex - secondEntry.messageIndex;
+  });
+
+  return messages.map((entry) => entry.message);
 };
 
 /**
@@ -182,11 +187,23 @@ const extractLastMessage = (task: ServerTask): Message | undefined => {
  * @returns Date object
  */
 const parseServerDate = (dateStr: string): Date => {
-  // JavaScript Date constructor handles this format natively
-  const date = new Date(dateStr);
+  // The history API emits UTC clock values without a timezone suffix.
+  const match = dateStr.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4}) (\d{1,2}):(\d{2}):(\d{2}) (AM|PM)$/i);
+  if (!match) {
+    throw new Error(`Invalid date format: ${dateStr}`);
+  }
 
-  // Validate the date
-  if (Number.isNaN(date.getTime())) {
+  const [, monthText, dayText, yearText, hourText, minuteText, secondText, period] = match;
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const year = Number(yearText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const utcHour = (hour % 12) + (period.toUpperCase() === 'PM' ? 12 : 0);
+  const date = new Date(Date.UTC(year, month - 1, day, utcHour, minute, second));
+
+  if (month < 1 || month > 12 || day < 1 || hour < 1 || hour > 12 || minute > 59 || second > 59 || date.getUTCDate() !== day) {
     throw new Error(`Invalid date format: ${dateStr}`);
   }
 

--- a/libs/a2a-core/src/react/__tests__/use-a2a-authoritative-history.test.tsx
+++ b/libs/a2a-core/src/react/__tests__/use-a2a-authoritative-history.test.tsx
@@ -1,0 +1,206 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentCard } from '../../types';
+import { useA2A } from '../use-a2a';
+
+vi.mock('../../client/a2a-client', () => ({
+  A2AClient: vi.fn(() => ({
+    getCapabilities: vi.fn(() => ({ streaming: true })),
+    message: {
+      stream: vi.fn(async function* () {
+        yield {
+          id: 'live-task',
+          state: 'running',
+          messages: [
+            {
+              role: 'assistant',
+              content: [{ type: 'text', content: 'Live response' }],
+            },
+          ],
+          artifacts: [],
+        };
+      }),
+    },
+  })),
+}));
+
+describe('useA2A authoritative history', () => {
+  const agentUrl = 'http://example.com/.well-known/agent-card.json';
+  const agentCard: AgentCard = {
+    name: 'Test Agent',
+    description: 'Test agent',
+    version: '1.0.0',
+    url: agentUrl,
+    serviceEndpoint: 'http://example.com/agent',
+    capabilities: [],
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should not let cached messages or context override parent history', async () => {
+    const sessionKey = 'test-session';
+    localStorage.setItem(
+      `a2a-messages-example-com-${sessionKey}`,
+      JSON.stringify([
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'Current',
+          timestamp: '2024-01-01T10:00:00Z',
+          metadata: { source: 'stale-cache' },
+        },
+      ])
+    );
+    localStorage.setItem(`a2a-context-example-com-${sessionKey}`, 'stale-context');
+    const initialMessages = [
+      {
+        id: 'message-1',
+        role: 'user' as const,
+        content: 'Current',
+        timestamp: new Date('2024-01-01T10:00:00Z'),
+        metadata: { source: 'parent-history' },
+      },
+    ];
+    const { result } = renderHook(() =>
+      useA2A({
+        persistSession: true,
+        sessionKey,
+        agentUrl,
+        initialContextId: 'authoritative-context',
+        initialMessages,
+      })
+    );
+
+    await act(async () => {
+      await result.current.connect(agentCard);
+    });
+
+    expect(result.current.messages).toEqual(initialMessages);
+    expect(result.current.messages[0]?.timestamp).toBeInstanceOf(Date);
+    expect(result.current.messages[0]?.metadata).toEqual({ source: 'parent-history' });
+    expect(result.current.contextId).toBe('authoritative-context');
+  });
+
+  it('should treat empty parent history as authoritative', async () => {
+    const sessionKey = 'empty-session';
+    localStorage.setItem(
+      `a2a-messages-example-com-${sessionKey}`,
+      JSON.stringify([{ id: 'stale-message', role: 'assistant', content: 'Stale', timestamp: '2024-01-01T09:00:00Z' }])
+    );
+    const { result } = renderHook(() =>
+      useA2A({
+        persistSession: true,
+        sessionKey,
+        agentUrl,
+        initialContextId: 'empty-context',
+        initialMessages: [],
+      })
+    );
+
+    await act(async () => {
+      await result.current.connect(agentCard);
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.contextId).toBe('empty-context');
+  });
+
+  it('should replace stale cache when parent history arrives after connection', async () => {
+    const sessionKey = 'late-history-session';
+    localStorage.setItem(
+      `a2a-messages-example-com-${sessionKey}`,
+      JSON.stringify([{ id: 'stale-message', role: 'assistant', content: 'Stale', timestamp: '2024-01-01T09:00:00Z' }])
+    );
+    localStorage.setItem(`a2a-context-example-com-${sessionKey}`, 'stale-context');
+    const initialMessages = [
+      {
+        id: 'message-1',
+        role: 'user' as const,
+        content: 'Current',
+        timestamp: new Date('2024-01-01T10:00:00Z'),
+      },
+    ];
+    const { result, rerender } = renderHook(
+      ({ messages, contextId }) =>
+        useA2A({
+          persistSession: true,
+          sessionKey,
+          agentUrl,
+          initialContextId: contextId,
+          initialMessages: messages,
+        }),
+      { initialProps: { messages: undefined as typeof initialMessages | undefined, contextId: undefined as string | undefined } }
+    );
+
+    await act(async () => {
+      await result.current.connect(agentCard);
+    });
+    expect(result.current.messages[0]?.id).toBe('stale-message');
+
+    rerender({ messages: initialMessages, contextId: 'authoritative-context' });
+
+    expect(result.current.messages).toEqual(initialMessages);
+    expect(result.current.contextId).toBe('authoritative-context');
+  });
+
+  it('should clear stale cache when empty parent history arrives after connection', async () => {
+    const sessionKey = 'late-empty-session';
+    localStorage.setItem(
+      `a2a-messages-example-com-${sessionKey}`,
+      JSON.stringify([{ id: 'stale-message', role: 'assistant', content: 'Stale', timestamp: '2024-01-01T09:00:00Z' }])
+    );
+    const { result, rerender } = renderHook(
+      ({ messages, contextId }) =>
+        useA2A({
+          persistSession: true,
+          sessionKey,
+          agentUrl,
+          initialContextId: contextId,
+          initialMessages: messages,
+        }),
+      { initialProps: { messages: undefined as [] | undefined, contextId: undefined as string | undefined } }
+    );
+
+    await act(async () => {
+      await result.current.connect(agentCard);
+    });
+    expect(result.current.messages[0]?.id).toBe('stale-message');
+
+    rerender({ messages: [], contextId: 'empty-context' });
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.contextId).toBe('empty-context');
+  });
+
+  it('should preserve an active turn when parent history arrives late', async () => {
+    const historicalMessages = [
+      {
+        id: 'history-message',
+        role: 'assistant' as const,
+        content: 'Earlier response',
+        timestamp: new Date('2024-01-01T10:00:00Z'),
+      },
+    ];
+    const { result, rerender } = renderHook(
+      ({ messages }) =>
+        useA2A({
+          initialMessages: messages,
+        }),
+      { initialProps: { messages: undefined as typeof historicalMessages | undefined } }
+    );
+
+    await act(async () => {
+      await result.current.connect(agentCard);
+      await result.current.sendMessage('Live request');
+    });
+    expect(result.current.messages.some((message) => message.id === 'assistant-live-task-0')).toBe(true);
+
+    rerender({ messages: historicalMessages });
+
+    expect(result.current.messages[0]).toEqual(historicalMessages[0]);
+    expect(result.current.messages.some((message) => message.role === 'user' && message.content === 'Live request')).toBe(true);
+    expect(result.current.messages.some((message) => message.id === 'assistant-live-task-0')).toBe(true);
+  });
+});

--- a/libs/a2a-core/src/react/components/ChatWindow/ChatWindow.test.tsx
+++ b/libs/a2a-core/src/react/components/ChatWindow/ChatWindow.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -151,6 +150,21 @@ describe('ChatWindow', () => {
       onMessage: undefined,
       onConnectionChange: undefined,
     });
+  });
+
+  it('should pass initial messages to the chat widget hook', () => {
+    const initialMessages = [
+      {
+        id: 'message-1',
+        role: 'user' as const,
+        content: 'Hello',
+        timestamp: new Date('2024-01-01T10:00:00Z'),
+      },
+    ];
+
+    render(<ChatWindow {...defaultProps} initialMessages={initialMessages} />);
+
+    expect(vi.mocked(useChatWidget)).toHaveBeenCalledWith(expect.objectContaining({ initialMessages }));
   });
 
   it('should use default agent name when not provided', () => {

--- a/libs/a2a-core/src/react/components/ChatWindow/ChatWindow.tsx
+++ b/libs/a2a-core/src/react/components/ChatWindow/ChatWindow.tsx
@@ -167,6 +167,7 @@ export function ChatWindow(props: ChatWindowProps) {
     onRenameSession,
     storageConfig,
     initialContextId,
+    initialMessages,
     mode = 'light',
   } = props;
 
@@ -188,6 +189,7 @@ export function ChatWindow(props: ChatWindowProps) {
     oboUserToken,
     storageConfig,
     initialContextId,
+    initialMessages,
     sessionId: props.sessionId, // Pass through sessionId for multi-session mode
   });
 

--- a/libs/a2a-core/src/react/components/MessageInput/MessageInput.test.tsx
+++ b/libs/a2a-core/src/react/components/MessageInput/MessageInput.test.tsx
@@ -266,12 +266,7 @@ describe('MessageInput', () => {
 
     expect(screen.getByText('test.txt')).toBeInTheDocument();
 
-    // Find and click the remove button (it's an icon button inside the badge)
-    const removeButtons = screen.getAllByRole('button');
-    const removeButton = removeButtons.find((btn) => btn.querySelector('svg')); // Find button with icon
-    if (removeButton) {
-      await user.click(removeButton);
-    }
+    await user.click(screen.getByRole('button', { name: 'Remove test.txt' }));
 
     expect(screen.queryByText('test.txt')).not.toBeInTheDocument();
   });
@@ -417,15 +412,8 @@ describe('MessageInput', () => {
   it('renders send button with icon', () => {
     render(<MessageInput onSendMessage={mockOnSendMessage} />);
 
-    const buttons = screen.getAllByRole('button');
-    expect(buttons.length).toBeGreaterThanOrEqual(1);
-
-    // The send button is the last button
-    const sendButton = buttons[buttons.length - 1];
+    const sendButton = screen.getByRole('button', { name: 'Send message' });
     expect(sendButton).toBeInTheDocument();
-
-    // Fluent UI icons are rendered as SVG elements
-    const svg = sendButton.querySelector('svg');
-    expect(svg).toBeInTheDocument();
+    expect(sendButton.firstElementChild).toBeInTheDocument();
   });
 });

--- a/libs/a2a-core/src/react/hooks/useChatWidget.test.ts
+++ b/libs/a2a-core/src/react/hooks/useChatWidget.test.ts
@@ -61,6 +61,101 @@ describe('useChatWidget', () => {
     expect(result.current.agentName).toBe('Agent');
   });
 
+  it('should replace visible messages when initial history changes', async () => {
+    const { useA2A } = await import('../use-a2a');
+    const { useChatStore } = await import('../store/chatStore');
+    const clearMessages = vi.fn();
+    const addMessage = vi.fn();
+    (useChatStore as any).mockReturnValue({
+      addMessage,
+      updateMessage: vi.fn(),
+      setConnected: vi.fn(),
+      setTyping: vi.fn(),
+      clearMessages,
+    });
+
+    const userMessage = {
+      id: 'message-1',
+      role: 'user' as const,
+      content: 'Hello',
+      timestamp: new Date('2024-01-01T10:00:00Z'),
+    };
+    const assistantMessage = {
+      id: 'message-2',
+      role: 'assistant' as const,
+      content: 'Hi there',
+      timestamp: new Date('2024-01-01T10:00:05Z'),
+    };
+    const { rerender } = renderHook(({ initialMessages }) => useChatWidget({ agentCard: 'https://example.com/agent', initialMessages }), {
+      initialProps: { initialMessages: [userMessage] },
+    });
+
+    expect(useA2A).toHaveBeenLastCalledWith(expect.objectContaining({ initialMessages: [userMessage] }));
+    expect(clearMessages).toHaveBeenCalledTimes(1);
+    expect(addMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'message-1', sender: 'user', timestamp: userMessage.timestamp, status: 'sent' })
+    );
+
+    clearMessages.mockClear();
+    addMessage.mockClear();
+    rerender({ initialMessages: [userMessage, assistantMessage] });
+
+    expect(clearMessages).toHaveBeenCalledTimes(1);
+    expect(addMessage).toHaveBeenCalledTimes(2);
+    expect(addMessage).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'message-1', timestamp: userMessage.timestamp }));
+    expect(addMessage).toHaveBeenNthCalledWith(2, expect.objectContaining({ id: 'message-2', timestamp: assistantMessage.timestamp }));
+  });
+
+  it('should preserve a live message when history arrives late', async () => {
+    const { useA2A } = await import('../use-a2a');
+    const { useChatStore } = await import('../store/chatStore');
+    const clearMessages = vi.fn();
+    const addMessage = vi.fn();
+    (useChatStore as any).mockReturnValue({
+      addMessage,
+      updateMessage: vi.fn(),
+      setConnected: vi.fn(),
+      setTyping: vi.fn(),
+      clearMessages,
+    });
+    const liveMessage = {
+      id: 'live-message',
+      role: 'assistant' as const,
+      content: 'Live response',
+      timestamp: new Date('2024-01-01T10:00:10Z'),
+      isStreaming: true,
+    };
+    (useA2A as any).mockReturnValue({
+      isConnected: true,
+      isLoading: true,
+      messages: [liveMessage],
+      agentCard: null,
+      contextId: 'context-1',
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      sendMessage: vi.fn(),
+      clearMessages: vi.fn(),
+    });
+    const historicalMessage = {
+      id: 'history-message',
+      role: 'user' as const,
+      content: 'Earlier request',
+      timestamp: new Date('2024-01-01T10:00:00Z'),
+    };
+    const { rerender } = renderHook(({ initialMessages }) => useChatWidget({ agentCard: 'https://example.com/agent', initialMessages }), {
+      initialProps: { initialMessages: undefined as (typeof historicalMessage)[] | undefined },
+    });
+
+    clearMessages.mockClear();
+    addMessage.mockClear();
+    rerender({ initialMessages: [historicalMessage] });
+
+    expect(clearMessages).toHaveBeenCalledTimes(1);
+    expect(addMessage).toHaveBeenCalledTimes(2);
+    expect(addMessage).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'history-message' }));
+    expect(addMessage).toHaveBeenNthCalledWith(2, expect.objectContaining({ content: 'Live response' }));
+  });
+
   it('should handle connection changes', async () => {
     const onConnectionChange = vi.fn();
     const { useA2A } = await import('../use-a2a');

--- a/libs/a2a-core/src/react/hooks/useChatWidget.ts
+++ b/libs/a2a-core/src/react/hooks/useChatWidget.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { useA2A } from '../use-a2a';
+import { useA2A, type ChatMessage } from '../use-a2a';
 import { AgentDiscovery } from '../../discovery/agent-discovery';
 import type { AgentCard } from '../../types';
 import type { AuthConfig, AuthRequiredHandler, UnauthorizedHandler, AuthRequiredEvent } from '../../client/types';
@@ -23,6 +23,7 @@ interface UseChatWidgetProps {
   oboUserToken?: string;
   storageConfig?: StorageConfig;
   initialContextId?: string;
+  initialMessages?: ChatMessage[];
   sessionId?: string; // For multi-session mode - reads messages from sessionMessages map
 }
 
@@ -39,12 +40,14 @@ export function useChatWidget({
   oboUserToken,
   storageConfig,
   initialContextId,
+  initialMessages,
   sessionId,
 }: UseChatWidgetProps) {
   const processedMessageIds = useRef<Set<string>>(new Set());
   const messageIdMap = useRef<Map<string, string>>(new Map());
   const sentMessageContents = useRef<Set<string>>(new Set());
   const contextIdRef = useRef<string | undefined>(undefined);
+  const sdkMessagesRef = useRef<ChatMessage[]>([]);
 
   const {
     addMessage,
@@ -104,6 +107,7 @@ export function useChatWidget({
           oboUserToken,
           storageConfig,
           initialContextId,
+          initialMessages,
         }
       : sessionId
         ? (undefined as any) // Disable useA2A in multi-session mode
@@ -120,8 +124,10 @@ export function useChatWidget({
             oboUserToken,
             storageConfig,
             initialContextId,
+            initialMessages,
           }
   );
+  sdkMessagesRef.current = messages;
 
   // Update contextIdRef when contextId changes
   useEffect(() => {
@@ -138,6 +144,46 @@ export function useChatWidget({
   useEffect(() => {
     setTyping(isLoading, contextId);
   }, [isLoading, setTyping, contextId]);
+
+  useEffect(() => {
+    clearLocalMessages();
+    processedMessageIds.current.clear();
+    messageIdMap.current.clear();
+    sentMessageContents.current.clear();
+
+    const initialMessageIds = new Set(initialMessages?.map((message) => message.id));
+    const latestInitialTimestamp = Math.max(
+      ...(initialMessages?.map((message) => message.timestamp.getTime()) ?? []),
+      Number.NEGATIVE_INFINITY
+    );
+    const liveMessages = sdkMessagesRef.current.filter(
+      (message) =>
+        !initialMessageIds.has(message.id) && message.timestamp instanceof Date && message.timestamp.getTime() > latestInitialTimestamp
+    );
+    const messagesToHydrate = initialMessages ? [...initialMessages, ...liveMessages] : [];
+
+    messagesToHydrate.forEach((initialMessage) => {
+      const internalMessage = createMessage(
+        initialMessage.content,
+        initialMessage.role === 'system' ? 'system' : initialMessage.role === 'user' ? 'user' : 'assistant'
+      );
+      internalMessage.id = initialMessage.id;
+      internalMessage.timestamp = initialMessage.timestamp;
+      internalMessage.status = 'sent';
+      internalMessage.metadata = {
+        ...initialMessage.metadata,
+        sdkMessageId: initialMessage.id,
+        timestamp: initialMessage.timestamp,
+        isStreaming: false,
+      };
+      internalMessage.files = initialMessage.files;
+      internalMessage.authEvent = initialMessage.authEvent;
+
+      processedMessageIds.current.add(initialMessage.id);
+      messageIdMap.current.set(initialMessage.id, internalMessage.id);
+      addMessage(internalMessage);
+    });
+  }, [initialMessages, addMessage, clearLocalMessages]);
 
   // Handle incoming messages from SDK
   useEffect(() => {
@@ -230,20 +276,12 @@ export function useChatWidget({
 
   // Clear processed messages when disconnecting
   useEffect(() => {
-    if (!isConnected) {
+    if (!isConnected && !initialMessages) {
       processedMessageIds.current.clear();
       messageIdMap.current.clear();
       sentMessageContents.current.clear();
     }
-  }, [isConnected]);
-
-  // Clear messages on mount to ensure clean state for new sessions
-  useEffect(() => {
-    clearLocalMessages();
-    processedMessageIds.current.clear();
-    messageIdMap.current.clear();
-    sentMessageContents.current.clear();
-  }, [clearLocalMessages]);
+  }, [isConnected, initialMessages]);
 
   // Auto-connect when agentCard is provided
   useEffect(() => {

--- a/libs/a2a-core/src/react/types/index.ts
+++ b/libs/a2a-core/src/react/types/index.ts
@@ -1,6 +1,7 @@
 import type { AgentCard } from '../../types';
 import type { AuthConfig, AuthRequiredPart, IdentityProvider } from '../../client/types';
 import type { StorageConfig } from '../../storage/history-storage';
+import type { ChatMessage } from '../use-a2a';
 
 // Re-export types from main module
 export type { AgentCard, AuthConfig, AuthRequiredPart, StorageConfig, IdentityProvider };
@@ -160,6 +161,7 @@ export interface ChatWidgetProps {
   onRenameSession?: (newName: string) => void | Promise<void>; // Callback for renaming the session
   storageConfig?: StorageConfig; // Optional storage configuration for server-side chat history
   initialContextId?: string; // Initial context ID for resuming existing server-side conversations
+  initialMessages?: ChatMessage[]; // Initial messages for hydrating an existing conversation
   sessionId?: string; // For multi-session mode - enables session-specific message isolation
   identityProviders?: Record<string, IdentityProvider>; // Identity providers configuration
 }

--- a/libs/a2a-core/src/react/use-a2a.ts
+++ b/libs/a2a-core/src/react/use-a2a.ts
@@ -41,6 +41,7 @@ export interface UseA2AOptions {
   oboUserToken?: string;
   storageConfig?: StorageConfig;
   initialContextId?: string; // Initial context ID for resuming existing conversations
+  initialMessages?: ChatMessage[];
 }
 
 export interface UseA2AReturn {
@@ -67,7 +68,7 @@ export interface UseA2AReturn {
 export function useA2A(options: UseA2AOptions = {}): UseA2AReturn {
   const [isConnected, setIsConnected] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [messages, setMessages] = useState<ChatMessage[]>(options.initialMessages ?? []);
   const [agentCard, setAgentCard] = useState<AgentCard>();
   const [error, setError] = useState<Error>();
   const [authState, setAuthState] = useState<{ isRequired: boolean; authEvent?: any }>({
@@ -79,6 +80,11 @@ export function useA2A(options: UseA2AOptions = {}): UseA2AReturn {
   const authMessageIdRef = useRef<string | undefined>(undefined);
   const authTaskIdRef = useRef<string | undefined>(undefined);
   const currentAgentUrlRef = useRef<string | undefined>(undefined);
+  const initialMessagesRef = useRef(options.initialMessages);
+  const initialContextIdRef = useRef(options.initialContextId);
+
+  initialMessagesRef.current = options.initialMessages;
+  initialContextIdRef.current = options.initialContextId;
 
   const initializeStorage = useChatStore((state) => state.initializeStorage);
   const loadSessions = useChatStore((state) => state.loadSessions);
@@ -90,6 +96,40 @@ export function useA2A(options: UseA2AOptions = {}): UseA2AReturn {
       contextIdRef.current = options.initialContextId;
     }
   }, [options.initialContextId]);
+
+  useEffect(() => {
+    const initialMessages = options.initialMessages;
+    if (initialMessages) {
+      setMessages((currentMessages) => {
+        const initialMessageIds = new Set(initialMessages.map((message) => message.id));
+        const latestInitialTimestamp = Math.max(...initialMessages.map((message) => message.timestamp.getTime()), Number.NEGATIVE_INFINITY);
+        const newerMessages = currentMessages.filter(
+          (message) =>
+            !initialMessageIds.has(message.id) && message.timestamp instanceof Date && message.timestamp.getTime() > latestInitialTimestamp
+        );
+        const reconciledMessages = [...initialMessages, ...newerMessages];
+        const isUnchanged =
+          reconciledMessages.length === currentMessages.length &&
+          reconciledMessages.every((message, index) => {
+            const currentMessage = currentMessages[index];
+            if (!currentMessage || !(currentMessage.timestamp instanceof Date)) {
+              return false;
+            }
+            return (
+              message.id === currentMessage.id &&
+              message.role === currentMessage.role &&
+              message.content === currentMessage.content &&
+              message.timestamp.getTime() === currentMessage.timestamp.getTime() &&
+              message.isStreaming === currentMessage.isStreaming &&
+              JSON.stringify(message.metadata) === JSON.stringify(currentMessage.metadata) &&
+              JSON.stringify(message.files) === JSON.stringify(currentMessage.files) &&
+              JSON.stringify(message.authEvent) === JSON.stringify(currentMessage.authEvent)
+            );
+          });
+        return isUnchanged ? currentMessages : reconciledMessages;
+      });
+    }
+  }, [options.initialMessages]);
 
   // Initialize storage when storageConfig is provided
   useEffect(() => {
@@ -265,7 +305,7 @@ export function useA2A(options: UseA2AOptions = {}): UseA2AReturn {
           const savedMessages = messagesKey ? localStorage.getItem(messagesKey) : null;
           const savedContextId = contextKey ? localStorage.getItem(contextKey) : null;
 
-          if (savedMessages) {
+          if (savedMessages && initialMessagesRef.current === undefined) {
             try {
               const parsedMessages = JSON.parse(savedMessages);
               setMessages(parsedMessages);
@@ -282,7 +322,7 @@ export function useA2A(options: UseA2AOptions = {}): UseA2AReturn {
             }
           }
 
-          if (savedContextId) {
+          if (savedContextId && initialContextIdRef.current === undefined) {
             try {
               contextIdRef.current = savedContextId;
             } catch (e) {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Restored iframe conversations could group messages by sender when server timestamps were equal, and offsetless history timestamps were interpreted in the browser timezone. This change preserves task-aware chronological order, treats server history clock values as UTC, hydrates Frame Blade history authoritatively, replaces stale cached history, and preserves newer active turns.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Restored iframe conversations retain their original back-and-forth order and display the original message time in the user's local timezone.
- **Developers**: Adds optional initial-message hydration through `ChatWidget`, `ChatWindow`, `useChatWidget`, and `useA2A`.
- **System**: No new dependencies; history reconciliation now prefers authoritative parent data while retaining newer live messages.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: 62 focused Vitest tests, `@microsoft/logic-apps-chat` typecheck/build, and iframe-app production build

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@rllyy97

## Screenshots/Videos
<!-- Visual changes only -->
Not applicable; this changes restored history data and timestamps without altering the visual design.