### PR TITLE
chore(vscode): backport CFS build and release updates to v5.991

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -48,6 +48,7 @@ parameters:
     default: VSCodeDeployLAUX
 
 variables:
+  - template: azdo-pipelines/azcode.variables.yml@azExtTemplates
   # Required by MicroBuild template
   - name: TeamName
     value: "Azure Logic Apps for VS Code"
@@ -63,6 +64,8 @@ extends:
       codeql:
         language: javascript # only build a codeql database for javascript, since the jsoncli pipeline handles csharp
       #   enabled: true # TODO: would like to enable only on scheduled builds but CodeQL cannot currently be disabled per https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/1es-codeql
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
       image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used
@@ -88,6 +91,8 @@ extends:
               - script: git checkout v${{ parameters.publishVersion }} # Replace with your desired version to release
                 displayName: 'Checkout to specific branch'
               - template: .azure-pipelines/templates/setup.yml@LogicAppsUX
+                parameters:
+                  feedBaseUrl: ${{ variables.feedBaseUrl }}
               - template: .azure-pipelines/templates/build.yml@LogicAppsUX
               - template: .azure-pipelines/templates/package.yml@LogicAppsUX
                 parameters:

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -21,6 +21,7 @@ resources:
       endpoint: GitHub-AzureTools # The service connection to use when accessing this repository
 
 variables:
+  - template: azdo-pipelines/azcode.variables.yml@azExtTemplates
   # Required by MicroBuild template
   - name: TeamName
     value: "Azure Tools for VS Code"
@@ -34,3 +35,4 @@ extends:
     publishVersion: ${{ parameters.publishVersion }}
     dryRun: ${{ parameters.dryRun }}
     environmentName: VSCodeDeployLAUX
+    npmFeed: ${{ variables.npmFeed }}

--- a/.azure-pipelines/templates/build.yml
+++ b/.azure-pipelines/templates/build.yml
@@ -2,4 +2,6 @@ steps:
   - script: pnpm run build:extension
     displayName: "Build with pnpm"
     workingDirectory: $(working_directory)
+    env:
+      NPM_CONFIG_USERCONFIG: $(npmrcFile)
     condition: succeeded()

--- a/.azure-pipelines/templates/package.yml
+++ b/.azure-pipelines/templates/package.yml
@@ -22,4 +22,6 @@ steps:
   - script: pnpm run vscode:designer:pack
     displayName: "Package with pnpm"
     workingDirectory: $(working_directory)
+    env:
+      NPM_CONFIG_USERCONFIG: $(npmrcFile)
     condition: succeeded()

--- a/.azure-pipelines/templates/package.yml
+++ b/.azure-pipelines/templates/package.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: publishVersion
     type: string
-    
+
 steps:
   - script: node scripts/update-versions.js ${{ parameters.publishVersion }}
     displayName: "Update Version in Package Files"
@@ -14,7 +14,7 @@ steps:
     workingDirectory: $(working_directory)
     condition: succeeded()
 
-  - script: npx replace-in-file setInGitHubBuild $(AI_KEY) apps/vs-code-designer/src/main.ts
+  - script: pnpm exec replace-in-file setInGitHubBuild $(AI_KEY) apps/vs-code-designer/src/main.ts
     displayName: "Replace Placeholder with Telemetry Key"
     workingDirectory: $(working_directory)
     condition: succeeded()
@@ -23,4 +23,3 @@ steps:
     displayName: "Package with pnpm"
     workingDirectory: $(working_directory)
     condition: succeeded()
-    

--- a/.azure-pipelines/templates/setup.yml
+++ b/.azure-pipelines/templates/setup.yml
@@ -1,3 +1,8 @@
+parameters:
+  - name: feedBaseUrl
+    type: string
+    default: ''
+
 steps:
   - task: NodeTool@0
     displayName: "Using Node.js"
@@ -5,8 +10,56 @@ steps:
       versionSpec: '24.x'
     condition: succeeded()
 
-  - script: npm install -g pnpm
-    displayName: "Install pnpm"
+  - pwsh: |
+      $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
+      if ([string]::IsNullOrWhiteSpace($feedBaseUrl)) {
+        Write-Error "feedBaseUrl is required so npm and pnpm restore through CFS."
+        exit 1
+      }
+
+      $npmrcPath = Join-Path "$(Build.SourcesDirectory)" ".npmrc"
+      $registry = "$feedBaseUrl/npm/registry/"
+      $lines = @()
+      if (Test-Path $npmrcPath) {
+        $lines = Get-Content $npmrcPath | Where-Object {
+          $_ -notmatch '^\s*registry\s*=' -and $_ -notmatch '^\s*always-auth\s*='
+        }
+      }
+
+      $lines += "registry=$registry"
+      $lines += "always-auth=true"
+      Set-Content -Path $npmrcPath -Value $lines
+      Write-Host "Configured npm/pnpm registry: $registry"
+      Write-Host "##vso[task.setvariable variable=npmrcFile]$npmrcPath"
+      Write-Host "##vso[task.setvariable variable=npmRegistry]$registry"
+    displayName: "Configure CFS npm registry"
+    workingDirectory: $(working_directory)
+    condition: succeeded()
+
+  - task: npmAuthenticate@0
+    displayName: "Authenticate CFS npm registry"
+    inputs:
+      workingFile: $(npmrcFile)
+    condition: succeeded()
+
+  - pwsh: |
+      $packageManager = (Get-Content "package.json" -Raw | ConvertFrom-Json).packageManager
+      if (-not $packageManager -or -not $packageManager.StartsWith("pnpm@")) {
+        Write-Error "package.json 'packageManager' must specify pnpm@<version>."
+        exit 1
+      }
+
+      $pnpmVersion = ($packageManager -replace '^pnpm@', '') -replace '\+.*$', ''
+      corepack disable pnpm 2>$null
+      npm install -g "pnpm@$pnpmVersion" --registry="$(npmRegistry)" --userconfig="$(npmrcFile)"
+      if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+      }
+
+      node --version
+      pnpm --version
+    displayName: "Install pinned pnpm from CFS"
+    workingDirectory: $(working_directory)
     condition: succeeded()
 
   - script: pnpm install --frozen-lockfile --strict-peer-dependencies --recursive

--- a/.azure-pipelines/templates/setup.yml
+++ b/.azure-pipelines/templates/setup.yml
@@ -4,10 +4,10 @@ parameters:
     default: ''
 
 steps:
-  - task: NodeTool@0
+  - task: UseNode@1
     displayName: "Using Node.js"
     inputs:
-      versionSpec: '24.x'
+      version: '24.x'
     condition: succeeded()
 
   - pwsh: |

--- a/.azure-pipelines/templates/sign.yml
+++ b/.azure-pipelines/templates/sign.yml
@@ -21,7 +21,7 @@ steps:
     name: package
     displayName: "\U0001F449 Get extension info from package.json"
 
-  - script: cd apps/vs-code-designer/dist && npx @vscode/vsce generate-manifest -i vscode-azurelogicapps-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
+  - script: pnpm --dir apps/vs-code-designer exec vsce generate-manifest -i dist/vscode-azurelogicapps-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
     condition: eq(variables['signprojExists'], True)
     displayName: "\U0001F449 Generate extension manifest"
 
@@ -45,4 +45,3 @@ steps:
       exit 0
     displayName: "\U0001F449 Verify extension.signature.p7s file was created"
     condition: eq(variables['signprojExists'], True)
-    

--- a/apps/vs-code-designer/package.json
+++ b/apps/vs-code-designer/package.json
@@ -60,11 +60,11 @@
   },
   "private": true,
   "scripts": {
-    "build:extension": "tsup && pnpm run copyFiles && cd dist && npm install --ignore-scripts",
+    "build:extension": "tsup && pnpm run copyFiles && node scripts/install-dist-dependencies.js --ignore-scripts",
     "build:ui": "tsup --config tsup.e2e.test.config.ts",
     "copyFiles": "node extension-copy-svgs.js",
     "vscode:designer:pack": "pnpm run vscode:designer:pack:step1 && pnpm run vscode:designer:pack:step2",
-    "vscode:designer:pack:step1": "cd ./dist && npm install",
+    "vscode:designer:pack:step1": "node scripts/install-dist-dependencies.js",
     "vscode:designer:pack:step2": "cd ./dist && vsce package",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "test:extension-unit": "vitest run --retry=3",

--- a/apps/vs-code-designer/scripts/install-dist-dependencies.js
+++ b/apps/vs-code-designer/scripts/install-dist-dependencies.js
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+const { spawnSync } = require('child_process');
+const { existsSync } = require('fs');
+const { join } = require('path');
+
+const distPath = join(__dirname, '..', 'dist');
+if (!existsSync(distPath)) {
+  console.error(`Extension dist folder does not exist: ${distPath}`);
+  process.exit(1);
+}
+
+const args = ['install', ...process.argv.slice(2)];
+const npmUserConfig = process.env.NPM_CONFIG_USERCONFIG?.trim();
+if (npmUserConfig) {
+  if (!existsSync(npmUserConfig)) {
+    console.error('NPM_CONFIG_USERCONFIG is set, but the configured npm userconfig file does not exist.');
+    process.exit(1);
+  }
+
+  console.log('Using npm userconfig from NPM_CONFIG_USERCONFIG.');
+  args.push('--userconfig', npmUserConfig);
+}
+
+const npmCliPath = join(process.execPath, '..', 'node_modules', 'npm', 'bin', 'npm-cli.js');
+const command = existsSync(npmCliPath) ? process.execPath : process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const commandArgs = existsSync(npmCliPath) ? [npmCliPath, ...args] : args;
+
+const result = spawnSync(command, commandArgs, {
+  cwd: distPath,
+  stdio: 'inherit',
+  shell: false,
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,7 @@
     },
     "vscode-designer#build:extension": {
       "cache": false,
+      "env": ["NPM_CONFIG_USERCONFIG"],
       "dependsOn": ["build"]
     },
     "vscode-react#build:extension": {
@@ -48,6 +49,7 @@
     },
     "vscode:designer:pack": {
       "cache": false,
+      "env": ["NPM_CONFIG_USERCONFIG"],
       "dependsOn": ["vscode-react#build:extension"]
     },
     "vscode:designer:e2e:ui": {


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Backports the four already-reviewed CFS build and release pipeline changes from #9520, #9521, #9522, and #9523 onto `hotfix/v5.991`, preserving their order and patch content. Together they route package restore through the authenticated CFS-backed Azure Artifacts feed, propagate the npm user configuration through the VS Code extension build and Turbo tasks, and update release packaging to use the supported 1ES tooling path.

The source commits were cherry-picked in this order:
1. #9520 `b3633b7bb38c64f2bbac14389340adc80146ff80` → `4ea7112ac8ba39c1a4d87696b61ec48c0ff2d3c5`
2. #9521 `4b3b6067c195316ade0f2533369c33e6f8239717` → `e23d5dc3f4e7b067116f3ec2e126cdf2f0a78617`
3. #9522 `e9d56c1f51e145580f0309db7c656c718ec1dadb` → `bbf7acd4e1f3fcad18cbc5fa8f2d5ac88b55c07e`
4. #9523 `7659a9ddff2a1a648e8dbedf285029a03ed27c5e` → `bca419970f69d20e71bce7d2d90de1ff3e00d11b`

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No product UI or runtime behavior changes; this only affects producing the v5.991 hotfix build.
- **Developers**: VS Code extension build and packaging steps now receive the authenticated npm user configuration, including nested installs under `dist`.
- **System**: Release and build pipelines use CFS-backed package restore and updated 1ES/Node tooling. A pipeline misconfiguration could block hotfix packaging, so the change is classified as medium risk.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Verified stable patch-id equality for every source/backport pair; ran `git diff --check`; ran `node --check` on `install-dist-dependencies.js`; parsed the changed package and Turbo JSON; parsed all six changed Azure Pipelines YAML files with `js-yaml`. No product code or test files changed, so focused static validation is the smallest relevant local check; the hotfix PR CI provides integration validation.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft and @Copilot

## Screenshots/Videos
<!-- Visual changes only -->
Not applicable; there are no visual changes.