### PR TITLE
chore(release): automate hotfix branch creation

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -90,7 +90,7 @@ jobs:
           git push origin ${{ steps.version.outputs.tag_name }}
 
       - name: 'Create and Push Hotfix Branch'
-        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
+        if: github.ref_name == 'main'
         run: |
           TAG_NAME="${{ steps.version.outputs.tag_name }}"
           HOTFIX_BRANCH="hotfix/${TAG_NAME%.0}"

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -89,6 +89,14 @@ jobs:
           git tag -a ${{ steps.version.outputs.tag_name }} -m "Release ${{ steps.version.outputs.tag_name }}"
           git push origin ${{ steps.version.outputs.tag_name }}
 
+      - name: 'Create and Push Hotfix Branch'
+        if: github.ref_name == 'main'
+        run: |
+          TAG_NAME="${{ steps.version.outputs.tag_name }}"
+          HOTFIX_BRANCH="hotfix/${TAG_NAME%.0}"
+          git branch "$HOTFIX_BRANCH" "$TAG_NAME"
+          git push origin "$HOTFIX_BRANCH"
+
       - name: 'Generate Release Notes'
         id: release-notes
         env:

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -90,7 +90,7 @@ jobs:
           git push origin ${{ steps.version.outputs.tag_name }}
 
       - name: 'Create and Push Hotfix Branch'
-        if: github.ref_name == 'main'
+        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
         run: |
           TAG_NAME="${{ steps.version.outputs.tag_name }}"
           HOTFIX_BRANCH="hotfix/${TAG_NAME%.0}"

--- a/VERSION_RELEASE_MIGRATION.md
+++ b/VERSION_RELEASE_MIGRATION.md
@@ -12,7 +12,7 @@ This repository has been migrated from `standard-version` to a custom tag-based 
 
 ### 2. Release Process
 - **Before**: Manual trigger with explicit version type (major/minor/patch) that commits to main
-- **After**: Manual trigger with explicit version type that only creates tags
+- **After**: Manual trigger with explicit version type that creates release tags and the corresponding hotfix branch for major/minor releases
 
 ### 3. Workflow Changes
 - **Old workflow**: `production-build.yml` (can be deprecated)
@@ -29,6 +29,7 @@ This repository has been migrated from `standard-version` to a custom tag-based 
 2. **Version updates during build**: The `scripts/update-versions.js` script updates package.json versions during CI/CD build time only
 3. **GitHub releases**: Created with auto-generated release notes
 4. **NPM publishing**: Uses the version from the git tag, not from package.json
+5. **Hotfix branch creation**: Major and minor releases atomically create `hotfix/v<major>.<minor>` from the new `v<major>.<minor>.0` tag
 
 ## Triggering Releases
 
@@ -47,7 +48,7 @@ Can also be triggered via:
 
 1. **Validation**: Ensures patch releases only on hotfix branches, major/minor only on main
 2. **Version Calculation**: Increments version based on selected type
-3. **Tag Creation**: Creates and pushes git tag
+3. **Release Ref Creation**: Major/minor releases atomically push the git tag and `hotfix/v<major>.<minor>` branch; patch releases push only the new tag
 4. **GitHub Release**: Creates release with auto-generated notes
 5. **Build & Publish**: Builds extension and publishes to NPM
 
@@ -63,7 +64,7 @@ Can also be triggered via:
 - [x] Remove `.versionrc` file
 - [x] Remove semantic-release dependencies
 - [ ] Deprecate old `production-build.yml` workflow
-- [ ] Update team documentation
+- [x] Update team documentation
 
 ## Rollback Plan
 

--- a/VERSION_RELEASE_MIGRATION.md
+++ b/VERSION_RELEASE_MIGRATION.md
@@ -29,7 +29,7 @@ This repository has been migrated from `standard-version` to a custom tag-based 
 2. **Version updates during build**: The `scripts/update-versions.js` script updates package.json versions during CI/CD build time only
 3. **GitHub releases**: Created with auto-generated release notes
 4. **NPM publishing**: Uses the version from the git tag, not from package.json
-5. **Hotfix branch creation**: Major and minor releases create `hotfix/v<major>.<minor>` from the new `v<major>.<minor>.0` tag
+5. **Hotfix branch creation**: Manually dispatched major and minor releases create `hotfix/v<major>.<minor>` from the new `v<major>.<minor>.0` tag
 
 ## Triggering Releases
 
@@ -48,7 +48,7 @@ Can also be triggered via:
 
 1. **Validation**: Ensures patch releases only on hotfix branches, major/minor only on main
 2. **Version Calculation**: Increments version based on selected type
-3. **Release Ref Creation**: Major/minor releases push the git tag and then the `hotfix/v<major>.<minor>` branch; patch releases push only the new tag
+3. **Release Ref Creation**: Manually dispatched major/minor releases push the git tag and then the `hotfix/v<major>.<minor>` branch; scheduled, repository-dispatched, and patch releases push only the new tag
 4. **GitHub Release**: Creates release with auto-generated notes
 5. **Build & Publish**: Builds extension and publishes to NPM
 

--- a/VERSION_RELEASE_MIGRATION.md
+++ b/VERSION_RELEASE_MIGRATION.md
@@ -29,7 +29,7 @@ This repository has been migrated from `standard-version` to a custom tag-based 
 2. **Version updates during build**: The `scripts/update-versions.js` script updates package.json versions during CI/CD build time only
 3. **GitHub releases**: Created with auto-generated release notes
 4. **NPM publishing**: Uses the version from the git tag, not from package.json
-5. **Hotfix branch creation**: Major and minor releases atomically create `hotfix/v<major>.<minor>` from the new `v<major>.<minor>.0` tag
+5. **Hotfix branch creation**: Major and minor releases create `hotfix/v<major>.<minor>` from the new `v<major>.<minor>.0` tag
 
 ## Triggering Releases
 
@@ -48,7 +48,7 @@ Can also be triggered via:
 
 1. **Validation**: Ensures patch releases only on hotfix branches, major/minor only on main
 2. **Version Calculation**: Increments version based on selected type
-3. **Release Ref Creation**: Major/minor releases atomically push the git tag and `hotfix/v<major>.<minor>` branch; patch releases push only the new tag
+3. **Release Ref Creation**: Major/minor releases push the git tag and then the `hotfix/v<major>.<minor>` branch; patch releases push only the new tag
 4. **GitHub Release**: Creates release with auto-generated notes
 5. **Build & Publish**: Builds extension and publishes to NPM
 

--- a/VERSION_RELEASE_MIGRATION.md
+++ b/VERSION_RELEASE_MIGRATION.md
@@ -29,7 +29,7 @@ This repository has been migrated from `standard-version` to a custom tag-based 
 2. **Version updates during build**: The `scripts/update-versions.js` script updates package.json versions during CI/CD build time only
 3. **GitHub releases**: Created with auto-generated release notes
 4. **NPM publishing**: Uses the version from the git tag, not from package.json
-5. **Hotfix branch creation**: Manually dispatched major and minor releases create `hotfix/v<major>.<minor>` from the new `v<major>.<minor>.0` tag
+5. **Hotfix branch creation**: Major and minor releases create `hotfix/v<major>.<minor>` from the new `v<major>.<minor>.0` tag
 
 ## Triggering Releases
 
@@ -48,7 +48,7 @@ Can also be triggered via:
 
 1. **Validation**: Ensures patch releases only on hotfix branches, major/minor only on main
 2. **Version Calculation**: Increments version based on selected type
-3. **Release Ref Creation**: Manually dispatched major/minor releases push the git tag and then the `hotfix/v<major>.<minor>` branch; scheduled, repository-dispatched, and patch releases push only the new tag
+3. **Release Ref Creation**: Major/minor releases push the git tag and then the `hotfix/v<major>.<minor>` branch; patch releases push only the new tag
 4. **GitHub Release**: Creates release with auto-generated notes
 5. **Build & Publish**: Builds extension and publishes to NPM
 

--- a/apps/docs/docs/release.md
+++ b/apps/docs/docs/release.md
@@ -19,7 +19,7 @@ Please note, this documentation applies solely to version 2.16.0 and subsequent 
 
 A standard release procedure is initiated against the main branch, accomplishing several tasks:
 
-1. It increments the Minor Version of the package (Major.Minor.Patch), creates a tag, and creates the corresponding `hotfix/v<major>.<minor>` branch from that tag. This process also generates a change log detailing the variations from the previous release.
+1. It increments the Minor Version of the package (Major.Minor.Patch), creates a tag, and, when manually dispatched, creates the corresponding `hotfix/v<major>.<minor>` branch from that tag. This process also generates a change log detailing the variations from the previous release.
 2. It creates NPM packages and forwards these packages to the production package repository.
 3. It constructs both VSCode Extensions: Logic Apps Standard and Logic Apps Data Mapper.
 4. It prepares a GitHub release inclusive of a change log and all artifacts intended for submission.

--- a/apps/docs/docs/release.md
+++ b/apps/docs/docs/release.md
@@ -19,7 +19,7 @@ Please note, this documentation applies solely to version 2.16.0 and subsequent 
 
 A standard release procedure is initiated against the main branch, accomplishing several tasks:
 
-1. It increments the Minor Version of the package (Major.Minor.Patch), while creating a tag on the git repository. This process also generates a change log detailing the variations from the previous release.
+1. It increments the Minor Version of the package (Major.Minor.Patch), creates a tag, and creates the corresponding `hotfix/v<major>.<minor>` branch from that tag. This process also generates a change log detailing the variations from the previous release.
 2. It creates NPM packages and forwards these packages to the production package repository.
 3. It constructs both VSCode Extensions: Logic Apps Standard and Logic Apps Data Mapper.
 4. It prepares a GitHub release inclusive of a change log and all artifacts intended for submission.
@@ -28,7 +28,7 @@ You should execute this procedure in preparation for a routine release cycle.
 
 ### Execution Steps
 
-1. Navigate to https://github.com/Azure/LogicAppsUX/actions/workflows/production-build.yml.
+1. Navigate to https://github.com/Azure/LogicAppsUX/actions/workflows/version-release.yml.
 2. Select 'Run Workflow', ensuring that the branch is set to 'main' and the release type is designated as 'Minor', as depicted below.
    ![Production Release Settings](./img/productionRelease.png)
 3. Initiate 'Run Workflow'.
@@ -53,31 +53,33 @@ This process will:
 The assumption here is that the necessary change has already been committed to the main branch. Only under rare circumstances should a change first be made in the hotfix branch.
 :::
 
-1. Begin with the repository on your local machine. Write permission is required on the main repository, and the normal fork process is insufficient.
-2. [If the minor version hotfix branch already exists, proceed to step 4] In your terminal of choice, create a branch based on the tag of your version within the repository.
+1. Locate the `hotfix/v<major>.<minor>` branch created automatically when the corresponding `v<major>.<minor>.0` release was published.
+
+2. If the hotfix branch predates this automation and does not exist, create it from the patch-zero tag and push it to the main repository. Write permission is required for this fallback.
    Example command (replace 'version' with your version):
 
 ```
 git checkout -b hotfix/v2.17 v2.17.0
+git push origin hotfix/v2.17
 ```
 
 :::note
 The tag version that the branch is created from should always be patch version 0. To achieve anything higher than 0, the hotfix branch must have been previously created.
 :::
 
-3. Cherry pick the required change to your new branch, ensuring there are no merge conflicts.
+3. Cherry pick the required change to your hotfix branch, ensuring there are no merge conflicts.
 
 ```
 git cherry-pick <commit-id>
 ```
 
-4. Push the new branch to the main repository.
+4. Push the updated branch to the main repository.
 
 ```
 git push
 ```
 
-5. Navigate to https://github.com/Azure/LogicAppsUX/actions/workflows/production-build.yml.
+5. Navigate to https://github.com/Azure/LogicAppsUX/actions/workflows/version-release.yml.
 
 6. Select 'Run Workflow', ensuring that the branch is set to your hotfix branch and the release type is 'Patch', as shown below.
    ![Hotfix Release Settings](./img/hotfixRelease.png)

--- a/apps/docs/docs/release.md
+++ b/apps/docs/docs/release.md
@@ -19,7 +19,7 @@ Please note, this documentation applies solely to version 2.16.0 and subsequent 
 
 A standard release procedure is initiated against the main branch, accomplishing several tasks:
 
-1. It increments the Minor Version of the package (Major.Minor.Patch), creates a tag, and, when manually dispatched, creates the corresponding `hotfix/v<major>.<minor>` branch from that tag. This process also generates a change log detailing the variations from the previous release.
+1. It increments the Minor Version of the package (Major.Minor.Patch), creates a tag, and creates the corresponding `hotfix/v<major>.<minor>` branch from that tag. This process also generates a change log detailing the variations from the previous release.
 2. It creates NPM packages and forwards these packages to the production package repository.
 3. It constructs both VSCode Extensions: Logic Apps Standard and Logic Apps Data Mapper.
 4. It prepares a GitHub release inclusive of a change log and all artifacts intended for submission.


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [ ] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [x] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [ ] Low - Minor changes, limited scope
- [x] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Preserves the existing release tag push and, for releases run from `main`, automatically derives and pushes the corresponding `hotfix/v<major>.<minor>` branch from the new patch-zero tag. This removes a manual release step and keeps the migration and release documentation aligned with the automated process.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: No direct product behavior change.
- **Developers**: Release operators can use the automatically created hotfix branch instead of creating it manually after a major or minor release.
- **System**: The version release workflow performs one additional branch creation and push after successfully pushing the release tag on `main`; patch releases remain unchanged.

## Test Plan
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] Tested in: Static workflow/docs validation: `git diff --check`; Bash assertions for `v1.2.0` → `hotfix/v1.2` and `v10.20.0` → `hotfix/v10.20`; documentation target/image reference checks; Prettier parsed all changed YAML/Markdown files (existing style differences remain in the workflow and migration document).

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->
@lambrianmsft and @Copilot

## Screenshots/Videos
<!-- Visual changes only -->
Not applicable — workflow and documentation changes only.