### PR TITLE
fix(vscode): Cherry picks to v5.991 hotfix

### DIFF
--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateFunctionAppFiles.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateFunctionAppFiles.ts
@@ -90,7 +90,6 @@ export class CreateFunctionAppFiles {
       'azureFunctions.preDeployTask': 'publish (functions)',
       'azureFunctions.templateFilter': 'Core',
       'azureFunctions.showTargetFrameworkWarning': false,
-      'azureFunctions.projectSubpath': `bin\\Release\\${targetFramework ?? TargetFramework.NetFx}\\publish`,
     };
     await fs.writeJson(filePath, content, { spaces: 2 });
   }

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppWorkspace.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/CreateLogicAppWorkspace.ts
@@ -171,14 +171,17 @@ export async function createLocalConfigurationFiles(
     '.git*',
     vscodeFolderName,
     localSettingsFileName,
-    'test',
     '.debug',
-    'workflow-designtime/',
+    'workflow-designtime',
   ];
   const localSettingsJson = generateLocalSettingsJson(logicAppFolderPath, logicAppType);
 
   if (logicAppType !== ProjectType.logicApp) {
     funcignore.push('global.json');
+  }
+
+  if (logicAppType === ProjectType.codeful) {
+    funcignore.push('.nuget', 'obj', 'bin');
   }
 
   const hostJsonPath: string = path.join(logicAppFolderPath, hostFileName);

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppVSCodeContents.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppVSCodeContents.test.ts
@@ -299,12 +299,12 @@ describe('CreateLogicAppVSCodeContents', () => {
       expect(settingsData).toHaveProperty('azureLogicAppsStandard.projectRuntime', '~4');
       expect(settingsData).toHaveProperty('debug.internalConsoleOptions', 'neverOpen');
       expect(settingsData).toHaveProperty('azureFunctions.suppressProject', true);
-      expect(settingsData).toHaveProperty('azureFunctions.deploySubpath');
-      expect(settingsData).toHaveProperty('azureFunctions.preDeployTask', 'publish');
-      expect(settingsData).toHaveProperty('azureFunctions.projectSubpath');
+      expect(settingsData).toHaveProperty('azureLogicAppsStandard.deploySubpath');
+      expect(settingsData).not.toHaveProperty('azureLogicAppsStandard.preDeployTask');
       expect(settingsData).toHaveProperty('omnisharp.enableMsBuildLoadProjectsOnDemand', false);
       expect(settingsData).toHaveProperty('omnisharp.disableMSBuildDiagnosticWarning', true);
-      expect(settingsData).not.toHaveProperty('azureLogicAppsStandard.deploySubpath');
+      expect(settingsData).not.toHaveProperty('azureFunctions.deploySubpath');
+      expect(settingsData).not.toHaveProperty('azureFunctions.preDeployTask');
     });
 
     it('should create launch.json with logicapp configuration for codeful projects', async () => {

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppVSCodeContents.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppVSCodeContents.test.ts
@@ -299,8 +299,9 @@ describe('CreateLogicAppVSCodeContents', () => {
       expect(settingsData).toHaveProperty('azureLogicAppsStandard.projectRuntime', '~4');
       expect(settingsData).toHaveProperty('debug.internalConsoleOptions', 'neverOpen');
       expect(settingsData).toHaveProperty('azureFunctions.suppressProject', true);
-      expect(settingsData).toHaveProperty('azureLogicAppsStandard.deploySubpath');
+      expect(settingsData).toHaveProperty('azureLogicAppsStandard.deploySubpath', '.');
       expect(settingsData).not.toHaveProperty('azureLogicAppsStandard.preDeployTask');
+      expect(settingsData).not.toHaveProperty('azureLogicAppsStandard.zipIgnorePattern');
       expect(settingsData).toHaveProperty('omnisharp.enableMsBuildLoadProjectsOnDemand', false);
       expect(settingsData).toHaveProperty('omnisharp.disableMSBuildDiagnosticWarning', true);
       expect(settingsData).not.toHaveProperty('azureFunctions.deploySubpath');

--- a/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
+++ b/apps/vs-code-designer/src/app/commands/createNewCodeProject/CodeProjectBase/__test__/CreateLogicAppWorkspace.test.ts
@@ -1331,9 +1331,8 @@ describe('createLocalConfigurationFiles', () => {
     expect(funcIgnoreContent).toContain('.git*');
     expect(funcIgnoreContent).toContain('.vscode');
     expect(funcIgnoreContent).toContain('local.settings.json');
-    expect(funcIgnoreContent).toContain('test');
     expect(funcIgnoreContent).toContain('.debug');
-    expect(funcIgnoreContent).toContain('workflow-designtime/');
+    expect(funcIgnoreContent).toContain('workflow-designtime');
   });
 
   it('should NOT include global.json in .funcignore for standard logic app projects', async () => {
@@ -1499,6 +1498,31 @@ describe('createLocalConfigurationFiles', () => {
 
     // Verify exactly 8 properties exist (5 standard + auth method + feature flag + codeful-enabled).
     expect(Object.keys(localSettingsData.Values)).toHaveLength(8);
+  });
+
+  it('should include codeful-specific build artifact patterns in .funcignore for codeful projects', async () => {
+    await CreateLogicAppWorkspaceModule.createLocalConfigurationFiles(mockContextCodeful, logicAppFolderPath);
+
+    const funcIgnoreCall = vi.mocked(fse.writeFile).mock.calls.find((call) => call[0].toString().includes('.funcignore'));
+    expect(funcIgnoreCall).toBeDefined();
+    const funcIgnoreContent = funcIgnoreCall![1] as string;
+
+    expect(funcIgnoreContent).toContain('.nuget');
+    expect(funcIgnoreContent).toContain('obj');
+    expect(funcIgnoreContent).toContain('bin');
+  });
+
+  it('should NOT include codeful-specific build artifact patterns in .funcignore for standard logic app', async () => {
+    await CreateLogicAppWorkspaceModule.createLocalConfigurationFiles(mockContext, logicAppFolderPath);
+
+    const funcIgnoreCall = vi.mocked(fse.writeFile).mock.calls.find((call) => call[0].toString().includes('.funcignore'));
+    expect(funcIgnoreCall).toBeDefined();
+    const funcIgnoreContent = funcIgnoreCall![1] as string;
+    const lines = funcIgnoreContent.split(/\r?\n/);
+
+    expect(funcIgnoreContent).not.toContain('.nuget');
+    expect(lines).not.toContain('obj');
+    expect(lines).not.toContain('bin');
   });
 
   it('should include extension bundle configuration in host.json', async () => {

--- a/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
+++ b/apps/vs-code-designer/src/app/commands/deploy/deploy.ts
@@ -71,10 +71,10 @@ import { uploadAppSettings } from '../appSettings/uploadAppSettings';
 import { getAppSettingsFromNode } from '../../utils/tree/slotTreeUtils';
 import { isNullOrUndefined, resolveConnectionsReferences } from '@microsoft/logic-apps-shared';
 import { tryBuildCustomCodeFunctionsProject } from '../buildCustomCodeFunctionsProject';
-import { publishCodefulProject } from '../publishCodefulProject';
 import { hasCodefulWorkflowSetting } from '../../utils/codeful';
 import { isProjectInitializedForVSCode } from '../../projectConsistency/vscodeConsistency';
 import { initProjectForVSCode } from '../initProjectForVSCode/initProjectForVSCode';
+import { publishCodefulProject } from '../publishCodefulProject';
 
 export async function deployProductionSlot(
   context: IActionContext,
@@ -168,22 +168,22 @@ async function deploy(
   const isWorkflowApp = nodeKind?.includes(logicAppKind);
   const isDeployingToKubernetes = nodeKind && nodeKind.indexOf(kubernetesKind) !== -1;
 
-  if (!isProjectInitializedForVSCode(effectiveDeployFsPath)) {
+  if (!isProjectInitializedForVSCode(originalDeployFsPath)) {
     const message: string = localize('initFolder', 'Initialize project for use with VS Code?');
     await deployContext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes);
     await callWithTelemetryAndErrorHandling('deploy.initProjectForVSCode', async (actionContext: IActionContext) => {
       actionContext.errorHandling.rethrow = true;
       actionContext.errorHandling.suppressDisplay = true;
-      await initProjectForVSCode(actionContext, effectiveDeployFsPath);
+      await initProjectForVSCode(actionContext, originalDeployFsPath);
     });
   }
 
   const language = nonNullOrEmptyValue(
-    getWorkspaceSetting(projectLanguageSetting, effectiveDeployFsPath),
+    getWorkspaceSetting(projectLanguageSetting, originalDeployFsPath),
     projectLanguageSetting
   ) as ProjectLanguage;
   const version = nonNullOrEmptyValue(
-    tryParseFuncVersion(getWorkspaceSetting(funcVersionSetting, effectiveDeployFsPath)),
+    tryParseFuncVersion(getWorkspaceSetting(funcVersionSetting, originalDeployFsPath)),
     funcVersionSetting
   ) as FuncVersion;
 

--- a/apps/vs-code-designer/src/app/commands/initProjectForVSCode/initDotnetProjectStep.ts
+++ b/apps/vs-code-designer/src/app/commands/initProjectForVSCode/initDotnetProjectStep.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { dotnetPublishTaskLabel, dotnetExtensionId, show64BitWarningSetting } from '../../../constants';
+import { show64BitWarningSetting } from '../../../constants';
 import { localize } from '../../../localize';
 import { getProjFiles, getTargetFramework, tryGetFuncVersion } from '../../utils/dotnet/dotnet';
 import type { ProjectFile } from '../../utils/dotnet/dotnet';
@@ -16,16 +16,6 @@ import * as path from 'path';
 import type { MessageItem } from 'vscode';
 
 export class InitDotnetProjectStep extends InitProjectStep {
-  protected preDeployTask: string = dotnetPublishTaskLabel;
-
-  protected getRecommendedExtensions(language: ProjectLanguage): string[] {
-    const recs: string[] = [dotnetExtensionId];
-    if (language === ProjectLanguage.FSharp) {
-      recs.push('ionide.ionide-fsharp');
-    }
-    return recs;
-  }
-
   /**
    * Detects the version based on the targetFramework from the proj file
    * Also performs a few validations and sets a few properties based on that targetFramework

--- a/apps/vs-code-designer/src/app/commands/initProjectForVSCode/initProjectStep.ts
+++ b/apps/vs-code-designer/src/app/commands/initProjectForVSCode/initProjectStep.ts
@@ -32,8 +32,6 @@ export class InitProjectStep extends AzureWizardExecuteStep<IProjectWizardContex
     // Default implementation does nothing
   }
 
-  protected getRecommendedExtensions?(language: ProjectLanguage): string[];
-
   public shouldExecute(): boolean {
     return true;
   }

--- a/apps/vs-code-designer/src/app/projectConsistency/__test__/projectFilesConsistency.test.ts
+++ b/apps/vs-code-designer/src/app/projectConsistency/__test__/projectFilesConsistency.test.ts
@@ -46,10 +46,6 @@ vi.mock('fs-extra', () => ({
   pathExists: vi.fn(),
   readFile: vi.fn(),
   readdir: vi.fn(),
-  lstat: vi.fn(),
-  readlink: vi.fn(),
-  symlink: vi.fn(),
-  remove: vi.fn(),
 }));
 
 vi.mock('../../utils/appSettings/localSettings', async (importActual) => {
@@ -93,10 +89,6 @@ const mockedFse = fse as unknown as {
   pathExists: ReturnType<typeof vi.fn>;
   readFile: ReturnType<typeof vi.fn>;
   readdir: ReturnType<typeof vi.fn>;
-  lstat: ReturnType<typeof vi.fn>;
-  readlink: ReturnType<typeof vi.fn>;
-  symlink: ReturnType<typeof vi.fn>;
-  remove: ReturnType<typeof vi.fn>;
 };
 const mockedAddOrUpdate = localSettings.addOrUpdateLocalAppSettings as unknown as ReturnType<typeof vi.fn>;
 const mockedGetLocalSettingsJson = localSettings.getLocalSettingsJson as unknown as ReturnType<typeof vi.fn>;
@@ -896,115 +888,6 @@ describe('projectFilesConsistency', () => {
             [workflowAuthenticationMethodKey]: 'managedServiceIdentity',
           },
         });
-      });
-    });
-
-    describe('artifacts junction', () => {
-      const designTimeDir = `${projectPath}/workflow-designtime`;
-      const artifactsTarget = `${projectPath}/Artifacts`;
-      const artifactsLink = `${designTimeDir}/Artifacts`;
-
-      beforeEach(() => {
-        // Default: valid design-time directory so host/settings are not rewritten
-        const hostPath = `${designTimeDir}/host.json`;
-        const settingsPath = `${designTimeDir}/local.settings.json`;
-        const validHost = JSON.stringify({
-          version: '2.0',
-          extensionBundle: { id: 'Microsoft.Azure.Functions.ExtensionBundle.Workflows', version: '[1.*, 2.0.0)' },
-          extensions: { workflow: { settings: { [workflowOperationDiscoveryHostModeKey]: 'true' } } },
-        });
-        const validSettings = JSON.stringify({
-          Values: {
-            APP_KIND: 'workflowapp',
-            FUNCTIONS_WORKER_RUNTIME: 'dotnet',
-            FUNCTIONS_INPROC_NET8_ENABLED: '1',
-            ProjectDirectoryPath: projectPath,
-          },
-        });
-        mockFiles({ [designTimeDir]: '', [hostPath]: validHost, [settingsPath]: validSettings, [artifactsTarget]: '' });
-        mockedFse.lstat.mockRejectedValue(new Error('ENOENT'));
-        mockedFse.symlink.mockResolvedValue(undefined);
-        mockedFse.readlink.mockResolvedValue(artifactsTarget);
-        mockedFse.remove.mockResolvedValue(undefined);
-      });
-
-      it('creates a junction when Artifacts exists and no link is present', async () => {
-        mockedFse.lstat.mockRejectedValue(new Error('ENOENT'));
-
-        await ensureDesignTimeFiles(context, projectPath);
-
-        expect(mockedFse.symlink).toHaveBeenCalledWith(
-          expect.stringContaining('Artifacts'),
-          expect.stringContaining('workflow-designtime'),
-          'junction'
-        );
-      });
-
-      it('does not create a junction when Artifacts folder does not exist', async () => {
-        // Remove Artifacts from the mock file system
-        mockFiles({
-          [designTimeDir]: '',
-          [`${designTimeDir}/host.json`]: JSON.stringify({
-            version: '2.0',
-            extensionBundle: { id: 'Microsoft.Azure.Functions.ExtensionBundle.Workflows', version: '[1.*, 2.0.0)' },
-            extensions: { workflow: { settings: { [workflowOperationDiscoveryHostModeKey]: 'true' } } },
-          }),
-          [`${designTimeDir}/local.settings.json`]: JSON.stringify({
-            Values: {
-              APP_KIND: 'workflowapp',
-              FUNCTIONS_WORKER_RUNTIME: 'dotnet',
-              FUNCTIONS_INPROC_NET8_ENABLED: '1',
-              ProjectDirectoryPath: projectPath,
-            },
-          }),
-        });
-
-        await ensureDesignTimeFiles(context, projectPath);
-
-        expect(mockedFse.symlink).not.toHaveBeenCalled();
-      });
-
-      it('does not recreate junction when it already points to correct target', async () => {
-        mockedFse.lstat.mockResolvedValue({ isSymbolicLink: () => true });
-        mockedFse.readlink.mockResolvedValue(artifactsTarget);
-
-        await ensureDesignTimeFiles(context, projectPath);
-
-        expect(mockedFse.symlink).not.toHaveBeenCalled();
-        expect(mockedFse.remove).not.toHaveBeenCalled();
-      });
-
-      it('recreates junction when it points to wrong target', async () => {
-        mockedFse.lstat.mockResolvedValue({ isSymbolicLink: () => true });
-        mockedFse.readlink.mockResolvedValue('/some/other/path');
-
-        await ensureDesignTimeFiles(context, projectPath);
-
-        expect(mockedFse.remove).toHaveBeenCalled();
-        expect(mockedFse.symlink).toHaveBeenCalledWith(
-          expect.stringContaining('Artifacts'),
-          expect.stringContaining('workflow-designtime'),
-          'junction'
-        );
-      });
-
-      it('does not overwrite a real directory at the link path', async () => {
-        mockedFse.lstat.mockResolvedValue({ isSymbolicLink: () => false });
-
-        await ensureDesignTimeFiles(context, projectPath);
-
-        expect(mockedFse.symlink).not.toHaveBeenCalled();
-        expect(mockedFse.remove).not.toHaveBeenCalled();
-      });
-
-      it('logs a warning when symlink creation fails', async () => {
-        mockedFse.lstat.mockRejectedValue(new Error('ENOENT'));
-        mockedFse.symlink.mockRejectedValue(new Error('EPERM'));
-
-        await ensureDesignTimeFiles(context, projectPath);
-
-        const lines = loggedLines();
-        expect(lines.some((l) => l.includes('junction'))).toBe(true);
       });
     });
   });

--- a/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/__test__/vscodeSettings.test.ts
+++ b/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/__test__/vscodeSettings.test.ts
@@ -55,8 +55,9 @@ describe('generateSettingsJson', () => {
       };
       const result = generateSettingsJson(config);
 
-      expect(result).toHaveProperty('azureLogicAppsStandard.deploySubpath');
+      expect(result).toHaveProperty('azureLogicAppsStandard.deploySubpath', '.');
       expect(result).not.toHaveProperty('azureLogicAppsStandard.preDeployTask');
+      expect(result).not.toHaveProperty('azureLogicAppsStandard.zipIgnorePattern');
       expect(result).toHaveProperty('omnisharp.enableMsBuildLoadProjectsOnDemand', false);
       expect(result).toHaveProperty('omnisharp.disableMSBuildDiagnosticWarning', true);
     });

--- a/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/__test__/vscodeSettings.test.ts
+++ b/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/__test__/vscodeSettings.test.ts
@@ -55,9 +55,8 @@ describe('generateSettingsJson', () => {
       };
       const result = generateSettingsJson(config);
 
-      expect(result).toHaveProperty('azureFunctions.deploySubpath');
-      expect(result).toHaveProperty('azureFunctions.preDeployTask', 'publish');
-      expect(result).toHaveProperty('azureFunctions.projectSubpath');
+      expect(result).toHaveProperty('azureLogicAppsStandard.deploySubpath');
+      expect(result).not.toHaveProperty('azureLogicAppsStandard.preDeployTask');
       expect(result).toHaveProperty('omnisharp.enableMsBuildLoadProjectsOnDemand', false);
       expect(result).toHaveProperty('omnisharp.disableMSBuildDiagnosticWarning', true);
     });
@@ -109,11 +108,11 @@ describe('generateSettingsJson', () => {
       });
       expect(Object.keys(result)).toEqual([
         'azureLogicAppsStandard.deploySubpath',
+        'azureLogicAppsStandard.preDeployTask',
         'azureLogicAppsStandard.projectLanguage',
         'azureLogicAppsStandard.projectRuntime',
         'debug.internalConsoleOptions',
         'azureFunctions.suppressProject',
-        'azureLogicAppsStandard.preDeployTask',
       ]);
     });
   });

--- a/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/vscodeSettings.ts
+++ b/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/vscodeSettings.ts
@@ -26,10 +26,8 @@ export function generateSettingsJson(config: VSCodeProjectConfig): Record<string
   if (projectType === ProjectType.codeful) {
     const deploySubPathValue = path.posix.join('bin', 'Release', targetFramework ?? TargetFramework.NetFx, 'publish');
     return {
+      [`${ext.prefix}.${deploySubpathSetting}`]: deploySubPathValue,
       ...baseSettings,
-      'azureFunctions.deploySubpath': deploySubPathValue,
-      'azureFunctions.preDeployTask': 'publish',
-      'azureFunctions.projectSubpath': deploySubPathValue,
       'omnisharp.enableMsBuildLoadProjectsOnDemand': false,
       'omnisharp.disableMSBuildDiagnosticWarning': true,
     };
@@ -39,8 +37,8 @@ export function generateSettingsJson(config: VSCodeProjectConfig): Record<string
     const deploySubPathValue = path.posix.join('bin', 'Release', targetFramework ?? TargetFramework.NetFx, 'publish');
     return {
       [`${ext.prefix}.${deploySubpathSetting}`]: deploySubPathValue,
-      ...baseSettings,
       [`${ext.prefix}.${preDeployTaskSetting}`]: 'publish',
+      ...baseSettings,
     };
   }
 

--- a/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/vscodeSettings.ts
+++ b/apps/vs-code-designer/src/app/projectConsistency/fileGenerators/vscodeSettings.ts
@@ -24,9 +24,8 @@ export function generateSettingsJson(config: VSCodeProjectConfig): Record<string
   };
 
   if (projectType === ProjectType.codeful) {
-    const deploySubPathValue = path.posix.join('bin', 'Release', targetFramework ?? TargetFramework.NetFx, 'publish');
     return {
-      [`${ext.prefix}.${deploySubpathSetting}`]: deploySubPathValue,
+      [`${ext.prefix}.${deploySubpathSetting}`]: '.',
       ...baseSettings,
       'omnisharp.enableMsBuildLoadProjectsOnDemand': false,
       'omnisharp.disableMSBuildDiagnosticWarning': true,

--- a/apps/vs-code-designer/src/app/projectConsistency/projectFilesConsistency.ts
+++ b/apps/vs-code-designer/src/app/projectConsistency/projectFilesConsistency.ts
@@ -5,7 +5,6 @@
 import {
   ProjectDirectoryPathKey,
   appKindSetting,
-  artifactsDirectory,
   connectionsFileName,
   designTimeDirectoryName,
   extensionBundleId,
@@ -270,10 +269,6 @@ export async function ensureDesignTimeFiles(
     changedArtifacts.push(`${designTimeArtifactPrefix}${localSettingsFileName}`);
   }
 
-  const artifactsTarget = path.join(projectPath, artifactsDirectory);
-  const artifactsLink = path.join(designTimeDirectory.fsPath, artifactsDirectory);
-  await ensureArtifactsSymlink(artifactsLink, artifactsTarget);
-
   return { changedArtifacts };
 }
 
@@ -425,25 +420,6 @@ async function readFileTextSafe(filePath: string): Promise<string> {
     // Ignore read errors and treat the file as empty.
   }
   return '';
-}
-
-async function ensureArtifactsSymlink(artifactsLink: string, artifactsTarget: string): Promise<void> {
-  if (await fse.pathExists(artifactsTarget)) {
-    try {
-      const linkStat = await fse.lstat(artifactsLink).catch(() => null);
-      if (linkStat && linkStat.isSymbolicLink()) {
-        const currentTarget = await fse.readlink(artifactsLink);
-        if (!arePathsEqual(currentTarget, artifactsTarget)) {
-          await fse.remove(artifactsLink);
-          await fse.symlink(artifactsTarget, artifactsLink, 'junction');
-        }
-      } else if (!linkStat) {
-        await fse.symlink(artifactsTarget, artifactsLink, 'junction');
-      }
-    } catch {
-      ext.outputChannel.appendLog(localize('artifactsJunctionFailed', 'Failed to create Artifacts junction in design-time directory.'));
-    }
-  }
 }
 
 function arePathsEqual(path1?: string, path2?: string): boolean {

--- a/apps/vs-code-designer/src/app/tree/LogicAppResourceTree.ts
+++ b/apps/vs-code-designer/src/app/tree/LogicAppResourceTree.ts
@@ -212,7 +212,7 @@ export class LogicAppResourceTree implements ResolvedAppResourceBase {
   }
 
   public async getApplicationSettings(context: IDeployContext): Promise<ApplicationSettings> {
-    const localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, context.effectiveDeployFsPath);
+    const localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, context.originalDeployFsPath);
     return localSettings.Values || {};
   }
 

--- a/apps/vs-code-designer/src/app/utils/__test__/verifyIsProject.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/verifyIsProject.test.ts
@@ -4,6 +4,13 @@ import * as path from 'path';
 import * as verifyIsProject from '../verifyIsProject';
 import { hostFileName, localSettingsFileName, workflowFileName } from '../../../constants';
 
+vi.mock('../../utils/vsCodeConfig/settings', () => ({
+  getWorkspaceSetting: vi.fn(),
+  updateWorkspaceSetting: vi.fn(),
+}));
+
+import { getWorkspaceSetting } from '../../utils/vsCodeConfig/settings';
+
 describe('isLogicAppProject', () => {
   const projectPath = path.join('test', 'LogicApp');
 
@@ -139,5 +146,76 @@ describe('isLogicAppProject', () => {
     );
 
     expect(await verifyIsProject.isLogicAppProject(projectPath)).toBe(false);
+  });
+});
+
+describe('tryGetLogicAppProjectRoot', () => {
+  const workspacePath = path.join('test', 'workspace');
+  const subprojectPath = path.join(workspacePath, 'MyLogicApp');
+  const mockContext = { telemetry: { properties: {} }, ui: {} } as any;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockLogicAppProjectAt(validProjectPath: string): void {
+    const wfPath = path.join(validProjectPath, 'stateful1', workflowFileName);
+    vi.spyOn(fse, 'pathExists').mockImplementation(async (p: fse.PathLike) => {
+      const s = String(p);
+      return s === workspacePath || s === validProjectPath || s === wfPath;
+    });
+    vi.spyOn(fse, 'readdir').mockImplementation(async (p: fse.PathLike) => {
+      const s = String(p);
+      if (s === validProjectPath) {
+        return ['stateful1'];
+      }
+      if (s === workspacePath) {
+        return [path.basename(validProjectPath)];
+      }
+      return [];
+    });
+    vi.spyOn(fse, 'readFile').mockImplementation(async (p: fse.PathLike) => {
+      if (String(p) === wfPath) {
+        return JSON.stringify({
+          definition: {
+            $schema: 'https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#',
+          },
+        });
+      }
+      return '';
+    });
+  }
+
+  it('returns configured projectSubpath when it points to a valid project', async () => {
+    vi.mocked(getWorkspaceSetting).mockReturnValue('MyLogicApp');
+    mockLogicAppProjectAt(subprojectPath);
+
+    const result = await verifyIsProject.tryGetLogicAppProjectRoot(mockContext, workspacePath);
+    expect(result).toBe(subprojectPath);
+  });
+
+  it('falls through to scanning when projectSubpath points to an invalid location', async () => {
+    vi.mocked(getWorkspaceSetting).mockReturnValue('NonExistent');
+    mockLogicAppProjectAt(subprojectPath);
+
+    const result = await verifyIsProject.tryGetLogicAppProjectRoot(mockContext, workspacePath, true);
+    expect(result).toBe(subprojectPath);
+  });
+
+  it('falls through to scanning when no projectSubpath is configured', async () => {
+    vi.mocked(getWorkspaceSetting).mockReturnValue(undefined);
+    mockLogicAppProjectAt(subprojectPath);
+
+    const result = await verifyIsProject.tryGetLogicAppProjectRoot(mockContext, workspacePath, true);
+    expect(result).toBe(subprojectPath);
+  });
+
+  it('returns undefined when no projects are found', async () => {
+    vi.mocked(getWorkspaceSetting).mockReturnValue(undefined);
+    vi.spyOn(fse, 'pathExists').mockImplementation(async (p: fse.PathLike) => String(p) === workspacePath);
+    vi.spyOn(fse, 'readdir').mockResolvedValue([]);
+
+    const result = await verifyIsProject.tryGetLogicAppProjectRoot(mockContext, workspacePath);
+    expect(result).toBeUndefined();
   });
 });

--- a/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
+++ b/apps/vs-code-designer/src/app/utils/verifyIsProject.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { extensionCommand, workflowFileName, extensionContext } from '../../constants';
+import { extensionCommand, workflowFileName, extensionContext, projectSubpathSetting } from '../../constants';
 import { localize } from '../../localize';
 import { getWorkspaceSetting, updateWorkspaceSetting } from './vsCodeConfig/settings';
 import { isNullOrUndefined, isString } from '@microsoft/logic-apps-shared';
@@ -13,8 +13,6 @@ import type { MessageItem, WorkspaceFolder } from 'vscode';
 import { NoWorkspaceError } from './errors';
 import * as vscode from 'vscode';
 import { hasCodefulSdkReference } from './codeful';
-
-const projectSubpathKey = 'projectSubpath';
 
 /**
  * Determines whether the given folder is a Logic Apps project.
@@ -119,7 +117,6 @@ export async function isLogicAppProjectInRoot(workspaceFolder: WorkspaceFolder |
  * Checks root folder and subFolders one level down
  * If a single logic app project is found, return that path.
  * If multiple projects are found, prompt to pick the project.
- * TODO - this is checking every root folder and subfolders of non-logic app projects in the workspace, can we optimize this?
  */
 export async function tryGetLogicAppProjectRoot(
   context: IActionContext,
@@ -129,14 +126,22 @@ export async function tryGetLogicAppProjectRoot(
   if (isNullOrUndefined(workspaceFolder)) {
     return undefined;
   }
-  let subpath: string | undefined = getWorkspaceSetting(projectSubpathKey, workspaceFolder);
+
   const folderPath = isString(workspaceFolder) ? workspaceFolder : workspaceFolder.uri.fsPath;
   if (!(await fse.pathExists(folderPath))) {
     return undefined;
   }
+
   if (await isLogicAppProject(folderPath)) {
     return folderPath;
   }
+
+  const configuredSubpath: string | undefined = getWorkspaceSetting(projectSubpathSetting, workspaceFolder);
+  const configuredProjectPath = configuredSubpath ? path.join(folderPath, configuredSubpath) : undefined;
+  if (configuredProjectPath && await isLogicAppProject(configuredProjectPath)) {
+    return configuredProjectPath;
+  }
+
   const subpaths: string[] = await fse.readdir(folderPath);
   const matchingSubpaths: string[] = [];
   await Promise.all(
@@ -148,14 +153,13 @@ export async function tryGetLogicAppProjectRoot(
   );
 
   if (matchingSubpaths.length === 1 || (matchingSubpaths.length !== 0 && suppressPrompt)) {
-    subpath = matchingSubpaths[0];
+    return path.join(folderPath, matchingSubpaths[0]);
   } else if (matchingSubpaths.length !== 0 && !suppressPrompt) {
-    subpath = await promptForProjectSubpath(context, folderPath, matchingSubpaths);
-  } else {
-    return undefined;
+    const subpath = await promptForProjectSubpath(context, folderPath, matchingSubpaths);
+    return path.join(folderPath, subpath);
   }
-
-  return path.join(folderPath, subpath);
+  
+  return undefined;
 }
 
 /**
@@ -202,7 +206,7 @@ async function promptForProjectSubpath(context: IActionContext, workspacePath: s
   });
   const placeHolder: string = localize('selectProject', 'Select the default project subpath');
   const subpath: string = (await context.ui.showQuickPick(picks, { placeHolder })).data;
-  await updateWorkspaceSetting(projectSubpathKey, subpath, workspacePath);
+  await updateWorkspaceSetting(projectSubpathSetting, subpath, workspacePath);
 
   return subpath;
 }

--- a/apps/vs-code-designer/src/test/e2e/integration/createWorkspace.test.ts
+++ b/apps/vs-code-designer/src/test/e2e/integration/createWorkspace.test.ts
@@ -228,9 +228,9 @@ suite('Create Logic App Workspace Tests', () => {
       path.join(vscodePath, 'settings.json'),
       JSON.stringify(
         {
-          'azureFunctions.deploySubpath': '.',
-          'azureFunctions.projectLanguage': 'JavaScript',
-          'azureFunctions.projectRuntime': '~4',
+          'azureLogicAppsStandard.deploySubpath': '.',
+          'azureLogicAppsStandard.projectLanguage': 'JavaScript',
+          'azureLogicAppsStandard.projectRuntime': '~4',
           'debug.internalConsoleOptions': 'neverOpen',
           'azureFunctions.suppressProject': true,
         },


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
Cherry picks the following changes into v5.991 release hotfix branch:
- Fixes multiple invalid setting values in .vscode/settings.json generator, fixes project path cache behavior
- Reverts a fix for issue loading artifacts dynamic list in designer using symlink at workflow-designtime/Artifacts due to regression (permissions error)
- Fixes deploySubpath for codeful projects, updates .funcignore

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Fixes the issues noted in cherry-picked commits
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge
