### PR TITLE
fix(vscode): Make design-time start non-blocking on activate

### DIFF
--- a/apps/vs-code-designer/src/__test__/main.test.ts
+++ b/apps/vs-code-designer/src/__test__/main.test.ts
@@ -1,7 +1,56 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
 import * as binaries from '../app/utils/binaries';
 import { isDevContainerWorkspace } from '../app/utils/devContainerUtils';
-import { shouldValidateAndInstallRuntimeDependencies } from '../app/utils/vsCodeConfig/settings';
+import { getWorkspaceSetting, shouldValidateAndInstallRuntimeDependencies, updateGlobalSetting } from '../app/utils/vsCodeConfig/settings';
+import { autoStartDesignTimeSetting, extensionCommand } from '../constants';
+import { ext } from '../extensionVariables';
+import { activate } from '../main';
+
+const mocks = vi.hoisted(() => ({
+  callWithTelemetryAndErrorHandling: vi.fn(),
+  codefulProjectsExist: vi.fn(),
+  createAzExtOutputChannel: vi.fn(),
+  downloadExtensionBundle: vi.fn(),
+  getAzureResourcesExtensionApi: vi.fn(),
+  getResourceGroupsApi: vi.fn(),
+  getWorkspaceLogicAppRoots: vi.fn(),
+  isAutoStartDesignTimeNotificationSuppressed: vi.fn(),
+  isManagedIdentityAuthNotificationSuppressed: vi.fn(),
+  scheduleStartAllDesignTimeApis: vi.fn(),
+  startDesignTimeApi: vi.fn(),
+}));
+
+vi.mock('@microsoft/vscode-azext-azureappservice', () => ({
+  registerAppServiceExtensionVariables: vi.fn(),
+}));
+
+vi.mock('@microsoft/vscode-azext-azureutils', () => ({
+  registerAzureUtilsExtensionVariables: vi.fn(),
+}));
+
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+  callWithTelemetryAndErrorHandling: mocks.callWithTelemetryAndErrorHandling,
+  createAzExtOutputChannel: mocks.createAzExtOutputChannel,
+  DialogResponses: {
+    yes: 'Yes',
+    no: 'No',
+    dontWarnAgain: "Don't warn again",
+  },
+  registerEvent: vi.fn(),
+  registerUIExtensionVariables: vi.fn(),
+}));
+
+vi.mock('@microsoft/vscode-azureresources-api', () => ({
+  getAzExtResourceType: vi.fn(() => 'logicApp'),
+  getAzureResourcesExtensionApi: mocks.getAzureResourcesExtensionApi,
+}));
+
+vi.mock('@vscode/extension-telemetry', () => ({
+  default: class {
+    public dispose = vi.fn();
+  },
+}));
 
 vi.mock('../app/utils/devContainerUtils', () => ({
   isDevContainerWorkspace: vi.fn(),
@@ -10,9 +59,146 @@ vi.mock('../app/utils/devContainerUtils', () => ({
 vi.mock('../app/utils/vsCodeConfig/settings', () => ({
   getGlobalSetting: vi.fn(),
   getWorkspaceSetting: vi.fn(),
+  isManagedIdentityAuthEnabled: vi.fn(() => true),
+  shouldParameterizeConnections: vi.fn(() => false),
   updateGlobalSetting: vi.fn(),
   shouldValidateAndInstallRuntimeDependencies: vi.fn(),
 }));
+
+vi.mock('../LogicAppResolver', () => ({
+  LogicAppResolver: class {},
+}));
+
+vi.mock('../app/commands/binaries/validateAndInstallBinaries', () => ({
+  validateAndInstallBinaries: vi.fn(),
+}));
+
+vi.mock('../app/commands/ensureWorkspace', () => ({
+  ensureWorkspace: vi.fn(),
+}));
+
+vi.mock('../app/commands/parameterizeConnections', () => ({
+  parameterizeAllConnections: vi.fn(),
+}));
+
+vi.mock('../app/commands/registerCommands', () => ({
+  registerCommands: vi.fn(),
+}));
+
+vi.mock('../app/commands/runProjectConsistencyCheck', () => ({
+  runProjectConsistencyCheck: vi.fn(),
+}));
+
+vi.mock('../app/languageServer/languageServer', () => ({
+  startLanguageServer: vi.fn(),
+}));
+
+vi.mock('../app/projectConsistency/projectFilesConsistency', () => ({
+  ensureProjectFiles: vi.fn(),
+}));
+
+vi.mock('../app/projectConsistency/vscodeConsistency', () => ({
+  ensureVSCodeFiles: vi.fn(),
+}));
+
+vi.mock('../app/resourcesExtension/getExtensionApi', () => ({
+  getResourceGroupsApi: mocks.getResourceGroupsApi,
+}));
+
+vi.mock('../app/state/notifications', () => ({
+  isAutoStartDesignTimeNotificationSuppressed: mocks.isAutoStartDesignTimeNotificationSuppressed,
+  isManagedIdentityAuthNotificationSuppressed: mocks.isManagedIdentityAuthNotificationSuppressed,
+  isParameterizeConnectionsNotificationSuppressed: vi.fn(() => true),
+  suppressAutoStartDesignTimeNotification: vi.fn(),
+  suppressManagedIdentityAuthNotification: vi.fn(),
+  suppressParameterizeConnectionsNotification: vi.fn(),
+}));
+
+vi.mock('../app/utils/bundleFeed', () => ({
+  downloadExtensionBundle: mocks.downloadExtensionBundle,
+}));
+
+vi.mock('../app/utils/cloudToLocalUtils', () => ({
+  runPostExtractStepsFromCache: vi.fn(),
+}));
+
+vi.mock('../app/utils/codeless/startDesignTimeApi', () => ({
+  scheduleStartAllDesignTimeApis: mocks.scheduleStartAllDesignTimeApis,
+  startDesignTimeApi: mocks.startDesignTimeApi,
+  stopAllDesignTimeApis: vi.fn(),
+}));
+
+vi.mock('../app/utils/codeless/urihandler', () => ({
+  UriHandler: class {},
+}));
+
+vi.mock('../app/utils/codeful', () => ({
+  codefulProjectsExist: mocks.codefulProjectsExist,
+}));
+
+vi.mock('../app/utils/debug', () => ({
+  logicAppDebugConfigProvider: {},
+}));
+
+vi.mock('../app/utils/extension', () => ({
+  getExtensionVersion: vi.fn(() => '1.0.0'),
+  initializeCustomExtensionContext: vi.fn(),
+  updateLogicAppsContext: vi.fn(),
+}));
+
+vi.mock('../app/utils/funcCoreTools/funcHostTask', () => ({
+  registerFuncHostTaskEvents: vi.fn(),
+}));
+
+vi.mock('../app/utils/managedIdentity', () => ({
+  enableLocalManagedIdentityAuth: vi.fn(),
+}));
+
+vi.mock('../app/utils/services/VSCodeAzureSubscriptionProvider', () => ({
+  createVSCodeAzureSubscriptionProvider: vi.fn(() => ({})),
+}));
+
+vi.mock('../app/utils/strictDependencyValidation', () => ({
+  shouldRequireStrictDependencyValidation: vi.fn(() => false),
+}));
+
+vi.mock('../app/utils/telemetry', () => ({
+  logExtensionSettings: vi.fn(),
+  logSubscriptions: vi.fn(),
+}));
+
+vi.mock('../app/utils/verifyIsProject', () => ({
+  tryGetLogicAppProjectRoot: vi.fn(),
+}));
+
+vi.mock('../app/utils/workspace', () => ({
+  getWorkspaceLogicAppRoots: mocks.getWorkspaceLogicAppRoots,
+}));
+
+vi.mock('../localize', () => ({
+  localize: (_key: string, defaultValue: string) => defaultValue,
+}));
+
+const createActionContext = () =>
+  ({
+    telemetry: { properties: {}, measurements: {} },
+    errorHandling: { issueProperties: {} },
+    ui: {},
+    valuesToMask: [],
+  }) as any;
+
+const createExtensionContext = () =>
+  ({
+    subscriptions: [],
+    globalState: {
+      get: vi.fn(),
+      update: vi.fn(),
+    },
+  }) as unknown as vscode.ExtensionContext;
+
+const flushPromises = async () => {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+};
 
 describe('useBinariesDependencies', () => {
   beforeEach(() => {
@@ -35,5 +221,124 @@ describe('useBinariesDependencies', () => {
     const result = await binaries.useBinariesDependencies();
 
     expect(result).toBe(true);
+  });
+});
+
+describe('activate design-time startup', () => {
+  let backgroundOperations: Promise<unknown>[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backgroundOperations = [];
+
+    (vscode as any).debug = {
+      registerDebugConfigurationProvider: vi.fn(),
+    };
+    (vscode.workspace as any).workspaceFolders = [];
+    (vscode.workspace as any).onDidChangeWorkspaceFolders = vi.fn();
+    (vscode.window as any).registerUriHandler = vi.fn();
+
+    mocks.callWithTelemetryAndErrorHandling.mockImplementation(
+      (eventName: string, callback: (context: ReturnType<typeof createActionContext>) => Promise<unknown>) => {
+        const operation = Promise.resolve(callback(createActionContext()));
+        if (eventName === extensionCommand.activate) {
+          return operation;
+        }
+
+        const guardedOperation = operation.catch(() => undefined);
+        backgroundOperations.push(guardedOperation);
+        return guardedOperation;
+      }
+    );
+
+    mocks.createAzExtOutputChannel.mockReturnValue({
+      appendLog: vi.fn(),
+      dispose: vi.fn(),
+    });
+    mocks.downloadExtensionBundle.mockResolvedValue(undefined);
+    mocks.getAzureResourcesExtensionApi.mockResolvedValue({});
+    mocks.getResourceGroupsApi.mockResolvedValue({
+      appResourceTree: {
+        _rootTreeItem: {},
+      },
+      registerApplicationResourceResolver: vi.fn(),
+    });
+    mocks.getWorkspaceLogicAppRoots.mockResolvedValue([]);
+    mocks.isAutoStartDesignTimeNotificationSuppressed.mockReturnValue(false);
+    mocks.isManagedIdentityAuthNotificationSuppressed.mockReturnValue(true);
+    mocks.codefulProjectsExist.mockResolvedValue(false);
+    mocks.startDesignTimeApi.mockResolvedValue(undefined);
+    vi.mocked(isDevContainerWorkspace).mockResolvedValue(false);
+    vi.mocked(shouldValidateAndInstallRuntimeDependencies).mockReturnValue(false);
+    vi.mocked(getWorkspaceSetting).mockReturnValue(false);
+    vi.mocked(updateGlobalSetting).mockResolvedValue(undefined);
+
+    ext.designTimeInstances.clear();
+  });
+
+  it('does not block activation while the auto-start prompt is unanswered', async () => {
+    let resolvePrompt!: (value: vscode.MessageItem | undefined) => void;
+    const promptPromise = new Promise<vscode.MessageItem | undefined>((resolve) => {
+      resolvePrompt = resolve;
+    });
+    vi.mocked(vscode.window.showWarningMessage).mockReturnValue(promptPromise);
+    mocks.getWorkspaceLogicAppRoots.mockResolvedValue(['D:\\workspace\\app-one']);
+
+    await activate(createExtensionContext());
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      'Always start the background design-time process at launch? The workflow designer will open faster.',
+      { title: 'Yes (Recommended)' },
+      { title: "Don't warn again" }
+    );
+    expect(mocks.getResourceGroupsApi).toHaveBeenCalled();
+    expect(mocks.startDesignTimeApi).not.toHaveBeenCalled();
+
+    resolvePrompt(undefined);
+    await flushPromises();
+    await Promise.all(backgroundOperations);
+  });
+
+  it('starts all workspace projects before waiting for any startup to finish', async () => {
+    let resolveFirstStartup!: () => void;
+    let resolveSecondStartup!: () => void;
+    const firstStartup = new Promise<void>((resolve) => {
+      resolveFirstStartup = resolve;
+    });
+    const secondStartup = new Promise<void>((resolve) => {
+      resolveSecondStartup = resolve;
+    });
+    mocks.getWorkspaceLogicAppRoots.mockResolvedValue(['D:\\workspace\\app-one', 'D:\\workspace\\app-two']);
+    vi.mocked(getWorkspaceSetting).mockImplementation((key: string) => key === autoStartDesignTimeSetting);
+    mocks.startDesignTimeApi.mockImplementation((_context, projectPath: string) => {
+      return projectPath.endsWith('app-one') ? firstStartup : secondStartup;
+    });
+
+    await activate(createExtensionContext());
+    await flushPromises();
+
+    expect(mocks.startDesignTimeApi).toHaveBeenCalledTimes(2);
+    expect(mocks.startDesignTimeApi).toHaveBeenCalledWith(expect.any(Object), 'D:\\workspace\\app-one');
+    expect(mocks.startDesignTimeApi).toHaveBeenCalledWith(expect.any(Object), 'D:\\workspace\\app-two');
+
+    resolveFirstStartup();
+    resolveSecondStartup();
+    await Promise.all(backgroundOperations);
+  });
+
+  it('attempts every project and keeps activation successful when one startup fails', async () => {
+    mocks.getWorkspaceLogicAppRoots.mockResolvedValue(['D:\\workspace\\app-one', 'D:\\workspace\\app-two']);
+    vi.mocked(getWorkspaceSetting).mockImplementation((key: string) => key === autoStartDesignTimeSetting);
+    mocks.startDesignTimeApi.mockImplementation((_context, projectPath: string) => {
+      return projectPath.endsWith('app-one') ? Promise.reject(new Error('startup failed')) : Promise.resolve();
+    });
+
+    await expect(activate(createExtensionContext())).resolves.toBeUndefined();
+    await flushPromises();
+    await Promise.all(backgroundOperations);
+
+    expect(mocks.startDesignTimeApi).toHaveBeenCalledTimes(2);
+    expect(mocks.startDesignTimeApi).toHaveBeenCalledWith(expect.any(Object), 'D:\\workspace\\app-one');
+    expect(mocks.startDesignTimeApi).toHaveBeenCalledWith(expect.any(Object), 'D:\\workspace\\app-two');
   });
 });

--- a/apps/vs-code-designer/src/main.ts
+++ b/apps/vs-code-designer/src/main.ts
@@ -167,7 +167,25 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Start background processes (design-time func, codeful language server)
     activateContext.telemetry.properties.lastStep = 'startDesignTime';
-    await startDesignTime(activateContext, isDevContainer);
+    callWithTelemetryAndErrorHandling('activate.startDesignTime', async (actionContext: IActionContext) => {
+      actionContext.telemetry.properties.isActivationEvent = 'true';
+      if (isDevContainer) {
+        actionContext.telemetry.properties.designTimeStartupMode = 'devContainerAutoStart';
+        actionContext.telemetry.properties.designTimeStartupState = 'scheduled';
+        scheduleStartAllDesignTimeApis();
+      } else {
+        const projectPaths = await getWorkspaceLogicAppRoots();
+        if (await promptShouldAutoStartDesignTime(projectPaths)) {
+          const startDesignTimePromises = projectPaths.map(async (projectPath) => 
+            callWithTelemetryAndErrorHandling('activate.startDesignTimeApi', async (innerActionContext: IActionContext) => {
+              innerActionContext.telemetry.properties.isActivationEvent = 'true';
+              await startDesignTimeApi(innerActionContext, projectPath);
+            })
+          );
+          await Promise.all(startDesignTimePromises);
+        }
+      }
+    });
 
     activateContext.telemetry.properties.lastStep = 'startLanguageServer';
     const hasCodefulProjects = await codefulProjectsExist();
@@ -315,26 +333,6 @@ async function ensureBinaries(activateContext: IActionContext, isDevContainer: b
       await updateGlobalSetting(nodeJsBinaryPathSettingKey, DependencyDefaultPath.node);
       await updateGlobalSetting(funcCoreToolsBinaryPathSettingKey, DependencyDefaultPath.funcCoreTools);
       activateContext.telemetry.properties.autoRuntimeDependenciesValidationAndInstallationSetting = 'false';
-    }
-  }
-}
-
-async function startDesignTime(activateContext: IActionContext, isDevContainer: boolean): Promise<void> {
-  if (isDevContainer) {
-    activateContext.telemetry.properties.designTimeStartupMode = 'devContainerAutoStart';
-    activateContext.telemetry.properties.designTimeStartupState = 'scheduled';
-    ext.outputChannel?.appendLog(
-      localize('schedulingDesignTimeStartup', 'Scheduling background design-time startup for devcontainer workspace.')
-    );
-    scheduleStartAllDesignTimeApis();
-  } else {
-    const projectPaths = await getWorkspaceLogicAppRoots();
-    if (await promptShouldAutoStartDesignTime(projectPaths)) {
-      for (const projectPath of projectPaths) {
-        callWithTelemetryAndErrorHandling('activate.startDesignTimeApi', async (actionContext: IActionContext) => {
-          await startDesignTimeApi(actionContext, projectPath);
-        });
-      }
     }
   }
 }


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
- Make 'auto start design-time' prompt non-blocking on activate

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Prevents extension activation getting blocked on prompt
- **Developers**: N/A
- **System**: N/A

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
@andrew-eldridge

