### PR TITLE
chore(vscode): Fix CFS pipeline npm auth

### DIFF
--- a/.azure-pipelines/templates/build.yml
+++ b/.azure-pipelines/templates/build.yml
@@ -2,4 +2,6 @@ steps:
   - script: pnpm run build:extension
     displayName: "Build with pnpm"
     workingDirectory: $(working_directory)
+    env:
+      NPM_CONFIG_USERCONFIG: $(npmrcFile)
     condition: succeeded()

--- a/.azure-pipelines/templates/setup.yml
+++ b/.azure-pipelines/templates/setup.yml
@@ -4,10 +4,10 @@ parameters:
     default: ''
 
 steps:
-  - task: NodeTool@0
+  - task: UseNode@1
     displayName: "Using Node.js"
     inputs:
-      versionSpec: '24.x'
+      version: '24.x'
     condition: succeeded()
 
   - pwsh: |


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Fixes two follow-up issues from the CFS / CFSClean pipeline migration:
- Passes the authenticated npm userconfig into the extension build task so the nested `npm install --ignore-scripts` in `apps/vs-code-designer/dist` uses the same CFS-backed Azure Artifacts registry authenticated by `npmAuthenticate@0`.
- Replaces deprecated `NodeTool@0` with `UseNode@1` in the shared setup template while keeping Node `24.x` behavior unchanged.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No product runtime impact.
- **Developers**: Main pipeline should no longer fail with npm `E401` during extension packaging after dependency restore succeeds.
- **System**: Keeps CFS package restore/authentication scoped to pipeline execution without copying `.npmrc` into packaged extension output.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: ADO run 14932595 log diagnosis; `git diff --check upstream/main..HEAD -- .azure-pipelines/templates/build.yml .azure-pipelines/templates/setup.yml`; final-newline and tab hygiene checks for changed YAML files.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft

## Screenshots/Videos
<!-- Visual changes only -->
N/A