### PR TITLE
feat(vscode): 'Add custom code' command for adding custom code to existing logic app

### DIFF
--- a/apps/vs-code-designer/src/app/commands/__test__/commandWebviewWrappers.test.ts
+++ b/apps/vs-code-designer/src/app/commands/__test__/commandWebviewWrappers.test.ts
@@ -156,6 +156,7 @@ describe('workspace webview command wrappers', () => {
       workspaceFileJson,
       logicAppsWithoutCustomCode: [{ label: 'LogicApp', description: expectedLogicAppPath, data: expectedLogicAppPath }],
       existingFolders: ['LogicApp', 'CSharpProject'],
+      workspaceRootFolder: workspaceRoot,
     });
     expect(config.dialogOptions?.workspace).toMatchObject({
       canSelectMany: false,
@@ -190,6 +191,7 @@ describe('workspace webview command wrappers', () => {
       workspaceFileJson,
       logicAppsWithoutCustomCode: [],
       existingFolders: ['LogicApp', 'AnotherProject'],
+      workspaceRootFolder: workspaceRoot,
     });
   });
 

--- a/apps/vs-code-designer/src/app/commands/__test__/commandWebviewWrappers.test.ts
+++ b/apps/vs-code-designer/src/app/commands/__test__/commandWebviewWrappers.test.ts
@@ -4,7 +4,8 @@ import * as vscode from 'vscode';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { ext } from '../../../extensionVariables';
 import { hasCodefulWorkflowSetting } from '../../utils/codeful';
-import { getLogicAppWithoutCustomCode, getWorkspaceRoot } from '../../utils/workspace';
+import { getWorkspaceRoot } from '../../utils/workspace';
+import { getEligibleLogicAppFoldersForCustomCode } from '../../utils/customCodeUtils';
 import { tryGetLogicAppProjectRoot } from '../../utils/verifyIsProject';
 import { cloudToLocal } from '../cloudToLocal/cloudToLocal';
 import { ensureWorkspace } from '../ensureWorkspace';
@@ -54,8 +55,11 @@ vi.mock('../createWorkflow/createLogicAppWorkflow', () => ({
 }));
 
 vi.mock('../../utils/workspace', () => ({
-  getLogicAppWithoutCustomCode: vi.fn(),
   getWorkspaceRoot: vi.fn(),
+}));
+
+vi.mock('../../utils/customCodeUtils', () => ({
+  getEligibleLogicAppFoldersForCustomCode: vi.fn(),
 }));
 
 vi.mock('../../utils/codeful', () => ({
@@ -73,7 +77,7 @@ function getLastWebviewConfig(): WorkspaceWebviewCommandConfig {
 
 describe('workspace webview command wrappers', () => {
   const context = { telemetry: { properties: {}, measurements: {} } } as any;
-  const workspaceRoot = 'D:\\workspace';
+  const workspaceRoot = path.resolve(path.sep, 'workspace');
   const logicAppRoot = path.join(workspaceRoot, 'LogicApp');
 
   beforeEach(() => {
@@ -83,7 +87,7 @@ describe('workspace webview command wrappers', () => {
     (getWorkspaceRoot as Mock).mockResolvedValue(workspaceRoot);
     (tryGetLogicAppProjectRoot as Mock).mockResolvedValue(logicAppRoot);
     (hasCodefulWorkflowSetting as Mock).mockResolvedValue(false);
-    (getLogicAppWithoutCustomCode as Mock).mockResolvedValue([]);
+    (getEligibleLogicAppFoldersForCustomCode as Mock).mockResolvedValue([]);
   });
 
   it('createWorkspace passes workspace config and invokes createLogicAppWorkspace', async () => {
@@ -126,9 +130,9 @@ describe('workspace webview command wrappers', () => {
   });
 
   it('createProject opens the project webview when a workspace is present', async () => {
-    const workspaceFile = { fsPath: 'D:\\workspace\\MyWorkspace.code-workspace' };
+    const workspaceFile = { fsPath: path.join(workspaceRoot, 'MyWorkspace.code-workspace') };
     const workspaceFileJson = { folders: [{ path: './LogicApp' }] };
-    const logicAppsWithoutCustomCode = ['LogicApp'];
+    const eligiblePaths = [path.join(workspaceRoot, 'LogicApp')];
     (vscode.workspace as any).workspaceFile = workspaceFile;
     (vscode.workspace.fs.readFile as Mock).mockResolvedValue(Buffer.from(JSON.stringify(workspaceFileJson)));
     (vscode.workspace.fs.readDirectory as Mock).mockResolvedValue([
@@ -136,7 +140,7 @@ describe('workspace webview command wrappers', () => {
       ['CSharpProject', 'directory'],
       ['MyWorkspace.code-workspace', 'file'],
     ]);
-    (getLogicAppWithoutCustomCode as Mock).mockResolvedValue(logicAppsWithoutCustomCode);
+    (getEligibleLogicAppFoldersForCustomCode as Mock).mockResolvedValue(eligiblePaths);
 
     await createProject(context);
 
@@ -147,9 +151,10 @@ describe('workspace webview command wrappers', () => {
       projectName: ProjectName.createLogicApp,
       createCommand: ExtensionCommand.createLogicApp,
     });
+    const expectedLogicAppPath = path.join(workspaceRoot, 'LogicApp');
     expect(config.extraInitializeData).toEqual({
       workspaceFileJson,
-      logicAppsWithoutCustomCode,
+      logicAppsWithoutCustomCode: [{ label: 'LogicApp', description: expectedLogicAppPath, data: expectedLogicAppPath }],
       existingFolders: ['LogicApp', 'CSharpProject'],
     });
     expect(config.dialogOptions?.workspace).toMatchObject({
@@ -166,7 +171,7 @@ describe('workspace webview command wrappers', () => {
   });
 
   it('getExistingFoldersOnDisk filters out non-directory entries using FileType mock', async () => {
-    const workspaceFile = { fsPath: 'D:\\workspace\\MyWorkspace.code-workspace' };
+    const workspaceFile = { fsPath: path.join(workspaceRoot, 'MyWorkspace.code-workspace') };
     const workspaceFileJson = { folders: [{ path: './LogicApp' }] };
     (vscode.workspace as any).workspaceFile = workspaceFile;
     (vscode.workspace.fs.readFile as Mock).mockResolvedValue(Buffer.from(JSON.stringify(workspaceFileJson)));

--- a/apps/vs-code-designer/src/app/commands/__test__/registerCommands.test.ts
+++ b/apps/vs-code-designer/src/app/commands/__test__/registerCommands.test.ts
@@ -96,6 +96,7 @@ vi.mock('../cloudToLocal/cloudToLocal', () => ({ cloudToLocal: vi.fn() }));
 vi.mock('../createProject/createProject', () => ({ createProject: vi.fn() }));
 vi.mock('../createWorkspace/createWorkspace', () => ({ createWorkspace: vi.fn() }));
 vi.mock('../createCustomCodeFunction/createCustomCodeFunction', () => ({ createCustomCodeFunction: vi.fn() }));
+vi.mock('../addCustomCode/addCustomCode', () => ({ addCustomCode: vi.fn() }));
 vi.mock('../createSlot', () => ({ createSlot: vi.fn() }));
 vi.mock('../createWorkflow/createWorkflow', () => ({ createWorkflow: vi.fn() }));
 vi.mock('../dataMapper/dataMapper', () => ({ createDataMap: vi.fn(), loadDataMapFile: vi.fn() }));
@@ -193,6 +194,12 @@ describe('registerCommands', () => {
       mockRegisterSiteCommand.mock.calls.length;
     // There should be many commands registered (at least 40+)
     expect(totalRegistrations).toBeGreaterThan(40);
+  });
+
+  it('should register the addCustomCode command', () => {
+    registerCommands();
+    const registeredCommands = mockRegisterCommand.mock.calls.map((call: any[]) => call[0]);
+    expect(registeredCommands).toContain('azureLogicAppsStandard.addCustomCode');
   });
 
   describe('error handler', () => {

--- a/apps/vs-code-designer/src/app/commands/addCustomCode/__test__/addCustomCode.test.ts
+++ b/apps/vs-code-designer/src/app/commands/addCustomCode/__test__/addCustomCode.test.ts
@@ -83,7 +83,7 @@ vi.mock('../../../../extensionVariables', () => ({
 vi.mock('../../../../constants', () => ({
   extensionContext: {
     customCodeFunctionsFolders: 'azureLogicAppsStandard.customCode.functionsFolders',
-    eligibleLogicAppFolders: 'azureLogicAppsStandard.customCode.eligibleLogicAppFolders',
+    customCodeEligibleLogicAppFolders: 'azureLogicAppsStandard.customCode.eligibleLogicAppFolders',
   },
 }));
 

--- a/apps/vs-code-designer/src/app/commands/addCustomCode/__test__/addCustomCode.test.ts
+++ b/apps/vs-code-designer/src/app/commands/addCustomCode/__test__/addCustomCode.test.ts
@@ -51,8 +51,6 @@ vi.mock('../../../utils/codeful', () => ({
 
 vi.mock('../../../utils/customCodeUtils', () => ({
   tryGetLogicAppCustomCodeFunctionsProjects: mockTryGetLogicAppCustomCodeFunctionsProjects,
-  getAllCustomCodeFunctionsProjects: vi.fn().mockResolvedValue([]),
-  getEligibleLogicAppFoldersForCustomCode: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('../../shared/workspaceWebviewCommandHandler', () => ({

--- a/apps/vs-code-designer/src/app/commands/addCustomCode/__test__/addCustomCode.test.ts
+++ b/apps/vs-code-designer/src/app/commands/addCustomCode/__test__/addCustomCode.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+
+// Hoisted mocks
+const {
+  mockIsLogicAppProject,
+  mockHasCodefulSdkReference,
+  mockTryGetLogicAppCustomCodeFunctionsProjects,
+  mockCreateWorkspaceWebviewCommandHandler,
+  mockShowErrorMessage,
+  mockCallWithTelemetryAndErrorHandling,
+} = vi.hoisted(() => ({
+  mockIsLogicAppProject: vi.fn(),
+  mockHasCodefulSdkReference: vi.fn(),
+  mockTryGetLogicAppCustomCodeFunctionsProjects: vi.fn(),
+  mockCreateWorkspaceWebviewCommandHandler: vi.fn(),
+  mockShowErrorMessage: vi.fn(),
+  mockCallWithTelemetryAndErrorHandling: vi.fn(async (_id: string, cb: any) =>
+    cb({
+      telemetry: { properties: {} },
+      errorHandling: {},
+    })
+  ),
+}));
+
+vi.mock('vscode', () => ({
+  window: {
+    showErrorMessage: mockShowErrorMessage,
+  },
+  workspace: {
+    workspaceFile: undefined as vscode.Uri | undefined,
+    fs: {
+      readFile: vi.fn(),
+      readDirectory: vi.fn().mockResolvedValue([]),
+    },
+  },
+  Uri: {
+    file: (p: string) => ({ fsPath: p, path: p, scheme: 'file' }),
+  },
+  FileType: { Directory: 2 },
+}));
+
+vi.mock('../../../utils/verifyIsProject', () => ({
+  isLogicAppProject: mockIsLogicAppProject,
+}));
+
+vi.mock('../../../utils/codeful', () => ({
+  hasCodefulSdkReference: mockHasCodefulSdkReference,
+}));
+
+vi.mock('../../../utils/customCodeUtils', () => ({
+  tryGetLogicAppCustomCodeFunctionsProjects: mockTryGetLogicAppCustomCodeFunctionsProjects,
+  getAllCustomCodeFunctionsProjects: vi.fn().mockResolvedValue([]),
+  getEligibleLogicAppFoldersForCustomCode: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../shared/workspaceWebviewCommandHandler', () => ({
+  createWorkspaceWebviewCommandHandler: mockCreateWorkspaceWebviewCommandHandler,
+}));
+
+vi.mock('../../createNewCodeProject/CodeProjectBase/CreateLogicAppProjects', () => ({
+  createLogicAppProject: vi.fn(),
+}));
+
+vi.mock('../../../../localize', () => ({
+  localize: (_key: string, msg: string, ...args: any[]) => {
+    let result = msg;
+    args.forEach((a, i) => {
+      result = result.replace(`{${i}}`, String(a));
+    });
+    return result;
+  },
+}));
+
+vi.mock('../../../../extensionVariables', () => ({
+  ext: {
+    outputChannel: { appendLog: vi.fn() },
+    webViewKey: { createLogicApp: 'createLogicApp' },
+    extensionVersion: '1.0.0',
+    context: { extensionPath: '/mock' },
+  },
+}));
+
+vi.mock('../../../../constants', () => ({
+  extensionContext: {
+    customCodeFunctionsFolders: 'azureLogicAppsStandard.customCode.functionsFolders',
+    eligibleLogicAppFolders: 'azureLogicAppsStandard.customCode.eligibleLogicAppFolders',
+  },
+}));
+
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+  callWithTelemetryAndErrorHandling: mockCallWithTelemetryAndErrorHandling,
+  AzureWizardPromptStep: vi.fn(),
+  AzureWizardExecuteStep: vi.fn(),
+  AzureWizard: class {
+    async prompt() {}
+    async execute() {}
+  },
+  registerCommand: vi.fn(),
+  registerCommandWithTreeNodeUnwrapping: vi.fn(),
+  registerErrorHandler: vi.fn(),
+  registerReportIssueCommand: vi.fn(),
+  unwrapTreeNodeCommandCallback: vi.fn(),
+  parseError: vi.fn(() => ({ message: 'mock error' })),
+  UserCancelledError: class extends Error {},
+  nonNullProp: vi.fn(),
+  nonNullValue: vi.fn(),
+  nonNullOrEmptyValue: vi.fn((v: any) => v),
+  DialogResponses: vi.fn(),
+  AzExtTreeItem: class {},
+  AzExtParentTreeItem: class {},
+  openUrl: vi.fn(),
+}));
+
+import { addCustomCode } from '../addCustomCode';
+
+describe('addCustomCode', () => {
+  const createContext = (): IActionContext =>
+    ({
+      telemetry: { properties: {}, measurements: {} },
+      errorHandling: {},
+      ui: {},
+      valuesToMask: [],
+    }) as unknown as IActionContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLogicAppProject.mockResolvedValue(false);
+    mockHasCodefulSdkReference.mockResolvedValue(false);
+    mockTryGetLogicAppCustomCodeFunctionsProjects.mockResolvedValue(undefined);
+  });
+
+  it('should show error when no URI is provided', async () => {
+    await addCustomCode(createContext(), undefined);
+    expect(mockShowErrorMessage).toHaveBeenCalledWith(expect.stringContaining('Explorer context menu'));
+    expect(mockCreateWorkspaceWebviewCommandHandler).not.toHaveBeenCalled();
+  });
+
+  it('should show error when folder is not a Logic App project', async () => {
+    mockIsLogicAppProject.mockResolvedValue(false);
+    const uri = vscode.Uri.file('/workspace/notALogicApp');
+    await addCustomCode(createContext(), uri);
+    expect(mockShowErrorMessage).toHaveBeenCalledWith(expect.stringContaining('not a Logic App project'));
+    expect(mockCreateWorkspaceWebviewCommandHandler).not.toHaveBeenCalled();
+  });
+
+  it('should show error when folder is a codeful project', async () => {
+    mockIsLogicAppProject.mockResolvedValue(true);
+    mockHasCodefulSdkReference.mockResolvedValue(true);
+    const uri = vscode.Uri.file('/workspace/codefulApp');
+    await addCustomCode(createContext(), uri);
+    expect(mockShowErrorMessage).toHaveBeenCalledWith(expect.stringContaining('.NET SDK project'));
+    expect(mockCreateWorkspaceWebviewCommandHandler).not.toHaveBeenCalled();
+  });
+
+  it('should show error when custom code already exists', async () => {
+    mockIsLogicAppProject.mockResolvedValue(true);
+    mockHasCodefulSdkReference.mockResolvedValue(false);
+    mockTryGetLogicAppCustomCodeFunctionsProjects.mockResolvedValue(['/workspace/MyFunctions']);
+    const uri = vscode.Uri.file('/workspace/myLogicApp');
+    await addCustomCode(createContext(), uri);
+    expect(mockShowErrorMessage).toHaveBeenCalledWith(expect.stringContaining('already has an associated custom code project'));
+    expect(mockCreateWorkspaceWebviewCommandHandler).not.toHaveBeenCalled();
+  });
+
+  it('should show error when no workspace file is open', async () => {
+    mockIsLogicAppProject.mockResolvedValue(true);
+    mockHasCodefulSdkReference.mockResolvedValue(false);
+    mockTryGetLogicAppCustomCodeFunctionsProjects.mockResolvedValue([]);
+    (vscode.workspace as any).workspaceFile = undefined;
+    const uri = vscode.Uri.file('/workspace/myLogicApp');
+    await addCustomCode(createContext(), uri);
+    expect(mockShowErrorMessage).toHaveBeenCalledWith(expect.stringContaining('.code-workspace'));
+    expect(mockCreateWorkspaceWebviewCommandHandler).not.toHaveBeenCalled();
+  });
+
+  it('should open wizard with pre-configured custom code data when all validations pass', async () => {
+    mockIsLogicAppProject.mockResolvedValue(true);
+    mockHasCodefulSdkReference.mockResolvedValue(false);
+    mockTryGetLogicAppCustomCodeFunctionsProjects.mockResolvedValue([]);
+    const workspaceUri = vscode.Uri.file('/workspace/myWorkspace.code-workspace');
+    (vscode.workspace as any).workspaceFile = workspaceUri;
+    (vscode.workspace.fs.readFile as any).mockResolvedValue(Buffer.from(JSON.stringify({ folders: [{ path: 'myLogicApp' }] })));
+    (vscode.workspace.fs.readDirectory as any).mockResolvedValue([['myLogicApp', vscode.FileType.Directory]]);
+
+    const uri = vscode.Uri.file('/workspace/myLogicApp');
+    await addCustomCode(createContext(), uri);
+
+    expect(mockCreateWorkspaceWebviewCommandHandler).toHaveBeenCalledTimes(1);
+    const config = mockCreateWorkspaceWebviewCommandHandler.mock.calls[0][0];
+    expect(config.extraInitializeData.isAddCustomCodeFlow).toBe(true);
+    expect(config.extraInitializeData.preselectedLogicAppName).toBe('myLogicApp');
+    expect(config.extraInitializeData.preselectedLogicAppType).toBe('customCode');
+    expect(config.extraInitializeData.logicAppsWithoutCustomCode).toEqual([expect.objectContaining({ label: 'myLogicApp' })]);
+  });
+});

--- a/apps/vs-code-designer/src/app/commands/addCustomCode/addCustomCode.ts
+++ b/apps/vs-code-designer/src/app/commands/addCustomCode/addCustomCode.ts
@@ -79,7 +79,7 @@ export async function addCustomCode(context: IActionContext, node?: vscode.Uri):
 
   context.telemetry.properties.lastStep = 'openWizard';
   await createWorkspaceWebviewCommandHandler({
-    panelName: localize('addCustomCodeProject', 'Add .NET custom code'),
+    panelName: localize('addCustomCodeProject', 'Add .NET custom code - {0}', logicAppName),
     panelGroupKey: ext.webViewKey.createLogicApp,
     projectName: ProjectName.createLogicApp,
     createCommand: ExtensionCommand.createLogicApp,

--- a/apps/vs-code-designer/src/app/commands/addCustomCode/addCustomCode.ts
+++ b/apps/vs-code-designer/src/app/commands/addCustomCode/addCustomCode.ts
@@ -7,16 +7,11 @@ import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microso
 import { ExtensionCommand, ProjectName, ProjectType } from '@microsoft/vscode-extension-logic-apps';
 import { localize } from '../../../localize';
 import { ext } from '../../../extensionVariables';
-import { extensionContext } from '../../../constants';
 import { createWorkspaceWebviewCommandHandler } from '../shared/workspaceWebviewCommandHandler';
 import { createLogicAppProject } from '../createNewCodeProject/CodeProjectBase/CreateLogicAppProjects';
 import { isLogicAppProject } from '../../utils/verifyIsProject';
 import { hasCodefulSdkReference } from '../../utils/codeful';
-import {
-  tryGetLogicAppCustomCodeFunctionsProjects,
-  getAllCustomCodeFunctionsProjects,
-  getEligibleLogicAppFoldersForCustomCode,
-} from '../../utils/customCodeUtils';
+import { tryGetLogicAppCustomCodeFunctionsProjects } from '../../utils/customCodeUtils';
 import * as vscode from 'vscode';
 import * as path from 'path';
 
@@ -27,7 +22,9 @@ import * as path from 'path';
 export async function addCustomCode(context: IActionContext, node?: vscode.Uri): Promise<void> {
   if (!node) {
     context.telemetry.properties.result = 'Failed';
-    vscode.window.showErrorMessage(localize('addCustomCodeNoUri', 'This command must be invoked from the Explorer context menu on a Logic App project folder.'));
+    vscode.window.showErrorMessage(
+      localize('addCustomCodeNoUri', 'This command must be invoked from the Explorer context menu on a Logic App project folder.')
+    );
     return;
   }
 
@@ -41,7 +38,9 @@ export async function addCustomCode(context: IActionContext, node?: vscode.Uri):
 
   if (await hasCodefulSdkReference(projectPath)) {
     context.telemetry.properties.result = 'Failed';
-    vscode.window.showErrorMessage(localize('addCustomCodeIsCodeful', 'This Logic App already uses a .NET SDK project. Custom code is not applicable.'));
+    vscode.window.showErrorMessage(
+      localize('addCustomCodeIsCodeful', 'This Logic App already uses a .NET SDK project. Custom code is not applicable.')
+    );
     return;
   }
 
@@ -61,7 +60,9 @@ export async function addCustomCode(context: IActionContext, node?: vscode.Uri):
 
   if (!vscode.workspace.workspaceFile) {
     context.telemetry.properties.result = 'Failed';
-    vscode.window.showErrorMessage(localize('addCustomCodeNoWorkspace', 'Please open a Logic App workspace (.code-workspace) before adding custom code.'));
+    vscode.window.showErrorMessage(
+      localize('addCustomCodeNoWorkspace', 'Please open a Logic App workspace (.code-workspace) before adding custom code.')
+    );
     return;
   }
 
@@ -85,19 +86,6 @@ export async function addCustomCode(context: IActionContext, node?: vscode.Uri):
     createHandler: async (data: any) => {
       await callWithTelemetryAndErrorHandling('addCustomCode.createHandler', async (actionContext: IActionContext) => {
         await createLogicAppProject(actionContext, data, workspaceRootFolder);
-      });
-      // Refresh context keys after successful creation
-      await callWithTelemetryAndErrorHandling('addCustomCode.refreshContext', async (actionContext: IActionContext) => {
-        vscode.commands.executeCommand(
-          'setContext',
-          extensionContext.customCodeFunctionsFolders,
-          await getAllCustomCodeFunctionsProjects(actionContext)
-        );
-        vscode.commands.executeCommand(
-          'setContext',
-          extensionContext.customCodeEligibleLogicAppFolders,
-          await getEligibleLogicAppFoldersForCustomCode()
-        );
       });
     },
     dialogOptions: {

--- a/apps/vs-code-designer/src/app/commands/addCustomCode/addCustomCode.ts
+++ b/apps/vs-code-designer/src/app/commands/addCustomCode/addCustomCode.ts
@@ -100,6 +100,7 @@ export async function addCustomCode(context: IActionContext, node?: vscode.Uri):
       workspaceFileJson,
       logicAppsWithoutCustomCode: [{ label: logicAppName, description: projectPath, data: projectPath }],
       existingFolders,
+      workspaceRootFolder,
       isAddCustomCodeFlow: true,
       preselectedLogicAppName: logicAppName,
       preselectedLogicAppType: ProjectType.customCode,

--- a/apps/vs-code-designer/src/app/commands/addCustomCode/addCustomCode.ts
+++ b/apps/vs-code-designer/src/app/commands/addCustomCode/addCustomCode.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { ExtensionCommand, ProjectName, ProjectType } from '@microsoft/vscode-extension-logic-apps';
+import { localize } from '../../../localize';
+import { ext } from '../../../extensionVariables';
+import { extensionContext } from '../../../constants';
+import { createWorkspaceWebviewCommandHandler } from '../shared/workspaceWebviewCommandHandler';
+import { createLogicAppProject } from '../createNewCodeProject/CodeProjectBase/CreateLogicAppProjects';
+import { isLogicAppProject } from '../../utils/verifyIsProject';
+import { hasCodefulSdkReference } from '../../utils/codeful';
+import {
+  tryGetLogicAppCustomCodeFunctionsProjects,
+  getAllCustomCodeFunctionsProjects,
+  getEligibleLogicAppFoldersForCustomCode,
+} from '../../utils/customCodeUtils';
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+/**
+ * Command handler for the "Add .NET custom code" Explorer context-menu action.
+ * Opens the Create Project wizard pre-configured for custom-code with the target Logic App locked.
+ */
+export async function addCustomCode(context: IActionContext, node?: vscode.Uri): Promise<void> {
+  if (!node) {
+    context.telemetry.properties.result = 'Failed';
+    vscode.window.showErrorMessage(localize('addCustomCodeNoUri', 'This command must be invoked from the Explorer context menu on a Logic App project folder.'));
+    return;
+  }
+
+  const projectPath = node.fsPath;
+  context.telemetry.properties.lastStep = 'validateFolder';
+  if (!(await isLogicAppProject(projectPath))) {
+    context.telemetry.properties.result = 'Failed';
+    vscode.window.showErrorMessage(localize('addCustomCodeNotLogicApp', 'The selected folder is not a Logic App project.'));
+    return;
+  }
+
+  if (await hasCodefulSdkReference(projectPath)) {
+    context.telemetry.properties.result = 'Failed';
+    vscode.window.showErrorMessage(localize('addCustomCodeIsCodeful', 'This Logic App already uses a .NET SDK project. Custom code is not applicable.'));
+    return;
+  }
+
+  context.telemetry.properties.lastStep = 'checkExistingCustomCode';
+  const existingCustomCode = await tryGetLogicAppCustomCodeFunctionsProjects(projectPath);
+  if (existingCustomCode && existingCustomCode.length > 0) {
+    context.telemetry.properties.result = 'Failed';
+    vscode.window.showErrorMessage(
+      localize(
+        'addCustomCodeAlreadyExists',
+        'This Logic App already has an associated custom code project: "{0}".',
+        path.basename(existingCustomCode[0])
+      )
+    );
+    return;
+  }
+
+  if (!vscode.workspace.workspaceFile) {
+    context.telemetry.properties.result = 'Failed';
+    vscode.window.showErrorMessage(localize('addCustomCodeNoWorkspace', 'Please open a Logic App workspace (.code-workspace) before adding custom code.'));
+    return;
+  }
+
+  const workspaceRootFolder = path.dirname(vscode.workspace.workspaceFile.fsPath);
+  const logicAppName = path.basename(projectPath);
+
+  context.telemetry.properties.lastStep = 'readWorkspace';
+  const workspaceFileContent = await vscode.workspace.fs.readFile(vscode.workspace.workspaceFile);
+  const workspaceFileJson = JSON.parse(workspaceFileContent.toString());
+
+  const existingFolders = await getExistingFoldersOnDisk(workspaceRootFolder);
+
+  ext.outputChannel.appendLog(`[addCustomCode] target=${logicAppName}, workspaceRoot=${workspaceRootFolder}`);
+
+  context.telemetry.properties.lastStep = 'openWizard';
+  await createWorkspaceWebviewCommandHandler({
+    panelName: localize('addCustomCodeProject', 'Add .NET custom code'),
+    panelGroupKey: ext.webViewKey.createLogicApp,
+    projectName: ProjectName.createLogicApp,
+    createCommand: ExtensionCommand.createLogicApp,
+    createHandler: async (data: any) => {
+      await callWithTelemetryAndErrorHandling('addCustomCode.createHandler', async (actionContext: IActionContext) => {
+        await createLogicAppProject(actionContext, data, workspaceRootFolder);
+      });
+      // Refresh context keys after successful creation
+      await callWithTelemetryAndErrorHandling('addCustomCode.refreshContext', async (actionContext: IActionContext) => {
+        vscode.commands.executeCommand(
+          'setContext',
+          extensionContext.customCodeFunctionsFolders,
+          await getAllCustomCodeFunctionsProjects(actionContext)
+        );
+        vscode.commands.executeCommand(
+          'setContext',
+          extensionContext.customCodeEligibleLogicAppFolders,
+          await getEligibleLogicAppFoldersForCustomCode()
+        );
+      });
+    },
+    dialogOptions: {
+      workspace: {
+        canSelectMany: false,
+        openLabel: localize('selectWorkspaceParentFolder', 'Select workspace parent folder'),
+        canSelectFiles: false,
+        canSelectFolders: true,
+      },
+    },
+    extraInitializeData: {
+      workspaceFileJson,
+      logicAppsWithoutCustomCode: [{ label: logicAppName, description: projectPath, data: projectPath }],
+      existingFolders,
+      isAddCustomCodeFlow: true,
+      preselectedLogicAppName: logicAppName,
+      preselectedLogicAppType: ProjectType.customCode,
+    },
+  });
+}
+
+/**
+ * Enumerates all directory names in the workspace root folder.
+ */
+async function getExistingFoldersOnDisk(workspaceRootFolder: string): Promise<string[]> {
+  try {
+    const rootUri = vscode.Uri.file(workspaceRootFolder);
+    const entries = await vscode.workspace.fs.readDirectory(rootUri);
+    return entries.filter(([, type]) => type === vscode.FileType.Directory).map(([name]) => name);
+  } catch {
+    return [];
+  }
+}

--- a/apps/vs-code-designer/src/app/commands/createProject/createProject.ts
+++ b/apps/vs-code-designer/src/app/commands/createProject/createProject.ts
@@ -12,9 +12,9 @@ import { createWorkspaceWebviewCommandHandler } from '../shared/workspaceWebview
 import * as vscode from 'vscode';
 import path from 'path';
 import { createLogicAppProject } from '../createNewCodeProject/CodeProjectBase/CreateLogicAppProjects';
-import { getLogicAppWithoutCustomCode } from '../../utils/workspace';
+import { getEligibleLogicAppFoldersForCustomCode } from '../../utils/customCodeUtils';
 
-export async function createProject(context: IActionContext): Promise<void> {
+export async function createProject(_context: IActionContext): Promise<void> {
   // Determine if in workspace, if not in workspace but there is a logic app project found,
   // prompt to see if they want to move the project over to a logic app workspace
   let workspaceRootFolder = '';
@@ -35,7 +35,12 @@ export async function createProject(context: IActionContext): Promise<void> {
   // Get workspace data for the webview
   const workspaceFileContent = await vscode.workspace.fs.readFile(vscode.workspace.workspaceFile);
   const workspaceFileJson = JSON.parse(workspaceFileContent.toString());
-  const logicAppsWithoutCustomCode = await getLogicAppWithoutCustomCode(context);
+  const customCodeEligibleProjectPaths = await getEligibleLogicAppFoldersForCustomCode();
+  const logicAppsWithoutCustomCode = customCodeEligibleProjectPaths.map((projectPath) => ({
+    label: path.basename(projectPath),
+    description: projectPath,
+    data: projectPath,
+  }));
 
   // Enumerate all existing directories on disk (includes C# project folders, etc.)
   const existingFolders = await getExistingFoldersOnDisk(workspaceRootFolder);

--- a/apps/vs-code-designer/src/app/commands/createProject/createProject.ts
+++ b/apps/vs-code-designer/src/app/commands/createProject/createProject.ts
@@ -68,6 +68,7 @@ export async function createProject(_context: IActionContext): Promise<void> {
       workspaceFileJson,
       logicAppsWithoutCustomCode,
       existingFolders,
+      workspaceRootFolder,
     },
   });
 }

--- a/apps/vs-code-designer/src/app/commands/registerCommands.ts
+++ b/apps/vs-code-designer/src/app/commands/registerCommands.ts
@@ -39,7 +39,7 @@ import { startStreamingLogs } from './logstream/startStreamingLogs';
 import { stopStreamingLogs } from './logstream/stopStreamingLogs';
 import { openFile } from './openFile';
 import { openInPortal } from './openInPortal';
-import { parameterizeAllConnections, parameterizeProjectConnections } from './parameterizeConnections';
+import { parameterizeProjectConnections } from './parameterizeConnections';
 import { pickFuncProcess } from './pickFuncProcess';
 import { startRemoteDebug } from './remoteDebug/startRemoteDebug';
 import { restartLogicApp } from './restartLogicApp';
@@ -82,6 +82,7 @@ import { enableDevContainer } from './enableDevContainer/enableDevContainer';
 import { toggleDesignTimeNodeWorker } from './toggleDesignTimeNodeWorker';
 import { enableLocalManagedIdentityAuth } from '../utils/managedIdentity';
 import { runProjectConsistencyCheck } from './runProjectConsistencyCheck';
+import { addCustomCode } from './addCustomCode/addCustomCode';
 
 export function registerCommands(): void {
   registerCommandWithTreeNodeUnwrapping(extensionCommand.openDesigner, openDesigner);
@@ -172,6 +173,7 @@ export function registerCommands(): void {
   // Custom code
   registerCommandWithTreeNodeUnwrapping(extensionCommand.buildCustomCodeFunctionsProject, tryBuildCustomCodeFunctionsProject);
   registerCommand(extensionCommand.createCustomCodeFunction, createCustomCodeFunction);
+  registerCommand(extensionCommand.addCustomCode, addCustomCode);
   registerCommand(extensionCommand.debugLogicApp, debugLogicApp);
   registerCommand(extensionCommand.switchToDataMapperV2, switchToDataMapperV2);
   registerCommand(extensionCommand.enableDevContainer, enableDevContainer);

--- a/apps/vs-code-designer/src/app/utils/__test__/customCodeUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/customCodeUtils.test.ts
@@ -1,12 +1,10 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as verifyProjectUtils from '../verifyIsProject';
-import * as workspaceUtils from '../workspace';
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
 import {
   CustomCodeFunctionsProjectMetadata,
   getCustomCodeFunctionsProjectMetadata,
-  getAllCustomCodeFunctionsProjects,
   getEligibleLogicAppFoldersForCustomCode,
   isCustomCodeFunctionsProject,
   isCustomCodeFunctionsProjectInRoot,
@@ -26,10 +24,6 @@ vi.mock('fs-extra', () => ({
 
 vi.mock('verifyProjectUtils', () => ({
   isLogicAppProject: vi.fn(),
-}));
-
-vi.mock('workspaceUtils', () => ({
-  getWorkspaceRoot: vi.fn(),
 }));
 
 vi.mock('../../../extensionVariables', () => ({
@@ -66,73 +60,6 @@ describe('customCodeUtils', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-  });
-
-  describe('getAllCustomCodeFunctionsProjects', () => {
-    const testContext: any = {};
-    const testWorkspaceRoot = path.join('test', 'workspace');
-
-    beforeEach(() => {
-      vi.restoreAllMocks();
-      vi.spyOn(workspaceUtils, 'getWorkspaceRoot').mockResolvedValue(testWorkspaceRoot);
-    });
-
-    it('should return an empty array if workspace root is undefined', async () => {
-      vi.spyOn(workspaceUtils, 'getWorkspaceRoot').mockResolvedValue(undefined);
-      const result = await getAllCustomCodeFunctionsProjects(testContext);
-      expect(result).toEqual([]);
-    });
-
-    it('should return custom code project paths for valid projects', async () => {
-      const subpaths = ['proj1', 'proj2', 'nonProject'];
-      const proj1Path = path.join(testWorkspaceRoot, 'proj1');
-      const proj2Path = path.join(testWorkspaceRoot, 'proj2');
-      const nonProjectPath = path.join(testWorkspaceRoot, 'nonProject');
-      const proj1Csproj = 'proj1.csproj';
-      const proj2Csproj = 'proj2.csproj';
-      const nonProjectFile = 'nonProject.txt';
-
-      vi.spyOn(fse, 'statSync').mockReturnValue({ isDirectory: () => true } as any);
-      vi.spyOn(fse, 'readdir').mockImplementation(async (p: string) => {
-        if (p === testWorkspaceRoot) return subpaths;
-        if (p === proj1Path) return [proj1Csproj];
-        if (p === proj2Path) return [proj2Csproj];
-        if (p === nonProjectPath) return [nonProjectFile];
-        return [];
-      });
-      vi.spyOn(fse, 'readFile').mockImplementation(async (p: string) => {
-        if (p === path.join(proj1Path, proj1Csproj)) return validNet8CsprojContent;
-        if (p === path.join(proj2Path, proj2Csproj)) return validNetFxCsprojContent;
-        return '';
-      });
-
-      const result = await getAllCustomCodeFunctionsProjects(testContext);
-      expect(result).toEqual([path.join(testWorkspaceRoot, 'proj1'), path.join(testWorkspaceRoot, 'proj2')]);
-    });
-
-    it('should return an empty array if no valid projects are found', async () => {
-      const subpaths = ['nonProject1', 'nonProject2'];
-      const nonProject1Path = path.join(testWorkspaceRoot, 'nonProject1');
-      const nonProject2Path = path.join(testWorkspaceRoot, 'nonProject2');
-      const nonProject1File = 'nonProject1.txt';
-      const nonProject2File = 'nonProject2.csproj';
-
-      vi.spyOn(fse, 'statSync').mockReturnValue({ isDirectory: () => true } as any);
-      vi.spyOn(fse, 'readdir').mockImplementation(async (p: string) => {
-        if (p === testWorkspaceRoot) return subpaths;
-        if (p === nonProject1Path) return [nonProject1File];
-        if (p === nonProject2Path) return [nonProject2File];
-        return [];
-      });
-      vi.spyOn(fse, 'readFile').mockImplementation(async (p: string) => {
-        if (p === path.join(nonProject1Path, nonProject1File)) return 'invalid content';
-        if (p === path.join(nonProject2Path, nonProject2File)) return '<Project></Project>';
-        return '';
-      });
-
-      const result = await getAllCustomCodeFunctionsProjects(testContext);
-      expect(result).toEqual([]);
-    });
   });
 
   describe('isCustomCodeFunctionsProject', () => {

--- a/apps/vs-code-designer/src/app/utils/__test__/customCodeUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/customCodeUtils.test.ts
@@ -1,7 +1,9 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as verifyProjectUtils from '../verifyIsProject';
-import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { hasCodefulSdkReference } from '../codeful';
+import { getWorkspaceLogicAppRoots } from '../workspace';
+import { describe, it, expect, vi, beforeEach, beforeAll, type Mock } from 'vitest';
 import {
   CustomCodeFunctionsProjectMetadata,
   getCustomCodeFunctionsProjectMetadata,
@@ -32,6 +34,14 @@ vi.mock('../../../extensionVariables', () => ({
       appendLog: vi.fn(),
     },
   },
+}));
+
+vi.mock('../codeful', () => ({
+  hasCodefulSdkReference: vi.fn(),
+}));
+
+vi.mock('../workspace', () => ({
+  getWorkspaceLogicAppRoots: vi.fn(),
 }));
 
 describe('customCodeUtils', () => {
@@ -392,6 +402,89 @@ describe('customCodeUtils', () => {
 
       const result = await tryGetLogicAppCustomCodeFunctionsProjects(testLogicAppFolder);
       expect(result).toEqual([path.join(testBaseFolder, testPeerProject)]);
+    });
+  });
+
+  describe('getEligibleLogicAppFoldersForCustomCode', () => {
+    const codelessApp = path.join(path.sep, 'workspace', 'CodelessApp');
+    const codefulApp = path.join(path.sep, 'workspace', 'CodefulApp');
+    const appWithCustomCode = path.join(path.sep, 'workspace', 'AppWithCustomCode');
+
+    beforeEach(() => {
+      (getWorkspaceLogicAppRoots as Mock).mockResolvedValue([]);
+      (hasCodefulSdkReference as Mock).mockResolvedValue(false);
+    });
+
+    it('should include codeless Logic App projects without existing custom code', async () => {
+      (getWorkspaceLogicAppRoots as Mock).mockResolvedValue([codelessApp]);
+      (hasCodefulSdkReference as Mock).mockResolvedValue(false);
+      vi.spyOn(fse, 'pathExists').mockResolvedValue(true);
+      vi.spyOn(verifyProjectUtils, 'isLogicAppProject').mockResolvedValue(true);
+      vi.spyOn(fse, 'readdir').mockResolvedValue([]);
+
+      const result = await getEligibleLogicAppFoldersForCustomCode();
+      expect(result).toEqual([codelessApp]);
+    });
+
+    it('should exclude codeful projects', async () => {
+      (getWorkspaceLogicAppRoots as Mock).mockResolvedValue([codefulApp]);
+      (hasCodefulSdkReference as Mock).mockImplementation(async (p: string) => p === codefulApp);
+
+      const result = await getEligibleLogicAppFoldersForCustomCode();
+      expect(result).toEqual([]);
+    });
+
+    it('should exclude projects that already have an associated custom code project', async () => {
+      const logicAppName = 'AppWithCustomCode';
+      // Build csproj content that references the Logic App by name
+      const csprojWithReference = validNet8CsprojContent.replace(
+        /<LogicAppFolderToPublish>[^<]*<\/LogicAppFolderToPublish>/,
+        `<LogicAppFolderToPublish>$(MSBuildProjectDirectory)\\..\\${logicAppName}</LogicAppFolderToPublish>`
+      );
+      const parentDir = path.dirname(appWithCustomCode);
+      const functionsPath = path.join(parentDir, 'ExistingFunctions');
+
+      (getWorkspaceLogicAppRoots as Mock).mockResolvedValue([appWithCustomCode]);
+      (hasCodefulSdkReference as Mock).mockResolvedValue(false);
+      vi.spyOn(fse, 'pathExists').mockResolvedValue(true);
+      vi.spyOn(verifyProjectUtils, 'isLogicAppProject').mockResolvedValue(true);
+      vi.spyOn(fse, 'readdir').mockImplementation(async (p: string) => {
+        if (p === parentDir) {
+          return [logicAppName, 'ExistingFunctions'];
+        }
+        if (p === functionsPath) {
+          return ['Functions.csproj'];
+        }
+        return [];
+      });
+      vi.spyOn(fse, 'statSync').mockReturnValue({ isDirectory: () => true } as any);
+      vi.spyOn(fse, 'readFile').mockImplementation(async (p: string) => {
+        if (String(p).endsWith('.csproj')) {
+          return csprojWithReference;
+        }
+        return '';
+      });
+
+      const result = await getEligibleLogicAppFoldersForCustomCode();
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when no workspace projects exist', async () => {
+      (getWorkspaceLogicAppRoots as Mock).mockResolvedValue([]);
+
+      const result = await getEligibleLogicAppFoldersForCustomCode();
+      expect(result).toEqual([]);
+    });
+
+    it('should filter correctly with a mix of eligible and ineligible projects', async () => {
+      (getWorkspaceLogicAppRoots as Mock).mockResolvedValue([codelessApp, codefulApp]);
+      (hasCodefulSdkReference as Mock).mockImplementation(async (p: string) => p === codefulApp);
+      vi.spyOn(fse, 'pathExists').mockResolvedValue(true);
+      vi.spyOn(verifyProjectUtils, 'isLogicAppProject').mockResolvedValue(true);
+      vi.spyOn(fse, 'readdir').mockResolvedValue([]);
+
+      const result = await getEligibleLogicAppFoldersForCustomCode();
+      expect(result).toEqual([codelessApp]);
     });
   });
 });

--- a/apps/vs-code-designer/src/app/utils/__test__/customCodeUtils.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/customCodeUtils.test.ts
@@ -7,6 +7,7 @@ import {
   CustomCodeFunctionsProjectMetadata,
   getCustomCodeFunctionsProjectMetadata,
   getAllCustomCodeFunctionsProjects,
+  getEligibleLogicAppFoldersForCustomCode,
   isCustomCodeFunctionsProject,
   isCustomCodeFunctionsProjectInRoot,
   tryGetCustomCodeFunctionsProjects,

--- a/apps/vs-code-designer/src/app/utils/__test__/extension.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/extension.test.ts
@@ -1,20 +1,21 @@
 import { extensionContext, logicAppsStandardExtensionId } from '../../../constants';
 import * as vscode from 'vscode';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  getExtensionVersion,
-  initializeCustomExtensionContext,
-  updateLogicAppsContext,
-} from '../extension';
+import { getExtensionVersion, initializeCustomExtensionContext, updateLogicAppsContext } from '../extension';
 import { getWorkspaceFolderWithoutPrompting } from '../workspace';
 import { isLogicAppProjectInRoot } from '../verifyIsProject';
 
 vi.mock('../workspace', () => ({
   getWorkspaceFolderWithoutPrompting: vi.fn(),
+  getWorkspaceCustomCodeFunctionsProjectRoots: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('../verifyIsProject', () => ({
   isLogicAppProjectInRoot: vi.fn(),
+}));
+
+vi.mock('../customCodeUtils', () => ({
+  getEligibleLogicAppFoldersForCustomCode: vi.fn().mockResolvedValue([]),
 }));
 
 describe('extension utilities', () => {
@@ -44,11 +45,7 @@ describe('extension utilities', () => {
       extensionContext.dataMapSupportedDataMapDefinitionFileExts,
       expect.any(Array)
     );
-    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
-      'setContext',
-      extensionContext.dataMapSupportedFileExts,
-      expect.any(Array)
-    );
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('setContext', extensionContext.dataMapSupportedFileExts, expect.any(Array));
   });
 
   it('updates project context when a Logic Apps project is present', async () => {

--- a/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
+++ b/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
@@ -6,8 +6,7 @@ import type { WorkspaceFolder } from 'vscode';
 import { isLogicAppProject } from './verifyIsProject';
 import { hasCodefulSdkReference } from './codeful';
 import { ext } from '../../extensionVariables';
-import { getWorkspaceLogicAppRoots, getWorkspaceRoot } from './workspace';
-import type { IActionContext } from '@microsoft/vscode-azext-utils';
+import { getWorkspaceLogicAppRoots } from './workspace';
 import { TargetFramework } from '@microsoft/vscode-extension-logic-apps';
 import { customDirectory, libDirectory } from '../../constants';
 
@@ -43,27 +42,6 @@ export async function customCodeArtifactsExist(projectPath: string): Promise<boo
   return false;
 }
 
-export async function getAllCustomCodeFunctionsProjects(context: IActionContext): Promise<string[]> {
-  const workspaceRoot: string | undefined = await getWorkspaceRoot(context);
-
-  if (isNullOrUndefined(workspaceRoot)) {
-    return [];
-  }
-
-  const subpaths: string[] = await fse.readdir(workspaceRoot);
-  const customCodeProjectPaths: string[] = [];
-  await Promise.all(
-    subpaths.map(async (s) => {
-      const currPath = path.join(workspaceRoot, s);
-      if (await isCustomCodeFunctionsProject(currPath)) {
-        customCodeProjectPaths.push(currPath);
-      }
-    })
-  );
-
-  return customCodeProjectPaths;
-}
-
 /**
  * Gets the paths of codeless Logic App workspace roots that do NOT already have an associated custom-code functions project.
  */
@@ -71,7 +49,7 @@ export async function getEligibleLogicAppFoldersForCustomCode(): Promise<string[
   const projectPaths = await getWorkspaceLogicAppRoots();
 
   const eligiblePathTasks = projectPaths.map(async (projectPath) => {
-    if ((await hasCodefulSdkReference(projectPath))) {
+    if (await hasCodefulSdkReference(projectPath)) {
       return undefined;
     }
     const existingCustomCode = await tryGetLogicAppCustomCodeFunctionsProjects(projectPath);

--- a/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
+++ b/apps/vs-code-designer/src/app/utils/customCodeUtils.ts
@@ -4,8 +4,9 @@ import { parseString } from 'xml2js';
 import { isNullOrUndefined, isString } from '@microsoft/logic-apps-shared';
 import type { WorkspaceFolder } from 'vscode';
 import { isLogicAppProject } from './verifyIsProject';
+import { hasCodefulSdkReference } from './codeful';
 import { ext } from '../../extensionVariables';
-import { getWorkspaceRoot } from './workspace';
+import { getWorkspaceLogicAppRoots, getWorkspaceRoot } from './workspace';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { TargetFramework } from '@microsoft/vscode-extension-logic-apps';
 import { customDirectory, libDirectory } from '../../constants';
@@ -64,6 +65,27 @@ export async function getAllCustomCodeFunctionsProjects(context: IActionContext)
 }
 
 /**
+ * Gets the paths of codeless Logic App workspace roots that do NOT already have an associated custom-code functions project.
+ */
+export async function getEligibleLogicAppFoldersForCustomCode(): Promise<string[]> {
+  const projectPaths = await getWorkspaceLogicAppRoots();
+
+  const eligiblePathTasks = projectPaths.map(async (projectPath) => {
+    if ((await hasCodefulSdkReference(projectPath))) {
+      return undefined;
+    }
+    const existingCustomCode = await tryGetLogicAppCustomCodeFunctionsProjects(projectPath);
+    if (existingCustomCode && existingCustomCode.length > 0) {
+      return undefined;
+    }
+    return projectPath;
+  });
+  const eligibleProjectPaths = (await Promise.all(eligiblePathTasks)).filter((p?: string) => p !== undefined);
+
+  return eligibleProjectPaths;
+}
+
+/**
  * Checks if the folder is a custom code functions project.
  * @param {string} folderPath - The folder path.
  * @returns {Promise<boolean>} Returns true if the folder is a custom code functions project, otherwise false.
@@ -93,7 +115,7 @@ export async function detectCustomCodeTargetFramework(projectPath: string): Prom
     const metadata = await getCustomCodeFunctionsProjectMetadata(customCodeProjects[0]);
     return metadata?.targetFramework;
   }
-  
+
   return undefined;
 }
 

--- a/apps/vs-code-designer/src/app/utils/extension.ts
+++ b/apps/vs-code-designer/src/app/utils/extension.ts
@@ -9,8 +9,9 @@ import {
   supportedDataMapperFolders,
   supportedSchemaFileExts,
 } from '../commands/dataMapper/extensionConfig';
-import { getWorkspaceFolderWithoutPrompting } from './workspace';
+import { getWorkspaceCustomCodeFunctionsProjectRoots, getWorkspaceFolderWithoutPrompting } from './workspace';
 import { isLogicAppProjectInRoot } from './verifyIsProject';
+import { getEligibleLogicAppFoldersForCustomCode } from './customCodeUtils';
 
 /**
  * Gets extension version from the package.json version.
@@ -46,5 +47,7 @@ export async function updateLogicAppsContext() {
     const workspaceFolder = await getWorkspaceFolderWithoutPrompting();
     const logicAppOpened = await isLogicAppProjectInRoot(workspaceFolder);
     await vscode.commands.executeCommand('setContext', extensionContext.hasProject, logicAppOpened);
+    await vscode.commands.executeCommand('setContext', extensionContext.customCodeFunctionsFolders, await getWorkspaceCustomCodeFunctionsProjectRoots());
+    await vscode.commands.executeCommand('setContext', extensionContext.customCodeEligibleLogicAppFolders, await getEligibleLogicAppFoldersForCustomCode());
   }
 }

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -6,12 +6,7 @@ import { workflowFileName } from '../../constants';
 import { localize } from '../../localize';
 import type { RemoteWorkflowTreeItem } from '../tree/remoteWorkflowsTree/RemoteWorkflowTreeItem';
 import { isPathEqual, isSubpath } from './fs';
-import {
-  isLogicAppProject,
-  promptOpenProjectOrWorkspace,
-  tryGetLogicAppProjectRoot,
-  getFirstLogicAppProjectRoot,
-} from './verifyIsProject';
+import { isLogicAppProject, promptOpenProjectOrWorkspace, tryGetLogicAppProjectRoot, getFirstLogicAppProjectRoot } from './verifyIsProject';
 import { isNullOrUndefined, isString } from '@microsoft/logic-apps-shared';
 import { UserCancelledError, nonNullValue } from '@microsoft/vscode-azext-utils';
 import type { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
@@ -21,7 +16,6 @@ import * as vscode from 'vscode';
 import { FileManagement } from '../commands/generateDeploymentScripts/iacGestureHelperFunctions';
 import { ext } from '../../extensionVariables';
 import * as fse from 'fs-extra';
-import { tryGetLogicAppCustomCodeFunctionsProjects } from './customCodeUtils';
 
 /**
  * Checks if the current workspace has a Logic App project.
@@ -300,133 +294,6 @@ async function getLogicAppWorkspaceFolder(
   }
 
   return selectedFolder;
-}
-
-/**
- * Gets user selection of either an existing logic app that isn't associated with a custom code project or new (undefined) logic app project.
- * @param {IActionContext} context - Command context.
- * @param {string} message - The message to display to the user if workspace is not open.
- * @returns {Promise<WorkspaceFolder | string | undefined>} Returns either the selected logic app or undefined for a new logic app.
- */
-export async function promptForLogicAppWithoutCustomCode(
-  context: IActionContext,
-  message?: string
-): Promise<vscode.WorkspaceFolder | string | undefined> {
-  const promptMessage: string = message ?? localize('noWorkspaceWarning', 'You must have a workspace open to perform this action.');
-
-  if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-    await promptOpenProjectOrWorkspace(context, promptMessage);
-  }
-
-  if (vscode.workspace.workspaceFolders.length === 1) {
-    const workspaceFolder = vscode.workspace.workspaceFolders[0];
-    const workspaceFolderPath = workspaceFolder.uri.fsPath;
-    if (!(await isLogicAppProject(workspaceFolderPath))) {
-      const folderContents = await fse.readdir(workspaceFolderPath, { withFileTypes: true });
-      const subFolders = folderContents
-        .filter((dirent) => dirent.isDirectory())
-        .map((dirent) => path.join(workspaceFolderPath, dirent.name));
-      return await selectLogicAppWorkspaceFolderWithoutCustomCode(context, false, subFolders);
-    }
-  }
-
-  return await selectLogicAppWorkspaceFolderWithoutCustomCode(context, true, null);
-}
-
-async function selectLogicAppWorkspaceFolderWithoutCustomCode(
-  context: IActionContext,
-  returnsWorkspaceFolder: boolean,
-  subFolders: string[]
-): Promise<vscode.WorkspaceFolder | string> {
-  const logicAppsWorkspaces = [];
-  for (const folder of returnsWorkspaceFolder ? vscode.workspace.workspaceFolders : subFolders) {
-    const projectRoot = await tryGetLogicAppProjectRoot(context, folder, true);
-    if (projectRoot) {
-      logicAppsWorkspaces.push(projectRoot);
-    }
-  }
-
-  const placeHolder: string = localize('selectProjectFolder', 'Select the folder containing your logic app project');
-  const folderPicksPromises = logicAppsWorkspaces.map(async (projectRoot) => {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.find((folder) => folder.uri.fsPath === projectRoot);
-    const logicAppCustomCodeFunctionsProjects = await tryGetLogicAppCustomCodeFunctionsProjects(projectRoot);
-    if (!logicAppCustomCodeFunctionsProjects || logicAppCustomCodeFunctionsProjects.length === 0) {
-      return {
-        label: path.basename(projectRoot),
-        description: projectRoot,
-        data: returnsWorkspaceFolder ? workspaceFolder : projectRoot,
-      };
-    }
-    return undefined;
-  });
-
-  const folderPicks = (await Promise.all(folderPicksPromises)).filter((item) => item !== undefined);
-
-  folderPicks.push({
-    label: localize('newLogicAppProject', 'Create a new Logic App project...'),
-    description: '',
-    data: undefined,
-  });
-
-  const selectedItem = await context.ui.showQuickPick(folderPicks, { placeHolder });
-  return selectedItem?.data;
-}
-
-interface FolderPicks {
-  label: any;
-  description: any;
-  data: any;
-}
-
-/**
- * Gets user selection of either an existing logic app that isn't associated with a custom code project or new (undefined) logic app project.
- * @param {IActionContext} context - Command context.
- * @returns {Promise<WorkspaceFolder | string | undefined>} Returns either the selected logic app or undefined for a new logic app.
- */
-export async function getLogicAppWithoutCustomCode(context: IActionContext): Promise<FolderPicks[] | undefined> {
-  if (vscode.workspace.workspaceFolders.length === 1) {
-    const workspaceFolder = vscode.workspace.workspaceFolders[0];
-    const workspaceFolderPath = workspaceFolder.uri.fsPath;
-    if (!(await isLogicAppProject(workspaceFolderPath))) {
-      const folderContents = await fse.readdir(workspaceFolderPath, { withFileTypes: true });
-      const subFolders = folderContents
-        .filter((dirent) => dirent.isDirectory())
-        .map((dirent) => path.join(workspaceFolderPath, dirent.name));
-      return await getLogicAppWorkspaceFolderWithoutCustomCode(context, false, subFolders);
-    }
-  }
-
-  return await getLogicAppWorkspaceFolderWithoutCustomCode(context, true, null);
-}
-
-export async function getLogicAppWorkspaceFolderWithoutCustomCode(
-  context: IActionContext,
-  returnsWorkspaceFolder: boolean,
-  subFolders: string[]
-): Promise<FolderPicks[]> {
-  const logicAppsWorkspaces = [];
-  for (const folder of returnsWorkspaceFolder ? vscode.workspace.workspaceFolders : subFolders) {
-    const projectRoot = await tryGetLogicAppProjectRoot(context, folder, true);
-    if (projectRoot) {
-      logicAppsWorkspaces.push(projectRoot);
-    }
-  }
-
-  const folderPicksPromises = logicAppsWorkspaces.map(async (projectRoot) => {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.find((folder) => folder.uri.fsPath === projectRoot);
-    const logicAppCustomCodeFunctionsProjects = await tryGetLogicAppCustomCodeFunctionsProjects(projectRoot);
-    if (!logicAppCustomCodeFunctionsProjects || logicAppCustomCodeFunctionsProjects.length === 0) {
-      return {
-        label: path.basename(projectRoot),
-        description: projectRoot,
-        data: returnsWorkspaceFolder ? workspaceFolder : projectRoot,
-      };
-    }
-    return undefined;
-  });
-
-  const folderPicks = (await Promise.all(folderPicksPromises)).filter((item) => item !== undefined);
-  return folderPicks;
 }
 
 /**

--- a/apps/vs-code-designer/src/app/utils/workspace.ts
+++ b/apps/vs-code-designer/src/app/utils/workspace.ts
@@ -16,6 +16,7 @@ import * as vscode from 'vscode';
 import { FileManagement } from '../commands/generateDeploymentScripts/iacGestureHelperFunctions';
 import { ext } from '../../extensionVariables';
 import * as fse from 'fs-extra';
+import { isCustomCodeFunctionsProject } from './customCodeUtils';
 
 /**
  * Checks if the current workspace has a Logic App project.
@@ -170,6 +171,54 @@ export async function tryGetWorkspaceFolderLogicApps(workspaceFolder: vscode.Wor
 
   const logicAppProjectRoots = (await Promise.all(logicAppProjectRootTasks)).filter((p) => p !== undefined);
   return logicAppProjectRoots;
+}
+
+/**
+ * Gets all custom code functions projects in the workspace.
+ */
+export async function getWorkspaceCustomCodeFunctionsProjectRoots(): Promise<string[]> {
+  if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+    return [];
+  }
+
+  const logicAppRootTasks = vscode.workspace.workspaceFolders.map(async (folder) => {
+    const projectRoots = await tryGetWorkspaceFolderCustomCodeFunctionsProjects(folder);
+    return projectRoots ? projectRoots : [];
+  });
+
+  const logicAppRoots = (await Promise.all(logicAppRootTasks)).flat();
+  return logicAppRoots;
+}
+
+/**
+ * Gets custom code projects from given workspace folder and subFolders one level down.
+ * @param {vscode.WorkspaceFolder | string | undefined} workspaceFolder - The workspace folder to check.
+ * @returns {Promise<string[]>} A promise that resolves to an array of custom code project roots.
+ */
+async function tryGetWorkspaceFolderCustomCodeFunctionsProjects(workspaceFolder: vscode.WorkspaceFolder | string | undefined): Promise<string[] | undefined> {
+  if (isNullOrUndefined(workspaceFolder)) {
+    return [];
+  }
+
+  const folderPath = isString(workspaceFolder) ? workspaceFolder : workspaceFolder.uri.fsPath;
+  if (!(await fse.pathExists(folderPath))) {
+    return [];
+  }
+
+  if (await isCustomCodeFunctionsProject(folderPath)) {
+    return [folderPath];
+  }
+
+  const subpaths: string[] = await fse.readdir(folderPath);
+  const customCodeProjectRootTasks = subpaths.map(async (s) => {
+    const subpath = path.join(folderPath, s);
+    if (await isCustomCodeFunctionsProject(subpath)) {
+      return subpath;
+    }
+  });
+
+  const customCodeProjectRoots = (await Promise.all(customCodeProjectRootTasks)).filter((p) => p !== undefined);
+  return customCodeProjectRoots;
 }
 
 /**

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -213,6 +213,7 @@ export const extensionCommand = {
   sdkLspApplyEdits: 'azureLogicAppsStandard.sdklsp.applyEdits',
   enableDevContainer: 'azureLogicAppsStandard.enableDevContainer',
   runProjectConsistencyCheck: 'azureLogicAppsStandard.runProjectConsistencyCheck',
+  addCustomCode: 'azureLogicAppsStandard.addCustomCode',
 } as const;
 export type extensionCommand = (typeof extensionCommand)[keyof typeof extensionCommand];
 
@@ -228,6 +229,7 @@ export const extensionContext = {
   hasProject: 'azureLogicAppsStandard.hasProject',
   isCodeful: 'azureLogicAppsStandard.isCodeful',
   customCodeFunctionsFolders: 'azureLogicAppsStandard.customCode.functionsFolders',
+  customCodeEligibleLogicAppFolders: 'azureLogicAppsStandard.customCode.eligibleLogicAppFolders',
   dataMapSupportedDataMapDefinitionFileExts: 'azureLogicAppsStandard.dataMap.supportedDataMapDefinitionFileExts',
   dataMapSupportedSchemaFileExts: 'azureLogicAppsStandard.dataMap.supportedSchemaFileExts',
   dataMapSupportedFileExts: 'azureLogicAppsStandard.dataMap.supportedFileExts',

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -39,7 +39,7 @@ import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ensureWorkspace } from './app/commands/ensureWorkspace';
 import TelemetryReporter from '@vscode/extension-telemetry';
-import { getAllCustomCodeFunctionsProjects } from './app/utils/customCodeUtils';
+import { getAllCustomCodeFunctionsProjects, getEligibleLogicAppFoldersForCustomCode } from './app/utils/customCodeUtils';
 import { createVSCodeAzureSubscriptionProvider } from './app/utils/services/VSCodeAzureSubscriptionProvider';
 import { logExtensionSettings, logSubscriptions } from './app/utils/telemetry';
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
@@ -96,6 +96,11 @@ export async function activate(context: vscode.ExtensionContext) {
       'setContext',
       extensionContext.customCodeFunctionsFolders,
       await getAllCustomCodeFunctionsProjects(activateContext)
+    );
+    vscode.commands.executeCommand(
+      'setContext',
+      extensionContext.customCodeEligibleLogicAppFolders,
+      await getEligibleLogicAppFoldersForCustomCode()
     );
 
     // Workspace setup and consistency checks

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -20,7 +20,6 @@ import {
   dotNetBinaryPathSettingKey,
   extensionCommand,
   extensionEvent,
-  extensionContext,
   funcCoreToolsBinaryPathSettingKey,
   logicAppFilter,
   nodeJsBinaryPathSettingKey,
@@ -39,7 +38,6 @@ import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ensureWorkspace } from './app/commands/ensureWorkspace';
 import TelemetryReporter from '@vscode/extension-telemetry';
-import { getAllCustomCodeFunctionsProjects, getEligibleLogicAppFoldersForCustomCode } from './app/utils/customCodeUtils';
 import { createVSCodeAzureSubscriptionProvider } from './app/utils/services/VSCodeAzureSubscriptionProvider';
 import { logExtensionSettings, logSubscriptions } from './app/utils/telemetry';
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
@@ -71,11 +69,6 @@ export async function activate(context: vscode.ExtensionContext) {
   initializeCustomExtensionContext();
   await updateLogicAppsContext();
 
-  const workspaceWatcher = vscode.workspace.onDidChangeWorkspaceFolders(() => {
-    updateLogicAppsContext();
-  });
-  context.subscriptions.push(workspaceWatcher);
-
   vscode.debug.registerDebugConfigurationProvider('logicapp', logicAppDebugConfigProvider);
 
   ext.context = context;
@@ -92,16 +85,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   await callWithTelemetryAndErrorHandling(extensionCommand.activate, async (activateContext: IActionContext) => {
     activateContext.telemetry.properties.isActivationEvent = 'true';
-    vscode.commands.executeCommand(
-      'setContext',
-      extensionContext.customCodeFunctionsFolders,
-      await getAllCustomCodeFunctionsProjects(activateContext)
-    );
-    vscode.commands.executeCommand(
-      'setContext',
-      extensionContext.customCodeEligibleLogicAppFolders,
-      await getEligibleLogicAppFoldersForCustomCode()
-    );
 
     // Workspace setup and consistency checks
     runPostExtractStepsFromCache();
@@ -145,11 +128,12 @@ export async function activate(context: vscode.ExtensionContext) {
       });
     }
 
-    activateContext.telemetry.properties.lastStep = 'registerProjectConsistencyCheckEvent';
+    activateContext.telemetry.properties.lastStep = 'registerWorkspaceFolderChangeEvent';
     registerEvent(
       extensionEvent.onDidChangeWorkspaceFolders,
       vscode.workspace.onDidChangeWorkspaceFolders,
       async (actionContext: IActionContext) => {
+        await updateLogicAppsContext();
         await runProjectConsistencyCheck(actionContext);
       }
     );

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -68,6 +68,11 @@
         }
       },
       {
+        "command": "azureLogicAppsStandard.addCustomCode",
+        "title": "Add .NET custom code",
+        "category": "Azure Logic Apps"
+      },
+      {
         "command": "azureLogicAppsStandard.createWorkspace",
         "title": "Create new logic app workspace...",
         "category": "Azure Logic Apps",
@@ -703,6 +708,11 @@
           "group": "zzz_LogicApptools@1"
         },
         {
+          "command": "azureLogicAppsStandard.addCustomCode",
+          "when": "azureLogicAppsStandard.hasProject && explorerResourceIsRoot == true && resourcePath in azureLogicAppsStandard.customCode.eligibleLogicAppFolders",
+          "group": "zzz_LogicApptools@1"
+        },
+        {
           "command": "azureLogicAppsStandard.createCustomCodeFunction",
           "when": "azureLogicAppsStandard.hasProject && explorerResourceIsRoot == true && resourcePath in azureLogicAppsStandard.customCode.functionsFolders",
           "group": "navigation@1"
@@ -815,6 +825,10 @@
         },
         {
           "command": "azureLogicAppsStandard.runProjectConsistencyCheck",
+          "when": "never"
+        },
+        {
+          "command": "azureLogicAppsStandard.addCustomCode",
           "when": "never"
         },
         {

--- a/apps/vs-code-react/src/app/createWorkspace/__test__/createWorkspace.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/__test__/createWorkspace.test.tsx
@@ -79,6 +79,7 @@ const createDefaultState = (overrides: Partial<CreateWorkspaceState> = {}): Crea
     isDevContainerProject: false,
     availableProjects: [],
     isAddCustomCodeFlow: false,
+    workspaceRootFolder: '',
     ...overrides,
   };
 };

--- a/apps/vs-code-react/src/app/createWorkspace/__test__/createWorkspace.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/__test__/createWorkspace.test.tsx
@@ -78,6 +78,7 @@ const createDefaultState = (overrides: Partial<CreateWorkspaceState> = {}): Crea
     platform: null,
     isDevContainerProject: false,
     availableProjects: [],
+    isAddCustomCodeFlow: false,
     ...overrides,
   };
 };

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/dotNetFrameworkStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/dotNetFrameworkStep.test.tsx
@@ -49,6 +49,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     platform: null,
     isDevContainerProject: false,
     availableProjects: [],
+    isAddCustomCodeFlow: false,
     ...overrides,
   };
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/dotNetFrameworkStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/dotNetFrameworkStep.test.tsx
@@ -50,6 +50,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     isDevContainerProject: false,
     availableProjects: [],
     isAddCustomCodeFlow: false,
+    workspaceRootFolder: '',
     ...overrides,
   };
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/logicAppTypeStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/logicAppTypeStep.test.tsx
@@ -44,9 +44,9 @@ vi.mock('@fluentui/react-components', async () => {
   const RadioGroupContext = React.createContext<((value: string) => void) | undefined>(undefined);
 
   return {
-    Combobox: ({ children, onChange, onOptionSelect, placeholder, value }: any) => (
+    Combobox: ({ children, onChange, onOptionSelect, placeholder, value, disabled }: any) => (
       <div>
-        <input aria-label={placeholder} onChange={onChange} placeholder={placeholder} value={value} />
+        <input aria-label={placeholder} onChange={onChange} placeholder={placeholder} value={value} disabled={disabled} />
         <div>{children}</div>
         <button onClick={() => onOptionSelect?.(undefined, { optionValue: 'ExistingApp' })} type="button">
           Choose ExistingApp
@@ -60,8 +60,8 @@ vi.mock('@fluentui/react-components', async () => {
         {validationMessage ? <span role="alert">{validationMessage}</span> : null}
       </label>
     ),
-    Input: ({ onChange, placeholder, value }: any) => (
-      <input aria-label={placeholder} onChange={onChange} placeholder={placeholder} value={value} />
+    Input: ({ onChange, placeholder, value, disabled }: any) => (
+      <input aria-label={placeholder} onChange={onChange} placeholder={placeholder} value={value} disabled={disabled} />
     ),
     Option: ({ children, value }: any) => <div data-value={value}>{children}</div>,
     Radio: ({ label, value }: any) => {
@@ -112,6 +112,7 @@ function createState(overrides: Partial<CreateWorkspaceState> = {}): CreateWorks
     workspaceName: 'Workspace',
     workspaceProjectPath: { fsPath: '/tmp/projects', path: '/tmp/projects' },
     availableProjects: [],
+    isAddCustomCodeFlow: false,
     ...overrides,
   };
 }
@@ -196,5 +197,30 @@ describe('LogicAppTypeStep', () => {
     fireEvent.change(screen.getByPlaceholderText('Enter logic app name'), { target: { value: 'csharpproject' } });
 
     expect(screen.getByRole('alert')).toHaveTextContent('Project already exists');
+  });
+
+  it('disables the logic app name input when isAddCustomCodeFlow is true', () => {
+    renderLogicAppType({
+      isAddCustomCodeFlow: true,
+      logicAppType: ProjectType.customCode,
+      logicAppName: 'PreselectedApp',
+    });
+
+    const input = screen.getByPlaceholderText('Enter logic app name');
+    expect(input).toBeDisabled();
+    expect(input).toHaveValue('PreselectedApp');
+  });
+
+  it('hides radio group when isAddCustomCodeFlow is true even in createLogicApp flow', () => {
+    renderLogicAppType({
+      isAddCustomCodeFlow: true,
+      flowType: 'createLogicApp',
+      logicAppType: ProjectType.customCode,
+      logicAppName: 'PreselectedApp',
+    });
+
+    // Radio buttons should not be rendered because shouldShowLogicAppSection is false
+    expect(screen.queryByRole('button', { name: 'Standard' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Custom code' })).not.toBeInTheDocument();
   });
 });

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/logicAppTypeStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/logicAppTypeStep.test.tsx
@@ -113,6 +113,7 @@ function createState(overrides: Partial<CreateWorkspaceState> = {}): CreateWorks
     workspaceProjectPath: { fsPath: '/tmp/projects', path: '/tmp/projects' },
     availableProjects: [],
     isAddCustomCodeFlow: false,
+    workspaceRootFolder: '',
     ...overrides,
   };
 }

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/reviewCreateStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/reviewCreateStep.test.tsx
@@ -49,6 +49,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     platform: null,
     isDevContainerProject: false,
     availableProjects: [],
+    isAddCustomCodeFlow: false,
     ...overrides,
   };
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/reviewCreateStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/reviewCreateStep.test.tsx
@@ -50,6 +50,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     isDevContainerProject: false,
     availableProjects: [],
     isAddCustomCodeFlow: false,
+    workspaceRootFolder: '',
     ...overrides,
   };
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workflowTypeStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workflowTypeStep.test.tsx
@@ -95,6 +95,7 @@ function createState(overrides: Partial<CreateWorkspaceState> = {}): CreateWorks
     logicAppsWithoutCustomCode: undefined,
     availableProjects: [],
     isAddCustomCodeFlow: false,
+    workspaceRootFolder: '',
     ...overrides,
   };
 }

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workflowTypeStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workflowTypeStep.test.tsx
@@ -94,6 +94,7 @@ function createState(overrides: Partial<CreateWorkspaceState> = {}): CreateWorks
     existingFolders: [],
     logicAppsWithoutCustomCode: undefined,
     availableProjects: [],
+    isAddCustomCodeFlow: false,
     ...overrides,
   };
 }

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workspaceNameStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workspaceNameStep.test.tsx
@@ -59,6 +59,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     platform: null,
     isDevContainerProject: false,
     availableProjects: [],
+    isAddCustomCodeFlow: false,
     ...overrides,
   };
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workspaceNameStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/workspaceNameStep.test.tsx
@@ -60,6 +60,7 @@ const createTestStore = (overrides: Partial<CreateWorkspaceState> = {}) => {
     isDevContainerProject: false,
     availableProjects: [],
     isAddCustomCodeFlow: false,
+    workspaceRootFolder: '',
     ...overrides,
   };
 

--- a/apps/vs-code-react/src/app/createWorkspace/steps/logicAppTypeStep.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/logicAppTypeStep.tsx
@@ -29,9 +29,10 @@ export const LogicAppTypeStep: React.FC = () => {
     existingFolders,
     flowType,
     separator,
+    isAddCustomCodeFlow,
   } = createWorkspaceState;
 
-  const shouldShowLogicAppSection = flowType === 'createWorkspace' || flowType === 'createLogicApp';
+  const shouldShowLogicAppSection = !isAddCustomCodeFlow && (flowType === 'createWorkspace' || flowType === 'createLogicApp');
 
   // Validation state
   const [logicAppNameError, setLogicAppNameError] = useState<string | undefined>(undefined);
@@ -139,6 +140,7 @@ export const LogicAppTypeStep: React.FC = () => {
               placeholder={intlText.ENTER_LOGIC_APP_NAME}
               className={styles.inputControl}
               freeform
+              disabled={isAddCustomCodeFlow}
             >
               {logicAppsWithoutCustomCode.map((app: { label: string }) => (
                 <Option key={app.label} value={app.label}>
@@ -152,6 +154,7 @@ export const LogicAppTypeStep: React.FC = () => {
               onChange={handleLogicAppNameChange}
               placeholder={intlText.ENTER_LOGIC_APP_NAME}
               className={styles.inputControl}
+              disabled={isAddCustomCodeFlow}
             />
           )}
           {logicAppName && workspaceName && workspaceProjectPath.fsPath && (

--- a/apps/vs-code-react/src/app/createWorkspace/steps/reviewCreateStep.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/reviewCreateStep.tsx
@@ -30,6 +30,7 @@ export const ReviewCreateStep: React.FC = () => {
     flowType,
     logicAppsWithoutCustomCode,
     separator,
+    workspaceRootFolder,
   } = createWorkspaceState;
 
   const needsDotNetFrameworkStep = logicAppType === ProjectType.customCode;
@@ -51,9 +52,10 @@ export const ReviewCreateStep: React.FC = () => {
 
   const workspaceBasePath =
     workspaceProjectPath.fsPath && workspaceName ? `${workspaceProjectPath.fsPath}${separator}${workspaceName}` : '';
+  const effectiveBasePath = workspaceBasePath || workspaceRootFolder;
   const workspaceFilePath = workspaceBasePath ? `${workspaceBasePath}${separator}${workspaceName}.code-workspace` : '';
-  const logicAppLocationPath = workspaceBasePath && logicAppName ? `${workspaceBasePath}${separator}${logicAppName}` : '';
-  const functionLocationPath = workspaceBasePath && functionFolderName ? `${workspaceBasePath}${separator}${functionFolderName}` : '';
+  const logicAppLocationPath = effectiveBasePath && logicAppName ? `${effectiveBasePath}${separator}${logicAppName}` : '';
+  const functionLocationPath = effectiveBasePath && functionFolderName ? `${effectiveBasePath}${separator}${functionFolderName}` : '';
 
   const getDotNetFrameworkDisplay = (framework: string) => {
     const frameworkDisplayMap: Record<string, string> = {

--- a/apps/vs-code-react/src/state/__test__/createWorkspaceSlice.test.ts
+++ b/apps/vs-code-react/src/state/__test__/createWorkspaceSlice.test.ts
@@ -63,6 +63,36 @@ describe('createWorkspaceSlice', () => {
       expect(result.platform).toBe(Platform.windows);
       expect(result.separator).toBe('\\');
     });
+
+    it('sets isAddCustomCodeFlow, logicAppType, and logicAppName when pre-selection data is provided', () => {
+      const result = createWorkspaceReducer(
+        getState(),
+        initializeProject({
+          workspaceFileJson: {},
+          logicAppsWithoutCustomCode: [{ label: 'MyApp' }],
+          isAddCustomCodeFlow: true,
+          preselectedLogicAppName: 'MyApp',
+          preselectedLogicAppType: 'customCode',
+        })
+      );
+      expect(result.isAddCustomCodeFlow).toBe(true);
+      expect(result.logicAppType).toBe('customCode');
+      expect(result.logicAppName).toBe('MyApp');
+      expect(result.logicAppsWithoutCustomCode).toEqual([{ label: 'MyApp' }]);
+    });
+
+    it('does not set isAddCustomCodeFlow when not provided', () => {
+      const result = createWorkspaceReducer(
+        getState(),
+        initializeProject({
+          workspaceFileJson: {},
+          logicAppsWithoutCustomCode: undefined,
+        })
+      );
+      expect(result.isAddCustomCodeFlow).toBe(false);
+      expect(result.logicAppType).toBe('');
+      expect(result.logicAppName).toBe('');
+    });
   });
 
   describe('resetState', () => {

--- a/apps/vs-code-react/src/state/createWorkspaceSlice.ts
+++ b/apps/vs-code-react/src/state/createWorkspaceSlice.ts
@@ -46,6 +46,7 @@ export interface CreateWorkspaceState {
   platform: Platform | null;
   isDevContainerProject: boolean;
   availableProjects: AvailableProject[];
+  isAddCustomCodeFlow: boolean;
 }
 
 const initialState: CreateWorkspaceState = {
@@ -84,6 +85,7 @@ const initialState: CreateWorkspaceState = {
   platform: null,
   isDevContainerProject: false,
   availableProjects: [],
+  isAddCustomCodeFlow: false,
 };
 
 export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseReducers<CreateWorkspaceState>, 'createWorkspace'>({
@@ -91,7 +93,16 @@ export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseR
   initialState,
   reducers: {
     initializeProject: (state, action: PayloadAction<any>) => {
-      const { workspaceFileJson, logicAppsWithoutCustomCode, existingFolders, platform, separator } = action.payload;
+      const {
+        workspaceFileJson,
+        logicAppsWithoutCustomCode,
+        existingFolders,
+        platform,
+        separator,
+        isAddCustomCodeFlow,
+        preselectedLogicAppName,
+        preselectedLogicAppType,
+      } = action.payload;
       state.workspaceFileJson = workspaceFileJson;
       state.logicAppsWithoutCustomCode = logicAppsWithoutCustomCode;
       state.existingFolders = existingFolders || [];
@@ -104,6 +115,12 @@ export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseR
       }
       if (separator !== undefined) {
         state.separator = separator;
+      }
+      // Support "Add .NET custom code" flow with pre-selected type and name
+      if (isAddCustomCodeFlow) {
+        state.isAddCustomCodeFlow = true;
+        state.logicAppType = preselectedLogicAppType || '';
+        state.logicAppName = preselectedLogicAppName || '';
       }
     },
     initializeWorkspace: (state, action: PayloadAction<any>) => {

--- a/apps/vs-code-react/src/state/createWorkspaceSlice.ts
+++ b/apps/vs-code-react/src/state/createWorkspaceSlice.ts
@@ -47,6 +47,7 @@ export interface CreateWorkspaceState {
   isDevContainerProject: boolean;
   availableProjects: AvailableProject[];
   isAddCustomCodeFlow: boolean;
+  workspaceRootFolder: string;
 }
 
 const initialState: CreateWorkspaceState = {
@@ -86,6 +87,7 @@ const initialState: CreateWorkspaceState = {
   isDevContainerProject: false,
   availableProjects: [],
   isAddCustomCodeFlow: false,
+  workspaceRootFolder: '',
 };
 
 export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseReducers<CreateWorkspaceState>, 'createWorkspace'>({
@@ -99,6 +101,7 @@ export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseR
         existingFolders,
         platform,
         separator,
+        workspaceRootFolder,
         isAddCustomCodeFlow,
         preselectedLogicAppName,
         preselectedLogicAppType,
@@ -106,6 +109,9 @@ export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseR
       state.workspaceFileJson = workspaceFileJson;
       state.logicAppsWithoutCustomCode = logicAppsWithoutCustomCode;
       state.existingFolders = existingFolders || [];
+      if (workspaceRootFolder) {
+        state.workspaceRootFolder = workspaceRootFolder;
+      }
       // platform and separator are host-environment values sent by the extension host in the
       // initialize_frame payload. The createProject (createLogicApp) webview flow only dispatches
       // initializeProject, so they must be captured here for platform-gated options (e.g. the


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Adds new extension command 'Add custom code' used for adding custom code functions project to existing logic app that wasn't initialized with custom code. Re-uses existing project creation flow

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Adds new command 'Add custom code'
- **Developers**: Cleans up some custom code related utils
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge
