### PR TITLE
fix(vscode): Fix invalid vscode settings.json values, codeful project deploy, project path cache

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateFunctionAppFiles.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateFunctionAppFiles.ts
@@ -90,7 +90,6 @@ export class CreateFunctionAppFiles {
       'azureFunctions.preDeployTask': 'publish (functions)',
       'azureFunctions.templateFilter': 'Core',
       'azureFunctions.showTargetFrameworkWarning': false,
-      'azureFunctions.projectSubpath': `bin\\Release\\${targetFramework ?? TargetFramework.NetFx}\\publish`,
     };
     await fs.writeJson(filePath, content, { spaces: 2 });
   }

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppVSCodeContents.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppVSCodeContents.test.ts
@@ -293,12 +293,12 @@ describe('CreateLogicAppVSCodeContents', () => {
       expect(settingsData).toHaveProperty('azureLogicAppsStandard.projectRuntime', '~4');
       expect(settingsData).toHaveProperty('debug.internalConsoleOptions', 'neverOpen');
       expect(settingsData).toHaveProperty('azureFunctions.suppressProject', true);
-      expect(settingsData).toHaveProperty('azureFunctions.deploySubpath');
-      expect(settingsData).toHaveProperty('azureFunctions.preDeployTask', 'publish');
-      expect(settingsData).toHaveProperty('azureFunctions.projectSubpath');
+      expect(settingsData).toHaveProperty('azureLogicAppsStandard.deploySubpath');
+      expect(settingsData).not.toHaveProperty('azureLogicAppsStandard.preDeployTask');
       expect(settingsData).toHaveProperty('omnisharp.enableMsBuildLoadProjectsOnDemand', false);
       expect(settingsData).toHaveProperty('omnisharp.disableMSBuildDiagnosticWarning', true);
-      expect(settingsData).not.toHaveProperty('azureLogicAppsStandard.deploySubpath');
+      expect(settingsData).not.toHaveProperty('azureFunctions.deploySubpath');
+      expect(settingsData).not.toHaveProperty('azureFunctions.preDeployTask');
     });
 
     it('should create launch.json with logicapp configuration for codeful projects', async () => {

--- a/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
@@ -71,10 +71,10 @@ import { uploadAppSettings } from '../appSettings/uploadAppSettings';
 import { getAppSettingsFromNode } from '../../utils/tree/slotTreeUtils';
 import { isNullOrUndefined, resolveConnectionsReferences } from '@microsoft/logic-apps-shared';
 import { tryBuildCustomCodeFunctionsProject } from '../buildCustomCodeFunctionsProject';
-import { publishCodefulProject } from '../publishCodefulProject';
 import { hasCodefulWorkflowSetting } from '../../utils/codeful';
 import { isProjectInitializedForVSCode } from '../../projectConsistency/vscodeConsistency';
 import { initProjectForVSCode } from '../initProjectForVSCode/initProjectForVSCode';
+import { publishCodefulProject } from '../publishCodefulProject';
 
 export async function deployProductionSlot(
   context: IActionContext,
@@ -168,22 +168,22 @@ async function deploy(
   const isWorkflowApp = nodeKind?.includes(logicAppKind);
   const isDeployingToKubernetes = nodeKind && nodeKind.indexOf(kubernetesKind) !== -1;
 
-  if (!isProjectInitializedForVSCode(effectiveDeployFsPath)) {
+  if (!isProjectInitializedForVSCode(originalDeployFsPath)) {
     const message: string = localize('initFolder', 'Initialize project for use with VS Code?');
     await deployContext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes);
     await callWithTelemetryAndErrorHandling('deploy.initProjectForVSCode', async (actionContext: IActionContext) => {
       actionContext.errorHandling.rethrow = true;
       actionContext.errorHandling.suppressDisplay = true;
-      await initProjectForVSCode(actionContext, effectiveDeployFsPath);
+      await initProjectForVSCode(actionContext, originalDeployFsPath);
     });
   }
 
   const language = nonNullOrEmptyValue(
-    getWorkspaceSetting(projectLanguageSetting, effectiveDeployFsPath),
+    getWorkspaceSetting(projectLanguageSetting, originalDeployFsPath),
     projectLanguageSetting
   ) as ProjectLanguage;
   const version = nonNullOrEmptyValue(
-    tryParseFuncVersion(getWorkspaceSetting(funcVersionSetting, effectiveDeployFsPath)),
+    tryParseFuncVersion(getWorkspaceSetting(funcVersionSetting, originalDeployFsPath)),
     funcVersionSetting
   ) as FuncVersion;
 

--- a/apps/vs-code-designer/src/app/commands/initProjectForVSCode/initDotnetProjectStep.ts
+++ b/apps/vs-code-designer/src/app/commands/initProjectForVSCode/initDotnetProjectStep.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { dotnetPublishTaskLabel, dotnetExtensionId, show64BitWarningSetting } from '../../../constants';
+import { show64BitWarningSetting } from '../../../constants';
 import { localize } from '../../../localize';
 import { getProjFiles, getTargetFramework, tryGetFuncVersion } from '../../utils/dotnet/dotnet';
 import type { ProjectFile } from '../../utils/dotnet/dotnet';
@@ -16,16 +16,6 @@ import * as path from 'path';
 import type { MessageItem } from 'vscode';
 
 export class InitDotnetProjectStep extends InitProjectStep {
-  protected preDeployTask: string = dotnetPublishTaskLabel;
-
-  protected getRecommendedExtensions(language: ProjectLanguage): string[] {
-    const recs: string[] = [dotnetExtensionId];
-    if (language === ProjectLanguage.FSharp) {
-      recs.push('ionide.ionide-fsharp');
-    }
-    return recs;
-  }
-
   /**
    * Detects the version based on the targetFramework from the proj file
    * Also performs a few validations and sets a few properties based on that targetFramework

--- a/apps/vs-code-designer/src/app/commands/initProjectForVSCode/initProjectStep.ts
+++ b/apps/vs-code-designer/src/app/commands/initProjectForVSCode/initProjectStep.ts
@@ -32,8 +32,6 @@ export class InitProjectStep extends AzureWizardExecuteStep<IProjectWizardContex
     // Default implementation does nothing
   }
 
-  protected getRecommendedExtensions?(language: ProjectLanguage): string[];
-
   public shouldExecute(): boolean {
     return true;
   }

--- a/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/__test__/vscodeSettings.test.ts
+++ b/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/__test__/vscodeSettings.test.ts
@@ -46,9 +46,8 @@ describe('generateSettingsJson', () => {
       };
       const result = generateSettingsJson(config);
 
-      expect(result).toHaveProperty('azureFunctions.deploySubpath');
-      expect(result).toHaveProperty('azureFunctions.preDeployTask', 'publish');
-      expect(result).toHaveProperty('azureFunctions.projectSubpath');
+      expect(result).toHaveProperty('azureLogicAppsStandard.deploySubpath');
+      expect(result).not.toHaveProperty('azureLogicAppsStandard.preDeployTask');
       expect(result).toHaveProperty('omnisharp.enableMsBuildLoadProjectsOnDemand', false);
       expect(result).toHaveProperty('omnisharp.disableMSBuildDiagnosticWarning', true);
     });
@@ -76,7 +75,7 @@ describe('generateSettingsJson', () => {
       const result = generateSettingsJson(config);
 
       expect(result).toHaveProperty('azureLogicAppsStandard.deploySubpath');
-      expect(result).toHaveProperty('azureFunctions.preDeployTask');
+      expect(result).toHaveProperty('azureLogicAppsStandard.preDeployTask');
       expect(result).not.toHaveProperty('omnisharp.enableMsBuildLoadProjectsOnDemand');
     });
 
@@ -96,7 +95,7 @@ describe('generateSettingsJson', () => {
         'azureLogicAppsStandard.projectRuntime': '~4',
         'debug.internalConsoleOptions': 'neverOpen',
         'azureFunctions.suppressProject': true,
-        'azureFunctions.preDeployTask': 'publish',
+        'azureLogicAppsStandard.preDeployTask': 'publish',
       });
     });
   });

--- a/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/vscodeSettings.ts
+++ b/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/vscodeSettings.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import type { VSCodeProjectConfig } from './types';
-import { deploySubpathSetting, funcVersionSetting, projectLanguageSetting } from '../../../constants';
+import { deploySubpathSetting, funcVersionSetting, preDeployTaskSetting, projectLanguageSetting } from '../../../constants';
 import { latestGAVersion, ProjectLanguage, ProjectPackageType, ProjectType, TargetFramework } from '@microsoft/vscode-extension-logic-apps';
 import * as path from 'path';
 import { ext } from '../../../extensionVariables';
@@ -27,9 +27,7 @@ export function generateSettingsJson(config: VSCodeProjectConfig): Record<string
     const deploySubPathValue = path.posix.join('bin', 'Release', targetFramework ?? TargetFramework.NetFx, 'publish');
     return {
       ...baseSettings,
-      'azureFunctions.deploySubpath': deploySubPathValue,
-      'azureFunctions.preDeployTask': 'publish',
-      'azureFunctions.projectSubpath': deploySubPathValue,
+      [`${ext.prefix}.${deploySubpathSetting}`]: deploySubPathValue,
       'omnisharp.enableMsBuildLoadProjectsOnDemand': false,
       'omnisharp.disableMSBuildDiagnosticWarning': true,
     };
@@ -40,7 +38,7 @@ export function generateSettingsJson(config: VSCodeProjectConfig): Record<string
     return {
       ...baseSettings,
       [`${ext.prefix}.${deploySubpathSetting}`]: deploySubPathValue,
-      'azureFunctions.preDeployTask': 'publish',
+      [`${ext.prefix}.${preDeployTaskSetting}`]: 'publish',
     };
   }
   

--- a/apps/vs-code-designer/src/app/tree/LogicAppResourceTree.ts
+++ b/apps/vs-code-designer/src/app/tree/LogicAppResourceTree.ts
@@ -212,7 +212,7 @@ export class LogicAppResourceTree implements ResolvedAppResourceBase {
   }
 
   public async getApplicationSettings(context: IDeployContext): Promise<ApplicationSettings> {
-    const localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, context.effectiveDeployFsPath);
+    const localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, context.originalDeployFsPath);
     return localSettings.Values || {};
   }
 

--- a/apps/vs-code-designer/src/app/utils/__test__/verifyIsProject.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/verifyIsProject.test.ts
@@ -152,7 +152,6 @@ describe('isLogicAppProject', () => {
 describe('tryGetLogicAppProjectRoot', () => {
   const workspacePath = path.join('test', 'workspace');
   const subprojectPath = path.join(workspacePath, 'MyLogicApp');
-  const workflowJsonPath = path.join(subprojectPath, 'stateful1', workflowFileName);
   const mockContext = { telemetry: { properties: {} }, ui: {} } as any;
 
   afterEach(() => {

--- a/apps/vs-code-designer/src/app/utils/__test__/verifyIsProject.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/verifyIsProject.test.ts
@@ -4,6 +4,13 @@ import * as path from 'path';
 import * as verifyIsProject from '../verifyIsProject';
 import { hostFileName, localSettingsFileName, workflowFileName } from '../../../constants';
 
+vi.mock('../../utils/vsCodeConfig/settings', () => ({
+  getWorkspaceSetting: vi.fn(),
+  updateWorkspaceSetting: vi.fn(),
+}));
+
+import { getWorkspaceSetting } from '../../utils/vsCodeConfig/settings';
+
 describe('isLogicAppProject', () => {
   const projectPath = path.join('test', 'LogicApp');
 
@@ -139,5 +146,77 @@ describe('isLogicAppProject', () => {
     );
 
     expect(await verifyIsProject.isLogicAppProject(projectPath)).toBe(false);
+  });
+});
+
+describe('tryGetLogicAppProjectRoot', () => {
+  const workspacePath = path.join('test', 'workspace');
+  const subprojectPath = path.join(workspacePath, 'MyLogicApp');
+  const workflowJsonPath = path.join(subprojectPath, 'stateful1', workflowFileName);
+  const mockContext = { telemetry: { properties: {} }, ui: {} } as any;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockLogicAppProjectAt(validProjectPath: string): void {
+    const wfPath = path.join(validProjectPath, 'stateful1', workflowFileName);
+    vi.spyOn(fse, 'pathExists').mockImplementation(async (p: fse.PathLike) => {
+      const s = String(p);
+      return s === workspacePath || s === validProjectPath || s === wfPath;
+    });
+    vi.spyOn(fse, 'readdir').mockImplementation(async (p: fse.PathLike) => {
+      const s = String(p);
+      if (s === validProjectPath) {
+        return ['stateful1'];
+      }
+      if (s === workspacePath) {
+        return [path.basename(validProjectPath)];
+      }
+      return [];
+    });
+    vi.spyOn(fse, 'readFile').mockImplementation(async (p: fse.PathLike) => {
+      if (String(p) === wfPath) {
+        return JSON.stringify({
+          definition: {
+            $schema: 'https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#',
+          },
+        });
+      }
+      return '';
+    });
+  }
+
+  it('returns configured projectSubpath when it points to a valid project', async () => {
+    vi.mocked(getWorkspaceSetting).mockReturnValue('MyLogicApp');
+    mockLogicAppProjectAt(subprojectPath);
+
+    const result = await verifyIsProject.tryGetLogicAppProjectRoot(mockContext, workspacePath);
+    expect(result).toBe(subprojectPath);
+  });
+
+  it('falls through to scanning when projectSubpath points to an invalid location', async () => {
+    vi.mocked(getWorkspaceSetting).mockReturnValue('NonExistent');
+    mockLogicAppProjectAt(subprojectPath);
+
+    const result = await verifyIsProject.tryGetLogicAppProjectRoot(mockContext, workspacePath, true);
+    expect(result).toBe(subprojectPath);
+  });
+
+  it('falls through to scanning when no projectSubpath is configured', async () => {
+    vi.mocked(getWorkspaceSetting).mockReturnValue(undefined);
+    mockLogicAppProjectAt(subprojectPath);
+
+    const result = await verifyIsProject.tryGetLogicAppProjectRoot(mockContext, workspacePath, true);
+    expect(result).toBe(subprojectPath);
+  });
+
+  it('returns undefined when no projects are found', async () => {
+    vi.mocked(getWorkspaceSetting).mockReturnValue(undefined);
+    vi.spyOn(fse, 'pathExists').mockImplementation(async (p: fse.PathLike) => String(p) === workspacePath);
+    vi.spyOn(fse, 'readdir').mockResolvedValue([]);
+
+    const result = await verifyIsProject.tryGetLogicAppProjectRoot(mockContext, workspacePath);
+    expect(result).toBeUndefined();
   });
 });

--- a/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
+++ b/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { extensionCommand, workflowFileName, extensionContext } from '../../constants';
+import { extensionCommand, workflowFileName, extensionContext, projectSubpathSetting } from '../../constants';
 import { localize } from '../../localize';
 import { getWorkspaceSetting, updateWorkspaceSetting } from './vsCodeConfig/settings';
 import { isNullOrUndefined, isString } from '@microsoft/logic-apps-shared';
@@ -13,8 +13,6 @@ import type { MessageItem, WorkspaceFolder } from 'vscode';
 import { NoWorkspaceError } from './errors';
 import * as vscode from 'vscode';
 import { hasCodefulSdkReference } from './codeful';
-
-const projectSubpathKey = 'projectSubpath';
 
 /**
  * Determines whether the given folder is a Logic Apps project.
@@ -119,7 +117,6 @@ export async function isLogicAppProjectInRoot(workspaceFolder: WorkspaceFolder |
  * Checks root folder and subFolders one level down
  * If a single logic app project is found, return that path.
  * If multiple projects are found, prompt to pick the project.
- * TODO - this is checking every root folder and subfolders of non-logic app projects in the workspace, can we optimize this?
  */
 export async function tryGetLogicAppProjectRoot(
   context: IActionContext,
@@ -129,14 +126,22 @@ export async function tryGetLogicAppProjectRoot(
   if (isNullOrUndefined(workspaceFolder)) {
     return undefined;
   }
-  let subpath: string | undefined = getWorkspaceSetting(projectSubpathKey, workspaceFolder);
+
   const folderPath = isString(workspaceFolder) ? workspaceFolder : workspaceFolder.uri.fsPath;
   if (!(await fse.pathExists(folderPath))) {
     return undefined;
   }
+
   if (await isLogicAppProject(folderPath)) {
     return folderPath;
   }
+
+  const configuredSubpath: string | undefined = getWorkspaceSetting(projectSubpathSetting, workspaceFolder);
+  const configuredProjectPath = configuredSubpath ? path.join(folderPath, configuredSubpath) : undefined;
+  if (configuredProjectPath && await isLogicAppProject(configuredProjectPath)) {
+    return configuredProjectPath;
+  }
+
   const subpaths: string[] = await fse.readdir(folderPath);
   const matchingSubpaths: string[] = [];
   await Promise.all(
@@ -148,14 +153,13 @@ export async function tryGetLogicAppProjectRoot(
   );
 
   if (matchingSubpaths.length === 1 || (matchingSubpaths.length !== 0 && suppressPrompt)) {
-    subpath = matchingSubpaths[0];
+    return path.join(folderPath, matchingSubpaths[0]);
   } else if (matchingSubpaths.length !== 0 && !suppressPrompt) {
-    subpath = await promptForProjectSubpath(context, folderPath, matchingSubpaths);
-  } else {
-    return undefined;
+    const subpath = await promptForProjectSubpath(context, folderPath, matchingSubpaths);
+    return path.join(folderPath, subpath);
   }
-
-  return path.join(folderPath, subpath);
+  
+  return undefined;
 }
 
 /**
@@ -202,7 +206,7 @@ async function promptForProjectSubpath(context: IActionContext, workspacePath: s
   });
   const placeHolder: string = localize('selectProject', 'Select the default project subpath');
   const subpath: string = (await context.ui.showQuickPick(picks, { placeHolder })).data;
-  await updateWorkspaceSetting(projectSubpathKey, subpath, workspacePath);
+  await updateWorkspaceSetting(projectSubpathSetting, subpath, workspacePath);
 
   return subpath;
 }

--- a/apps/vs-code-designer/src/test/e2e/integration/createWorkspace.test.ts
+++ b/apps/vs-code-designer/src/test/e2e/integration/createWorkspace.test.ts
@@ -228,9 +228,9 @@ suite('Create Logic App Workspace Tests', () => {
       path.join(vscodePath, 'settings.json'),
       JSON.stringify(
         {
-          'azureFunctions.deploySubpath': '.',
-          'azureFunctions.projectLanguage': 'JavaScript',
-          'azureFunctions.projectRuntime': '~4',
+          'azureLogicAppsStandard.deploySubpath': '.',
+          'azureLogicAppsStandard.projectLanguage': 'JavaScript',
+          'azureLogicAppsStandard.projectRuntime': '~4',
           'debug.internalConsoleOptions': 'neverOpen',
           'azureFunctions.suppressProject': true,
         },


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
- Fixes invalid extension prefix used on some settings in .vscode/settings.json (preDeployTask, deploySubpath, projectSubpath)
- Fixes codeful project deploy behavior (only deploys bin/Release/.../publish contents), should significantly improve deployment speed
- Fixes usage of cached workspace folder projectSubpath value to improve project detection time

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes unexpected deploy behavior for codeful projects, fixes incorrect extension prefix on some settings in settings.json, improve project detection speed
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge
