### PR TITLE
feat(designer-v2): add host option for filtering expressions

### DIFF
--- a/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
+++ b/libs/designer-v2/src/lib/core/state/designerOptions/designerOptionsInterfaces.ts
@@ -55,6 +55,7 @@ export interface DesignerOptionsState {
     disableMcpClientTools?: boolean; // hide MCP client tools from browse panel
     disableNativeMcpClientTools?: boolean; // hide native (built-in) MCP client tools tab from browse panel
     enableEditableCodeView?: boolean; // allow editing an action's JSON inline from the node code view tab (opt-in per host)
+    supportedExpressionFunctions?: string[]; // allow-list of expression function names shown in the token picker; when omitted, all functions are shown
     integrationAccount?: { id?: string; name?: string }; // integration account linked to the workflow
   };
   nodeSelectAdditionalCallback?: (nodeId: string) => any;

--- a/libs/designer-v2/src/lib/core/utils/__test__/tokens.spec.ts
+++ b/libs/designer-v2/src/lib/core/utils/__test__/tokens.spec.ts
@@ -1,5 +1,5 @@
 import { createWorkflowEdge, createWorkflowNode } from '../graph';
-import { getTokenNodeIds, filterTokensForAgentPerInput, convertOutputsToTokens } from '../tokens';
+import { getTokenNodeIds, filterTokensForAgentPerInput, convertOutputsToTokens, getExpressionTokenSections } from '../tokens';
 import { WORKFLOW_NODE_TYPES } from '@microsoft/logic-apps-shared';
 import { TokenType } from '@microsoft/designer-ui';
 import { describe, vi, beforeEach, afterEach, beforeAll, afterAll, it, test, expect } from 'vitest';
@@ -358,6 +358,33 @@ describe('Token Picker Utilities', () => {
       // Should include all outputs for non-Agent types
       expect(result).toHaveLength(2);
       expect(result.map((r) => r.key)).toEqual(['body1', 'output1']);
+    });
+  });
+
+  describe('getExpressionTokenSections', () => {
+    it('returns all function groups when no allow-list is provided', () => {
+      const sections = getExpressionTokenSections();
+      expect(sections.length).toBeGreaterThan(0);
+      expect(sections.every((section) => section.tokens.length > 0)).toBe(true);
+      const allNames = sections.flatMap((section) => section.tokens.map((token) => token.name));
+      expect(allNames).toEqual(expect.arrayContaining(['contains', 'and', 'equals']));
+    });
+
+    it('restricts functions to the allow-list and drops emptied groups', () => {
+      const sections = getExpressionTokenSections(['contains', 'and', 'equals']);
+      const allNames = sections.flatMap((section) => section.tokens.map((token) => token.name));
+      expect(new Set(allNames)).toEqual(new Set(['contains', 'and', 'equals']));
+      expect(sections.every((section) => section.tokens.length > 0)).toBe(true);
+    });
+
+    it('matches allow-list entries case-insensitively', () => {
+      const sections = getExpressionTokenSections(['CONTAINS', 'And']);
+      const allNames = sections.flatMap((section) => section.tokens.map((token) => token.name));
+      expect(new Set(allNames)).toEqual(new Set(['contains', 'and']));
+    });
+
+    it('treats an empty allow-list as no restriction', () => {
+      expect(getExpressionTokenSections([]).length).toBe(getExpressionTokenSections().length);
     });
   });
 });

--- a/libs/designer-v2/src/lib/core/utils/tokens.ts
+++ b/libs/designer-v2/src/lib/core/utils/tokens.ts
@@ -241,11 +241,13 @@ export const convertOutputsToTokens = (
   });
 };
 
-export const getExpressionTokenSections = (): TokenGroup[] => {
+export const getExpressionTokenSections = (supportedFunctions?: string[]): TokenGroup[] => {
+  const allowedFunctions = supportedFunctions?.length ? new Set(supportedFunctions.map((name) => name.toLowerCase())) : undefined;
   return TemplateFunctions.map((functionGroup) => {
     const { id, name, functions } = functionGroup;
-    const hasAdvanced = functions.some((func) => func.isAdvanced);
-    const tokens = functions.map(({ name, defaultSignature, description, isAdvanced }: FunctionDefinition) => ({
+    const includedFunctions = allowedFunctions ? functions.filter((func) => allowedFunctions.has(func.name.toLowerCase())) : functions;
+    const hasAdvanced = includedFunctions.some((func) => func.isAdvanced);
+    const tokens = includedFunctions.map(({ name, defaultSignature, description, isAdvanced }: FunctionDefinition) => ({
       key: name,
       brandColor: FxBrandColor,
       icon: FxIcon,
@@ -267,7 +269,7 @@ export const getExpressionTokenSections = (): TokenGroup[] => {
       showAdvanced: false,
       tokens,
     };
-  });
+  }).filter((group) => group.tokens.length > 0);
 };
 
 export const getOutputTokenSections = (

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/handoffTab/HandoffToolEntry.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/handoffTab/HandoffToolEntry.tsx
@@ -28,7 +28,7 @@ import { useOperationParameterByName } from '../../../../../core/state/operation
 import constants from '../../../../../common/constants';
 import { removeAgentHandoff } from '../../../../../core/actions/bjsworkflow/handoff';
 import { ParameterSection } from '../parametersTab';
-import { useReadOnly } from '../../../../../core/state/designerOptions/designerOptionsSelectors';
+import { useHostOptions, useReadOnly } from '../../../../../core/state/designerOptions/designerOptionsSelectors';
 import { SUBGRAPH_TYPES, equals } from '@microsoft/logic-apps-shared';
 
 const ExpandIcon = bundleIcon(ChevronRight24Filled, ChevronRight24Regular);
@@ -42,6 +42,7 @@ interface HandoffToolEntryProps {
 
 export const HandoffToolEntry = ({ agentId, toolId }: HandoffToolEntryProps) => {
   const isReadOnly = useReadOnly();
+  const { supportedExpressionFunctions } = useHostOptions();
   const intl = useIntl();
   const dispatch = useDispatch<AppDispatch>();
 
@@ -202,7 +203,7 @@ export const HandoffToolEntry = ({ agentId, toolId }: HandoffToolEntryProps) => 
     workflowState,
     replacedIds
   );
-  const expressionGroup = getExpressionTokenSections();
+  const expressionGroup = getExpressionTokenSections(supportedExpressionFunctions);
 
   return (
     <div className={styles.handoffToolEntry}>

--- a/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
+++ b/libs/designer-v2/src/lib/ui/panel/nodeDetailsPanel/tabs/parametersTab/index.tsx
@@ -175,6 +175,7 @@ export const ParametersTab: React.FC<ParametersTabProps> = (props) => {
   }));
   const nodeType = useSelector((state: RootState) => state.operations.operationInfo[selectedNodeId]?.type);
   const readOnly = useReadOnly() || isTabReadOnly;
+  const { supportedExpressionFunctions } = useHostOptions();
   const nodesInitialized = useNodesInitialized();
 
   const connectionName = useNodeConnectionName(selectedNodeId);
@@ -238,7 +239,7 @@ export const ParametersTab: React.FC<ParametersTabProps> = (props) => {
     workflowState,
     replacedIds
   );
-  const expressionGroup = getExpressionTokenSections();
+  const expressionGroup = getExpressionTokenSections(supportedExpressionFunctions);
 
   return (
     <>


### PR DESCRIPTION
## Commit Type
<!-- Select one -->
- [x] feature - New functionality
- [ ] fix - Bug fix
- [ ] refactor - Code restructuring without behavior change
- [ ] perf - Performance improvement
- [ ] docs - Documentation update
- [ ] test - Test-related changes
- [ ] chore - Maintenance/tooling

## Risk Level
<!-- Select one based on potential impact -->
- [x] Low - Minor changes, limited scope
- [ ] Medium - Moderate changes, some user impact
- [ ] High - Major changes, significant user/system impact

## What & Why
<!-- Brief context: What does this change and why? -->
Adds a host option to the v2 designer to optionally limit the list of supported expression functions. Shows all if not set.

## Impact of Change
<!-- Who/what is affected? -->
- **Users**: <!-- User-facing changes, if any -->
- **Developers**: <!-- API changes, new patterns, etc. -->
- **System**: <!-- Performance, architecture, dependencies -->
Not sure if this is considered user or developer impact, but this allows people using the library with a custom runtime to choose which functions to support.

## Test Plan
<!-- How was this tested? -->
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [ ] Tested in: <!-- environments/scenarios -->

## Contributors
<!-- Tag team members who contributed ideas, reviews, or implementation -->

## Screenshots/Videos
<!-- Visual changes only -->
