### PR TITLE
fix(vscode): restore signing packages through CFS

### DIFF
--- a/.azure-pipelines/templates/setup.yml
+++ b/.azure-pipelines/templates/setup.yml
@@ -13,7 +13,7 @@ steps:
   - pwsh: |
       $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
       if ([string]::IsNullOrWhiteSpace($feedBaseUrl)) {
-        Write-Error "feedBaseUrl is required so npm and pnpm restore through CFS."
+        Write-Error "feedBaseUrl is required so package restores use CFS."
         exit 1
       }
 
@@ -32,7 +32,21 @@ steps:
       Write-Host "Configured npm/pnpm registry: $registry"
       Write-Host "##vso[task.setvariable variable=npmrcFile]$npmrcPath"
       Write-Host "##vso[task.setvariable variable=npmRegistry]$registry"
-    displayName: "Configure CFS npm registry"
+
+      $nugetConfigPath = Join-Path "$(Build.SourcesDirectory)" "NuGet.config"
+      $nugetSource = "$feedBaseUrl/nuget/v3/index.json"
+      @(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<configuration>'
+        '  <packageSources>'
+        '    <clear />'
+        "    <add key=`"azcode`" value=`"$nugetSource`" />"
+        '  </packageSources>'
+        '</configuration>'
+      ) | Set-Content -Path $nugetConfigPath
+      Write-Host "Configured NuGet source: $nugetSource"
+      Write-Host "##vso[task.setvariable variable=nugetConfigFile]$nugetConfigPath"
+    displayName: "Configure CFS package registries"
     workingDirectory: $(working_directory)
     condition: succeeded()
 

--- a/.azure-pipelines/templates/sign.yml
+++ b/.azure-pipelines/templates/sign.yml
@@ -25,6 +25,19 @@ steps:
     condition: eq(variables['signprojExists'], True)
     displayName: "\U0001F449 Generate extension manifest"
 
+  - task: NuGetAuthenticate@1
+    condition: eq(variables['signprojExists'], True)
+    displayName: "\U0001F449 Authenticate CFS NuGet feed"
+
+  - task: DotNetCoreCLI@2
+    condition: eq(variables['signprojExists'], True)
+    displayName: "\U0001F449 Restore signing dependencies from CFS"
+    inputs:
+      command: 'restore'
+      projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
+      feedsToUse: 'config'
+      nugetConfigPath: $(nugetConfigFile)
+
   # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
   - task: DotNetCoreCLI@2
     condition: eq(variables['signprojExists'], True)
@@ -32,6 +45,7 @@ steps:
     inputs:
       command: 'build'
       projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
+      arguments: '--no-restore'
 
   - pwsh: |
       $filePath = "extension.signature.p7s"

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="azcode" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
The release build can complete npm packaging but fail while signing because MSBuild implicitly restores `Microsoft.Build.NoTargets` from public nuget.org, which is blocked by SR21 network isolation. This ports the fix from [hotfix PR #9532](https://github.com/Azure/LogicAppsUX/pull/9532) to `main`: signing dependencies restore through the authenticated `azcode` CFS NuGet endpoint, and the subsequent build cannot perform another implicit restore.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No product behavior changes; enables production of a signed VS Code extension package.
- **Developers**: Release setup regenerates a CFS-only `NuGet.config` after release-tag checkout and exposes it through `nugetConfigFile`.
- **System**: Signing now authenticates Azure Artifacts, explicitly restores the signing project from that config, and builds with `--no-restore`. Setup and signing remain in the same build job so the pipeline variable persists.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Parsed both Azure Pipelines templates with the repository's `yaml@2.8.3`; parsed and asserted the checked-in and generated NuGet configs contain only the DevDiv `azcode` endpoint; verified task ordering, `nugetConfigFile` wiring, exact patch equivalence to `604b39df6`, the exact three-file diff, `git diff --check`, and an independent read-only code review.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft

## Screenshots/Videos
<!-- Visual changes only -->
Not applicable — pipeline-only change with no visual impact.
