### PR TITLE
fix: clarify request URL publish guidance

### DIFF
--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/a2arequest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/a2arequest.ts
@@ -14,7 +14,7 @@ export default {
         agentUrl: {
           type: 'string',
           title: 'Agent URL',
-          description: 'URL will be generated after save',
+          description: 'URL will be generated after publish',
           'x-ms-editor': 'copyable',
           'x-ms-serialization': {
             skip: true,

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/a2arequest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/a2arequest.ts
@@ -14,7 +14,7 @@ export default {
         agentUrl: {
           type: 'string',
           title: 'Agent URL',
-          description: 'URL will be generated after publish',
+          description: 'Publish the workflow to generate the URL.',
           'x-ms-editor': 'copyable',
           'x-ms-serialization': {
             skip: true,

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/request.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/request.ts
@@ -15,7 +15,7 @@ export default {
         callbackUrl: {
           type: 'string',
           title: 'HTTP URL',
-          description: 'URL will be generated after publish',
+          description: 'Publish the workflow to generate the URL.',
           'x-ms-visiblity': 'important',
           'x-ms-editor': 'copyable',
           'x-ms-serialization': {
@@ -27,7 +27,7 @@ export default {
           title: 'Method',
           'x-ms-visiblity': 'important',
           'x-ms-editor': 'combobox',
-          description: 'URL will be generated after publish',
+          description: 'Publish the workflow to generate the URL.',
           'x-ms-editor-options': {
             options: [
               {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/request.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/base/manifests/request.ts
@@ -15,7 +15,7 @@ export default {
         callbackUrl: {
           type: 'string',
           title: 'HTTP URL',
-          description: 'URL will be generated after save',
+          description: 'URL will be generated after publish',
           'x-ms-visiblity': 'important',
           'x-ms-editor': 'copyable',
           'x-ms-serialization': {
@@ -27,7 +27,7 @@ export default {
           title: 'Method',
           'x-ms-visiblity': 'important',
           'x-ms-editor': 'combobox',
-          description: 'URL will be generated after save',
+          description: 'URL will be generated after publish',
           'x-ms-editor-options': {
             options: [
               {

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/a2arequest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/a2arequest.ts
@@ -15,7 +15,7 @@ export default {
         agentUrl: {
           type: 'string',
           title: 'Agent URL',
-          description: 'URL will be generated after publish',
+          description: 'Publish the workflow to generate the URL.',
           'x-ms-editor': 'copyable',
           'x-ms-serialization': {
             skip: true,

--- a/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/a2arequest.ts
+++ b/libs/logic-apps-shared/src/designer-client-services/lib/consumption/manifests/a2arequest.ts
@@ -15,7 +15,7 @@ export default {
         agentUrl: {
           type: 'string',
           title: 'Agent URL',
-          description: 'URL will be generated after save',
+          description: 'URL will be generated after publish',
           'x-ms-editor': 'copyable',
           'x-ms-serialization': {
             skip: true,


### PR DESCRIPTION
## Commit Type
- [ ] feature: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding missing tests or correcting existing tests
- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Other changes that don't modify src or test files
- [ ] revert: Reverts a previous commit

## Risk Level
- [x] Low: Minor changes with minimal impact
- [ ] Medium: Changes that may affect existing functionality
- [ ] High: Significant changes that could cause breaking changes

## What & Why

Closes #8559.

Request and A2A Request URLs are generated after a workflow is published, so the current "after save" descriptions give users the wrong lifecycle step. All four affected descriptions now tell users to publish the workflow to generate the URL.

## Impact of Change
- **Users**: See accurate guidance for when the generated URL becomes available.
- **Developers**: No API or behavioral changes.
- **System**: Copy-only manifest changes.

## Test Plan
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in:
  - `pnpm --filter @microsoft/logic-apps-shared build:lib`
  - `pnpm --filter @microsoft/logic-apps-shared test:lib` (52 files, 966 tests)

## Contributors

@miachillgood

## Screenshots/Videos

Not applicable; this is a text-only correction.
