### PR TITLE
fix(vscode): restore signing packages through CFS

### DIFF
--- a/.azure-pipelines/templates/setup.yml
+++ b/.azure-pipelines/templates/setup.yml
@@ -13,7 +13,7 @@ steps:
   - pwsh: |
       $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
       if ([string]::IsNullOrWhiteSpace($feedBaseUrl)) {
-        Write-Error "feedBaseUrl is required so npm and pnpm restore through CFS."
+        Write-Error "feedBaseUrl is required so package restores use CFS."
         exit 1
       }
 
@@ -32,7 +32,21 @@ steps:
       Write-Host "Configured npm/pnpm registry: $registry"
       Write-Host "##vso[task.setvariable variable=npmrcFile]$npmrcPath"
       Write-Host "##vso[task.setvariable variable=npmRegistry]$registry"
-    displayName: "Configure CFS npm registry"
+
+      $nugetConfigPath = Join-Path "$(Build.SourcesDirectory)" "NuGet.config"
+      $nugetSource = "$feedBaseUrl/nuget/v3/index.json"
+      @(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<configuration>'
+        '  <packageSources>'
+        '    <clear />'
+        "    <add key=`"azcode`" value=`"$nugetSource`" />"
+        '  </packageSources>'
+        '</configuration>'
+      ) | Set-Content -Path $nugetConfigPath
+      Write-Host "Configured NuGet source: $nugetSource"
+      Write-Host "##vso[task.setvariable variable=nugetConfigFile]$nugetConfigPath"
+    displayName: "Configure CFS package registries"
     workingDirectory: $(working_directory)
     condition: succeeded()
 

--- a/.azure-pipelines/templates/sign.yml
+++ b/.azure-pipelines/templates/sign.yml
@@ -25,6 +25,19 @@ steps:
     condition: eq(variables['signprojExists'], True)
     displayName: "\U0001F449 Generate extension manifest"
 
+  - task: NuGetAuthenticate@1
+    condition: eq(variables['signprojExists'], True)
+    displayName: "\U0001F449 Authenticate CFS NuGet feed"
+
+  - task: DotNetCoreCLI@2
+    condition: eq(variables['signprojExists'], True)
+    displayName: "\U0001F449 Restore signing dependencies from CFS"
+    inputs:
+      command: 'restore'
+      projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
+      feedsToUse: 'config'
+      nugetConfigPath: $(nugetConfigFile)
+
   # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
   - task: DotNetCoreCLI@2
     condition: eq(variables['signprojExists'], True)
@@ -32,6 +45,7 @@ steps:
     inputs:
       command: 'build'
       projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
+      arguments: '--no-restore'
 
   - pwsh: |
       $filePath = "extension.signature.p7s"

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="azcode" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
The v5.991 release build now completes npm packaging but fails while signing because MSBuild implicitly restores `Microsoft.Build.NoTargets` from public nuget.org. This change routes signing dependencies through the authenticated `azcode` CFS NuGet endpoint and prevents the subsequent build from performing another implicit restore.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No product behavior changes; enables production of a signed VS Code extension package.
- **Developers**: Signing restores now use an explicit CFS-only `NuGet.config` generated after release-tag checkout.
- **System**: Adds Azure Artifacts authentication, an explicit restore, and `--no-restore` for the signing build so CI has no direct NuGet Gallery dependency.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: PowerShell runtime-config generation and XML validation, CFS source-policy validation, `git diff --check`, Biome, and independent pipeline diff review. The release pipeline will validate authenticated package restore and signing end to end.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft

## Screenshots/Videos
<!-- Visual changes only -->
N/A — pipeline-only change.