### PR TITLE
fix(designer): guard undefined operation/action type to prevent renderComponentIntoRoot crash

### DIFF
--- a/libs/designer-v2/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer-v2/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -80,6 +80,7 @@ import {
   removeConnectionPrefix,
   getBrandColorFromConnector,
   getIconUriFromConnector,
+  isNullOrUndefined,
 } from '@microsoft/logic-apps-shared';
 import type { InputParameter, OutputParameter, LogicAppsV2, OperationManifest } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
@@ -136,6 +137,15 @@ export const initializeOperationMetadata = async (
     if (operationId === Constants.NODE.TYPE.PLACEHOLDER_TRIGGER) {
       continue;
     }
+
+    // Guard against an undefined operation in the deserialized workflow data. Accessing
+    // operation.type below on an undefined value throws "Cannot read properties of undefined
+    // (reading 'type')" during load, which the portal error boundary surfaces as the generic
+    // "renderComponentIntoRoot" error and blanks the entire Designer/Run History/Code view.
+    if (isNullOrUndefined(operation)) {
+      continue;
+    }
+
     const isTrigger = isTriggerNode(operationId, nodesMetadata);
 
     if (isTrigger) {

--- a/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -659,7 +659,7 @@ const addActionsInstanceMetaData = (
 
   Object.entries(updatedNodesData).forEach(([key, node]) => {
     const nodeRunData = runInstanceActions?.[key];
-    const isAgent = allActions[key]?.type.toLowerCase() === constants.NODE.TYPE.AGENT;
+    const isAgent = allActions[key]?.type?.toLowerCase() === constants.NODE.TYPE.AGENT;
     const isRunning = nodeRunData?.status === 'Running';
     const runIndex = isAgent && isRunning ? (nodeRunData?.iterationCount ? nodeRunData.iterationCount - 1 : 0) : 0;
 

--- a/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/BJSDeserializer.spec.ts
+++ b/libs/designer-v2/src/lib/core/parsers/BJSWorkflow/__test__/BJSDeserializer.spec.ts
@@ -33,4 +33,47 @@ describe('core/parsers/BJSWorkflow/BJSDeserializer', () => {
     const test = Deserialize(agentMcpWorkflowDefinitionInput, null);
     expect(test).toEqual(expectedAgentMcpWorkflowDefinitionOutput);
   });
+
+  it('should not throw when a run instance is provided and an action is missing its type', () => {
+    // Regression: an action whose deserialized shape lacks `type` previously caused
+    // `allActions[key]?.type.toLowerCase()` to throw "Cannot read properties of undefined",
+    // which the portal error boundary surfaces as the generic "renderComponentIntoRoot" error
+    // and blanks the Run History / Designer / Code view.
+    const definitionWithTypelessAction: any = {
+      $schema: 'https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#',
+      contentVersion: '1.0.0.0',
+      triggers: {
+        manual: {
+          type: 'Request',
+          kind: 'Http',
+          inputs: {},
+        },
+      },
+      actions: {
+        Broken_Action: {
+          inputs: {},
+          runAfter: {},
+        },
+      },
+    };
+    const runInstance: any = {
+      id: '/workflows/test/runs/run1',
+      name: 'run1',
+      type: 'workflows/runs',
+      properties: {
+        status: 'Succeeded',
+        startTime: '2024-01-01T00:00:00Z',
+        endTime: '2024-01-01T00:00:01Z',
+        trigger: { name: 'manual', status: 'Succeeded', startTime: '2024-01-01T00:00:00Z', endTime: '2024-01-01T00:00:00Z' },
+        actions: {
+          Broken_Action: { status: 'Succeeded', startTime: '2024-01-01T00:00:00Z', endTime: '2024-01-01T00:00:01Z' },
+        },
+      },
+    };
+
+    expect(() => Deserialize(definitionWithTypelessAction, runInstance)).not.toThrow();
+    const result = Deserialize(definitionWithTypelessAction, runInstance);
+    expect(result.actionData['Broken_Action']).toBeDefined();
+    expect(result.nodesMetadata['Broken_Action']).toBeDefined();
+  });
 });

--- a/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
+++ b/libs/designer/src/lib/core/actions/bjsworkflow/operationdeserializer.ts
@@ -80,6 +80,7 @@ import {
   removeConnectionPrefix,
   getBrandColorFromConnector,
   getIconUriFromConnector,
+  isNullOrUndefined,
 } from '@microsoft/logic-apps-shared';
 import type { InputParameter, OutputParameter, LogicAppsV2, OperationManifest } from '@microsoft/logic-apps-shared';
 import type { Dispatch } from '@reduxjs/toolkit';
@@ -135,6 +136,15 @@ export const initializeOperationMetadata = async (
     if (operationId === Constants.NODE.TYPE.PLACEHOLDER_TRIGGER) {
       continue;
     }
+
+    // Guard against an undefined operation in the deserialized workflow data. Accessing
+    // operation.type below on an undefined value throws "Cannot read properties of undefined
+    // (reading 'type')" during load, which the portal error boundary surfaces as the generic
+    // "renderComponentIntoRoot" error and blanks the entire Designer/Run History/Code view.
+    if (isNullOrUndefined(operation)) {
+      continue;
+    }
+
     const isTrigger = isTriggerNode(operationId, nodesMetadata);
 
     if (isTrigger) {

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/BJSDeserializer.ts
@@ -659,7 +659,7 @@ const addActionsInstanceMetaData = (
 
   Object.entries(updatedNodesData).forEach(([key, node]) => {
     const nodeRunData = runInstanceActions?.[key];
-    const isAgent = allActions[key]?.type.toLowerCase() === constants.NODE.TYPE.AGENT;
+    const isAgent = allActions[key]?.type?.toLowerCase() === constants.NODE.TYPE.AGENT;
     const isRunning = nodeRunData?.status === 'Running';
     const runIndex = isAgent && isRunning ? (nodeRunData?.iterationCount ? nodeRunData.iterationCount - 1 : 0) : 0;
 

--- a/libs/designer/src/lib/core/parsers/BJSWorkflow/__test__/BJSDeserializer.spec.ts
+++ b/libs/designer/src/lib/core/parsers/BJSWorkflow/__test__/BJSDeserializer.spec.ts
@@ -26,4 +26,47 @@ describe('core/parsers/BJSWorkflow/BJSDeserializer', () => {
     const test = Deserialize(switchWorkflowDefinitionInput, null, false);
     expect(test).toEqual(expectedSwitchWorkflowDefinitionOutputWithoutAddCase);
   });
+
+  it('should not throw when a run instance is provided and an action is missing its type', () => {
+    // Regression: an action whose deserialized shape lacks `type` previously caused
+    // `allActions[key]?.type.toLowerCase()` to throw "Cannot read properties of undefined",
+    // which the portal error boundary surfaces as the generic "renderComponentIntoRoot" error
+    // and blanks the Run History / Designer / Code view.
+    const definitionWithTypelessAction: any = {
+      $schema: 'https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#',
+      contentVersion: '1.0.0.0',
+      triggers: {
+        manual: {
+          type: 'Request',
+          kind: 'Http',
+          inputs: {},
+        },
+      },
+      actions: {
+        Broken_Action: {
+          inputs: {},
+          runAfter: {},
+        },
+      },
+    };
+    const runInstance: any = {
+      id: '/workflows/test/runs/run1',
+      name: 'run1',
+      type: 'workflows/runs',
+      properties: {
+        status: 'Succeeded',
+        startTime: '2024-01-01T00:00:00Z',
+        endTime: '2024-01-01T00:00:01Z',
+        trigger: { name: 'manual', status: 'Succeeded', startTime: '2024-01-01T00:00:00Z', endTime: '2024-01-01T00:00:00Z' },
+        actions: {
+          Broken_Action: { status: 'Succeeded', startTime: '2024-01-01T00:00:00Z', endTime: '2024-01-01T00:00:01Z' },
+        },
+      },
+    };
+
+    expect(() => Deserialize(definitionWithTypelessAction, runInstance)).not.toThrow();
+    const result = Deserialize(definitionWithTypelessAction, runInstance);
+    expect(result.actionData['Broken_Action']).toBeDefined();
+    expect(result.nodesMetadata['Broken_Action']).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Commit Type
- [x] fix - Bug fix

## Risk Level
- [x] Low - Minor changes, limited scope

## What & Why
The designer's React error boundary surfaces any uncaught render/load exception as the generic message **"The renderComponentIntoRoot component encountered an error while loading"**, which blanks the entire **Designer / Run History / Code** view. This is a long-standing catch-all symptom (see #9249 and related), where the underlying cause is a different unguarded access each time.

One such trigger is an **undefined operation** or a **missing `type`** in the deserialized workflow data, which throws `TypeError: Cannot read properties of undefined (reading 'type')` during load. Because it happens in shared deserialization code, a single malformed/edge-case node takes down the whole blade rather than degrading gracefully.

This PR adds defensive guards on the two workflow-load paths. The same two spots exist in **both `libs/designer` (v1) and `libs/designer-v2`**, so the fix is applied to both to keep them in sync:

- **`operationdeserializer.ts`** — skip an `undefined` operation before reading `operation.type`, so one malformed node cannot fail the entire `initializeOperationMetadata` loop.
- **`BJSDeserializer.ts`** (run-instance metadata) — optional-chain `type` when computing the agent flag: `allActions[key]?.type?.toLowerCase()`, so a typeless action doesn't throw while building Run History metadata.

Net effect: a single bad node degrades gracefully instead of blanking the view.

## Impact of Change
- **Users**: Designer / Run History / Code views no longer crash to the generic error boundary when a workflow contains an undefined operation or an action missing its `type` — in both the v1 and v2 designers.
- **Developers**: No API change; purely additive null-safety.
- **System**: No behavioral change on well-formed workflows; no perf impact.

## Test Plan
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed

Added a regression test in `BJSDeserializer.spec.ts` (mirrored across both `libs/designer` and `libs/designer-v2`) that deserializes a workflow with a run instance and an action missing its `type`. It reproduces the crash on the previous code (`Cannot read properties of undefined`) and passes with the guard. Verified `BJSDeserializer.spec.ts` and `operationdeserializer.spec.ts` pass locally in both packages.
