### PR TITLE
fix(iframe-app): validate agent card postMessage payloads

### DIFF
--- a/apps/iframe-app/README.md
+++ b/apps/iframe-app/README.md
@@ -293,13 +293,14 @@ All messages use this format:
 
 ### Trusted Origins
 
-The iframe validates portal messages from these origins:
+The iframe validates the portal `trustedAuthority` value against these hosts (HTTPS only):
 
 - `df.onecloud.azure-test.net`
 - `portal.azure.com`
 - `ms.portal.azure.com`
 - `rc.portal.azure.com`
-- `localhost:55555` (development)
+
+A `localhost` (or `127.0.0.1`) parent authority is honored only when the iframe itself is served from localhost, so a production iframe can never be embedded and driven by a localhost origin.
 
 ## Security
 
@@ -323,11 +324,23 @@ credentialed fetches occur.
 
 ### Configuration Example
 
-```html
-<!-- Configure this in the served iframe.html, not on the embedding page's iframe element. -->
-<html lang="en" data-allowed-origins="https://app.example.com,*.trusted.example.com">
+Inbound trust is configured on the **served `iframe.html`** document, not on the host page that embeds it.
 
-<!-- The embedding page can then request postMessage configuration. -->
+**Served `iframe.html`** — sets the origins allowed to send `postMessage` configuration:
+
+```html
+<!-- Rendered by the server that hosts the iframe. The data-allowed-origins attribute on
+     this document's <html> element is what authorizes inbound postMessage senders. -->
+<html lang="en" data-allowed-origins="https://app.example.com,*.trusted.example.com">
+  <!-- ... iframe app ... -->
+</html>
+```
+
+**Host page** — embeds the iframe; it must NOT carry `data-allowed-origins`:
+
+```html
+<!-- Rendered by the embedding application. It only references the iframe URL; the
+     data-allowed-origins attribute belongs on the iframe document shown above. -->
 <iframe src="https://your-domain.com/iframe.html?expectPostMessage=true"></iframe>
 ```
 

--- a/apps/iframe-app/README.md
+++ b/apps/iframe-app/README.md
@@ -91,7 +91,9 @@ The iframe supports configuration via **URL parameters** or **data attributes**.
 | `expectPostMessage` | boolean | Wait for postMessage configuration            | false     |
 | `inPortal`          | boolean | Azure Portal context mode                     | false     |
 | `trustedAuthority`  | string  | Portal's origin for auth                      | -         |
-| `allowedOrigins`    | string  | Comma-separated allowed postMessage origins   | -         |
+
+For non-Portal cross-origin postMessage embedding, configure `data-allowed-origins` on the `<html>` element in the served iframe
+document. An `allowedOrigins` query parameter is not trusted and is ignored.
 
 ### Preset Themes
 
@@ -196,7 +198,7 @@ The iframe supports dynamic configuration and bi-directional communication with 
           type: 'SET_AGENT_CARD',
           agentCard: {
             name: 'Support Bot',
-            url: 'https://api.example.com/rpc',
+            url: 'https://support-agent.logic.azure.com/rpc',
             capabilities: { streaming: true },
           },
         },
@@ -216,6 +218,9 @@ The iframe supports dynamic configuration and bi-directional communication with 
 #### Parent → Iframe
 
 **SET_AGENT_CARD** - Send agent configuration:
+
+The payload may be a Microsoft HTTPS agent-card URL string or an object with a `url` on a `logic.azure.com` or
+`logic-apps.azure.com` host.
 
 ```javascript
 {
@@ -300,28 +305,30 @@ The iframe validates portal messages from these origins:
 
 ### Origin Validation
 
-The iframe implements three-tier origin validation for postMessage:
+The iframe requires `SET_AGENT_CARD` messages to come from `window.parent` and an independently trusted origin.
 
-1. **Explicit Configuration** (highest priority)
-   - Via `allowedOrigins` URL parameter
-   - Via `data-allowed-origins` attribute
+1. **Explicit Configuration**
+   - Via a server-rendered `data-allowed-origins` attribute on the iframe document's `<html>` element
+   - Via the validated Azure Portal `trustedAuthority` configuration
    - Supports wildcard subdomains: `*.example.com`
 
-2. **Default Allowed Origins** (medium priority)
+2. **Default Allowed Origins**
    - Current iframe's own origin
-   - Document referrer origin
-   - Development origins (localhost)
+   - Fixed localhost development origins when the iframe itself runs on localhost
 
-3. **Wildcard Matching**
-   - Patterns like `*.example.com` match all subdomains
-   - Patterns like `https://*.azure.com` match all Azure subdomains
+The `allowedOrigins` query parameter and `document.referrer` do not authorize inbound messages.
+
+Every accepted agent-card URL is also restricted to HTTPS Microsoft Logic Apps hosts before state changes, acknowledgment, or
+credentialed fetches occur.
 
 ### Configuration Example
 
 ```html
-<iframe
-  src="https://your-domain.com/iframe.html?allowedOrigins=https://app.example.com,https://*.example.com,https://*.azure.com"
-></iframe>
+<!-- Configure this in the served iframe.html, not on the embedding page's iframe element. -->
+<html lang="en" data-allowed-origins="https://app.example.com,*.trusted.example.com">
+
+<!-- The embedding page can then request postMessage configuration. -->
+<iframe src="https://your-domain.com/iframe.html?expectPostMessage=true"></iframe>
 ```
 
 ### CORS Requirements
@@ -585,7 +592,7 @@ pnpm format
 
 ```javascript
 // Debug mode - add to URL
-?agentCard=https://api.example.com&debug=true
+?agentCard=https://support-agent.logic.azure.com&debug=true
 ```
 
 ### PostMessage Not Working
@@ -601,8 +608,8 @@ pnpm format
 
 ```javascript
 // Check console for origin validation warnings
-// Add explicit allowed origins
-?allowedOrigins=https://app.example.com
+// Configure the served iframe document:
+// <html data-allowed-origins="https://app.example.com">
 ```
 
 ### Authentication Errors
@@ -754,7 +761,7 @@ data-theme-primary="#0066cc" data-theme-background="#ffffff"
               type: 'SET_AGENT_CARD',
               agentCard: {
                 name: `${user.name}'s Assistant`,
-                url: 'https://api.example.com/rpc',
+                url: 'https://support-agent.logic.azure.com/rpc',
                 capabilities: { streaming: true },
               },
             },

--- a/apps/iframe-app/src/components/IframeWrapper.tsx
+++ b/apps/iframe-app/src/components/IframeWrapper.tsx
@@ -19,7 +19,7 @@ export function IframeWrapper({ config }: IframeWrapperProps) {
   const { props, multiSession, apiKey, oboUserToken, mode: initialMode = 'light', inPortal, trustedParentOrigin, contextId } = config;
 
   // State
-  const [agentCard, setAgentCard] = useState<any>(null);
+  const [agentCard, setAgentCard] = useState<ChatWidgetProps['agentCard'] | null>(null);
   const [currentTheme, setCurrentTheme] = useState<'light' | 'dark'>(initialMode);
   const [authToken, setAuthToken] = useState<string | null>(null);
   const [needsLogin, setNeedsLogin] = useState(true);
@@ -144,6 +144,7 @@ export function IframeWrapper({ config }: IframeWrapperProps) {
   // Parent communication
   const { isWaitingForAgentCard } = useParentCommunication({
     enabled: expectPostMessage,
+    trustedParentOrigin,
     onAgentCardReceived: setAgentCard,
   });
 

--- a/apps/iframe-app/src/components/__tests__/IframeWrapper.test.tsx
+++ b/apps/iframe-app/src/components/__tests__/IframeWrapper.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { IframeWrapper } from '../IframeWrapper';
-import type { IframeConfig } from '../../lib/utils/config-parser';
+import type { AgentCardPayload, IframeConfig } from '../../lib/utils/config-parser';
 import * as authHandler from '../../lib/authHandler';
 
 // Mock the dependencies
@@ -143,8 +143,9 @@ describe('IframeWrapper', () => {
 
   it('should handle agent card from postMessage', async () => {
     const { useParentCommunication } = await import('../../lib/hooks/useParentCommunication');
+    const { useAgentCard } = await import('../../hooks/useAgentCard');
 
-    let capturedCallback: ((agentCard: any) => void) | undefined;
+    let capturedCallback: ((agentCard: AgentCardPayload) => void) | undefined;
 
     vi.mocked(useParentCommunication).mockImplementation(({ onAgentCardReceived }) => {
       capturedCallback = onAgentCardReceived;
@@ -161,7 +162,7 @@ describe('IframeWrapper', () => {
     // Simulate receiving agent card
     act(() => {
       if (capturedCallback) {
-        capturedCallback({ name: 'New Agent', endpoint: 'https://new.api.com' });
+        capturedCallback('https://new-agent.logic.azure.com/.well-known/agent-card.json');
       }
     });
 
@@ -169,6 +170,28 @@ describe('IframeWrapper', () => {
 
     // Wait for auth check to complete
     await screen.findByTestId('chat-widget');
+    expect(useAgentCard).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        apiUrl: 'https://new-agent.logic.azure.com/.well-known/agent-card.json',
+      })
+    );
+  });
+
+  it('passes the validated trusted parent origin to parent communication', async () => {
+    const { useParentCommunication } = await import('../../lib/hooks/useParentCommunication');
+    const portalConfig: IframeConfig = {
+      ...defaultConfig,
+      inPortal: true,
+      trustedParentOrigin: 'https://portal.azure.com',
+    };
+
+    render(<IframeWrapper config={portalConfig} />);
+
+    expect(useParentCommunication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trustedParentOrigin: 'https://portal.azure.com',
+      })
+    );
   });
 
   it('should handle theme changes from Frame Blade', async () => {

--- a/apps/iframe-app/src/lib/hooks/__tests__/useParentCommunication.test.ts
+++ b/apps/iframe-app/src/lib/hooks/__tests__/useParentCommunication.test.ts
@@ -1,240 +1,216 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useParentCommunication } from '../useParentCommunication';
 
-// Mock the origin validator module
 vi.mock('../../utils/origin-validator', () => ({
-  getAllowedOrigins: vi.fn(() => ['http://localhost:3000', 'https://parent.example.com']),
-  isOriginAllowed: vi.fn((origin, allowed) => allowed.includes(origin)),
-  getParentOrigin: vi.fn(() => 'https://parent.example.com'),
+  getAllowedOrigins: vi.fn((trustedParentOrigin?: string) => [
+    'http://localhost:3000',
+    'https://parent.example.com',
+    ...(trustedParentOrigin ? [trustedParentOrigin] : []),
+  ]),
+  isOriginAllowed: vi.fn((origin: string, allowedOrigins: string[]) => allowedOrigins.includes(origin)),
+  getParentOrigin: vi.fn((trustedParentOrigin?: string) => trustedParentOrigin ?? 'https://parent.example.com'),
 }));
 
 describe('useParentCommunication', () => {
+  let parentWindow: Window;
   let mockPostMessage: ReturnType<typeof vi.fn>;
-  let messageListeners: Array<(event: MessageEvent) => void> = [];
+  let messageListeners: Array<(event: MessageEvent) => void>;
 
   beforeEach(() => {
-    // Mock window.parent.postMessage
     mockPostMessage = vi.fn();
-    window.parent = {
-      postMessage: mockPostMessage,
-    } as any;
-
-    // Make window.parent different from window
+    parentWindow = { postMessage: mockPostMessage } as unknown as Window;
     Object.defineProperty(window, 'parent', {
-      value: { postMessage: mockPostMessage },
+      value: parentWindow,
       configurable: true,
     });
 
-    // Capture event listeners
     messageListeners = [];
-    window.addEventListener = vi.fn((event, handler) => {
+    vi.spyOn(window, 'addEventListener').mockImplementation((event, handler) => {
       if (event === 'message') {
-        messageListeners.push(handler as any);
+        messageListeners.push(handler as (event: MessageEvent) => void);
       }
-    }) as any;
-
-    window.removeEventListener = vi.fn((event, handler) => {
+    });
+    vi.spyOn(window, 'removeEventListener').mockImplementation((event, handler) => {
       if (event === 'message') {
-        const index = messageListeners.indexOf(handler as any);
-        if (index > -1) {
+        const index = messageListeners.indexOf(handler as (event: MessageEvent) => void);
+        if (index >= 0) {
           messageListeners.splice(index, 1);
         }
       }
-    }) as any;
+    });
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
-  it('should not wait for agent card when disabled', () => {
-    const { result } = renderHook(() =>
-      useParentCommunication({
-        enabled: false,
-      })
-    );
+  const dispatchMessage = (data: unknown, origin = 'https://parent.example.com', source: MessageEventSource = parentWindow) => {
+    const event = new MessageEvent('message', { origin, data, source });
+    act(() => {
+      messageListeners.forEach((listener) => listener(event));
+    });
+  };
+
+  it('does not wait for an agent card when disabled', () => {
+    const { result } = renderHook(() => useParentCommunication({ enabled: false }));
 
     expect(result.current.isWaitingForAgentCard).toBe(false);
   });
 
-  it('should wait for agent card when enabled', () => {
-    const { result } = renderHook(() =>
-      useParentCommunication({
-        enabled: true,
-      })
-    );
+  it('waits for an agent card and sends IFRAME_READY when enabled', () => {
+    const { result } = renderHook(() => useParentCommunication({ enabled: true }));
 
     expect(result.current.isWaitingForAgentCard).toBe(true);
-  });
-
-  it('should send IFRAME_READY message when enabled', () => {
-    renderHook(() =>
-      useParentCommunication({
-        enabled: true,
-      })
-    );
-
     expect(mockPostMessage).toHaveBeenCalledWith({ type: 'IFRAME_READY' }, 'https://parent.example.com');
   });
 
-  it('should handle SET_AGENT_CARD message', () => {
-    const onAgentCardReceived = vi.fn();
-    const mockSource = {
-      postMessage: vi.fn(),
-    };
+  it('uses the trusted parent origin for outbound messages', () => {
+    const { result } = renderHook(() =>
+      useParentCommunication({
+        enabled: true,
+        trustedParentOrigin: 'https://portal.azure.com',
+      })
+    );
 
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'IFRAME_READY' }, 'https://portal.azure.com');
+
+    result.current.sendMessageToParent({ type: 'CUSTOM_MESSAGE' });
+
+    expect(mockPostMessage).toHaveBeenLastCalledWith({ type: 'CUSTOM_MESSAGE' }, 'https://portal.azure.com');
+  });
+
+  it.each([
+    ['string', 'https://agent.logic.azure.com/.well-known/agent-card.json'],
+    ['object', { name: 'Test Agent', url: 'https://agent.logic-apps.azure.com/rpc' }],
+  ])('accepts a valid Microsoft HTTPS %s agent card', (_shape, agentCard) => {
+    const onAgentCardReceived = vi.fn();
     const { result } = renderHook(() =>
       useParentCommunication({
         enabled: true,
         onAgentCardReceived,
       })
     );
+    mockPostMessage.mockClear();
 
-    expect(result.current.isWaitingForAgentCard).toBe(true);
-
-    // Simulate agent card message
-    const agentCard = { name: 'Test Agent', endpoint: 'https://api.example.com' };
-    const event = new MessageEvent('message', {
-      origin: 'https://parent.example.com',
-      data: {
-        type: 'SET_AGENT_CARD',
-        agentCard,
-      },
-      source: mockSource as any,
-    });
-
-    act(() => {
-      messageListeners.forEach((listener) => listener(event));
-    });
+    dispatchMessage({ type: 'SET_AGENT_CARD', agentCard });
 
     expect(onAgentCardReceived).toHaveBeenCalledWith(agentCard);
     expect(result.current.isWaitingForAgentCard).toBe(false);
-    expect(mockSource.postMessage).toHaveBeenCalledWith({ type: 'AGENT_CARD_RECEIVED' }, 'https://parent.example.com');
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'AGENT_CARD_RECEIVED' }, 'https://parent.example.com');
   });
 
-  it('should ignore messages from untrusted origins', () => {
+  it.each([
+    ['external URL', 'https://attacker.example/agent-card.json'],
+    ['HTTP URL', 'http://agent.logic.azure.com/agent-card.json'],
+    ['malformed URL', 'not-a-url'],
+    ['object without URL', { name: 'Missing URL' }],
+    ['object with a non-string URL', { url: 42 }],
+  ])('rejects an agent card with an %s without side effects', (_case, agentCard) => {
     const onAgentCardReceived = vi.fn();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { result } = renderHook(() =>
+      useParentCommunication({
+        enabled: true,
+        onAgentCardReceived,
+      })
+    );
+    mockPostMessage.mockClear();
 
+    dispatchMessage({ type: 'SET_AGENT_CARD', agentCard });
+
+    expect(onAgentCardReceived).not.toHaveBeenCalled();
+    expect(result.current.isWaitingForAgentCard).toBe(true);
+    expect(mockPostMessage).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith('Ignoring SET_AGENT_CARD message with an invalid agent card:', expect.any(String));
+  });
+
+  it('rejects SET_AGENT_CARD from a non-parent source without side effects', () => {
+    const onAgentCardReceived = vi.fn();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { result } = renderHook(() =>
+      useParentCommunication({
+        enabled: true,
+        onAgentCardReceived,
+      })
+    );
+    mockPostMessage.mockClear();
+
+    dispatchMessage({ type: 'SET_AGENT_CARD', agentCard: 'https://agent.logic.azure.com/agent-card.json' }, 'https://parent.example.com', {
+      postMessage: vi.fn(),
+    } as unknown as Window);
+
+    expect(onAgentCardReceived).not.toHaveBeenCalled();
+    expect(result.current.isWaitingForAgentCard).toBe(true);
+    expect(mockPostMessage).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith('Ignoring SET_AGENT_CARD message from an unexpected source.');
+  });
+
+  it('rejects SET_AGENT_CARD from an untrusted origin without side effects', () => {
+    const onAgentCardReceived = vi.fn();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { result } = renderHook(() =>
+      useParentCommunication({
+        enabled: true,
+        onAgentCardReceived,
+      })
+    );
+    mockPostMessage.mockClear();
+
+    dispatchMessage({ type: 'SET_AGENT_CARD', agentCard: 'https://agent.logic.azure.com/agent-card.json' }, 'https://untrusted.example');
+
+    expect(onAgentCardReceived).not.toHaveBeenCalled();
+    expect(result.current.isWaitingForAgentCard).toBe(true);
+    expect(mockPostMessage).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith('Ignoring SET_AGENT_CARD message from an untrusted origin:', 'https://untrusted.example');
+  });
+
+  it('ignores unrelated messages', () => {
+    const onAgentCardReceived = vi.fn();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     renderHook(() =>
       useParentCommunication({
         enabled: true,
         onAgentCardReceived,
       })
     );
+    mockPostMessage.mockClear();
 
-    // Simulate message from untrusted origin
-    const event = new MessageEvent('message', {
-      origin: 'https://untrusted.com',
-      data: {
-        type: 'SET_AGENT_CARD',
-        agentCard: {},
-      },
-    });
-
-    act(() => {
-      messageListeners.forEach((listener) => listener(event));
-    });
+    dispatchMessage({ type: 'OTHER_MESSAGE' });
 
     expect(onAgentCardReceived).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledWith('Ignoring message from untrusted origin:', 'https://untrusted.com');
-
-    warnSpy.mockRestore();
+    expect(mockPostMessage).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('should ignore non-SET_AGENT_CARD messages', () => {
-    const onAgentCardReceived = vi.fn();
+  it('allows an explicit target origin for outbound messages', () => {
+    const { result } = renderHook(() => useParentCommunication({ enabled: true }));
 
-    renderHook(() =>
-      useParentCommunication({
-        enabled: true,
-        onAgentCardReceived,
-      })
-    );
+    result.current.sendMessageToParent({ type: 'CUSTOM_MESSAGE' }, 'https://custom.example.com');
 
-    // Simulate different message type
-    const event = new MessageEvent('message', {
-      origin: 'https://parent.example.com',
-      data: {
-        type: 'OTHER_MESSAGE',
-        data: {},
-      },
-    });
-
-    act(() => {
-      messageListeners.forEach((listener) => listener(event));
-    });
-
-    expect(onAgentCardReceived).not.toHaveBeenCalled();
+    expect(mockPostMessage).toHaveBeenLastCalledWith({ type: 'CUSTOM_MESSAGE' }, 'https://custom.example.com');
   });
 
-  it('should provide sendMessageToParent function', () => {
-    const { result } = renderHook(() =>
-      useParentCommunication({
-        enabled: true,
-      })
-    );
-
-    const message = { type: 'CUSTOM_MESSAGE', data: 'test' };
-
-    act(() => {
-      result.current.sendMessageToParent(message);
-    });
-
-    expect(mockPostMessage).toHaveBeenCalledWith(message, 'https://parent.example.com');
-  });
-
-  it('should allow custom target origin in sendMessageToParent', () => {
-    const { result } = renderHook(() =>
-      useParentCommunication({
-        enabled: true,
-      })
-    );
-
-    const message = { type: 'CUSTOM_MESSAGE', data: 'test' };
-    const customOrigin = 'https://custom.example.com';
-
-    act(() => {
-      result.current.sendMessageToParent(message, customOrigin);
-    });
-
-    expect(mockPostMessage).toHaveBeenCalledWith(message, customOrigin);
-  });
-
-  it('should not send messages when window.parent equals window', () => {
-    // Make window.parent equal to window
+  it('does not send messages when window.parent equals window', () => {
     Object.defineProperty(window, 'parent', {
       value: window,
       configurable: true,
     });
-
-    const { result } = renderHook(() =>
-      useParentCommunication({
-        enabled: true,
-      })
-    );
-
+    const { result } = renderHook(() => useParentCommunication({ enabled: true }));
     mockPostMessage.mockClear();
 
-    act(() => {
-      result.current.sendMessageToParent({ type: 'TEST' });
-    });
+    result.current.sendMessageToParent({ type: 'TEST' });
 
     expect(mockPostMessage).not.toHaveBeenCalled();
   });
 
-  it('should clean up event listeners on unmount', () => {
-    const { unmount } = renderHook(() =>
-      useParentCommunication({
-        enabled: true,
-      })
-    );
+  it('cleans up the message listener on unmount', () => {
+    const { unmount } = renderHook(() => useParentCommunication({ enabled: true }));
 
-    expect(messageListeners.length).toBe(1);
+    expect(messageListeners).toHaveLength(1);
 
     unmount();
 
-    expect(window.removeEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+    expect(messageListeners).toHaveLength(0);
   });
 });

--- a/apps/iframe-app/src/lib/hooks/useParentCommunication.ts
+++ b/apps/iframe-app/src/lib/hooks/useParentCommunication.ts
@@ -1,59 +1,87 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getAllowedOrigins, isOriginAllowed, getParentOrigin } from '../utils/origin-validator';
+import { validateAgentCardPayload, type AgentCardPayload } from '../utils/config-parser';
 
 interface UseParentCommunicationOptions {
   enabled: boolean;
-  onAgentCardReceived?: (agentCard: any) => void;
+  trustedParentOrigin?: string;
+  onAgentCardReceived?: (agentCard: AgentCardPayload) => void;
 }
 
 interface UseParentCommunicationResult {
   isWaitingForAgentCard: boolean;
-  sendMessageToParent: (message: any, targetOrigin?: string) => void;
+  sendMessageToParent: (message: unknown, targetOrigin?: string) => void;
+}
+
+interface SetAgentCardMessage {
+  type: 'SET_AGENT_CARD';
+  agentCard?: unknown;
+}
+
+function isSetAgentCardMessage(data: unknown): data is SetAgentCardMessage {
+  return typeof data === 'object' && data !== null && 'type' in data && data.type === 'SET_AGENT_CARD';
 }
 
 /**
  * Custom hook to handle postMessage communication with parent window
  * Used for receiving agent card configuration and other messages
  */
-export function useParentCommunication({ enabled, onAgentCardReceived }: UseParentCommunicationOptions): UseParentCommunicationResult {
+export function useParentCommunication({
+  enabled,
+  trustedParentOrigin,
+  onAgentCardReceived,
+}: UseParentCommunicationOptions): UseParentCommunicationResult {
   const [isWaitingForAgentCard, setIsWaitingForAgentCard] = useState(enabled);
 
   // Send message to parent window
-  const sendMessageToParent = useCallback((message: any, targetOrigin?: string) => {
-    if (window.parent === window) {
-      return; // Not in iframe
-    }
+  const sendMessageToParent = useCallback(
+    (message: unknown, targetOrigin?: string) => {
+      if (window.parent === window) {
+        return; // Not in iframe
+      }
 
-    const origin = targetOrigin || getParentOrigin();
-    window.parent.postMessage(message, origin);
-  }, []);
+      const origin = targetOrigin || getParentOrigin(trustedParentOrigin);
+      window.parent.postMessage(message, origin);
+    },
+    [trustedParentOrigin]
+  );
 
   useEffect(() => {
     if (!enabled) {
       return;
     }
 
-    const allowedOrigins = getAllowedOrigins();
+    const allowedOrigins = getAllowedOrigins(trustedParentOrigin);
 
     const handleMessage = (event: MessageEvent) => {
-      // Verify origin
-      if (!isOriginAllowed(event.origin, allowedOrigins)) {
-        console.warn('Ignoring message from untrusted origin:', event.origin);
+      if (!isSetAgentCardMessage(event.data)) {
         return;
       }
 
-      // Handle SET_AGENT_CARD message
-      if (event.data && event.data.type === 'SET_AGENT_CARD') {
-        if (onAgentCardReceived) {
-          onAgentCardReceived(event.data.agentCard);
-        }
-        setIsWaitingForAgentCard(false);
-
-        // Send acknowledgment
-        if (event.source && typeof event.source.postMessage === 'function') {
-          event.source.postMessage({ type: 'AGENT_CARD_RECEIVED' }, event.origin as any);
-        }
+      if (event.source !== window.parent) {
+        console.warn('Ignoring SET_AGENT_CARD message from an unexpected source.');
+        return;
       }
+
+      if (!isOriginAllowed(event.origin, allowedOrigins)) {
+        console.warn('Ignoring SET_AGENT_CARD message from an untrusted origin:', event.origin);
+        return;
+      }
+
+      let agentCard: AgentCardPayload;
+      try {
+        agentCard = validateAgentCardPayload(event.data.agentCard);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : 'Unknown validation error';
+        console.warn('Ignoring SET_AGENT_CARD message with an invalid agent card:', reason);
+        return;
+      }
+
+      if (onAgentCardReceived) {
+        onAgentCardReceived(agentCard);
+      }
+      setIsWaitingForAgentCard(false);
+      window.parent.postMessage({ type: 'AGENT_CARD_RECEIVED' }, event.origin);
     };
 
     window.addEventListener('message', handleMessage);
@@ -64,7 +92,7 @@ export function useParentCommunication({ enabled, onAgentCardReceived }: UsePare
     return () => {
       window.removeEventListener('message', handleMessage);
     };
-  }, [enabled, onAgentCardReceived, sendMessageToParent]);
+  }, [enabled, trustedParentOrigin, onAgentCardReceived, sendMessageToParent]);
 
   return {
     isWaitingForAgentCard,

--- a/apps/iframe-app/src/lib/iframe.test.tsx
+++ b/apps/iframe-app/src/lib/iframe.test.tsx
@@ -1,123 +1,191 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createRoot } from 'react-dom/client';
+import { act, cleanup, screen, waitFor } from '@testing-library/react';
+import type * as TestingLibraryReact from '@testing-library/react';
+import type * as ReactDomClient from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IframeConfig } from './utils/config-parser';
 
-// Mock dependencies
-vi.mock('react-dom/client');
-vi.mock('@microsoft/logic-apps-chat', () => ({
-  ChatWidget: vi.fn(() => null),
+const { createdRoots, errorDisplayMock, iframeWrapperMock, parseIframeConfigMock } = vi.hoisted(() => ({
+  createdRoots: [] as Array<{ unmount: () => void }>,
+  errorDisplayMock: vi.fn(
+    ({ details, message, title }: { details?: { parameters?: string; url?: string }; message: string; title: string }) => (
+      <div data-testid="error-display">
+        <span>{title}</span>
+        <span>{message}</span>
+        <span>{details?.url}</span>
+        <span>{details?.parameters}</span>
+      </div>
+    )
+  ),
+  iframeWrapperMock: vi.fn(({ config }: { config: IframeConfig }) => (
+    <div data-testid="iframe-wrapper">
+      {typeof config.props.agentCard === 'string' ? config.props.agentCard : config.props.agentCard.url}
+    </div>
+  )),
+  parseIframeConfigMock: vi.fn(),
 }));
-vi.mock('../styles/base.css', () => ({}));
-vi.mock('./hooks/useIframeConfig', () => ({
-  useIframeConfig: vi.fn(() => ({
-    apiUrl: 'http://localhost:3000',
-    allowedOrigins: ['*'],
-    contextId: 'test-context',
-  })),
-}));
-vi.mock('../components/IframeWrapper', () => ({
-  IframeWrapper: vi.fn(() => null),
-}));
+
+vi.mock('react-dom/client', async () => {
+  const { act: rtlAct } = await vi.importActual<typeof TestingLibraryReact>('@testing-library/react');
+  const actual = await vi.importActual<typeof ReactDomClient>('react-dom/client');
+
+  return {
+    ...actual,
+    createRoot: (container: Parameters<typeof actual.createRoot>[0], options?: Parameters<typeof actual.createRoot>[1]) => {
+      const root = actual.createRoot(container, options);
+      const wrappedRoot = {
+        render: (node: Parameters<typeof root.render>[0]) => {
+          rtlAct(() => {
+            root.render(node);
+          });
+        },
+        unmount: () => {
+          root.unmount();
+        },
+      };
+
+      createdRoots.push(wrappedRoot);
+      return wrappedRoot;
+    },
+  };
+});
+
 vi.mock('../components/ErrorDisplay', () => ({
-  ErrorDisplay: vi.fn(() => null),
+  ErrorDisplay: errorDisplayMock,
 }));
+
+vi.mock('../components/IframeWrapper', () => ({
+  IframeWrapper: iframeWrapperMock,
+}));
+
+vi.mock('./utils/config-parser', () => ({
+  parseIframeConfig: parseIframeConfigMock,
+}));
+
+vi.mock('../styles/base.css', () => ({}));
 
 describe('iframe initialization', () => {
-  let mockCreateRoot: ReturnType<typeof vi.fn>;
-  let mockRoot: { render: ReturnType<typeof vi.fn> };
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  const validAgentCardUrl = 'https://api.example.com/agent-card.json';
+  const validConfig: IframeConfig = {
+    inPortal: false,
+    mode: 'light',
+    multiSession: false,
+    props: {
+      agentCard: validAgentCardUrl,
+    },
+  };
+
+  const importIframe = async () => {
+    await act(async () => {
+      await import('./iframe');
+    });
+  };
 
   beforeEach(() => {
-    // Clear module cache to allow re-importing
     vi.resetModules();
-
-    // Mock createRoot
-    mockRoot = { render: vi.fn() };
-    mockCreateRoot = vi.fn().mockReturnValue(mockRoot);
-    vi.mocked(createRoot).mockImplementation(mockCreateRoot);
-
-    // Mock console.error
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    // Create chat-root element
+    vi.clearAllMocks();
+    createdRoots.length = 0;
     document.body.innerHTML = '<div id="chat-root"></div>';
+    window.history.replaceState({}, '', '/iframe?foo=bar');
 
-    // Mock document.readyState
     Object.defineProperty(document, 'readyState', {
+      configurable: true,
       value: 'complete',
       writable: true,
-      configurable: true,
     });
   });
 
   afterEach(() => {
-    consoleErrorSpy?.mockRestore();
-    vi.clearAllMocks();
+    cleanup();
+
+    while (createdRoots.length > 0) {
+      const root = createdRoots.pop();
+      root?.unmount();
+    }
+
     document.body.innerHTML = '';
   });
 
-  it('initializes successfully when chat-root element exists', async () => {
-    await import('./iframe');
+  it('renders the iframe wrapper when configuration parses successfully', async () => {
+    parseIframeConfigMock.mockReturnValue(validConfig);
 
-    // Wait a bit for initialization to complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await importIframe();
 
-    expect(mockCreateRoot).toHaveBeenCalledWith(document.getElementById('chat-root'));
-    expect(mockRoot.render).toHaveBeenCalled();
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
-  }, 10000);
-
-  it('displays error when chat-root element is missing', async () => {
-    document.body.innerHTML = '';
-
-    await import('./iframe');
-
-    // The code renders ErrorDisplay to document.body when chat-root is missing
-    expect(mockCreateRoot).toHaveBeenCalledWith(document.body);
-    expect(mockRoot.render).toHaveBeenCalled();
+    expect(await screen.findByTestId('iframe-wrapper')).toHaveTextContent(validAgentCardUrl);
+    expect(parseIframeConfigMock).toHaveBeenCalledTimes(1);
+    expect(errorDisplayMock).not.toHaveBeenCalled();
+    expect(iframeWrapperMock.mock.calls[0][0]).toMatchObject({ config: validConfig });
   });
 
-  it.skip('handles non-error objects gracefully', async () => {
-    document.body.innerHTML = '';
-
-    let callCount = 0;
-    // Mock createRoot to throw on first call, succeed on second
-    vi.mocked(createRoot).mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        throw 'String error';
-      }
-      // Return a mock root for the error display
-      return mockRoot;
+  it('renders a configuration error when parsing throws', async () => {
+    parseIframeConfigMock.mockImplementation(() => {
+      throw new Error('Invalid iframe configuration');
     });
 
-    await import('./iframe');
+    await importIframe();
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to initialize chat widget:', 'String error');
+    const errorDisplay = await screen.findByTestId('error-display');
 
-    // Should render error display
-    expect(mockRoot.render).toHaveBeenCalled();
+    expect(errorDisplay).toHaveTextContent('Configuration error');
+    expect(errorDisplay).toHaveTextContent('Invalid iframe configuration');
+    expect(errorDisplay).toHaveTextContent('http://localhost:3000/iframe?foo=bar');
+    expect(errorDisplay).toHaveTextContent('?foo=bar');
+    expect(parseIframeConfigMock).toHaveBeenCalledTimes(1);
+    expect(iframeWrapperMock).not.toHaveBeenCalled();
   });
 
-  it('waits for DOMContentLoaded when document is still loading', async () => {
+  it('renders nothing when parsing returns null without throwing', async () => {
+    parseIframeConfigMock.mockReturnValue(null);
+
+    await importIframe();
+
+    await waitFor(() => {
+      expect(parseIframeConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(document.getElementById('chat-root')?.innerHTML).toBe('');
+    expect(screen.queryByTestId('iframe-wrapper')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error-display')).not.toBeInTheDocument();
+  });
+
+  it('renders a load error when the chat root element is missing', async () => {
+    document.body.innerHTML = '';
+
+    await importIframe();
+
+    const errorDisplay = await screen.findByTestId('error-display');
+
+    expect(errorDisplay).toHaveTextContent('Failed to load chat widget');
+    expect(errorDisplay).toHaveTextContent('Chat root element not found');
+    expect(errorDisplay).toHaveTextContent('http://localhost:3000/iframe?foo=bar');
+    expect(errorDisplay).toHaveTextContent('?foo=bar');
+    expect(parseIframeConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('waits for DOMContentLoaded when the document is still loading', async () => {
+    parseIframeConfigMock.mockReturnValue(validConfig);
+
     Object.defineProperty(document, 'readyState', {
+      configurable: true,
       value: 'loading',
       writable: true,
-      configurable: true,
     });
 
     const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
 
-    await import('./iframe');
+    await importIframe();
 
-    expect(addEventListenerSpy).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function));
-    expect(mockCreateRoot).not.toHaveBeenCalled();
+    const domContentLoadedHandler = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'DOMContentLoaded'
+    )?.[1] as EventListener;
 
-    // Simulate DOMContentLoaded
-    const handler = addEventListenerSpy.mock.calls[0][1] as EventListener;
-    handler(new Event('DOMContentLoaded'));
+    expect(domContentLoadedHandler).toBeTypeOf('function');
+    expect(screen.queryByTestId('iframe-wrapper')).not.toBeInTheDocument();
 
-    expect(mockCreateRoot).toHaveBeenCalled();
-    expect(mockRoot.render).toHaveBeenCalled();
+    act(() => {
+      domContentLoadedHandler(new Event('DOMContentLoaded'));
+    });
+
+    expect(await screen.findByTestId('iframe-wrapper')).toHaveTextContent(validAgentCardUrl);
 
     addEventListenerSpy.mockRestore();
   });

--- a/apps/iframe-app/src/lib/iframe.tsx
+++ b/apps/iframe-app/src/lib/iframe.tsx
@@ -2,16 +2,17 @@
  * Iframe integration for A2A Chat Widget
  *
  * Security: This component implements origin verification for postMessage communication.
- * To configure allowed origins, use one of these methods:
+ * To configure allowed origins, use one of these trusted methods:
  *
- * 1. URL parameter: ?allowedOrigins=https://example.com,https://app.example.com
- * 2. Data attribute: <html data-allowed-origins="https://example.com,https://app.example.com">
- * 3. Wildcard subdomains: ?allowedOrigins=*.example.com
+ * 1. Render a data attribute inside the served iframe document:
+ *    <html data-allowed-origins="https://example.com,https://app.example.com">
+ * 2. Use the validated trustedAuthority configuration for Azure Portal.
  *
  * If no origins are specified, the iframe will:
  * - Allow messages from its own origin
- * - Allow messages from the document referrer (parent frame)
  * - In development (localhost), allow common development ports
+ *
+ * Query parameters and document.referrer never authorize inbound messages.
  */
 
 import { useState, useMemo } from 'react';

--- a/apps/iframe-app/src/lib/utils/__tests__/config-parser.spec.ts
+++ b/apps/iframe-app/src/lib/utils/__tests__/config-parser.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { parseIframeConfig, parseIdentityProviders } from '../config-parser';
+import { parseIframeConfig, parseIdentityProviders, validateAgentCardPayload, validateAgentCardUrl } from '../config-parser';
 
 describe('config-parser', () => {
   const originalLocation = window.location;
@@ -139,6 +139,37 @@ describe('config-parser', () => {
       mockLocation('https://agents.logic.azure.com/api/agentsChat/myAgent/IFrame?agentCard=https://localhost:3000/agent-card.json');
 
       expect(() => parseIframeConfig()).toThrow('localhost are only allowed during local development');
+    });
+  });
+
+  describe('agent card payload validation', () => {
+    it('accepts a Microsoft HTTPS agent card URL', () => {
+      const agentCardUrl = 'https://agent.logic.azure.com/.well-known/agent-card.json';
+
+      expect(validateAgentCardUrl(agentCardUrl)).toBe(agentCardUrl);
+      expect(validateAgentCardPayload(agentCardUrl)).toBe(agentCardUrl);
+    });
+
+    it('accepts and preserves an object with a Microsoft HTTPS URL', () => {
+      const agentCard = {
+        name: 'Test Agent',
+        url: 'https://agent.logic-apps.azure.com/rpc',
+        capabilities: { streaming: true },
+      };
+
+      expect(validateAgentCardPayload(agentCard)).toBe(agentCard);
+    });
+
+    it.each([
+      ['external', 'https://attacker.example/agent-card.json'],
+      ['HTTP', 'http://agent.logic.azure.com/agent-card.json'],
+      ['malformed', 'not-a-url'],
+    ])('rejects a %s agent card URL', (_case, agentCard) => {
+      expect(() => validateAgentCardPayload(agentCard)).toThrow();
+    });
+
+    it.each([undefined, null, {}, { name: 'Missing URL' }, { url: 42 }])('rejects a malformed agent card payload: %s', (agentCard) => {
+      expect(() => validateAgentCardPayload(agentCard)).toThrow('Agent card must be a URL string or an object with a URL string.');
     });
   });
 

--- a/apps/iframe-app/src/lib/utils/__tests__/config-parser.test.ts
+++ b/apps/iframe-app/src/lib/utils/__tests__/config-parser.test.ts
@@ -351,6 +351,15 @@ describe('parseIframeConfig', () => {
       expect(config.trustedParentOrigin).toBe('https://subdomain.portal.azure.com');
     });
 
+    it('normalizes the trusted authority to its canonical origin', () => {
+      document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
+      window.location.search = '?inPortal=true&trustedAuthority=https://portal.azure.com/tenant/resource';
+
+      const config = parseIframeConfig();
+
+      expect(config.trustedParentOrigin).toBe('https://portal.azure.com');
+    });
+
     it('throws error for untrusted authority', () => {
       document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
       window.location.search = '?inPortal=true&trustedAuthority=https://evil.com';
@@ -358,14 +367,70 @@ describe('parseIframeConfig', () => {
       expect(() => parseIframeConfig()).toThrow("The origin 'evil.com' is not trusted for Frame Blade");
     });
 
-    it('allows localhost for development', () => {
+    it('rejects a trustedAuthority that is not a valid URL', () => {
       document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
-      window.location.search = '?inPortal=true&trustedAuthority=https://localhost:3000';
+      window.location.search = '?inPortal=true&trustedAuthority=not-a-valid-url';
+
+      expect(() => parseIframeConfig()).toThrow('is not trusted for Frame Blade');
+    });
+
+    it('rejects a non-https scheme for a trusted portal host', () => {
+      document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
+      window.location.search = '?inPortal=true&trustedAuthority=http://portal.azure.com';
+
+      expect(() => parseIframeConfig()).toThrow("The origin 'portal.azure.com' is not trusted for Frame Blade");
+    });
+
+    it('rejects a javascript: scheme masquerading as a portal host', () => {
+      document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
+      window.location.search = '?inPortal=true&trustedAuthority=javascript:alert(document.domain)';
+
+      expect(() => parseIframeConfig()).toThrow('is not trusted for Frame Blade');
+    });
+
+    it('allows a localhost parent only when the iframe itself runs locally', () => {
+      (window as any).location.hostname = 'localhost';
+      document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
+      window.location.search = '?inPortal=true&trustedAuthority=http://localhost:4200';
 
       const config = parseIframeConfig();
 
       expect(config.inPortal).toBe(true);
-      expect(config.trustedParentOrigin).toBe('https://localhost:3000');
+      expect(config.trustedParentOrigin).toBe('http://localhost:4200');
+    });
+
+    it('allows a 127.0.0.1 parent when the iframe itself runs locally', () => {
+      (window as any).location.hostname = '127.0.0.1';
+      document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
+      window.location.search = '?inPortal=true&trustedAuthority=https://127.0.0.1:3000';
+
+      const config = parseIframeConfig();
+
+      expect(config.trustedParentOrigin).toBe('https://127.0.0.1:3000');
+    });
+
+    it('rejects non-http localhost authorities during local development', () => {
+      (window as any).location.hostname = 'localhost';
+      document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
+      window.location.search = '?inPortal=true&trustedAuthority=ftp://localhost:21';
+
+      expect(() => parseIframeConfig()).toThrow("The origin 'localhost' is not trusted for Frame Blade");
+    });
+
+    it('rejects an http localhost parent when the iframe runs in production', () => {
+      (window as any).location.hostname = 'iframe.logic.azure.com';
+      document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
+      window.location.search = '?inPortal=true&trustedAuthority=http://localhost:3000';
+
+      expect(() => parseIframeConfig()).toThrow("The origin 'localhost:3000' is not trusted for Frame Blade");
+    });
+
+    it('rejects an https localhost parent when the iframe runs in production', () => {
+      (window as any).location.hostname = 'iframe.logic.azure.com';
+      document.documentElement.dataset.agentCard = 'https://test.logic.azure.com/agent-card.json';
+      window.location.search = '?inPortal=true&trustedAuthority=https://localhost:3000';
+
+      expect(() => parseIframeConfig()).toThrow("The origin 'localhost:3000' is not trusted for Frame Blade");
     });
   });
 });

--- a/apps/iframe-app/src/lib/utils/__tests__/origin-validator.test.ts
+++ b/apps/iframe-app/src/lib/utils/__tests__/origin-validator.test.ts
@@ -1,66 +1,83 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { getAllowedOrigins, isOriginAllowed, getParentOrigin } from '../origin-validator';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getAllowedOrigins, getParentOrigin, isOriginAllowed } from '../origin-validator';
 
 describe('origin-validator', () => {
-  beforeEach(() => {
-    // Reset window.location
-    delete (window as any).location;
-    (window as any).location = new URL('http://localhost:3000');
+  const originalLocation = window.location;
 
-    // Reset document properties
+  const setLocation = (url: string) => {
+    Object.defineProperty(window, 'location', {
+      value: new URL(url),
+      configurable: true,
+    });
+  };
+
+  beforeEach(() => {
+    setLocation('https://iframe.logic.azure.com/iframe.html');
     Object.defineProperty(document, 'referrer', {
       value: '',
       configurable: true,
     });
-
-    // Clear dataset properties
     Object.keys(document.documentElement.dataset).forEach((key) => {
       delete document.documentElement.dataset[key];
     });
   });
 
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      configurable: true,
+    });
+  });
+
   describe('getAllowedOrigins', () => {
-    it('should return current origin by default', () => {
-      const origins = getAllowedOrigins();
-      expect(origins).toContain('http://localhost:3000');
+    it('allows the iframe origin by default', () => {
+      expect(getAllowedOrigins()).toEqual(['https://iframe.logic.azure.com']);
     });
 
-    it('should add development origins when on localhost', () => {
-      const origins = getAllowedOrigins();
-      expect(origins).toContain('http://localhost:3000');
-      expect(origins).toContain('http://localhost:3001');
-      expect(origins).toContain('http://127.0.0.1:3000');
+    it('allows fixed development origins only when the iframe is local', () => {
+      setLocation('http://localhost:5173/iframe.html');
+
+      expect(getAllowedOrigins()).toEqual(
+        expect.arrayContaining(['http://localhost:5173', 'http://localhost:3000', 'http://localhost:3001', 'http://127.0.0.1:3000'])
+      );
     });
 
-    it('should parse allowed origins from URL parameter', () => {
-      (window as any).location = new URL('http://localhost:3000?allowedOrigins=https://example.com,https://app.example.com');
+    it('does not enable development origins for a localhost lookalike hostname', () => {
+      setLocation('https://localhost.attacker.example/iframe.html');
 
-      const origins = getAllowedOrigins();
-      expect(origins).toContain('https://example.com');
-      expect(origins).toContain('https://app.example.com');
+      expect(getAllowedOrigins()).toEqual(['https://localhost.attacker.example']);
     });
 
-    it('should parse allowed origins from data attribute', () => {
-      document.documentElement.dataset.allowedOrigins = 'https://data1.com,https://data2.com';
+    it('uses origins configured inside the iframe document', () => {
+      document.documentElement.dataset.allowedOrigins = 'https://designer.example.com,https://admin.example.com';
 
-      const origins = getAllowedOrigins();
-      expect(origins).toContain('https://data1.com');
-      expect(origins).toContain('https://data2.com');
+      expect(getAllowedOrigins()).toEqual(expect.arrayContaining(['https://designer.example.com', 'https://admin.example.com']));
     });
 
-    it('should include document referrer if present', () => {
+    it('uses an already validated trusted parent origin', () => {
+      expect(getAllowedOrigins('https://portal.azure.com')).toEqual(
+        expect.arrayContaining(['https://iframe.logic.azure.com', 'https://portal.azure.com'])
+      );
+    });
+
+    it('does not trust origins supplied only through the iframe query string', () => {
+      setLocation('https://iframe.logic.azure.com/iframe.html?allowedOrigins=https://attacker.example,https://other.example');
+
+      expect(getAllowedOrigins()).toEqual(['https://iframe.logic.azure.com']);
+    });
+
+    it('does not trust the document referrer by itself', () => {
       Object.defineProperty(document, 'referrer', {
-        value: 'https://parent.example.com/page',
+        value: 'https://attacker.example/embed',
         configurable: true,
       });
 
-      const origins = getAllowedOrigins();
-      expect(origins).toContain('https://parent.example.com');
+      expect(getAllowedOrigins()).toEqual(['https://iframe.logic.azure.com']);
     });
   });
 
   describe('isOriginAllowed', () => {
-    it('should allow direct match', () => {
+    it('allows direct matches only', () => {
       const allowedOrigins = ['https://example.com', 'https://app.example.com'];
 
       expect(isOriginAllowed('https://example.com', allowedOrigins)).toBe(true);
@@ -68,44 +85,61 @@ describe('origin-validator', () => {
       expect(isOriginAllowed('https://other.com', allowedOrigins)).toBe(false);
     });
 
-    it('should support wildcard subdomain patterns', () => {
+    it('supports explicitly configured wildcard subdomains', () => {
       const allowedOrigins = ['*.example.com'];
 
       expect(isOriginAllowed('https://app.example.com', allowedOrigins)).toBe(true);
-      expect(isOriginAllowed('https://admin.example.com', allowedOrigins)).toBe(true);
       expect(isOriginAllowed('https://deep.sub.example.com', allowedOrigins)).toBe(true);
       expect(isOriginAllowed('https://example.com', allowedOrigins)).toBe(false);
       expect(isOriginAllowed('https://notexample.com', allowedOrigins)).toBe(false);
     });
 
-    it('should handle invalid URLs gracefully', () => {
-      const allowedOrigins = ['*.example.com'];
-
-      expect(isOriginAllowed('not-a-url', allowedOrigins)).toBe(false);
+    it('handles invalid origins gracefully', () => {
+      expect(isOriginAllowed('not-a-url', ['*.example.com'])).toBe(false);
     });
   });
 
   describe('getParentOrigin', () => {
-    it('should return referrer origin if available', () => {
+    it('prefers an already validated trusted parent origin', () => {
+      expect(getParentOrigin('https://portal.azure.com')).toBe('https://portal.azure.com');
+    });
+
+    it('uses a referrer that is independently configured inside the iframe document', () => {
+      document.documentElement.dataset.allowedOrigins = 'https://parent.example.com';
       Object.defineProperty(document, 'referrer', {
-        value: 'https://parent.example.com/page',
+        value: 'https://parent.example.com/embed',
         configurable: true,
       });
 
       expect(getParentOrigin()).toBe('https://parent.example.com');
     });
 
-    it('should fallback to current origin if no referrer', () => {
+    it('uses a local development referrer covered by fixed defaults', () => {
+      setLocation('http://localhost:5173/iframe.html');
+      Object.defineProperty(document, 'referrer', {
+        value: 'http://localhost:3000/embed',
+        configurable: true,
+      });
+
       expect(getParentOrigin()).toBe('http://localhost:3000');
     });
 
-    it('should handle invalid referrer gracefully', () => {
+    it('does not use an untrusted referrer as the parent origin', () => {
+      Object.defineProperty(document, 'referrer', {
+        value: 'https://attacker.example/embed',
+        configurable: true,
+      });
+
+      expect(getParentOrigin()).toBe('https://iframe.logic.azure.com');
+    });
+
+    it('falls back to the current origin for an invalid referrer', () => {
       Object.defineProperty(document, 'referrer', {
         value: 'not-a-valid-url',
         configurable: true,
       });
 
-      expect(getParentOrigin()).toBe('http://localhost:3000');
+      expect(getParentOrigin()).toBe('https://iframe.logic.azure.com');
     });
   });
 });

--- a/apps/iframe-app/src/lib/utils/config-parser.ts
+++ b/apps/iframe-app/src/lib/utils/config-parser.ts
@@ -51,11 +51,17 @@ function validatePortalSecurity(params: URLSearchParams): PortalValidationResult
 
 const ALLOWED_AGENT_CARD_DOMAINS = ['.logic.azure.com', '.logic-apps.azure.com'];
 
+export type AgentCardPayload = ChatWidgetProps['agentCard'];
+
+function isAgentCardObject(value: unknown): value is Exclude<AgentCardPayload, string> {
+  return typeof value === 'object' && value !== null && 'url' in value && typeof value.url === 'string';
+}
+
 /**
  * Validates that an agent card URL uses HTTPS and points to a trusted Microsoft domain.
  * Blocks arbitrary external URLs to prevent chat hijacking via agentCard parameter injection.
  */
-function validateAgentCardUrl(url: string): string {
+export function validateAgentCardUrl(url: string): string {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -66,7 +72,7 @@ function validateAgentCardUrl(url: string): string {
   // Allow localhost only when the iframe itself is running locally (development)
   const isLocalDevelopment = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
   if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
-    if (isLocalDevelopment) {
+    if (isLocalDevelopment && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
       return url;
     }
     throw new Error('Agent card URLs pointing to localhost are only allowed during local development.');
@@ -85,6 +91,24 @@ function validateAgentCardUrl(url: string): string {
   }
 
   return url;
+}
+
+/**
+ * Validates the URL carried by either supported agent-card payload shape.
+ * The original payload is returned so object-based agent cards retain their metadata.
+ */
+export function validateAgentCardPayload(agentCard: unknown): AgentCardPayload {
+  if (typeof agentCard === 'string') {
+    validateAgentCardUrl(agentCard);
+    return agentCard;
+  }
+
+  if (isAgentCardObject(agentCard)) {
+    validateAgentCardUrl(agentCard.url);
+    return agentCard;
+  }
+
+  throw new Error('Agent card must be a URL string or an object with a URL string.');
 }
 
 function extractAgentCardUrl(params: URLSearchParams, dataset: DOMStringMap): string {

--- a/apps/iframe-app/src/lib/utils/config-parser.ts
+++ b/apps/iframe-app/src/lib/utils/config-parser.ts
@@ -16,13 +16,15 @@ interface PortalValidationResult {
   trustedParentOrigin?: string;
 }
 
-const ALLOWED_PORTAL_AUTHORITIES = [
-  'df.onecloud.azure-test.net',
-  'portal.azure.com',
-  'ms.portal.azure.com',
-  'rc.portal.azure.com',
-  'localhost:55555', // For local development
-];
+const ALLOWED_PORTAL_AUTHORITIES = ['df.onecloud.azure-test.net', 'portal.azure.com', 'ms.portal.azure.com', 'rc.portal.azure.com'];
+
+function isIframeRunningLocally(): boolean {
+  return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+}
+
+function isLocalhostHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1';
+}
 
 function validatePortalSecurity(params: URLSearchParams): PortalValidationResult {
   const trustedAuthority = params.get('trustedAuthority') || '';
@@ -30,23 +32,45 @@ function validatePortalSecurity(params: URLSearchParams): PortalValidationResult
     return {};
   }
 
-  const parentTrustedAuthority = (trustedAuthority.split('//')[1] || '').toLowerCase();
+  // Canonicalize the query-supplied authority so downstream trust decisions operate on a
+  // parsed origin instead of raw, attacker-controllable text.
+  let parsedAuthority: URL;
+  try {
+    parsedAuthority = new URL(trustedAuthority);
+  } catch {
+    throw new Error(`The origin '${trustedAuthority}' is not trusted for Frame Blade.`);
+  }
+
+  const parentHost = parsedAuthority.host.toLowerCase();
+  const parentHostname = parsedAuthority.hostname.toLowerCase();
+
+  // Localhost parents are only honored when the iframe itself is running locally, so a
+  // production iframe can never be embedded and driven by a localhost origin.
+  if (isLocalhostHostname(parentHostname)) {
+    if (!isIframeRunningLocally() || (parsedAuthority.protocol !== 'http:' && parsedAuthority.protocol !== 'https:')) {
+      throw new Error(`The origin '${parentHost}' is not trusted for Frame Blade.`);
+    }
+    return { trustedParentOrigin: parsedAuthority.origin };
+  }
+
+  // Non-localhost portal hosts must use HTTPS; any other scheme is rejected.
+  if (parsedAuthority.protocol !== 'https:') {
+    throw new Error(`The origin '${parentHost}' is not trusted for Frame Blade.`);
+  }
 
   const isTrustedOrigin = ALLOWED_PORTAL_AUTHORITIES.some((allowedOrigin) => {
-    if (allowedOrigin === parentTrustedAuthority) {
+    if (allowedOrigin === parentHost) {
       return true;
     }
     const subdomainSuffix = `.${allowedOrigin}`;
-    return (
-      parentTrustedAuthority.length > subdomainSuffix.length && parentTrustedAuthority.slice(-subdomainSuffix.length) === subdomainSuffix
-    );
+    return parentHost.length > subdomainSuffix.length && parentHost.slice(-subdomainSuffix.length) === subdomainSuffix;
   });
 
-  if (!isTrustedOrigin && !parentTrustedAuthority.startsWith('localhost:')) {
-    throw new Error(`The origin '${parentTrustedAuthority}' is not trusted for Frame Blade.`);
+  if (!isTrustedOrigin) {
+    throw new Error(`The origin '${parentHost}' is not trusted for Frame Blade.`);
   }
 
-  return { trustedParentOrigin: trustedAuthority };
+  return { trustedParentOrigin: parsedAuthority.origin };
 }
 
 const ALLOWED_AGENT_CARD_DOMAINS = ['.logic.azure.com', '.logic-apps.azure.com'];

--- a/apps/iframe-app/src/lib/utils/origin-validator.ts
+++ b/apps/iframe-app/src/lib/utils/origin-validator.ts
@@ -2,39 +2,32 @@
  * Security utilities for validating message origins
  */
 
-export function getAllowedOrigins(): string[] {
-  const params = new URLSearchParams(window.location.search);
+function isLocalDevelopment(): boolean {
+  return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+}
+
+export function getAllowedOrigins(trustedParentOrigin?: string): string[] {
   const dataset = document.documentElement.dataset;
-
-  // Check for explicitly configured allowed origins
-  const allowedOriginsStr = dataset.allowedOrigins || params.get('allowedOrigins');
-
-  if (allowedOriginsStr) {
-    return allowedOriginsStr.split(',').map((origin) => origin.trim());
-  }
-
-  // Default allowed origins
   const currentOrigin = window.location.origin;
   const allowedOrigins = [currentOrigin];
 
-  // Add development origins if in dev environment
-  if (currentOrigin.includes('localhost') || currentOrigin.includes('127.0.0.1')) {
+  // These origins are fixed development defaults, not iframe query data.
+  if (isLocalDevelopment()) {
     allowedOrigins.push('http://localhost:3000', 'http://localhost:3001', 'http://127.0.0.1:3000');
   }
 
-  // Add document referrer if it exists
-  if (document.referrer) {
-    try {
-      const referrerOrigin = new URL(document.referrer).origin;
-      if (!allowedOrigins.includes(referrerOrigin)) {
-        allowedOrigins.push(referrerOrigin);
-      }
-    } catch (_e) {
-      // Invalid referrer URL, ignore
-    }
+  // Only configuration rendered inside the iframe document may extend inbound trust.
+  const configuredOrigins = dataset.allowedOrigins;
+  if (configuredOrigins) {
+    allowedOrigins.push(...configuredOrigins.split(',').map((origin) => origin.trim()));
   }
 
-  return allowedOrigins;
+  // trustedParentOrigin has already been allowlisted by config-parser.
+  if (trustedParentOrigin) {
+    allowedOrigins.push(trustedParentOrigin);
+  }
+
+  return [...new Set(allowedOrigins.filter(Boolean))];
 }
 
 export function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
@@ -62,11 +55,19 @@ export function isOriginAllowed(origin: string, allowedOrigins: string[]): boole
   return false;
 }
 
-export function getParentOrigin(): string {
-  // Try to get parent origin from referrer
+export function getParentOrigin(trustedParentOrigin?: string): string {
+  if (trustedParentOrigin) {
+    return trustedParentOrigin;
+  }
+
+  // A referrer may target the non-sensitive ready signal only when independently
+  // authorized by same-origin, local-development, or document configuration.
   if (document.referrer) {
     try {
-      return new URL(document.referrer).origin;
+      const referrerOrigin = new URL(document.referrer).origin;
+      if (isOriginAllowed(referrerOrigin, getAllowedOrigins())) {
+        return referrerOrigin;
+      }
     } catch (_e) {
       // Invalid referrer URL
     }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] fix - Bug fix
- [ ] feature - New functionality
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Validates every `SET_AGENT_CARD` payload before callback, state mutation, acknowledgment, or credentialed fetch. The iframe now accepts only trusted Microsoft HTTPS agent-card URLs, requires messages to come from `window.parent`, and no longer treats query-string origins or `document.referrer` as inbound authorization.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Prevents untrusted embedders or non-parent windows from redirecting authenticated agent-card requests.
- **Developers**: Cross-origin postMessage embedding must use validated Portal configuration or server-rendered `data-allowed-origins`; query/referrer-only trust is rejected.
- **System**: Preserves same-origin and local-development behavior while enforcing the existing Logic Apps agent-card domain policy at the postMessage sink.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in: Biome and ESLint passed on changed files; 121 focused iframe security/initialization tests passed with 100% line coverage for `src/lib/iframe.tsx`; iframe production build passed. Iframe type-check was attempted and remains blocked by pre-existing unrelated errors in `LoginPrompt.spec.tsx` and `MultiSessionChat.test.tsx`. All required GitHub checks passed on head `88f11213d`.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@Copilot

## Screenshots/Videos
<!-- Visual changes only -->
Not applicable (nonvisual security change).