### PR TITLE
fix(vscode): Pass CFS npmrc through Turbo

### DIFF
--- a/.azure-pipelines/templates/package.yml
+++ b/.azure-pipelines/templates/package.yml
@@ -22,4 +22,6 @@ steps:
   - script: pnpm run vscode:designer:pack
     displayName: "Package with pnpm"
     workingDirectory: $(working_directory)
+    env:
+      NPM_CONFIG_USERCONFIG: $(npmrcFile)
     condition: succeeded()

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,7 @@
     },
     "vscode-designer#build:extension": {
       "cache": false,
+      "env": ["NPM_CONFIG_USERCONFIG"],
       "dependsOn": ["build"]
     },
     "vscode-react#build:extension": {
@@ -48,6 +49,7 @@
     },
     "vscode:designer:pack": {
       "cache": false,
+      "env": ["NPM_CONFIG_USERCONFIG"],
       "dependsOn": ["vscode-react#build:extension"]
     },
     "vscode:designer:e2e:ui": {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
ADO run still failed after the CFS npm registry migration because the failing `Build with pnpm` path invokes `pnpm run build:extension`, which runs through Turbo. The pipeline task set `NPM_CONFIG_USERCONFIG=$(npmrcFile)`, but Turbo strict environment filtering did not pass that variable into the `vscode-designer#build:extension` task. As a result, the nested `apps/vs-code-designer/dist` `npm install` did not receive the authenticated CFS npmrc and failed with E401.

This PR fixes that remaining gap by allowing the authenticated npm userconfig through Turbo for the VS Code extension build/package tasks and by setting the same environment variable on the later package step.

| EngHub / SR21 CFS guidance | Corresponding change | Why it matters |
|---|---|---|
| Public npm package access must go through the CFS-backed authenticated feed. | `turbo.json` now allows `NPM_CONFIG_USERCONFIG` for `vscode-designer#build:extension` and `vscode:designer:pack`. | The nested `dist` npm install can use the CFS-authenticated `.npmrc` instead of attempting unauthenticated public npm access. |
| Every npm install path in the pipeline must receive the authenticated npm config. | `.azure-pipelines/templates/package.yml` now sets `NPM_CONFIG_USERCONFIG: $(npmrcFile)` for `Package with pnpm`. | The later package stage invokes the same VS Code extension packaging path and must use the same authenticated CFS npmrc. |
| CFSClean compliance requires eliminating direct/public package-feed calls, not only configuring the root install. | The fix covers the Turbo-filtered nested install that was still missing the authenticated npmrc. | The root `pnpm install` was already using CFS; this closes the remaining unauthenticated nested npm install that produced the ADO E401. |

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No user-facing product changes.
- **Developers**: VS Code extension Turbo tasks now explicitly pass through the CFS npm userconfig environment variable used by CI.
- **System**: ADO build/package steps can pass the authenticated CFS npmrc to nested npm installs under 1ES Network Isolation / CFSClean.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: `pnpm exec biome check --write turbo.json .azure-pipelines\templates\package.yml`; strict Turbo validation with a temporary non-secret `NPM_CONFIG_USERCONFIG` confirmed `vscode-designer:build:extension` ran `node scripts/install-dist-dependencies.js --ignore-scripts` and logged `Using npm userconfig from NPM_CONFIG_USERCONFIG.` GitHub PR checks, including `validate-pr`, are passing on this PR.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft

## Screenshots/Videos
<!-- Visual changes only -->
N/A