### PR TITLE
fix: distinguish run with payload tooltip

### DIFF
--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/__tests__/floatingRunButton.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/__tests__/floatingRunButton.spec.tsx
@@ -4,7 +4,7 @@
 import '@testing-library/jest-dom/vitest';
 import type { ComponentProps } from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
@@ -324,13 +324,15 @@ describe('FloatingRunButton', () => {
       expect(buttons.length).toBeGreaterThan(1);
     });
 
-    it('should identify the payload action with a distinct tooltip', () => {
+    it('should identify the payload action with a distinct tooltip', async () => {
       (LogicAppsShared.canRunBeInvokedWithPayload as Mock).mockReturnValue(true);
 
       renderWithProviders(defaultProps);
 
       const payloadButton = screen.getByRole('button', { name: 'Run with payload' });
-      expect(payloadButton).toHaveAttribute('title', 'Run with payload');
+      fireEvent.focus(payloadButton);
+
+      expect(await screen.findByRole('tooltip')).toHaveTextContent('Run with payload');
     });
 
     it('should render split button in draft mode even when canRunBeInvokedWithPayload returns false', () => {

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/__tests__/floatingRunButton.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/__tests__/floatingRunButton.spec.tsx
@@ -324,6 +324,15 @@ describe('FloatingRunButton', () => {
       expect(buttons.length).toBeGreaterThan(1);
     });
 
+    it('should identify the payload action with a distinct tooltip', () => {
+      (LogicAppsShared.canRunBeInvokedWithPayload as Mock).mockReturnValue(true);
+
+      renderWithProviders(defaultProps);
+
+      const payloadButton = screen.getByRole('button', { name: 'Run with payload' });
+      expect(payloadButton).toHaveAttribute('title', 'Run with payload');
+    });
+
     it('should render split button in draft mode even when canRunBeInvokedWithPayload returns false', () => {
       (LogicAppsShared.canRunBeInvokedWithPayload as Mock).mockReturnValue(false);
 

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -382,6 +382,7 @@ export const FloatingRunButton = ({
   );
 
   const [popoverOpen, setPopoverOpen] = useState(false);
+  const [isPayloadButtonActive, setIsPayloadButtonActive] = useState(false);
 
   if (isA2AWorkflow) {
     return (
@@ -403,7 +404,7 @@ export const FloatingRunButton = ({
   if (canBeRunWithPayload) {
     return (
       <div className={styles.container}>
-        <Tooltip withArrow content={tooltipText} relationship="description">
+        <Tooltip withArrow content={isPayloadButtonActive ? strings.RUN_PAYLOAD_TOOLTIP : tooltipText} relationship="description">
           <SplitButton
             {...buttonCommonProps}
             primaryActionButton={{
@@ -415,7 +416,13 @@ export const FloatingRunButton = ({
             }}
             menuButton={{
               icon: runIsLoading && runHasPayload ? <Spinner size="tiny" /> : <RunWithPayloadIcon />,
+              'aria-label': strings.RUN_PAYLOAD_TOOLTIP,
+              title: strings.RUN_PAYLOAD_TOOLTIP,
               onClick: () => setPopoverOpen(true),
+              onFocus: () => setIsPayloadButtonActive(true),
+              onBlur: () => setIsPayloadButtonActive(false),
+              onMouseEnter: () => setIsPayloadButtonActive(true),
+              onMouseLeave: () => setIsPayloadButtonActive(false),
               ref: payloadButtonRef,
               disabled: isDisabled || runIsLoading || !canBeRunWithPayload || !triggerId,
             }}

--- a/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
+++ b/libs/designer-v2/src/lib/ui/FloatingRunButton/index.tsx
@@ -417,7 +417,6 @@ export const FloatingRunButton = ({
             menuButton={{
               icon: runIsLoading && runHasPayload ? <Spinner size="tiny" /> : <RunWithPayloadIcon />,
               'aria-label': strings.RUN_PAYLOAD_TOOLTIP,
-              title: strings.RUN_PAYLOAD_TOOLTIP,
               onClick: () => setPopoverOpen(true),
               onFocus: () => setIsPayloadButtonActive(true),
               onBlur: () => setIsPayloadButtonActive(false),


### PR DESCRIPTION
## Commit Type
- [ ] feature: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding missing tests or correcting existing tests
- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Other changes that don't modify src or test files
- [ ] revert: Reverts a previous commit

## Risk Level
- [x] Low: Minor changes with minimal impact
- [ ] Medium: Changes that may affect existing functionality
- [ ] High: Significant changes that could cause breaking changes

## What & Why

Closes #8623.

The split Run button currently applies the same generic workflow tooltip to both actions. The payload action now exposes the existing "Run with payload" string as its tooltip and accessible label, while the primary action keeps the existing run tooltip.

## Impact of Change
- **Users**: Can distinguish the payload action before selecting it.
- **Developers**: Adds a focused regression test for the payload button tooltip.
- **System**: No workflow execution behavior changes.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in:
  - `vitest run src/lib/ui/FloatingRunButton/__tests__/floatingRunButton.spec.tsx` (33 tests)
  - `pnpm --filter @microsoft/logic-apps-designer-v2 build:lib`

## Contributors

@miachillgood

## Screenshots/Videos

Not applicable; the change affects tooltip copy and accessibility metadata.
