### PR TITLE
chore(vscode): Onboard release pipelines to CFS

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -48,6 +48,7 @@ parameters:
     default: VSCodeDeployLAUX
 
 variables:
+  - template: azdo-pipelines/azcode.variables.yml@azExtTemplates
   # Required by MicroBuild template
   - name: TeamName
     value: "Azure Logic Apps for VS Code"
@@ -63,6 +64,8 @@ extends:
       codeql:
         language: javascript # only build a codeql database for javascript, since the jsoncli pipeline handles csharp
       #   enabled: true # TODO: would like to enable only on scheduled builds but CodeQL cannot currently be disabled per https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/1es-codeql
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
       image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used
@@ -88,6 +91,8 @@ extends:
               - script: git checkout v${{ parameters.publishVersion }} # Replace with your desired version to release
                 displayName: 'Checkout to specific branch'
               - template: .azure-pipelines/templates/setup.yml@LogicAppsUX
+                parameters:
+                  feedBaseUrl: ${{ variables.feedBaseUrl }}
               - template: .azure-pipelines/templates/build.yml@LogicAppsUX
               - template: .azure-pipelines/templates/package.yml@LogicAppsUX
                 parameters:

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -21,6 +21,7 @@ resources:
       endpoint: GitHub-AzureTools # The service connection to use when accessing this repository
 
 variables:
+  - template: azdo-pipelines/azcode.variables.yml@azExtTemplates
   # Required by MicroBuild template
   - name: TeamName
     value: "Azure Tools for VS Code"
@@ -34,3 +35,4 @@ extends:
     publishVersion: ${{ parameters.publishVersion }}
     dryRun: ${{ parameters.dryRun }}
     environmentName: VSCodeDeployLAUX
+    npmFeed: ${{ variables.npmFeed }}

--- a/.azure-pipelines/templates/package.yml
+++ b/.azure-pipelines/templates/package.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: publishVersion
     type: string
-    
+
 steps:
   - script: node scripts/update-versions.js ${{ parameters.publishVersion }}
     displayName: "Update Version in Package Files"
@@ -14,7 +14,7 @@ steps:
     workingDirectory: $(working_directory)
     condition: succeeded()
 
-  - script: npx replace-in-file setInGitHubBuild $(AI_KEY) apps/vs-code-designer/src/main.ts
+  - script: pnpm exec replace-in-file setInGitHubBuild $(AI_KEY) apps/vs-code-designer/src/main.ts
     displayName: "Replace Placeholder with Telemetry Key"
     workingDirectory: $(working_directory)
     condition: succeeded()
@@ -23,4 +23,3 @@ steps:
     displayName: "Package with pnpm"
     workingDirectory: $(working_directory)
     condition: succeeded()
-    

--- a/.azure-pipelines/templates/setup.yml
+++ b/.azure-pipelines/templates/setup.yml
@@ -1,3 +1,8 @@
+parameters:
+  - name: feedBaseUrl
+    type: string
+    default: ''
+
 steps:
   - task: NodeTool@0
     displayName: "Using Node.js"
@@ -5,8 +10,56 @@ steps:
       versionSpec: '24.x'
     condition: succeeded()
 
-  - script: npm install -g pnpm
-    displayName: "Install pnpm"
+  - pwsh: |
+      $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
+      if ([string]::IsNullOrWhiteSpace($feedBaseUrl)) {
+        Write-Error "feedBaseUrl is required so npm and pnpm restore through CFS."
+        exit 1
+      }
+
+      $npmrcPath = Join-Path "$(Build.SourcesDirectory)" ".npmrc"
+      $registry = "$feedBaseUrl/npm/registry/"
+      $lines = @()
+      if (Test-Path $npmrcPath) {
+        $lines = Get-Content $npmrcPath | Where-Object {
+          $_ -notmatch '^\s*registry\s*=' -and $_ -notmatch '^\s*always-auth\s*='
+        }
+      }
+
+      $lines += "registry=$registry"
+      $lines += "always-auth=true"
+      Set-Content -Path $npmrcPath -Value $lines
+      Write-Host "Configured npm/pnpm registry: $registry"
+      Write-Host "##vso[task.setvariable variable=npmrcFile]$npmrcPath"
+      Write-Host "##vso[task.setvariable variable=npmRegistry]$registry"
+    displayName: "Configure CFS npm registry"
+    workingDirectory: $(working_directory)
+    condition: succeeded()
+
+  - task: npmAuthenticate@0
+    displayName: "Authenticate CFS npm registry"
+    inputs:
+      workingFile: $(npmrcFile)
+    condition: succeeded()
+
+  - pwsh: |
+      $packageManager = (Get-Content "package.json" -Raw | ConvertFrom-Json).packageManager
+      if (-not $packageManager -or -not $packageManager.StartsWith("pnpm@")) {
+        Write-Error "package.json 'packageManager' must specify pnpm@<version>."
+        exit 1
+      }
+
+      $pnpmVersion = ($packageManager -replace '^pnpm@', '') -replace '\+.*$', ''
+      corepack disable pnpm 2>$null
+      npm install -g "pnpm@$pnpmVersion" --registry="$(npmRegistry)" --userconfig="$(npmrcFile)"
+      if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+      }
+
+      node --version
+      pnpm --version
+    displayName: "Install pinned pnpm from CFS"
+    workingDirectory: $(working_directory)
     condition: succeeded()
 
   - script: pnpm install --frozen-lockfile --strict-peer-dependencies --recursive

--- a/.azure-pipelines/templates/sign.yml
+++ b/.azure-pipelines/templates/sign.yml
@@ -21,7 +21,7 @@ steps:
     name: package
     displayName: "\U0001F449 Get extension info from package.json"
 
-  - script: cd apps/vs-code-designer/dist && npx @vscode/vsce generate-manifest -i vscode-azurelogicapps-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
+  - script: pnpm --dir apps/vs-code-designer exec vsce generate-manifest -i dist/vscode-azurelogicapps-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
     condition: eq(variables['signprojExists'], True)
     displayName: "\U0001F449 Generate extension manifest"
 
@@ -45,4 +45,3 @@ steps:
       exit 0
     displayName: "\U0001F449 Verify extension.signature.p7s file was created"
     condition: eq(variables['signprojExists'], True)
-    


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Updates Azure Pipelines release/build configuration for AzRel MountainPass SR21 / 1ES Network Isolation CFS adoption. The build now configures the CFS-backed DevDiv Azure Artifacts npm registry before package restore, authenticates that feed, installs the pinned pnpm version through that authenticated CFS registry, and applies the CFSClean network-isolation policy. The release pipeline keeps its existing Azure Tools release template and explicitly passes the same CFS-backed npm feed for the template's `vsce` install step. Also updates the build setup from deprecated `NodeTool@0` to `UseNode@1` to remove the ADO task deprecation warning.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No product UI/runtime impact.
- **Developers**: Release/build pipeline dependency restore now requires the configured CFS-backed Azure Artifacts feed and authentication.
- **System**: Pipeline network behavior is constrained to support CFSClean policy compliance and avoid public npm restore paths.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Local pipeline YAML/static checks: `git diff --check`, no-tab/final-newline hygiene checks, and targeted scan for public npm registry, package feed proxy, `npx`, deprecated `NodeTool@0`, hosted `vmImage`, raw artifact publish, and unintended release-template migration references under `.azure-pipelines`.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
N/A

## Screenshots/Videos
<!-- Visual changes only -->
N/A