### PR TITLE
fix(designer): apply disabled styling to Reassign

### DIFF
--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/allConnections/__test__/connectionEntry.spec.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/allConnections/__test__/connectionEntry.spec.tsx
@@ -89,6 +89,7 @@ describe('ConnectionEntry', () => {
 
     const reassignButton = screen.getByRole('button', { name: 'Reassign all connected actions to a new connection' });
     expect(reassignButton.hasAttribute('disabled')).toBe(true);
+    expect(reassignButton.hasAttribute('style')).toBe(false);
 
     fireEvent.click(reassignButton);
     expect(mockDispatch).not.toHaveBeenCalled();

--- a/libs/designer-v2/src/lib/ui/panel/connectionsPanel/allConnections/connectionEntry.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/connectionsPanel/allConnections/connectionEntry.tsx
@@ -148,7 +148,7 @@ export const ConnectionEntry = ({ connectorId, refId, connectionReference, iconU
               icon={<ArrowSwap24Filled />}
               disabled={readOnly}
               onClick={readOnly ? undefined : onReassignButtonClick}
-              style={{ color: 'var(--colorBrandForeground1)' }}
+              style={readOnly ? undefined : { color: 'var(--colorBrandForeground1)' }}
             >
               {reassignButtonText}
             </Button>

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/__test__/connectionEntry.spec.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/__test__/connectionEntry.spec.tsx
@@ -89,6 +89,7 @@ describe('ConnectionEntry', () => {
 
     const reassignButton = screen.getByRole('button', { name: 'Reassign all connected actions to a new connection' });
     expect(reassignButton.hasAttribute('disabled')).toBe(true);
+    expect(reassignButton.hasAttribute('style')).toBe(false);
 
     fireEvent.click(reassignButton);
     expect(mockDispatch).not.toHaveBeenCalled();

--- a/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/connectionEntry.tsx
+++ b/libs/designer/src/lib/ui/panel/connectionsPanel/allConnections/connectionEntry.tsx
@@ -148,7 +148,7 @@ export const ConnectionEntry = ({ connectorId, refId, connectionReference, iconU
               icon={<ArrowSwap24Filled />}
               disabled={readOnly}
               onClick={readOnly ? undefined : onReassignButtonClick}
-              style={{ color: 'var(--colorBrandForeground1)' }}
+              style={readOnly ? undefined : { color: 'var(--colorBrandForeground1)' }}
             >
               {reassignButtonText}
             </Button>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [x] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Both the original and V2 Connections panels disabled Reassign in read-only mode, but an inline brand-color override kept the action text blue. This removes that override for disabled actions so Fluent renders the entire Reassign action, including its text, with the proper disabled styling.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: Read-only designers now show Reassign as consistently disabled instead of visually suggesting the action is clickable.
- **Developers**: Focused tests protect the disabled visual contract in both designer implementations.
- **System**: No API, state, dependency, or runtime behavior changes.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] Tested in: Focused ConnectionEntry unit tests for original and V2 designers; package type-checks; Biome.

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->

<img width="1294" height="970" alt="image" src="https://github.com/user-attachments/assets/97c62a09-6471-443c-9187-bcba641fcfd4" />

Read only has the text disabled as well
<img width="1309" height="975" alt="image" src="https://github.com/user-attachments/assets/8e1b960d-7310-4830-97f8-3d78e2793f14" />